### PR TITLE
feat: support for ollama users who run their models locally.

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -479,7 +479,8 @@ def get_user_selections():
     )
     selected_shallow_thinker = select_shallow_thinking_agent(selected_llm_provider)
     selected_deep_thinker = select_deep_thinking_agent(selected_llm_provider)
-
+    selected_embedding_model = select_embedding_agent(selected_llm_provider)
+    
     return {
         "ticker": selected_ticker,
         "analysis_date": analysis_date,
@@ -489,6 +490,7 @@ def get_user_selections():
         "backend_url": backend_url,
         "shallow_thinker": selected_shallow_thinker,
         "deep_thinker": selected_deep_thinker,
+        "embedding_model": selected_embedding_model,
     }
 
 
@@ -741,6 +743,7 @@ def run_analysis():
     config["max_risk_discuss_rounds"] = selections["research_depth"]
     config["quick_think_llm"] = selections["shallow_thinker"]
     config["deep_think_llm"] = selections["deep_thinker"]
+    config["embedding_model"] = selections["embedding_model"]
     config["backend_url"] = selections["backend_url"]
     config["llm_provider"] = selections["llm_provider"].lower()
 

--- a/main.py
+++ b/main.py
@@ -3,10 +3,11 @@ from tradingagents.default_config import DEFAULT_CONFIG
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "google"  # Use a different model
-config["backend_url"] = "https://generativelanguage.googleapis.com/v1"  # Use a different backend
-config["deep_think_llm"] = "gemini-2.0-flash"  # Use a different model
-config["quick_think_llm"] = "gemini-2.0-flash"  # Use a different model
+config["llm_provider"] = "ollama"  # Use a different model
+config["backend_url"] = "http://localhost:11434"  # Use a different backend
+config["deep_think_llm"] = "mixtral:8x7b-instruct-v0.1-q4_K_M"  # Use a different model
+config["quick_think_llm"] = "phi3:mini"  # Use a different model
+config["embedding_model"] = "fingpt:7b"  # Use a different embedding model
 config["max_debate_rounds"] = 1  # Increase debate rounds
 config["online_tools"] = True  # Increase debate rounds
 
@@ -14,7 +15,7 @@ config["online_tools"] = True  # Increase debate rounds
 ta = TradingAgentsGraph(debug=True, config=config)
 
 # forward propagate
-_, decision = ta.propagate("NVDA", "2024-05-10")
+_, decision = ta.propagate("NVDA", "2025-07-07")
 print(decision)
 
 # Memorize mistakes and reflect

--- a/tradingagents/agents/__init__.py
+++ b/tradingagents/agents/__init__.py
@@ -1,6 +1,7 @@
 from .utils.agent_utils import Toolkit, create_msg_delete
 from .utils.agent_states import AgentState, InvestDebateState, RiskDebateState
 from .utils.memory import FinancialSituationMemory
+from .utils.safe_bind_tools import safe_bind_tools
 
 from .analysts.fundamentals_analyst import create_fundamentals_analyst
 from .analysts.market_analyst import create_market_analyst
@@ -21,6 +22,7 @@ from .trader.trader import create_trader
 
 __all__ = [
     "FinancialSituationMemory",
+    "safe_bind_tools",
     "Toolkit",
     "AgentState",
     "create_msg_delete",

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -1,3 +1,4 @@
+from tradingagents.agents.utils.safe_bind_tools import safe_bind_tools
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 import time
 import json
@@ -47,7 +48,7 @@ def create_fundamentals_analyst(llm, toolkit):
         prompt = prompt.partial(current_date=current_date)
         prompt = prompt.partial(ticker=ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | safe_bind_tools(llm, tools)
 
         result = chain.invoke(state["messages"])
 

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,3 +1,4 @@
+from tradingagents.agents.utils.safe_bind_tools import safe_bind_tools
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 import time
 import json
@@ -72,7 +73,7 @@ Volume-Based Indicators:
         prompt = prompt.partial(current_date=current_date)
         prompt = prompt.partial(ticker=ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | safe_bind_tools(llm, tools)
 
         result = chain.invoke(state["messages"])
 

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,3 +1,4 @@
+from tradingagents.agents.utils.safe_bind_tools import safe_bind_tools
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 import time
 import json
@@ -44,7 +45,7 @@ def create_news_analyst(llm, toolkit):
         prompt = prompt.partial(current_date=current_date)
         prompt = prompt.partial(ticker=ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | safe_bind_tools(llm, tools)
         result = chain.invoke(state["messages"])
 
         report = ""

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -1,3 +1,4 @@
+from tradingagents.agents.utils.safe_bind_tools import safe_bind_tools
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 import time
 import json
@@ -43,7 +44,7 @@ def create_social_media_analyst(llm, toolkit):
         prompt = prompt.partial(current_date=current_date)
         prompt = prompt.partial(ticker=ticker)
 
-        chain = prompt | llm.bind_tools(tools)
+        chain = prompt | safe_bind_tools(llm, tools)
 
         result = chain.invoke(state["messages"])
 

--- a/tradingagents/agents/utils/safe_bind_tools.py
+++ b/tradingagents/agents/utils/safe_bind_tools.py
@@ -1,0 +1,82 @@
+"""
+safe_bind_tools.py
+────────────────────────────────────────────────────────
+Attach tool schemas only when the underlying LLM truly
+supports OpenAI-style function calling.
+
+• OpenAI / Anthropic / Google models  →  always attach
+• ChatOllama models                  →  attach **only**
+  if the Ollama tag contains `"tools": true`
+• All other cases                    →  silently fall
+  back to plain text reasoning
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+from typing import Any, Sequence
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+
+log = logging.getLogger(__name__)
+
+def _ollama_has_tools_flag(model_name: str) -> bool:
+    """
+    Return True iff `ollama show <model_name>` contains `"tools": true`.
+    If the command fails (e.g. Windows, sandbox), fall back to False.
+    """
+    try:
+        output = subprocess.check_output(
+            shlex.split(f"ollama show {model_name}"), text=True
+        )
+        return '"tools": true' in output
+    except (NotImplementedError, AttributeError) as e:
+        log.debug("Could not inspect model %s: %s", model_name, e)
+        return False
+
+def safe_bind_tools(
+    llm: BaseChatModel, tools: Sequence[dict[str, Any]]
+) -> BaseChatModel:
+    """
+    Attach `tools` to an LLM **only** if the model can actually handle them.
+    Otherwise, return the original LLM unchanged.
+
+    Parameters
+    ----------
+    llm
+        Any LangChain chat model instance.
+    tools
+        List of tool schemas compatible with OpenAI function calling.
+
+    Returns
+    -------
+    BaseChatModel
+        Either the bound LLM (when tool calling is available) or the
+        original LLM (fallback).
+    """
+    # LLM has no bind_tools method at all → nothing to do
+    if not hasattr(llm, "bind_tools"):
+        return llm
+
+    # Special-case ChatOllama: check the `"tools": true` tag first
+    if isinstance(llm, BaseChatModel) and not _ollama_has_tools_flag(llm.model):
+        log.info(
+            "[safe_bind_tools] Model %s lacks tools support -- skipping.",
+            llm.model,
+        )
+        return llm
+
+    # Generic path: try to bind; fall back gracefully on failure
+    try:
+        return llm.bind_tools(tools)
+    except (NotImplementedError, AttributeError) as e:
+        log.debug(
+            "[safe_bind_tools] bind_tools failed for %s: %s – "
+            "falling back to plain reasoning.",
+            llm.__class__.__name__,
+            e,
+        )
+        return llm

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -13,6 +13,7 @@ DEFAULT_CONFIG = {
     "deep_think_llm": "o4-mini",
     "quick_think_llm": "gpt-4o-mini",
     "backend_url": "https://api.openai.com/v1",
+    "embedding_model": "text-embedding-3-small",
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -9,7 +9,7 @@ from typing import Dict, Any, Tuple, List, Optional
 from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
-
+from langchain_ollama.chat_models import ChatOllama
 from langgraph.prebuilt import ToolNode
 
 from tradingagents.agents import *
@@ -58,7 +58,19 @@ class TradingAgentsGraph:
         )
 
         # Initialize LLMs
-        if self.config["llm_provider"].lower() == "openai" or self.config["llm_provider"] == "ollama" or self.config["llm_provider"] == "openrouter":
+        if self.config.get("llm_provider") == "ollama":
+            self.deep_thinking_llm = ChatOllama(
+                model=self.config["deep_think_llm"],
+                base_url=self.config["backend_url"],
+                temperature=0.2,
+                gpu_layers=32,          # ← 這裡就能塞 Ollama 特有參數
+            )
+            self.quick_thinking_llm = ChatOllama(
+                model=self.config["quick_think_llm"],
+                base_url=self.config["backend_url"].rstrip("/v1"),  # Remove trailing slash
+                temperature=0.1,
+            )
+        elif self.config["llm_provider"].lower() == "openai" or self.config["llm_provider"] == "ollama" or self.config["llm_provider"] == "openrouter":
             self.deep_thinking_llm = ChatOpenAI(model=self.config["deep_think_llm"], base_url=self.config["backend_url"])
             self.quick_thinking_llm = ChatOpenAI(model=self.config["quick_think_llm"], base_url=self.config["backend_url"])
         elif self.config["llm_provider"].lower() == "anthropic":


### PR DESCRIPTION
### Motivation
Running TradingAgents on local Ollama models that lack the "tools" tag currently fails with a 400 error and OpenAI API.  This PR makes the framework automatically downgrade to plain reasoning so that fully open-source users can still run the main.py file. In addition, allow local Ollama model to be manually entried in CLI.

### What’s in This PR
* `utils.safe_bind_tools` helper (some ollama models don't have `.bind_tools` attribute)
* All analyst / researcher / trader nodes updated to use it (replace `.bind_tools` with `safe_bind_tools`)
* `utils.memory` embedding model is updated (if ollama model is used, the original OpenAI model is replaced with a custom model)
* `cli/utils.py` added local ollama model selections, where user can input their model.
* `cli/main.py`  added ollama model for embedding to avoid errors raised by OpenAI API.

### Test Models Used in `main.py`
| model:tag                                    | tools attached | status |
|------------------------------------|----------------|--------|
| fingpt:7b                                              | ❌ no         | works |
| mixtral:8x7b-instruct-v0.1-q4_K_M`     | ❌ no         | works |
| phi3:latest                                            | ❌ no         | works |
| mistral-nemo:latest                             | ✅ yes        | works |

### CLI Test
```
Select your LLM Provider: 
Ollama

Select Your [Quick-Thinking LLM Engine] LLM Engine: 
Custom model (type manually)

Enter the exact Ollama model name for Quick-Thinking LLM Engine: 
phi3:mini

Select Your [Deep-Thinking LLM Engine] LLM Engine: 
Custom model (type manually)

Enter the exact Ollama model name for Deep-Thinking LLM Engine: 
mistral-nemo:latest

Select Your [Embedding LLM Engine] LLM Engine:
Custom model (type manually)

Enter the exact Ollama model name for Embedding LLM Engine:
fingpt:7b
```

### Backward Compatibility
Ollama backend url is changed in `BASE_URLS` @ cli/utils.py/select_llm_provider
`/v1` in the original url is removed. If any error arises, restore `/v1` in the tail of this backend url.

### My Platform
* Windows 10 (WSL v.2.5.9.0)
* CPU: Intel 13600k
* GPU: Nvidia RTX 4070 Ti Super 16GB
* RAM: DDR4 3200 64 GB


### Example
python main.py
python -m cli.main

