### PR TITLE
feat: Add Clickable Links to TradingAgents CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -17,12 +17,14 @@ from rich.markdown import Markdown
 from rich.layout import Layout
 from rich.text import Text
 from rich.table import Table
+from rich.markup import escape
 from collections import deque
 import time
 from rich.tree import Tree
 from rich import box
 from rich.align import Align
 from rich.rule import Rule
+import re
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
@@ -32,6 +34,32 @@ from cli.announcements import fetch_announcements, display_announcements
 from cli.stats_handler import StatsCallbackHandler
 
 console = Console()
+
+def make_links_clickable(text):
+    """Convert URLs and markdown links to clickable Rich links"""
+    # Pattern to match markdown links [text](url)
+    markdown_link_pattern = r'\[([^\]]+)\]\((https?://[^\)]+)\)'
+    
+    def replace_markdown_link(match):
+        text = match.group(1)
+        url = match.group(2)
+        return f'[link={url}]{text}[/link]'
+    
+    # Replace markdown links with Rich clickable links
+    text = re.sub(markdown_link_pattern, replace_markdown_link, text)
+    
+    # Pattern to match standalone URLs
+    url_pattern = r'(https?://[^\s\]]+)'
+    
+    def replace_url(match):
+        url = match.group(1)
+        return f'[link={url}]{url}[/link]'
+    
+    # Replace standalone URLs with clickable links (but not ones already in [link] tags)
+    if '[link=' not in text:
+        text = re.sub(url_pattern, replace_url, text)
+    
+    return text
 
 app = typer.Typer(
     name="TradingAgents",
@@ -258,7 +286,7 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     layout["header"].update(
         Panel(
             "[bold green]Welcome to TradingAgents CLI[/bold green]\n"
-            "[dim]© [Tauric Research](https://github.com/TauricResearch)[/dim]",
+            "[dim]© [link=https://github.com/TauricResearch]Tauric Research[/link][/dim]",
             title="Welcome to TradingAgents",
             border_style="green",
             padding=(1, 2),
@@ -365,11 +393,13 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     # Add tool calls
     for timestamp, tool_name, args in message_buffer.tool_calls:
         formatted_args = format_tool_args(args)
-        all_messages.append((timestamp, "Tool", f"{tool_name}: {formatted_args}"))
+        tool_content = make_links_clickable(f"{tool_name}: {formatted_args}")
+        all_messages.append((timestamp, "Tool", tool_content))
 
     # Add regular messages
     for timestamp, msg_type, content in message_buffer.messages:
         content_str = str(content) if content else ""
+        content_str = make_links_clickable(content_str)
         if len(content_str) > 200:
             content_str = content_str[:197] + "..."
         all_messages.append((timestamp, msg_type, content_str))
@@ -386,7 +416,7 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     # Add messages to table (already in newest-first order)
     for timestamp, msg_type, content in recent_messages:
         # Format content with word wrapping
-        wrapped_content = Text(content, overflow="fold")
+        wrapped_content = Text.from_markup(content, overflow="fold")
         messages_table.add_row(timestamp, msg_type, wrapped_content)
 
     layout["messages"].update(
@@ -400,9 +430,11 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
 
     # Analysis panel showing current report
     if message_buffer.current_report:
+        # Make any URLs in the report clickable
+        report_with_links = make_links_clickable(message_buffer.current_report)
         layout["analysis"].update(
             Panel(
-                Markdown(message_buffer.current_report),
+                Markdown(report_with_links),
                 title="Current Report",
                 border_style="green",
                 padding=(1, 2),
@@ -470,10 +502,8 @@ def get_user_selections():
     welcome_content = f"{welcome_ascii}\n"
     welcome_content += "[bold green]TradingAgents: Multi-Agents LLM Financial Trading Framework - CLI[/bold green]\n\n"
     welcome_content += "[bold]Workflow Steps:[/bold]\n"
-    welcome_content += "I. Analyst Team → II. Research Team → III. Trader → IV. Risk Management → V. Portfolio Management\n\n"
-    welcome_content += (
-        "[dim]Built by [Tauric Research](https://github.com/TauricResearch)[/dim]"
-    )
+    welcome_content += "I. Analyst Team -> II. Research Team -> III. Trader -> IV. Risk Management -> V. Portfolio Management\n\n"
+    welcome_content += "[dim]Built by [link=https://github.com/TauricResearch]Tauric Research[/link][/dim]"
 
     # Create and center the welcome box
     welcome_box = Panel(


### PR DESCRIPTION
### Summary

Enhanced the TradingAgents CLI by adding automatic conversion of URLs and markdown links to **clickable Rich terminal links** across all interface sections.

---

### Key Features

* **URL Detection**: Converts raw `https://...` links to clickable format
* **Markdown Support**: Transforms `[text](url)` to Rich-style links
* **Universal Integration**: Applies across headers, footers, messages, tool outputs, and reports (e.g., SEC, Yahoo Finance)

---

### Implementation

* Core function: `make_links_clickable(text)`

  * Converts markdown and plain URLs using Rich’s `[link=url]text[/link]` syntax
  * Prevents double-processing of existing links

---

### Benefits

* **Improved UX** with direct access to financial sources
* **Professional and accessible** CLI experience
* **Zero performance impact**

---

### How is it tested.

Tested locally using Ctrl + Click on the URL.

https://github.com/user-attachments/assets/bca36b65-13c6-4047-8fb4-6d5be2c42705
https://github.com/user-attachments/assets/61a54169-90c6-43b4-a609-b5b9d4539e4a


