### PR TITLE
chore: switch default LLM config to Google Gemini 2.5

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,9 +8,10 @@ load_dotenv()
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-5-mini"  # Use a different model
-config["quick_think_llm"] = "gpt-5-mini"  # Use a different model
-config["max_debate_rounds"] = 1  # Increase debate rounds
+config["llm_provider"] = "google"
+config["deep_think_llm"] = "gemini-2.5-pro"
+config["quick_think_llm"] = "gemini-2.5-flash"
+config["max_debate_rounds"] = 1
 
 # Configure data vendors (default uses yfinance, no extra API keys needed)
 config["data_vendors"] = {


### PR DESCRIPTION
## Summary
- Replace placeholder gpt-5-mini model names with gemini-2.5-pro (deep think) and gemini-2.5-flash (quick think)
- Set llm_provider to google in the example main.py config
- Gemini 2.5 Flash is free-tier accessible, lowering the barrier to get started

## Test plan
- [ ] Set GOOGLE_API_KEY in .env
- [ ] Run python main.py and confirm it connects to Gemini without errors
- [ ] Verify a trading decision is returned for NVDA
