### PR TITLE
fix(llm_clients): warn on unknown models

### DIFF
--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -16,47 +16,49 @@ class LLMClientModelValidationTests(unittest.TestCase):
             str(warning_records[0].message),
         )
 
-    def test_openai_client_warns_for_unknown_model(self):
-        model = "fake-openai-model"
+    def test_client_warns_for_unknown_model(self):
+        test_cases = [
+            {
+                "client_class": OpenAIClient,
+                "patch_target": "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
+                "provider_name": "OpenAI",
+                "model": "fake-openai-model",
+                "kwargs": {},
+            },
+            {
+                "client_class": AnthropicClient,
+                "patch_target": "tradingagents.llm_clients.anthropic_client.ChatAnthropic",
+                "provider_name": "Anthropic",
+                "model": "fake-claude-model",
+                "kwargs": {},
+            },
+            {
+                "client_class": GoogleClient,
+                "patch_target": "tradingagents.llm_clients.google_client.NormalizedChatGoogleGenerativeAI",
+                "provider_name": "Google",
+                "model": "fake-gemini-model",
+                "kwargs": {},
+            },
+            {
+                "client_class": OpenAIClient,
+                "patch_target": "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
+                "provider_name": "opena",
+                "model": "gpt-5-mini",
+                "kwargs": {"provider": "opena"},
+            },
+        ]
 
-        with patch(
-            "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
-            side_effect=lambda **kwargs: kwargs,
-        ):
-            with warnings.catch_warnings(record=True) as warning_records:
-                warnings.simplefilter("always")
-                llm = OpenAIClient(model).get_llm()
+        for case in test_cases:
+            with self.subTest(provider=case["provider_name"]):
+                with patch(case["patch_target"], side_effect=lambda **kwargs: kwargs):
+                    with warnings.catch_warnings(record=True) as warning_records:
+                        warnings.simplefilter("always")
+                        llm = case["client_class"](case["model"], **case["kwargs"]).get_llm()
 
-        self.assertEqual(llm["model"], model)
-        self.assert_single_unknown_model_warning(warning_records, "OpenAI", model)
-
-    def test_anthropic_client_warns_for_unknown_model(self):
-        model = "fake-claude-model"
-
-        with patch(
-            "tradingagents.llm_clients.anthropic_client.ChatAnthropic",
-            side_effect=lambda **kwargs: kwargs,
-        ):
-            with warnings.catch_warnings(record=True) as warning_records:
-                warnings.simplefilter("always")
-                llm = AnthropicClient(model).get_llm()
-
-        self.assertEqual(llm["model"], model)
-        self.assert_single_unknown_model_warning(warning_records, "Anthropic", model)
-
-    def test_google_client_warns_for_unknown_model(self):
-        model = "fake-gemini-model"
-
-        with patch(
-            "tradingagents.llm_clients.google_client.NormalizedChatGoogleGenerativeAI",
-            side_effect=lambda **kwargs: kwargs,
-        ):
-            with warnings.catch_warnings(record=True) as warning_records:
-                warnings.simplefilter("always")
-                llm = GoogleClient(model).get_llm()
-
-        self.assertEqual(llm["model"], model)
-        self.assert_single_unknown_model_warning(warning_records, "Google", model)
+                self.assertEqual(llm["model"], case["model"])
+                self.assert_single_unknown_model_warning(
+                    warning_records, case["provider_name"], case["model"]
+                )
 
     def test_openai_client_does_not_warn_for_known_model(self):
         with patch(

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -1,0 +1,90 @@
+import warnings
+import unittest
+from unittest.mock import patch
+
+from tradingagents.llm_clients.anthropic_client import AnthropicClient
+from tradingagents.llm_clients.google_client import GoogleClient
+from tradingagents.llm_clients.openai_client import OpenAIClient
+
+
+class LLMClientModelValidationTests(unittest.TestCase):
+    def assert_single_unknown_model_warning(self, warning_records, provider_name, model):
+        self.assertEqual(len(warning_records), 1)
+        self.assertIs(warning_records[0].category, UserWarning)
+        self.assertIn(
+            f"Unknown {provider_name} model '{model}'.",
+            str(warning_records[0].message),
+        )
+
+    def test_openai_client_warns_for_unknown_model(self):
+        model = "fake-openai-model"
+
+        with patch(
+            "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
+            side_effect=lambda **kwargs: kwargs,
+        ):
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                llm = OpenAIClient(model).get_llm()
+
+        self.assertEqual(llm["model"], model)
+        self.assert_single_unknown_model_warning(warning_records, "OpenAI", model)
+
+    def test_anthropic_client_warns_for_unknown_model(self):
+        model = "fake-claude-model"
+
+        with patch(
+            "tradingagents.llm_clients.anthropic_client.ChatAnthropic",
+            side_effect=lambda **kwargs: kwargs,
+        ):
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                llm = AnthropicClient(model).get_llm()
+
+        self.assertEqual(llm["model"], model)
+        self.assert_single_unknown_model_warning(warning_records, "Anthropic", model)
+
+    def test_google_client_warns_for_unknown_model(self):
+        model = "fake-gemini-model"
+
+        with patch(
+            "tradingagents.llm_clients.google_client.NormalizedChatGoogleGenerativeAI",
+            side_effect=lambda **kwargs: kwargs,
+        ):
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                llm = GoogleClient(model).get_llm()
+
+        self.assertEqual(llm["model"], model)
+        self.assert_single_unknown_model_warning(warning_records, "Google", model)
+
+    def test_openai_client_does_not_warn_for_known_model(self):
+        with patch(
+            "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
+            side_effect=lambda **kwargs: kwargs,
+        ):
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                llm = OpenAIClient("gpt-5-mini").get_llm()
+
+        self.assertEqual(llm["model"], "gpt-5-mini")
+        self.assertEqual(warning_records, [])
+
+    def test_openrouter_allows_custom_model_without_warning(self):
+        model = "custom-openrouter-model"
+
+        with patch(
+            "tradingagents.llm_clients.openai_client.UnifiedChatOpenAI",
+            side_effect=lambda **kwargs: kwargs,
+        ):
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                llm = OpenAIClient(model, provider="openrouter").get_llm()
+
+        self.assertEqual(llm["model"], model)
+        self.assertEqual(llm["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(warning_records, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/llm_clients/TODO.md
+++ b/tradingagents/llm_clients/TODO.md
@@ -2,8 +2,8 @@
 
 ## Issues to Fix
 
-### 1. `validate_model()` is never called
-- Add validation call in `get_llm()` with warning (not error) for unknown models
+### 1. Resolved: `validate_model()` is now called in `get_llm()`
+- Added shared warning-based validation via `warn_if_unknown_model()` in each provider client
 
 ### 2. Inconsistent parameter handling
 | Client | API Key Param | Special Params |

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from langchain_anthropic import ChatAnthropic
 
 from .base_client import BaseLLMClient
-from .validators import validate_model
+from .validators import validate_model, warn_if_unknown_model
 
 
 class AnthropicClient(BaseLLMClient):
@@ -14,6 +14,7 @@ class AnthropicClient(BaseLLMClient):
 
     def get_llm(self) -> Any:
         """Return configured ChatAnthropic instance."""
+        warn_if_unknown_model("anthropic", self.model)
         llm_kwargs = {"model": self.model}
 
         for key in ("timeout", "max_retries", "api_key", "max_tokens", "callbacks", "http_client", "http_async_client"):

--- a/tradingagents/llm_clients/google_client.py
+++ b/tradingagents/llm_clients/google_client.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from .base_client import BaseLLMClient
-from .validators import validate_model
+from .validators import validate_model, warn_if_unknown_model
 
 
 class NormalizedChatGoogleGenerativeAI(ChatGoogleGenerativeAI):
@@ -36,6 +36,7 @@ class GoogleClient(BaseLLMClient):
 
     def get_llm(self) -> Any:
         """Return configured ChatGoogleGenerativeAI instance."""
+        warn_if_unknown_model("google", self.model)
         llm_kwargs = {"model": self.model}
 
         for key in ("timeout", "max_retries", "google_api_key", "callbacks", "http_client", "http_async_client"):

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from langchain_openai import ChatOpenAI
 
 from .base_client import BaseLLMClient
-from .validators import validate_model
+from .validators import validate_model, warn_if_unknown_model
 
 
 class UnifiedChatOpenAI(ChatOpenAI):
@@ -41,6 +41,7 @@ class OpenAIClient(BaseLLMClient):
 
     def get_llm(self) -> Any:
         """Return configured ChatOpenAI instance."""
+        warn_if_unknown_model(self.provider, self.model)
         llm_kwargs = {"model": self.model}
 
         if self.provider == "xai":

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -4,6 +4,8 @@ Only validates model names - does NOT enforce limits.
 Let LLM providers use their own defaults for unspecified params.
 """
 
+import warnings
+
 VALID_MODELS = {
     "openai": [
         # GPT-5 series
@@ -50,6 +52,15 @@ VALID_MODELS = {
     ],
 }
 
+PROVIDER_DISPLAY_NAMES = {
+    "openai": "OpenAI",
+    "anthropic": "Anthropic",
+    "google": "Google",
+    "xai": "xAI",
+    "ollama": "Ollama",
+    "openrouter": "OpenRouter",
+}
+
 
 def validate_model(provider: str, model: str) -> bool:
     """Check if model name is valid for the given provider.
@@ -65,3 +76,19 @@ def validate_model(provider: str, model: str) -> bool:
         return True
 
     return model in VALID_MODELS[provider_lower]
+
+
+def warn_if_unknown_model(provider: str, model: str) -> bool:
+    """Warn for unknown models while allowing execution to continue."""
+    is_valid = validate_model(provider, model)
+    if not is_valid:
+        provider_name = PROVIDER_DISPLAY_NAMES.get(provider.lower(), provider)
+        warnings.warn(
+            (
+                f"Unknown {provider_name} model '{model}'. "
+                "Continuing without blocking because providers may add models before this list is updated."
+            ),
+            UserWarning,
+            stacklevel=2,
+        )
+    return is_valid

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -61,6 +61,9 @@ PROVIDER_DISPLAY_NAMES = {
     "openrouter": "OpenRouter",
 }
 
+PERMISSIVE_PROVIDERS = {"ollama", "openrouter"}
+KNOWN_PROVIDERS = set(VALID_MODELS) | PERMISSIVE_PROVIDERS
+
 
 def validate_model(provider: str, model: str) -> bool:
     """Check if model name is valid for the given provider.
@@ -69,11 +72,11 @@ def validate_model(provider: str, model: str) -> bool:
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in PERMISSIVE_PROVIDERS:
         return True
 
-    if provider_lower not in VALID_MODELS:
-        return True
+    if provider_lower not in KNOWN_PROVIDERS:
+        return False
 
     return model in VALID_MODELS[provider_lower]
 


### PR DESCRIPTION
## Summary
- warn on unknown models in LLM clients without blocking initialization
- add unit tests for model validation warning behavior
- mark the related TODO item as resolved

## Testing
- `python -m unittest discover -s tests -p 'test_llm_clients.py' -v`
