### PR TITLE
fix(dataflows): add missing pandas import in y_finance.py

### DIFF
--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -1,10 +1,16 @@
-from typing import Annotated
 from datetime import datetime
+from typing import Annotated
+
 from dateutil.relativedelta import relativedelta
 import pandas as pd
 import yfinance as yf
-import os
-from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
+
+from .stockstats_utils import (
+    StockstatsUtils,
+    filter_financials_by_date,
+    load_ohlcv,
+    yf_retry,
+)
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import pandas as pd
 import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date


### PR DESCRIPTION
Fix a missing `import pandas as pd` in `y_finance.py`.

The `_get_stock_stats_bulk()` function uses `pd.isna()` on line 213 but pandas was never imported in this file. It worked by accident because `stockstats_utils` was imported at module level and loaded pandas into the process namespace. This is a fragile implicit dependency that breaks if import order changes.