### PR TITLE
Fix missing pandas import in y_finance bulk indicators

### DIFF
--- a/tests/test_y_finance_bulk_indicator.py
+++ b/tests/test_y_finance_bulk_indicator.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+
+class YFinanceBulkIndicatorTests(unittest.TestCase):
+    def test_bulk_indicator_maps_nan_to_na(self):
+        fake_stockstats = types.ModuleType("stockstats")
+        fake_stockstats.wrap = lambda df: df
+
+        with patch.dict(sys.modules, {"stockstats": fake_stockstats}):
+            sys.modules.pop("tradingagents.dataflows.stockstats_utils", None)
+            sys.modules.pop("tradingagents.dataflows.y_finance", None)
+
+            try:
+                y_finance = importlib.import_module("tradingagents.dataflows.y_finance")
+                sample_df = pd.DataFrame(
+                    {
+                        "Date": pd.to_datetime(["2024-01-02", "2024-01-03"]),
+                        "rsi": [float("nan"), 55.5],
+                    }
+                )
+
+                with patch.object(y_finance, "load_ohlcv", return_value=sample_df):
+                    result = y_finance._get_stock_stats_bulk("AAPL", "rsi", "2024-01-03")
+            finally:
+                sys.modules.pop("tradingagents.dataflows.stockstats_utils", None)
+                sys.modules.pop("tradingagents.dataflows.y_finance", None)
+
+        self.assertEqual(result["2024-01-02"], "N/A")
+        self.assertEqual(result["2024-01-03"], "55.5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_y_finance_bulk_indicator.py
+++ b/tests/test_y_finance_bulk_indicator.py
@@ -13,10 +13,10 @@ class YFinanceBulkIndicatorTests(unittest.TestCase):
         fake_stockstats.wrap = lambda df: df
 
         with patch.dict(sys.modules, {"stockstats": fake_stockstats}):
-            sys.modules.pop("tradingagents.dataflows.stockstats_utils", None)
-            sys.modules.pop("tradingagents.dataflows.y_finance", None)
+            with patch.dict(sys.modules):
+                sys.modules.pop("tradingagents.dataflows.stockstats_utils", None)
+                sys.modules.pop("tradingagents.dataflows.y_finance", None)
 
-            try:
                 y_finance = importlib.import_module("tradingagents.dataflows.y_finance")
                 sample_df = pd.DataFrame(
                     {
@@ -27,12 +27,9 @@ class YFinanceBulkIndicatorTests(unittest.TestCase):
 
                 with patch.object(y_finance, "load_ohlcv", return_value=sample_df):
                     result = y_finance._get_stock_stats_bulk("AAPL", "rsi", "2024-01-03")
-            finally:
-                sys.modules.pop("tradingagents.dataflows.stockstats_utils", None)
-                sys.modules.pop("tradingagents.dataflows.y_finance", None)
 
-        self.assertEqual(result["2024-01-02"], "N/A")
-        self.assertEqual(result["2024-01-03"], "55.5")
+                self.assertEqual(result["2024-01-02"], "N/A")
+                self.assertEqual(result["2024-01-03"], "55.5")
 
 
 if __name__ == "__main__":

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import pandas as pd
 import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date


### PR DESCRIPTION
## Summary
- add the missing `pandas` import used by `_get_stock_stats_bulk()` in `tradingagents/dataflows/y_finance.py`
- add a regression test covering bulk indicator handling when the computed value is `NaN`

## Root cause
`_get_stock_stats_bulk()` calls `pd.isna(...)`, but `pandas` was never imported in `y_finance.py`. That causes a `NameError` when bulk indicator results contain missing values.

## Impact
This fixes bulk stockstats indicator lookups so missing indicator values are converted to `"N/A"` instead of crashing.

## Testing
- `PYTHONPATH=/tmp/tradingagents-upstream-pr pytest -q tests/test_y_finance_bulk_indicator.py`