### PR TITLE
fix: do not pass base_url to ChatGoogleGenerativeAI

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -192,7 +192,7 @@ def select_llm_provider() -> tuple[str, str]:
     # Define OpenAI api options with their corresponding endpoints
     BASE_URLS = [
         ("OpenAI", "https://api.openai.com/v1"),
-        ("Google", "https://generativelanguage.googleapis.com/v1"),
+        ("Google", None),  # google-genai SDK manages its own endpoint internally
         ("Anthropic", "https://api.anthropic.com/"),
         ("xAI", "https://api.x.ai/v1"),
         ("Openrouter", "https://openrouter.ai/api/v1"),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -188,8 +188,8 @@ def select_deep_thinking_agent(provider) -> str:
     return choice
 
 def select_llm_provider() -> tuple[str, str | None]:
-    """Select the OpenAI api url using interactive selection."""
-    # Define OpenAI api options with their corresponding endpoints
+    """Select the LLM provider and its API URL using interactive selection."""
+    # Define LLM provider options with their corresponding endpoints
     BASE_URLS = [
         ("OpenAI", "https://api.openai.com/v1"),
         ("Google", None),  # google-genai SDK manages its own endpoint internally

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -192,7 +192,7 @@ def select_llm_provider() -> tuple[str, str | None]:
     # Define LLM provider options with their corresponding endpoints
     BASE_URLS = [
         ("OpenAI", "https://api.openai.com/v1"),
-        ("Google", None),  # google-genai SDK manages its own endpoint internally
+        ("Google", None),  # google-generativeai SDK manages its own endpoint internally
         ("Anthropic", "https://api.anthropic.com/"),
         ("xAI", "https://api.x.ai/v1"),
         ("Openrouter", "https://openrouter.ai/api/v1"),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -187,7 +187,7 @@ def select_deep_thinking_agent(provider) -> str:
 
     return choice
 
-def select_llm_provider() -> tuple[str, str]:
+def select_llm_provider() -> tuple[str, str | None]:
     """Select the OpenAI api url using interactive selection."""
     # Define OpenAI api options with their corresponding endpoints
     BASE_URLS = [

--- a/tradingagents/llm_clients/google_client.py
+++ b/tradingagents/llm_clients/google_client.py
@@ -28,10 +28,8 @@ class GoogleClient(BaseLLMClient):
         self.warn_if_unknown_model()
         llm_kwargs = {"model": self.model}
 
-        # base_url is intentionally NOT passed to ChatGoogleGenerativeAI.
-        # The google-genai SDK manages its own endpoint and API versioning internally.
-        # Passing a base_url (e.g. https://generativelanguage.googleapis.com/v1)
-        # causes 404s because the SDK appends its own paths onto the override URL.
+        if self.base_url:
+            llm_kwargs["base_url"] = self.base_url
 
         for key in ("timeout", "max_retries", "callbacks", "http_client", "http_async_client"):
             if key in self.kwargs:

--- a/tradingagents/llm_clients/google_client.py
+++ b/tradingagents/llm_clients/google_client.py
@@ -28,8 +28,10 @@ class GoogleClient(BaseLLMClient):
         self.warn_if_unknown_model()
         llm_kwargs = {"model": self.model}
 
-        if self.base_url:
-            llm_kwargs["base_url"] = self.base_url
+        # base_url is intentionally NOT passed to ChatGoogleGenerativeAI.
+        # The google-genai SDK manages its own endpoint and API versioning internally.
+        # Passing a base_url (e.g. https://generativelanguage.googleapis.com/v1)
+        # causes 404s because the SDK appends its own paths onto the override URL.
 
         for key in ("timeout", "max_retries", "callbacks", "http_client", "http_async_client"):
             if key in self.kwargs:


### PR DESCRIPTION
## Problem

The CLI hardcodes `backend_url` as `https://generativelanguage.googleapis.com/v1` for the Google provider (see `cli/utils.py`), which gets forwarded as `base_url` to `ChatGoogleGenerativeAI`. The `google-genai` SDK manages its own endpoint and API versioning internally — when an external `base_url` is injected, the SDK constructs incorrect request paths that return **404 Not Found for all Gemini models**, including stable ones like `gemini-2.5-flash`.

## Reproducer

```python
from langchain_google_genai import ChatGoogleGenerativeAI

ChatGoogleGenerativeAI(
    model="gemini-2.5-flash",
    base_url="https://generativelanguage.googleapis.com/v1",
).invoke("Hello")
# → ChatGoogleGenerativeAIError: Error calling model 'gemini-2.5-flash' (Not Found): 404 Not Found
```

Without `base_url`, the same call succeeds.

## Fix

Set the Google provider's `backend_url` to `None` in `cli/utils.py` so the SDK uses its default endpoint.

**`google_client.py` is intentionally unchanged.** The `base_url` forwarding logic is kept so users who need a custom endpoint (proxy, regional endpoint, etc.) can still provide one programmatically. The root cause is the CLI passing a bad hardcoded default — not the forwarding logic itself.

## Test plan

- [ ] Run analysis with Google provider + `gemini-2.5-flash` — should no longer 404
- [ ] Run analysis with Google provider + `gemini-3.1-flash-lite-preview` — should no longer 404
- [ ] Confirm OpenAI / Anthropic / xAI providers are unaffected (change is isolated to `cli/utils.py`)