### PR TITLE
fix: make news article limits and lookback window configurable

### DIFF
--- a/tradingagents/agents/utils/news_data_tools.py
+++ b/tradingagents/agents/utils/news_data_tools.py
@@ -23,16 +23,18 @@ def get_news(
 @tool
 def get_global_news(
     curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
-    look_back_days: Annotated[int, "Number of days to look back"] = 7,
-    limit: Annotated[int, "Maximum number of articles to return"] = 5,
+    look_back_days: Annotated[int | None, "Number of days to look back (defaults to global_news_lookback_days config)"] = None,
+    limit: Annotated[int | None, "Maximum number of articles to return (defaults to global_news_article_limit config)"] = None,
 ) -> str:
     """
     Retrieve global news data.
     Uses the configured news_data vendor.
     Args:
         curr_date (str): Current date in yyyy-mm-dd format
-        look_back_days (int): Number of days to look back (default 7)
-        limit (int): Maximum number of articles to return (default 5)
+        look_back_days (int | None): Number of days to look back. If None, uses
+            the global_news_lookback_days value from DEFAULT_CONFIG (7).
+        limit (int | None): Maximum number of articles to return. If None, uses
+            the global_news_article_limit value from DEFAULT_CONFIG (10).
     Returns:
         str: A formatted string containing global news data
     """

--- a/tradingagents/dataflows/alpha_vantage_news.py
+++ b/tradingagents/dataflows/alpha_vantage_news.py
@@ -1,4 +1,5 @@
 from .alpha_vantage_common import _make_api_request, format_datetime_for_api
+from .config import get_config
 
 def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
     """Returns live and historical market news & sentiment data from premier news outlets worldwide.
@@ -22,20 +23,26 @@ def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
 
     return _make_api_request("NEWS_SENTIMENT", params)
 
-def get_global_news(curr_date, look_back_days: int = 7, limit: int = 50) -> dict[str, str] | str:
+def get_global_news(curr_date, look_back_days: int = None, limit: int = None) -> dict[str, str] | str:
     """Returns global market news & sentiment data without ticker-specific filtering.
 
     Covers broad market topics like financial markets, economy, and more.
 
     Args:
         curr_date: Current date in yyyy-mm-dd format.
-        look_back_days: Number of days to look back (default 7).
-        limit: Maximum number of articles (default 50).
+        look_back_days: Number of days to look back (defaults to global_news_lookback_days config).
+        limit: Maximum number of articles (defaults to global_news_article_limit config).
 
     Returns:
         Dictionary containing global news sentiment data or JSON string.
     """
     from datetime import datetime, timedelta
+
+    config = get_config()
+    if look_back_days is None:
+        look_back_days = config.get("global_news_lookback_days", 7)
+    if limit is None:
+        limit = config.get("global_news_article_limit", 50)
 
     # Calculate start date
     curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")

--- a/tradingagents/dataflows/alpha_vantage_news.py
+++ b/tradingagents/dataflows/alpha_vantage_news.py
@@ -15,15 +15,17 @@ def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
         Dictionary containing news sentiment data or JSON string.
     """
 
+    limit = get_config().get("news_article_limit", 20)
     params = {
         "tickers": ticker,
         "time_from": format_datetime_for_api(start_date),
         "time_to": format_datetime_for_api(end_date),
+        "limit": str(limit),
     }
 
     return _make_api_request("NEWS_SENTIMENT", params)
 
-def get_global_news(curr_date, look_back_days: int = None, limit: int = None) -> dict[str, str] | str:
+def get_global_news(curr_date: str, look_back_days: int | None = None, limit: int | None = None) -> dict[str, str] | str:
     """Returns global market news & sentiment data without ticker-specific filtering.
 
     Covers broad market topics like financial markets, economy, and more.
@@ -42,7 +44,7 @@ def get_global_news(curr_date, look_back_days: int = None, limit: int = None) ->
     if look_back_days is None:
         look_back_days = config.get("global_news_lookback_days", 7)
     if limit is None:
-        limit = config.get("global_news_article_limit", 50)
+        limit = config.get("global_news_article_limit", 10)
 
     # Calculate start date
     curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -108,8 +108,8 @@ def get_news_yfinance(
 
 def get_global_news_yfinance(
     curr_date: str,
-    look_back_days: int = None,
-    limit: int = None,
+    look_back_days: int | None = None,
+    limit: int | None = None,
 ) -> str:
     """
     Retrieve global/macro economic news using yfinance Search.

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from .stockstats_utils import yf_retry
+from .config import get_config
 
 
 def _extract_article_data(article: dict) -> dict:
@@ -66,7 +67,8 @@ def get_news_yfinance(
     """
     try:
         stock = yf.Ticker(ticker)
-        news = yf_retry(lambda: stock.get_news(count=20))
+        count = get_config().get("news_article_limit", 20)
+        news = yf_retry(lambda: stock.get_news(count=count))
 
         if not news:
             return f"No news found for {ticker}"
@@ -106,20 +108,25 @@ def get_news_yfinance(
 
 def get_global_news_yfinance(
     curr_date: str,
-    look_back_days: int = 7,
-    limit: int = 10,
+    look_back_days: int = None,
+    limit: int = None,
 ) -> str:
     """
     Retrieve global/macro economic news using yfinance Search.
 
     Args:
         curr_date: Current date in yyyy-mm-dd format
-        look_back_days: Number of days to look back
-        limit: Maximum number of articles to return
+        look_back_days: Number of days to look back (defaults to global_news_lookback_days config)
+        limit: Maximum number of articles to return (defaults to global_news_article_limit config)
 
     Returns:
         Formatted string containing global news articles
     """
+    config = get_config()
+    if look_back_days is None:
+        look_back_days = config.get("global_news_lookback_days", 7)
+    if limit is None:
+        limit = config.get("global_news_article_limit", 10)
     # Search queries for macro/global news
     search_queries = [
         "stock market economy",

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -22,6 +22,10 @@ DEFAULT_CONFIG = {
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,
     "max_recur_limit": 100,
+    # News fetching configuration
+    "news_article_limit": 20,           # max articles per ticker for get_news
+    "global_news_lookback_days": 7,     # lookback window (days) for get_global_news
+    "global_news_article_limit": 10,    # max articles returned by get_global_news
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)
     "data_vendors": {


### PR DESCRIPTION
Fixes #562

## Problem

Three data-fetching parameters were hardcoded with no way to override them via `DEFAULT_CONFIG`:

| Parameter | Location | Hardcoded value |
|---|---|---|
| `count=20` | `get_news_yfinance` → `yf.Ticker.get_news(count=20)` | 20 articles max per ticker |
| `look_back_days=7` | `get_global_news_yfinance` default | 7 days macro lookback |
| `limit=10` | `get_global_news_yfinance` default | 10 global articles max |

Users running weekly or monthly rebalancing strategies need broader news coverage than daily analysis, but had no way to adjust these without modifying library source code.

## Solution

Added three new keys to `DEFAULT_CONFIG` with the same values as the previous hardcoded defaults (no behaviour change for existing users):

```python
DEFAULT_CONFIG = {
    ...
    "news_article_limit": 20,           # max articles per ticker for get_news
    "global_news_lookback_days": 7,     # lookback window (days) for get_global_news
    "global_news_article_limit": 10,    # max articles returned by get_global_news
    ...
}
```

Both the `yfinance` and `alpha_vantage` news implementations now read these values from config via `get_config()`. Users can override them at initialisation time:

```python
from tradingagents.graph.trading_graph import TradingAgentsGraph

ta = TradingAgentsGraph(config={
    **DEFAULT_CONFIG,
    "news_article_limit": 50,          # fetch more articles per ticker
    "global_news_lookback_days": 30,   # 30-day macro lookback for monthly strategies
    "global_news_article_limit": 25,   # more global articles
})
```

## Testing

- Default behaviour is unchanged (all three new config keys fall back to the original hardcoded values when not specified).
- No new dependencies introduced.