### PR TITLE
fix: persistent memory + hallucination guard for empty memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code local files
+CLAUDE.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/tests/test_hallucination_guard.py
+++ b/tests/test_hallucination_guard.py
@@ -1,0 +1,204 @@
+"""Tests for memory hallucination guard across all five agents.
+
+Verifies that:
+- Memory section headers are ABSENT from prompts when memory is empty.
+- Memory content IS injected when memory is populated.
+
+No LLM API calls are made — llm.invoke() is mocked.
+"""
+
+from unittest.mock import MagicMock
+
+from tradingagents.agents.researchers.bull_researcher import create_bull_researcher
+from tradingagents.agents.researchers.bear_researcher import create_bear_researcher
+from tradingagents.agents.trader.trader import create_trader
+from tradingagents.agents.managers.research_manager import create_research_manager
+from tradingagents.agents.managers.portfolio_manager import create_portfolio_manager
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_state():
+    return {
+        "investment_debate_state": {
+            "history": "",
+            "bull_history": "",
+            "bear_history": "",
+            "current_response": "",
+            "count": 0,
+        },
+        "market_report": "market data",
+        "sentiment_report": "sentiment data",
+        "news_report": "news data",
+        "fundamentals_report": "fundamentals data",
+        "company_of_interest": "AAPL",
+        "trade_date": "2024-01-15",
+        "investment_plan": "buy AAPL",
+        "trader_investment_plan": "",
+        "risk_debate_state": {
+            "history": "",
+            "aggressive_history": "",
+            "conservative_history": "",
+            "neutral_history": "",
+            "judge_decision": "",
+            "count": 0,
+            "latest_speaker": "",
+            "current_aggressive_response": "",
+            "current_conservative_response": "",
+            "current_neutral_response": "",
+        },
+    }
+
+
+def _mock_llm():
+    llm = MagicMock()
+    llm.invoke.return_value = MagicMock(content="mocked response")
+    return llm
+
+
+def _empty_memory():
+    m = MagicMock()
+    m.get_memories.return_value = []
+    return m
+
+
+def _populated_memory(lesson="Past lesson: watch macro risk"):
+    m = MagicMock()
+    m.get_memories.return_value = [{"recommendation": lesson, "similarity_score": 0.9}]
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Bull Researcher
+# ---------------------------------------------------------------------------
+
+def test_bull_omits_memory_section_when_empty():
+    """No reflections header or instruction when memory is empty."""
+    llm = _mock_llm()
+    node = create_bull_researcher(llm, _empty_memory())
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Reflections from similar situations" not in prompt
+    assert "address reflections" not in prompt.lower()
+    assert "learn from lessons and mistakes" not in prompt.lower()
+
+
+def test_bull_includes_memory_section_when_populated():
+    """Lesson text appears in prompt when memory is populated."""
+    llm = _mock_llm()
+    node = create_bull_researcher(llm, _populated_memory("Reduce tech exposure on rate hikes"))
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Reduce tech exposure on rate hikes" in prompt
+    assert "Reflections from similar situations" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Bear Researcher
+# ---------------------------------------------------------------------------
+
+def test_bear_omits_memory_section_when_empty():
+    """No reflections header or instruction when memory is empty."""
+    llm = _mock_llm()
+    node = create_bear_researcher(llm, _empty_memory())
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Reflections from similar situations" not in prompt
+    assert "address reflections" not in prompt.lower()
+    assert "learn from lessons and mistakes" not in prompt.lower()
+
+
+def test_bear_includes_memory_section_when_populated():
+    """Lesson text appears in prompt when memory is populated."""
+    llm = _mock_llm()
+    node = create_bear_researcher(llm, _populated_memory("Overestimated resilience in 2022"))
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Overestimated resilience in 2022" in prompt
+    assert "Reflections from similar situations" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Trader
+# ---------------------------------------------------------------------------
+
+def test_trader_omits_reflection_clause_when_empty():
+    """No reflection text or 'No past memories found.' in system message when empty."""
+    llm = _mock_llm()
+    node = create_trader(llm, _empty_memory())
+    node(_make_state())
+
+    messages = llm.invoke.call_args[0][0]
+    system_content = messages[0]["content"]
+    assert "No past memories found" not in system_content
+    assert "Here are reflections" not in system_content
+    assert "Apply lessons from past decisions" not in system_content
+
+
+def test_trader_includes_reflection_clause_when_populated():
+    """Lesson text appears in system message when memory is populated."""
+    llm = _mock_llm()
+    node = create_trader(llm, _populated_memory("Avoid chasing momentum tops"))
+    node(_make_state())
+
+    messages = llm.invoke.call_args[0][0]
+    system_content = messages[0]["content"]
+    assert "Avoid chasing momentum tops" in system_content
+    assert "Apply lessons from past decisions" in system_content
+
+
+# ---------------------------------------------------------------------------
+# Research Manager
+# ---------------------------------------------------------------------------
+
+def test_research_manager_omits_memory_section_when_empty():
+    """No past reflections header when memory is empty."""
+    llm = _mock_llm()
+    node = create_research_manager(llm, _empty_memory())
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Here are your past reflections on mistakes" not in prompt
+    assert "Take into account your past mistakes" not in prompt
+
+
+def test_research_manager_includes_memory_section_when_populated():
+    """Lesson text and header appear in prompt when memory is populated."""
+    llm = _mock_llm()
+    node = create_research_manager(llm, _populated_memory("Missed earnings surprise signal"))
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Missed earnings surprise signal" in prompt
+    assert "Here are your past reflections on mistakes" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Portfolio Manager
+# ---------------------------------------------------------------------------
+
+def test_portfolio_manager_omits_lessons_line_when_empty():
+    """No 'Lessons from past decisions' line when memory is empty."""
+    llm = _mock_llm()
+    node = create_portfolio_manager(llm, _empty_memory())
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Lessons from past decisions" not in prompt
+
+
+def test_portfolio_manager_includes_lessons_line_when_populated():
+    """Lesson text and label appear in prompt when memory is populated."""
+    llm = _mock_llm()
+    node = create_portfolio_manager(llm, _populated_memory("Size down in low-liquidity names"))
+    node(_make_state())
+
+    prompt = llm.invoke.call_args[0][0]
+    assert "Size down in low-liquidity names" in prompt
+    assert "Lessons from past decisions" in prompt

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -1,0 +1,166 @@
+"""Tests for FinancialSituationMemory persistence (issue #563)."""
+
+import json
+import pytest
+from pathlib import Path
+
+from tradingagents.agents.utils.memory import FinancialSituationMemory
+
+
+@pytest.fixture
+def persist_dir(tmp_path):
+    return str(tmp_path / "memory")
+
+
+def make_config(persist_dir):
+    return {"memory_persist_dir": persist_dir}
+
+
+# ---------------------------------------------------------------------------
+# Persistence: data survives a fresh instance
+# ---------------------------------------------------------------------------
+
+def test_data_survives_restart(persist_dir):
+    """Documents and recommendations loaded by a new instance after save."""
+    m1 = FinancialSituationMemory("test", make_config(persist_dir))
+    m1.add_situations([("situation A", "recommendation A")])
+
+    m2 = FinancialSituationMemory("test", make_config(persist_dir))
+    assert m2.documents == ["situation A"]
+    assert m2.recommendations == ["recommendation A"]
+
+
+def test_multiple_entries_survive_restart(persist_dir):
+    """All entries are preserved across instances."""
+    m1 = FinancialSituationMemory("test", make_config(persist_dir))
+    m1.add_situations([
+        ("situation A", "rec A"),
+        ("situation B", "rec B"),
+    ])
+
+    m2 = FinancialSituationMemory("test", make_config(persist_dir))
+    assert len(m2.documents) == 2
+    assert len(m2.recommendations) == 2
+
+
+def test_bm25_index_rebuilt_on_load(persist_dir):
+    """BM25 index is functional after loading from disk."""
+    m1 = FinancialSituationMemory("test", make_config(persist_dir))
+    m1.add_situations([("rising interest rates inflation", "reduce duration")])
+
+    m2 = FinancialSituationMemory("test", make_config(persist_dir))
+    results = m2.get_memories("inflation rate rising", n_matches=1)
+    assert len(results) == 1
+    assert results[0]["recommendation"] == "reduce duration"
+
+
+# ---------------------------------------------------------------------------
+# RAM-only mode: no persist_dir → no file written
+# ---------------------------------------------------------------------------
+
+def test_no_persist_dir_no_file(tmp_path):
+    """When memory_persist_dir is absent, no persist path is set and data stays in RAM."""
+    m = FinancialSituationMemory("test", config={})
+    m.add_situations([("situation", "rec")])
+    assert m._persist_path is None
+    # Data is still accessible in RAM
+    assert m.documents == ["situation"]
+    assert m.recommendations == ["rec"]
+    # Nothing was written to disk
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_none_config_no_file(tmp_path):
+    """When config is None (default), no persist path is set and data stays in RAM."""
+    m = FinancialSituationMemory("test")
+    m.add_situations([("situation", "rec")])
+    assert m._persist_path is None
+    # Data is still accessible in RAM
+    assert m.documents == ["situation"]
+    assert m.recommendations == ["rec"]
+    # Nothing was written to disk
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Instance isolation: separate names → separate files
+# ---------------------------------------------------------------------------
+
+def test_separate_names_separate_files(persist_dir):
+    """Two instances with different names do not share state."""
+    bull = FinancialSituationMemory("bull_memory", make_config(persist_dir))
+    bear = FinancialSituationMemory("bear_memory", make_config(persist_dir))
+
+    bull.add_situations([("bull situation", "buy")])
+    bear.add_situations([("bear situation", "sell")])
+
+    bull2 = FinancialSituationMemory("bull_memory", make_config(persist_dir))
+    bear2 = FinancialSituationMemory("bear_memory", make_config(persist_dir))
+
+    assert bull2.documents == ["bull situation"]
+    assert bear2.documents == ["bear situation"]
+
+    files = {f.name for f in Path(persist_dir).iterdir()}
+    assert "bull_memory.json" in files
+    assert "bear_memory.json" in files
+
+
+# ---------------------------------------------------------------------------
+# clear() persists the empty state
+# ---------------------------------------------------------------------------
+
+def test_clear_persists(persist_dir):
+    """After clear(), a new instance starts empty rather than reloading old data."""
+    m1 = FinancialSituationMemory("test", make_config(persist_dir))
+    m1.add_situations([("situation", "rec")])
+    m1.clear()
+
+    m2 = FinancialSituationMemory("test", make_config(persist_dir))
+    assert m2.documents == []
+    assert m2.bm25 is None
+
+
+# ---------------------------------------------------------------------------
+# Resilience: corrupt or mismatched files fall back to empty memory
+# ---------------------------------------------------------------------------
+
+def test_corrupt_json_falls_back_to_empty(persist_dir):
+    """A corrupt JSON file is ignored and memory starts empty (no crash)."""
+    Path(persist_dir).mkdir(parents=True, exist_ok=True)
+    (Path(persist_dir) / "test.json").write_text("not valid json", encoding="utf-8")
+
+    m = FinancialSituationMemory("test", make_config(persist_dir))
+    assert m.documents == []
+    assert m.bm25 is None
+
+
+def test_mismatched_lengths_falls_back_to_empty(persist_dir):
+    """A file with mismatched documents/recommendations lengths is ignored."""
+    Path(persist_dir).mkdir(parents=True, exist_ok=True)
+    (Path(persist_dir) / "test.json").write_text(
+        json.dumps({"documents": ["a", "b"], "recommendations": ["r1"]}),
+        encoding="utf-8",
+    )
+
+    m = FinancialSituationMemory("test", make_config(persist_dir))
+    assert m.documents == []
+    assert m.bm25 is None
+
+
+# ---------------------------------------------------------------------------
+# File format: JSON is human-readable and well-formed
+# ---------------------------------------------------------------------------
+
+def test_file_is_valid_json(persist_dir):
+    """The persisted file is valid JSON with expected top-level keys."""
+    m = FinancialSituationMemory("test", make_config(persist_dir))
+    m.add_situations([("situation", "rec")])
+
+    file_path = Path(persist_dir) / "test.json"
+    assert file_path.exists()
+    with open(file_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert "documents" in data
+    assert "recommendations" in data
+    assert isinstance(data["documents"], list)
+    assert isinstance(data["recommendations"], list)

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -18,9 +18,11 @@ def create_portfolio_manager(llm, memory):
         curr_situation = f"{market_research_report}\n\n{sentiment_report}\n\n{news_report}\n\n{fundamentals_report}"
         past_memories = memory.get_memories(curr_situation, n_matches=2)
 
-        past_memory_str = ""
-        for i, rec in enumerate(past_memories, 1):
-            past_memory_str += rec["recommendation"] + "\n\n"
+        if past_memories:
+            past_memory_str = "".join(rec["recommendation"] + "\n\n" for rec in past_memories)
+            lessons_line = f"- Lessons from past decisions: **{past_memory_str}**\n"
+        else:
+            lessons_line = ""
 
         prompt = f"""As the Portfolio Manager, synthesize the risk analysts' debate and deliver the final trading decision.
 
@@ -38,7 +40,7 @@ def create_portfolio_manager(llm, memory):
 **Context:**
 - Research Manager's investment plan: **{research_plan}**
 - Trader's transaction proposal: **{trader_plan}**
-- Lessons from past decisions: **{past_memory_str}**
+{lessons_line}
 
 **Required Output Structure:**
 1. **Rating**: State one of Buy / Overweight / Hold / Underweight / Sell.

--- a/tradingagents/agents/managers/research_manager.py
+++ b/tradingagents/agents/managers/research_manager.py
@@ -16,9 +16,15 @@ def create_research_manager(llm, memory):
         curr_situation = f"{market_research_report}\n\n{sentiment_report}\n\n{news_report}\n\n{fundamentals_report}"
         past_memories = memory.get_memories(curr_situation, n_matches=2)
 
-        past_memory_str = ""
-        for i, rec in enumerate(past_memories, 1):
-            past_memory_str += rec["recommendation"] + "\n\n"
+        if past_memories:
+            past_memory_str = "".join(rec["recommendation"] + "\n\n" for rec in past_memories)
+            memory_section = (
+                "Take into account your past mistakes on similar situations."
+                " Use these insights to refine your decision-making and ensure you are learning and improving.\n\n"
+                f"Here are your past reflections on mistakes:\n\"{past_memory_str}\"\n"
+            )
+        else:
+            memory_section = ""
 
         prompt = f"""As the portfolio manager and debate facilitator, your role is to critically evaluate this round of debate and make a definitive decision: align with the bear analyst, the bull analyst, or choose Hold only if it is strongly justified based on the arguments presented.
 
@@ -29,11 +35,9 @@ Additionally, develop a detailed investment plan for the trader. This should inc
 Your Recommendation: A decisive stance supported by the most convincing arguments.
 Rationale: An explanation of why these arguments lead to your conclusion.
 Strategic Actions: Concrete steps for implementing the recommendation.
-Take into account your past mistakes on similar situations. Use these insights to refine your decision-making and ensure you are learning and improving. Present your analysis conversationally, as if speaking naturally, without special formatting. 
+Present your analysis conversationally, as if speaking naturally, without special formatting.
 
-Here are your past reflections on mistakes:
-\"{past_memory_str}\"
-
+{memory_section}
 {instrument_context}
 
 Here is the debate:

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -15,9 +15,12 @@ def create_bear_researcher(llm, memory):
         curr_situation = f"{market_research_report}\n\n{sentiment_report}\n\n{news_report}\n\n{fundamentals_report}"
         past_memories = memory.get_memories(curr_situation, n_matches=2)
 
-        past_memory_str = ""
-        for i, rec in enumerate(past_memories, 1):
-            past_memory_str += rec["recommendation"] + "\n\n"
+        memory_section = (
+            "Reflections from similar situations and lessons learned:\n"
+            + "".join(rec["recommendation"] + "\n\n" for rec in past_memories)
+            + "\nUse these past reflections to strengthen your argument."
+            if past_memories else ""
+        )
 
         prompt = f"""You are a Bear Analyst making the case against investing in the stock. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
 
@@ -37,8 +40,8 @@ Latest world affairs news: {news_report}
 Company fundamentals report: {fundamentals_report}
 Conversation history of the debate: {history}
 Last bull argument: {current_response}
-Reflections from similar situations and lessons learned: {past_memory_str}
-Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the stock. You must also address reflections and learn from lessons and mistakes you made in the past.
+{memory_section}
+Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the stock.
 """
 
         response = llm.invoke(prompt)

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -15,9 +15,12 @@ def create_bull_researcher(llm, memory):
         curr_situation = f"{market_research_report}\n\n{sentiment_report}\n\n{news_report}\n\n{fundamentals_report}"
         past_memories = memory.get_memories(curr_situation, n_matches=2)
 
-        past_memory_str = ""
-        for i, rec in enumerate(past_memories, 1):
-            past_memory_str += rec["recommendation"] + "\n\n"
+        memory_section = (
+            "Reflections from similar situations and lessons learned:\n"
+            + "".join(rec["recommendation"] + "\n\n" for rec in past_memories)
+            + "\nUse these past reflections to strengthen your argument."
+            if past_memories else ""
+        )
 
         prompt = f"""You are a Bull Analyst advocating for investing in the stock. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
 
@@ -35,8 +38,8 @@ Latest world affairs news: {news_report}
 Company fundamentals report: {fundamentals_report}
 Conversation history of the debate: {history}
 Last bear argument: {current_response}
-Reflections from similar situations and lessons learned: {past_memory_str}
-Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position. You must also address reflections and learn from lessons and mistakes you made in the past.
+{memory_section}
+Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.
 """
 
         response = llm.invoke(prompt)

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -16,12 +16,12 @@ def create_trader(llm, memory):
         curr_situation = f"{market_research_report}\n\n{sentiment_report}\n\n{news_report}\n\n{fundamentals_report}"
         past_memories = memory.get_memories(curr_situation, n_matches=2)
 
-        past_memory_str = ""
-        if past_memories:
-            for i, rec in enumerate(past_memories, 1):
-                past_memory_str += rec["recommendation"] + "\n\n"
-        else:
-            past_memory_str = "No past memories found."
+        reflection_clause = (
+            " Apply lessons from past decisions to strengthen your analysis."
+            " Here are reflections from similar situations you traded in and the lessons learned:\n"
+            + "".join(rec["recommendation"] + "\n\n" for rec in past_memories)
+            if past_memories else ""
+        )
 
         context = {
             "role": "user",
@@ -31,7 +31,7 @@ def create_trader(llm, memory):
         messages = [
             {
                 "role": "system",
-                "content": f"""You are a trading agent analyzing market data to make investment decisions. Based on your analysis, provide a specific recommendation to buy, sell, or hold. End with a firm decision and always conclude your response with 'FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL**' to confirm your recommendation. Apply lessons from past decisions to strengthen your analysis. Here are reflections from similar situations you traded in and the lessons learned: {past_memory_str}""",
+                "content": f"""You are a trading agent analyzing market data to make investment decisions. Based on your analysis, provide a specific recommendation to buy, sell, or hold. End with a firm decision and always conclude your response with 'FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL**' to confirm your recommendation.{reflection_clause}""",
             },
             context,
         ]

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -4,6 +4,12 @@ Uses BM25 (Best Matching 25) algorithm for retrieval - no API calls,
 no token limits, works offline with any LLM provider.
 """
 
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 from rank_bm25 import BM25Okapi
 from typing import List, Tuple
 import re
@@ -17,12 +23,75 @@ class FinancialSituationMemory:
 
         Args:
             name: Name identifier for this memory instance
-            config: Configuration dict (kept for API compatibility, not used for BM25)
+            config: Configuration dict. If config contains a non-empty
+                    ``memory_persist_dir`` key, documents and recommendations
+                    are loaded from (and saved to) that directory.
         """
         self.name = name
         self.documents: List[str] = []
         self.recommendations: List[str] = []
         self.bm25 = None
+        self._persist_path = None
+
+        if config:
+            persist_dir = config.get("memory_persist_dir")
+            if persist_dir:
+                self._persist_path = Path(persist_dir) / f"{name}.json"
+                self._load()
+
+    def _load(self):
+        """Load documents and recommendations from disk if the persist file exists."""
+        if not (self._persist_path and self._persist_path.exists()):
+            return
+        try:
+            with open(self._persist_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            docs = data.get("documents", [])
+            recs = data.get("recommendations", [])
+            if len(docs) != len(recs):
+                logger.warning(
+                    "Memory file %s is corrupt (documents/recommendations length mismatch). "
+                    "Starting with empty memory.",
+                    self._persist_path,
+                )
+                return
+            self.documents = docs
+            self.recommendations = recs
+            if self.documents:
+                self._rebuild_index()
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Could not load memory from %s (%s). Starting with empty memory.",
+                self._persist_path,
+                exc,
+            )
+
+    def _save(self):
+        """Persist documents and recommendations to disk atomically."""
+        if not self._persist_path:
+            return
+        self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self._persist_path.parent,
+                delete=False,
+                suffix=".tmp",
+            ) as tmp:
+                json.dump(
+                    {
+                        "documents": self.documents,
+                        "recommendations": self.recommendations,
+                    },
+                    tmp,
+                    indent=2,
+                    ensure_ascii=False,
+                )
+                tmp_path = Path(tmp.name)
+            tmp_path.replace(self._persist_path)
+        except OSError as exc:
+            logger.warning("Could not save memory to %s (%s).", self._persist_path, exc)
 
     def _tokenize(self, text: str) -> List[str]:
         """Tokenize text for BM25 indexing.
@@ -53,6 +122,7 @@ class FinancialSituationMemory:
 
         # Rebuild BM25 index with new documents
         self._rebuild_index()
+        self._save()
 
     def get_memories(self, current_situation: str, n_matches: int = 1) -> List[dict]:
         """Find matching recommendations using BM25 similarity.
@@ -96,6 +166,7 @@ class FinancialSituationMemory:
         self.documents = []
         self.recommendations = []
         self.bm25 = None
+        self._save()
 
 
 if __name__ == "__main__":

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -6,13 +6,14 @@ no token limits, works offline with any LLM provider.
 
 import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
 from rank_bm25 import BM25Okapi
 from typing import List, Tuple
-import re
+
+logger = logging.getLogger(__name__)
 
 
 class FinancialSituationMemory:

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -6,6 +6,7 @@ DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", os.path.join(_TRADINGAGENTS_HOME, "logs")),
     "data_cache_dir": os.getenv("TRADINGAGENTS_CACHE_DIR", os.path.join(_TRADINGAGENTS_HOME, "cache")),
+    "memory_persist_dir": os.path.join(_TRADINGAGENTS_HOME, "memory"),
     # LLM settings
     "llm_provider": "openai",
     "deep_think_llm": "gpt-5.4",


### PR DESCRIPTION
## Summary

- **Persist `FinancialSituationMemory` to disk** (closes #563) — lessons learned via `reflect_and_remember()` now survive process restarts. Adds `memory_persist_dir` config key (defaults to `~/.tradingagents/memory/`); uses atomic JSON write via `tempfile` + `replace()` with graceful fallback on corruption.
- **Suppress memory injection when memory is empty** (closes #572) — all five agents previously injected an empty string into their prompts while still instructing the LLM to *"address reflections and learn from past mistakes"*, causing the LLM to hallucinate fabricated lessons on first run. Each agent now conditionally builds its memory section only when `past_memories` is non-empty.

These are companion fixes: persistence without the guard still hallucinates on first run; the guard without persistence keeps the corpus perpetually empty for CLI users.

## Changes

| File | Change |
|------|--------|
| `tradingagents/agents/utils/memory.py` | `_load()` / `_save()` persistence + import ordering fix |
| `tradingagents/default_config.py` | `memory_persist_dir` config key |
| `tradingagents/agents/researchers/bull_researcher.py` | Conditional memory section |
| `tradingagents/agents/researchers/bear_researcher.py` | Conditional memory section |
| `tradingagents/agents/trader/trader.py` | Conditional reflection clause |
| `tradingagents/agents/managers/research_manager.py` | Conditional memory section |
| `tradingagents/agents/managers/portfolio_manager.py` | Conditional lessons line |
| `tests/test_memory_persistence.py` | 10 tests for persistence (survive restart, isolation, BM25 rebuild, RAM-only, clear, corruption fallback) |
| `tests/test_hallucination_guard.py` | 10 tests for guard — empty and populated memory across all 5 agents |

## Test plan

- [x] `pytest tests/test_memory_persistence.py tests/test_hallucination_guard.py -v` — 20/20 passed
- [x] Manual run on MSFT (first run) — no fabricated past lessons in report output
- [ ] Call `ta.reflect_and_remember(returns)` after a trade, restart, run again — memory is recalled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)