### PR TITLE
feat: add MiniMax OpenAI-compatible provider support

### DIFF
--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -9,6 +9,7 @@ from .azure_client import AzureOpenAIClient
 # Providers that use the OpenAI-compatible chat completions API
 _OPENAI_COMPATIBLE = (
     "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
+    "minimax",
 )
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -32,6 +32,7 @@ _PROVIDER_CONFIG = {
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
     "ollama": ("http://localhost:11434/v1", None),
+    "minimax": ("https://api.minimaxi.com/v1", "MINIMAX_CN_API_KEY"),
 }
 
 


### PR DESCRIPTION
## Summary

Adds MiniMax as a new LLM provider using the OpenAI-compatible endpoint.

### Changes

- **`tradingagents/llm_clients/factory.py`**: Added `minimax` to `_OPENAI_COMPATIBLE` tuple
- **`tradingagents/llm_clients/openai_client.py`**: Added minimax entry to `_PROVIDER_CONFIG`:
  - Base URL: `https://api.minimaxi.com/v1`
  - Auth env var: `MINIMAX_CN_API_KEY`

### Usage

```python
config = DEFAULT_CONFIG.copy()
config["llm_provider"] = "minimax"
config["deep_think_llm"] = "MiniMax-M2.7"
config["quick_think_llm"] = "MiniMax-M2.7"

ta = TradingAgentsGraph(debug=True, config=config)
decision = ta.propagate("NVDA", "2024-05-10")
```

### Environment

Set `MINIMAX_CN_API_KEY` in your `.env` file. Get your key at https://platform.minimaxi.com

---

Tested with MiniMax-M2.7 model via OpenAI-compatible chat completions endpoint.