### PR TITLE
feat: configure LLM provider, models and gateway URL via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ DEEPSEEK_API_KEY=
 DASHSCOPE_API_KEY=
 ZHIPU_API_KEY=
 OPENROUTER_API_KEY=
+
+# Custom LLM gateway (optional). If set, overrides provider default endpoint.
+LLM_BACKEND_URL=
+
+# LLM model/provider selection (optional). Fallback to default_config.py when empty.
+LLM_PROVIDER=
+DEEP_THINK_LLM=
+QUICK_THINK_LLM=

--- a/main.py
+++ b/main.py
@@ -12,14 +12,14 @@ load_dotenv()
 config = DEFAULT_CONFIG.copy()
 
 # LLM overrides from .env (fall back to DEFAULT_CONFIG when unset)
-if os.getenv("LLM_PROVIDER"):
-    config["llm_provider"] = os.getenv("LLM_PROVIDER")
-if os.getenv("DEEP_THINK_LLM"):
-    config["deep_think_llm"] = os.getenv("DEEP_THINK_LLM")
-if os.getenv("QUICK_THINK_LLM"):
-    config["quick_think_llm"] = os.getenv("QUICK_THINK_LLM")
-if os.getenv("LLM_BACKEND_URL"):
-    config["backend_url"] = os.getenv("LLM_BACKEND_URL")
+for env_var, config_key in [
+    ("LLM_PROVIDER", "llm_provider"),
+    ("DEEP_THINK_LLM", "deep_think_llm"),
+    ("QUICK_THINK_LLM", "quick_think_llm"),
+    ("LLM_BACKEND_URL", "backend_url"),
+]:
+    if value := os.getenv(env_var):
+        config[config_key] = value
 
 config["max_debate_rounds"] = 1  # Increase debate rounds
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import os
+
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
@@ -8,8 +10,17 @@ load_dotenv()
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-5.4-mini"  # Use a different model
-config["quick_think_llm"] = "gpt-5.4-mini"  # Use a different model
+
+# LLM overrides from .env (fall back to DEFAULT_CONFIG when unset)
+if os.getenv("LLM_PROVIDER"):
+    config["llm_provider"] = os.getenv("LLM_PROVIDER")
+if os.getenv("DEEP_THINK_LLM"):
+    config["deep_think_llm"] = os.getenv("DEEP_THINK_LLM")
+if os.getenv("QUICK_THINK_LLM"):
+    config["quick_think_llm"] = os.getenv("QUICK_THINK_LLM")
+if os.getenv("LLM_BACKEND_URL"):
+    config["backend_url"] = os.getenv("LLM_BACKEND_URL")
+
 config["max_debate_rounds"] = 1  # Increase debate rounds
 
 # Configure data vendors (default uses yfinance, no extra API keys needed)


### PR DESCRIPTION
## Summary
- Let users point the runtime at a custom LLM gateway (e.g. an internal OpenAI-compatible proxy) without editing code
- `main.py` now reads `LLM_PROVIDER`, `DEEP_THINK_LLM`, `QUICK_THINK_LLM`, and `LLM_BACKEND_URL` from the environment, falling back to `DEFAULT_CONFIG` when unset
- `.env.example` documents the new variables

## Motivation
Previously the deep/quick models were hardcoded in `main.py` and `backend_url` could only be changed by editing `tradingagents/default_config.py`. For users behind a self-hosted LLM gateway this meant patching source every time. These four env vars make the common cases configuration-only.

The `backend_url=None` default in `default_config.py` is preserved — the provider-leak fix from 4016fd4 still applies: when `LLM_BACKEND_URL` is unset, each provider client falls back to its native default endpoint.

## Test plan
- [ ] With no LLM env vars set, `python main.py` behaves as before (uses DEFAULT_CONFIG)
- [ ] With `LLM_BACKEND_URL=<custom>` + `LLM_PROVIDER=openai`, requests hit the custom gateway
- [ ] With `LLM_PROVIDER=google` and `LLM_BACKEND_URL` empty, Gemini still uses its official endpoint (no backend_url leak regression)