### PR TITLE
fix: rename social_media_analyst to sentiment_analyst with accurate prompt

### DIFF
--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -3,7 +3,7 @@
 Previously named ``social_media_analyst``. Renamed because the only available
 data tool is ``get_news`` (Yahoo Finance headlines), not a social media feed.
 The prompt has been updated to reflect what the agent actually does: it
-analyses the *tone* and *sentiment* of recent news articles rather than
+analyzes the *tone* and *sentiment* of recent news articles rather than
 claiming to process Reddit, X/Twitter, or StockTwits data that it does not
 have access to.
 
@@ -16,7 +16,6 @@ from tradingagents.agents.utils.agent_utils import (
     get_language_instruction,
     get_news,
 )
-from tradingagents.dataflows.config import get_config
 
 
 def create_sentiment_analyst(llm):
@@ -37,7 +36,7 @@ def create_sentiment_analyst(llm):
 
         system_message = (
             "You are a financial news sentiment analyst. "
-            "Your task is to analyse recent news articles and headlines for a specific company "
+            "Your task is to analyze recent news articles and headlines for a specific company "
             "and produce a comprehensive sentiment report covering: "
             "(1) the overall tone of coverage — bullish, bearish, or neutral — and how it has "
             "shifted over the past week; "
@@ -49,8 +48,8 @@ def create_sentiment_analyst(llm):
             "(the News Analyst covers factual content separately). "
             "Note: this analysis is based on news headlines and article summaries only — "
             "live social media feeds (Reddit, X/Twitter, StockTwits) are not currently available. "
-            "Be transparent about this scope limitation in your report."
-            + " Make sure to append a Markdown table at the end of the report to organise key "
+            "Be transparent about this scope limitation in your report. "
+            "Make sure to append a Markdown table at the end of the report to organize key "
             "sentiment signals, their direction, and supporting evidence."
             + get_language_instruction()
         )
@@ -65,7 +64,7 @@ def create_sentiment_analyst(llm):
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    " You have access to the following tools: {tool_names}.\n{system_message}\n"
                     "For your reference, the current date is {current_date}. {instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
@@ -99,7 +98,7 @@ def create_social_media_analyst(llm):
     """Deprecated alias for :func:`create_sentiment_analyst`.
 
     The agent was renamed from ``social_media_analyst`` to ``sentiment_analyst``
-    because it does not actually consume social media data — it analyses the
+    because it does not actually consume social media data — it analyzes the
     tone of Yahoo Finance news headlines.  This alias is kept so that existing
     code that imports ``create_social_media_analyst`` continues to work without
     modification.

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -1,0 +1,117 @@
+"""Sentiment analyst — qualitative tone and sentiment analysis of recent news.
+
+Previously named ``social_media_analyst``. Renamed because the only available
+data tool is ``get_news`` (Yahoo Finance headlines), not a social media feed.
+The prompt has been updated to reflect what the agent actually does: it
+analyses the *tone* and *sentiment* of recent news articles rather than
+claiming to process Reddit, X/Twitter, or StockTwits data that it does not
+have access to.
+
+See: https://github.com/TauricResearch/TradingAgents/issues/557
+"""
+
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.agents.utils.agent_utils import (
+    build_instrument_context,
+    get_language_instruction,
+    get_news,
+)
+from tradingagents.dataflows.config import get_config
+
+
+def create_sentiment_analyst(llm):
+    """Create a sentiment analyst node for the trading graph.
+
+    This analyst reads recent news headlines and articles for the target
+    company and assesses the overall qualitative sentiment and tone — bullish,
+    bearish, or neutral — along with any notable narrative shifts.  It does
+    *not* process live social media data; that capability would require
+    additional data tools (e.g. Reddit via PRAW, StockTwits public API).
+    """
+
+    def sentiment_analyst_node(state):
+        current_date = state["trade_date"]
+        instrument_context = build_instrument_context(state["company_of_interest"])
+
+        tools = [get_news]
+
+        system_message = (
+            "You are a financial news sentiment analyst. "
+            "Your task is to analyse recent news articles and headlines for a specific company "
+            "and produce a comprehensive sentiment report covering: "
+            "(1) the overall tone of coverage — bullish, bearish, or neutral — and how it has "
+            "shifted over the past week; "
+            "(2) the key themes and narratives appearing repeatedly across sources; "
+            "(3) any notable risks or catalysts surfaced by the news; "
+            "(4) a qualitative summary of public and analyst perception based on the articles. "
+            "Use the get_news(query, start_date, end_date) tool to retrieve recent company-specific "
+            "news articles. Focus on tone, framing, and recurring signals rather than raw facts "
+            "(the News Analyst covers factual content separately). "
+            "Note: this analysis is based on news headlines and article summaries only — "
+            "live social media feeds (Reddit, X/Twitter, StockTwits) are not currently available. "
+            "Be transparent about this scope limitation in your report."
+            + " Make sure to append a Markdown table at the end of the report to organise key "
+            "sentiment signals, their direction, and supporting evidence."
+            + get_language_instruction()
+        )
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are a helpful AI assistant, collaborating with other assistants."
+                    " Use the provided tools to progress towards answering the question."
+                    " If you are unable to fully answer, that's OK; another assistant with different tools"
+                    " will help where you left off. Execute what you can to make progress."
+                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    "For your reference, the current date is {current_date}. {instrument_context}",
+                ),
+                MessagesPlaceholder(variable_name="messages"),
+            ]
+        )
+
+        prompt = prompt.partial(system_message=system_message)
+        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
+        prompt = prompt.partial(current_date=current_date)
+        prompt = prompt.partial(instrument_context=instrument_context)
+
+        chain = prompt | llm.bind_tools(tools)
+        result = chain.invoke(state["messages"])
+
+        report = ""
+        if len(result.tool_calls) == 0:
+            report = result.content
+
+        return {
+            "messages": [result],
+            "sentiment_report": report,
+        }
+
+    return sentiment_analyst_node
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility shim
+# ---------------------------------------------------------------------------
+def create_social_media_analyst(llm):
+    """Deprecated alias for :func:`create_sentiment_analyst`.
+
+    The agent was renamed from ``social_media_analyst`` to ``sentiment_analyst``
+    because it does not actually consume social media data — it analyses the
+    tone of Yahoo Finance news headlines.  This alias is kept so that existing
+    code that imports ``create_social_media_analyst`` continues to work without
+    modification.
+
+    .. deprecated::
+        Import :func:`create_sentiment_analyst` directly instead.
+    """
+    import warnings
+    warnings.warn(
+        "create_social_media_analyst is deprecated and will be removed in a "
+        "future version. Use create_sentiment_analyst instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return create_sentiment_analyst(llm)

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -1,57 +1,23 @@
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from tradingagents.agents.utils.agent_utils import build_instrument_context, get_language_instruction, get_news
-from tradingagents.dataflows.config import get_config
+"""Backwards-compatibility shim for the renamed social_media_analyst module.
 
+The social media analyst has been renamed to ``sentiment_analyst`` because its
+only data tool is ``get_news`` (Yahoo Finance), not a social media feed.
 
-def create_social_media_analyst(llm):
-    def social_media_analyst_node(state):
-        current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+Import from ``tradingagents.agents.analysts.sentiment_analyst`` going forward.
 
-        tools = [
-            get_news,
-        ]
+See: https://github.com/TauricResearch/TradingAgents/issues/557
+"""
 
-        system_message = (
-            "You are a social media and company specific news researcher/analyst tasked with analyzing social media posts, recent company news, and public sentiment for a specific company over the past week. You will be given a company's name your objective is to write a comprehensive long report detailing your analysis, insights, and implications for traders and investors on this company's current state after looking at social media and what people are saying about that company, analyzing sentiment data of what people feel each day about the company, and looking at recent company news. Use the get_news(query, start_date, end_date) tool to search for company-specific news and social media discussions. Try to look at all sources possible from social media to sentiment to news. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
-            + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
-            + get_language_instruction()
-        )
+import warnings as _warnings
 
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                (
-                    "system",
-                    "You are a helpful AI assistant, collaborating with other assistants."
-                    " Use the provided tools to progress towards answering the question."
-                    " If you are unable to fully answer, that's OK; another assistant with different tools"
-                    " will help where you left off. Execute what you can to make progress."
-                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
-                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
-                ),
-                MessagesPlaceholder(variable_name="messages"),
-            ]
-        )
+from tradingagents.agents.analysts.sentiment_analyst import (  # noqa: F401
+    create_sentiment_analyst,
+    create_social_media_analyst,
+)
 
-        prompt = prompt.partial(system_message=system_message)
-        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
-        prompt = prompt.partial(current_date=current_date)
-        prompt = prompt.partial(instrument_context=instrument_context)
-
-        chain = prompt | llm.bind_tools(tools)
-
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
-
-        return {
-            "messages": [result],
-            "sentiment_report": report,
-        }
-
-    return social_media_analyst_node
+_warnings.warn(
+    "tradingagents.agents.analysts.social_media_analyst is deprecated. "
+    "Import from tradingagents.agents.analysts.sentiment_analyst instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
Closes #557

## Problem

The `social_media_analyst` claimed to analyze *"social media posts, recent company news, and public sentiment"* but its only tool was `get_news`, which calls `yf.Ticker.get_news()` — the same Yahoo Finance feed used by the News Analyst.

This created two issues:
1. Users believed they were receiving Reddit/X/StockTwits sentiment — they were not
2. The News Analyst and Social Media Analyst were reading from identical data sources, making one redundant

## Solution

**Option A from the issue** — rename + fix the prompt to be honest about scope.

- Creates `tradingagents/agents/analysts/sentiment_analyst.py` with:
  - `create_sentiment_analyst()` — the main function with an accurate prompt focused on *news tone and sentiment analysis* (not social media claims)
  - A `create_social_media_analyst()` backwards-compat alias with a `DeprecationWarning`
- Updates `social_media_analyst.py` to a thin shim that re-exports from the new module so any existing imports continue to work without modification

The new prompt is transparent: it explicitly tells the LLM it is analyzing *news article tone*, not live social feeds, and instructs it to note this scope limitation in the report.

## Files changed
- `tradingagents/agents/analysts/sentiment_analyst.py` — new file, main implementation
- `tradingagents/agents/analysts/social_media_analyst.py` — replaced with backwards-compat shim

## Future work
Adding real social data (PRAW for Reddit, StockTwits public API) would make this analyst genuinely distinct from the News Analyst and is tracked separately in #557.