### PR TITLE
fix: support DeepSeek V4 models

### DIFF
--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -4,6 +4,7 @@ import warnings
 import pytest
 
 from tradingagents.llm_clients.base_client import BaseLLMClient
+from tradingagents.llm_clients.openai_client import OpenAIClient
 from tradingagents.llm_clients.model_catalog import get_known_models
 from tradingagents.llm_clients.validators import validate_model
 
@@ -53,3 +54,19 @@ class ModelValidationTests(unittest.TestCase):
                     client.get_llm()
 
                 self.assertEqual(caught, [])
+
+    def test_deepseek_v4_disables_thinking_for_tool_call_compatibility(self):
+        client = OpenAIClient("deepseek-v4-pro", provider="deepseek")
+        llm = client.get_llm()
+
+        self.assertEqual(llm.extra_body, {"thinking": {"type": "disabled"}})
+
+    def test_deepseek_v4_preserves_explicit_extra_body(self):
+        client = OpenAIClient(
+            "deepseek-v4-pro",
+            provider="deepseek",
+            extra_body={"thinking": {"type": "enabled"}},
+        )
+        llm = client.get_llm()
+
+        self.assertEqual(llm.extra_body, {"thinking": {"type": "enabled"}})

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -65,10 +65,14 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "deepseek": {
         "quick": [
+            ("DeepSeek V4 Flash - Latest fast model, 1M context", "deepseek-v4-flash"),
+            ("DeepSeek V4 Pro - Latest flagship model, 1M context", "deepseek-v4-pro"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),
         ],
         "deep": [
+            ("DeepSeek V4 Pro - Latest flagship model, 1M context", "deepseek-v4-pro"),
+            ("DeepSeek V4 Flash - Latest fast model, 1M context", "deepseek-v4-flash"),
             ("DeepSeek V3.2 (thinking)", "deepseek-reasoner"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -38,6 +38,7 @@ class NormalizedChatOpenAI(ChatOpenAI):
 _PASSTHROUGH_KWARGS = (
     "timeout", "max_retries", "reasoning_effort",
     "api_key", "callbacks", "http_client", "http_async_client",
+    "extra_body",
 )
 
 # Provider base URLs and API key env vars
@@ -92,6 +93,17 @@ class OpenAIClient(BaseLLMClient):
         for key in _PASSTHROUGH_KWARGS:
             if key in self.kwargs:
                 llm_kwargs[key] = self.kwargs[key]
+
+        # DeepSeek V4 defaults to thinking mode. In thinking mode, DeepSeek
+        # requires reasoning_content to be sent back after tool calls; the
+        # OpenAI-compatible LangChain message path does not preserve that field.
+        # Disable thinking unless the caller explicitly supplied extra_body.
+        if (
+            self.provider == "deepseek"
+            and self.model.startswith("deepseek-v4")
+            and "extra_body" not in llm_kwargs
+        ):
+            llm_kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
 
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 Pro and V4 Flash to the DeepSeek model catalog for CLI selection and validation.
- Pass through ChatOpenAI extra_body options for OpenAI-compatible providers.
- Disable DeepSeek V4 thinking mode by default to keep LangChain tool-call flows compatible, while preserving explicit caller-provided extra_body overrides.

## Why
DeepSeek V4 defaults to thinking mode. In tool-call workflows, DeepSeek requires reasoning_content to be preserved across follow-up requests, but the current OpenAI-compatible LangChain path does not retain that field. Disabling thinking for DeepSeek V4 by default avoids 400 errors during tool-call continuations.

## Tests
- uv run --with pytest --no-sync pytest

Result: 94 passed.