### PR TITLE
fix(security): validate ticker symbols before using them as path components

### DIFF
--- a/tests/test_safe_ticker_component.py
+++ b/tests/test_safe_ticker_component.py
@@ -33,6 +33,13 @@ class TestSafeTickerComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             safe_ticker_component("A" * 33)
 
+    def test_rejects_dot_only_values(self):
+        # '.' and '..' pass the regex but traverse when used as a path
+        # component (e.g. ``Path(results_dir) / ticker / "logs"``).
+        for bad in (".", "..", "...", "...."):
+            with self.assertRaises(ValueError):
+                safe_ticker_component(bad)
+
     def test_traversal_string_does_not_escape_join(self):
         """Sanity: sanitized values stay within base when joined."""
         base = os.path.realpath("/tmp/cache")

--- a/tests/test_safe_ticker_component.py
+++ b/tests/test_safe_ticker_component.py
@@ -1,0 +1,45 @@
+"""Tests for the ticker path-component validator that blocks directory traversal."""
+
+import os
+import unittest
+
+import pytest
+
+from tradingagents.dataflows.utils import safe_ticker_component
+
+
+@pytest.mark.unit
+class TestSafeTickerComponent(unittest.TestCase):
+    def test_accepts_common_ticker_formats(self):
+        for ticker in ("AAPL", "BRK-B", "BRK.A", "0700.HK", "7203.T", "BHP.AX", "^GSPC"):
+            self.assertEqual(safe_ticker_component(ticker), ticker)
+
+    def test_rejects_path_separators(self):
+        for bad in ("../etc", "a/b", "a\\b", "/abs", "..\\..\\x"):
+            with self.assertRaises(ValueError):
+                safe_ticker_component(bad)
+
+    def test_rejects_null_byte_and_whitespace(self):
+        for bad in ("AAP L", "AAPL\x00", "AAPL\n", "\tAAPL"):
+            with self.assertRaises(ValueError):
+                safe_ticker_component(bad)
+
+    def test_rejects_empty_or_non_string(self):
+        for bad in ("", None, 123, b"AAPL"):
+            with self.assertRaises(ValueError):
+                safe_ticker_component(bad)
+
+    def test_rejects_overlong_input(self):
+        with self.assertRaises(ValueError):
+            safe_ticker_component("A" * 33)
+
+    def test_traversal_string_does_not_escape_join(self):
+        """Sanity: sanitized values stay within base when joined."""
+        base = os.path.realpath("/tmp/cache")
+        ticker = safe_ticker_component("AAPL")
+        joined = os.path.realpath(os.path.join(base, f"{ticker}.csv"))
+        self.assertTrue(joined.startswith(base + os.sep))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -8,6 +8,7 @@ from stockstats import wrap
 from typing import Annotated
 import os
 from .config import get_config
+from .utils import safe_ticker_component
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,10 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     subsequent calls the cache is reused. Rows after curr_date are
     filtered out so backtests never see future prices.
     """
+    # Reject ticker values that would escape the cache directory when
+    # interpolated into the cache filename (e.g. ``../../tmp/x``).
+    safe_symbol = safe_ticker_component(symbol)
+
     config = get_config()
     curr_date_dt = pd.to_datetime(curr_date)
 
@@ -63,7 +68,7 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     os.makedirs(config["data_cache_dir"], exist_ok=True)
     data_file = os.path.join(
         config["data_cache_dir"],
-        f"{symbol}-YFin-data-{start_str}-{end_str}.csv",
+        f"{safe_symbol}-YFin-data-{start_str}-{end_str}.csv",
     )
 
     if os.path.exists(data_file):

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -1,10 +1,39 @@
 import os
+import re
 import json
 import pandas as pd
 from datetime import date, timedelta, datetime
 from typing import Annotated
 
 SavePathType = Annotated[str, "File path to save data. If None, data is not saved."]
+
+# Tickers can contain letters, digits, dot, dash, underscore, and caret
+# (for index symbols like ^GSPC). Anything else is rejected so the value
+# never escapes a containing directory when interpolated into a path.
+_TICKER_PATH_RE = re.compile(r"^[A-Za-z0-9._\-\^]+$")
+
+
+def safe_ticker_component(value: str, *, max_len: int = 32) -> str:
+    """Validate ``value`` is safe to interpolate into a filesystem path.
+
+    Tickers come from user CLI input or from LLM tool calls, both of which
+    can be influenced by attacker-controlled content (e.g. prompt injection
+    embedded in fetched news). Without validation, a value like
+    ``"../../../etc/foo"`` flows into ``os.path.join`` / ``Path /`` and
+    escapes the configured cache, checkpoint, or results directory.
+
+    Returns ``value`` unchanged when it matches the allowed pattern; raises
+    ``ValueError`` otherwise.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"ticker must be a non-empty string, got {value!r}")
+    if len(value) > max_len:
+        raise ValueError(f"ticker exceeds {max_len} chars: {value!r}")
+    if not _TICKER_PATH_RE.fullmatch(value):
+        raise ValueError(
+            f"ticker contains characters not allowed in a filesystem path: {value!r}"
+        )
+    return value
 
 def save_output(data: pd.DataFrame, tag: str, save_path: SavePathType = None) -> None:
     if save_path:

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -33,6 +33,11 @@ def safe_ticker_component(value: str, *, max_len: int = 32) -> str:
         raise ValueError(
             f"ticker contains characters not allowed in a filesystem path: {value!r}"
         )
+    # The regex above allows '.', so values like '.', '..', '...' would pass
+    # — and as a path component they traverse the parent directory. Reject
+    # any value that's only dots.
+    if set(value) == {"."}:
+        raise ValueError(f"ticker cannot consist solely of dots: {value!r}")
     return value
 
 def save_output(data: pd.DataFrame, tag: str, save_path: SavePathType = None) -> None:

--- a/tradingagents/graph/checkpointer.py
+++ b/tradingagents/graph/checkpointer.py
@@ -13,12 +13,16 @@ from typing import Generator
 
 from langgraph.checkpoint.sqlite import SqliteSaver
 
+from tradingagents.dataflows.utils import safe_ticker_component
+
 
 def _db_path(data_dir: str | Path, ticker: str) -> Path:
     """Return the SQLite checkpoint DB path for a ticker."""
+    # Reject ticker values that would escape the checkpoints directory.
+    safe = safe_ticker_component(ticker).upper()
     p = Path(data_dir) / "checkpoints"
     p.mkdir(parents=True, exist_ok=True)
-    return p / f"{ticker.upper()}.db"
+    return p / f"{safe}.db"
 
 
 def thread_id(ticker: str, date: str) -> str:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -18,6 +18,7 @@ from tradingagents.llm_clients import create_llm_client
 from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import TradingMemoryLog
+from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.agents.utils.agent_states import (
     AgentState,
     InvestDebateState,
@@ -378,8 +379,10 @@ class TradingAgentsGraph:
             "final_trade_decision": final_state["final_trade_decision"],
         }
 
-        # Save to file
-        directory = Path(self.config["results_dir"]) / self.ticker / "TradingAgentsStrategy_logs"
+        # Save to file. Reject ticker values that would escape the
+        # results directory when joined as a path component.
+        safe_ticker = safe_ticker_component(self.ticker)
+        directory = Path(self.config["results_dir"]) / safe_ticker / "TradingAgentsStrategy_logs"
         directory.mkdir(parents=True, exist_ok=True)
 
         log_path = directory / f"full_states_log_{trade_date}.json"


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** Path traversal (ticker symbol → filesystem path)
**Severity:** Medium
**Locations:**
- `tradingagents/dataflows/stockstats_utils.py::load_ohlcv` (cache file)
- `tradingagents/graph/checkpointer.py::_db_path` (sqlite db file)
- `tradingagents/graph/trading_graph.py::_log_state` (results dir)

### Description

Three call sites interpolate the ticker directly into a filesystem path with no validation:

```python
# stockstats_utils.py
data_file = os.path.join(
    config["data_cache_dir"],
    f"{symbol}-YFin-data-{start_str}-{end_str}.csv",
)

# checkpointer.py
return p / f"{ticker.upper()}.db"

# trading_graph.py
directory = Path(self.config["results_dir"]) / self.ticker / "TradingAgentsStrategy_logs"
```

A ticker containing path separators or `..` — e.g. `"../../../tmp/x"` — escapes the configured cache / checkpoint / results directory.

The ticker reaches these sites two ways:

1. **Direct user input** — programmatic callers of `TradingAgentsGraph.propagate(company_name, ...)` (e.g. anyone embedding this library behind an API).
2. **LLM tool calls under prompt injection** — the agents fetch news from yfinance / Alpha Vantage and pass it back as tool output. A news article containing prompt-injection text can steer the LLM into calling `get_indicators` / `get_stock_data` with an attacker-chosen symbol, which then flows into `load_ohlcv` and writes/reads at an attacker-controlled path.

### Impact

- **Read side:** if a target file already exists at the traversed path (e.g. another CSV elsewhere on disk), `pd.read_csv(data_file)` ingests it and the contents flow into the agent context — info disclosure to the LLM (and to whatever logs/outputs the LLM produces).
- **Write side:** arbitrary CSV files (yfinance output, possibly empty) get created outside the configured cache/results dirs. Plus the SQLite checkpoint DB at `_db_path` can be planted anywhere writable.

### Fix

Add a single `safe_ticker_component()` helper in `tradingagents/dataflows/utils.py` that allows only `[A-Za-z0-9._^-]` (covers `AAPL`, `BRK.A`, `BRK-B`, `0700.HK`, `7203.T`, `^GSPC` — every ticker format already exercised in `tests/test_ticker_symbol_handling.py` and `agent_utils.build_instrument_context`) and rejects anything else, including `..`, `/`, `\`, null bytes, whitespace, and oversized inputs. Apply it at each of the three path-build sites.

### Tests

- Existing tests use ticker values like `"TEST"`, `"AAPL"`, `"7203.T"`, `"CNC.TO"` — all pass the validator unchanged.
- New `tests/test_safe_ticker_component.py` covers accept/reject paths, including path-separator, null-byte, whitespace, empty, non-string, and overlong inputs.

### Diff stat

```
 tests/test_safe_ticker_component.py         | 45 +++++++++++++++++++++++++++++
 tradingagents/dataflows/stockstats_utils.py |  7 ++++++-
 tradingagents/dataflows/utils.py            | 29 +++++++++++++++++++++++++++++
 tradingagents/graph/checkpointer.py         |  6 +++++-
 tradingagents/graph/trading_graph.py        |  7 +++++--
 5 files changed, 90 insertions(+), 4 deletions(-)
```

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner.