### PR TITLE
feat(polygon): Polygon as default vendor + Anthropic thinking/structured-output bug fix

### DIFF
--- a/tests/test_anthropic_thinking_structured.py
+++ b/tests/test_anthropic_thinking_structured.py
@@ -1,0 +1,184 @@
+"""Regression tests for the Anthropic-thinking + structured-output fix.
+
+When Claude is served through GitHub Copilot (a ``ChatOpenAI``-shaped
+client pointed at ``api.githubcopilot.com``), the model id encodes the
+extended-thinking effort level via a suffix:
+``claude-opus-4.7-xhigh``. Any structured-output call against that model
+fails with::
+
+    400 - Thinking may not be enabled when tool_choice forces tool use.
+
+``bind_structured`` is supposed to detect this combination and build a
+*non-thinking twin* (same model id with the suffix stripped) that can
+accept the forced ``tool_choice`` LangChain emits for structured output.
+The original thinking-enabled LLM stays in use everywhere else.
+
+These tests stub the LLM so they don't hit the network — what we care
+about is that the routing logic picks the right twin and falls back to
+the original LLM when no remediation is possible.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from tradingagents.agents.utils import structured as struct_mod
+
+
+class _DummyPlan(BaseModel):
+    decision: str
+
+
+# ---------------------------------------------------------------------------
+# _strip_thinking_suffix
+# ---------------------------------------------------------------------------
+
+
+class TestStripThinkingSuffix:
+    def test_strips_xhigh(self):
+        assert struct_mod._strip_thinking_suffix("claude-opus-4.7-xhigh") == "claude-opus-4.7"
+
+    def test_strips_high(self):
+        assert struct_mod._strip_thinking_suffix("claude-opus-4.7-high") == "claude-opus-4.7"
+
+    def test_strips_medium(self):
+        assert struct_mod._strip_thinking_suffix("claude-sonnet-4.5-medium") == "claude-sonnet-4.5"
+
+    def test_strips_low(self):
+        assert struct_mod._strip_thinking_suffix("claude-haiku-4.5-low") == "claude-haiku-4.5"
+
+    def test_strips_minimal(self):
+        assert struct_mod._strip_thinking_suffix("claude-opus-4.7-minimal") == "claude-opus-4.7"
+
+    def test_passthrough_when_no_suffix(self):
+        # Plain Claude model ids (no thinking) should be returned unchanged.
+        assert struct_mod._strip_thinking_suffix("claude-opus-4.7") == "claude-opus-4.7"
+
+    def test_passthrough_for_non_string_input(self):
+        # Defensive: don't blow up on None or non-string LLM model fields.
+        assert struct_mod._strip_thinking_suffix(None) is None
+
+    def test_does_not_strip_unrelated_dashes(self):
+        # ``-4.7`` is a version segment, not an effort suffix — must stay.
+        assert struct_mod._strip_thinking_suffix("claude-opus-4.7") == "claude-opus-4.7"
+
+
+# ---------------------------------------------------------------------------
+# _build_structured_twin
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_chat_openai(model_name: str):
+    """Build an LLM-shaped object that supports ``model_copy`` like a real
+    pydantic ChatOpenAI instance, without actually constructing one (which
+    would require a real API key)."""
+    fake = MagicMock()
+    fake.model_name = model_name
+    # Simulate pydantic's model_copy: returns a *new* MagicMock with the
+    # updated field. We track the swap so we can assert on it.
+    def _model_copy(update=None):
+        twin = MagicMock()
+        twin.model_name = (update or {}).get("model_name", model_name)
+        twin.with_structured_output = MagicMock(return_value="STRUCTURED_TWIN_OUTPUT")
+        return twin
+    fake.model_copy = _model_copy
+    fake.with_structured_output = MagicMock(return_value="STRUCTURED_ORIGINAL_OUTPUT")
+    return fake
+
+
+def _make_fake_chat_anthropic(model: str):
+    """Same pattern but using ``model`` (matches ChatAnthropic's field name)."""
+    fake = MagicMock(spec=["model", "model_copy", "with_structured_output"])
+    fake.model = model
+    def _model_copy(update=None):
+        twin = MagicMock(spec=["model", "with_structured_output"])
+        twin.model = (update or {}).get("model", model)
+        twin.with_structured_output = MagicMock(return_value="STRUCTURED_TWIN_OUTPUT")
+        return twin
+    fake.model_copy = _model_copy
+    fake.with_structured_output = MagicMock(return_value="STRUCTURED_ORIGINAL_OUTPUT")
+    return fake
+
+
+class TestBuildStructuredTwin:
+    def test_claude_with_thinking_suffix_returns_stripped_twin(self):
+        llm = _make_fake_chat_openai("claude-opus-4.7-xhigh")
+        twin = struct_mod._build_structured_twin(llm)
+        # The twin must be a different object with the suffix stripped.
+        assert twin is not llm
+        assert getattr(twin, "model_name", None) == "claude-opus-4.7"
+
+    def test_claude_without_thinking_suffix_returns_original(self):
+        llm = _make_fake_chat_openai("claude-opus-4.7")
+        twin = struct_mod._build_structured_twin(llm)
+        assert twin is llm  # no remediation needed
+
+    def test_non_claude_model_returns_original(self):
+        # GPT-5 with reasoning effort doesn't have the same restriction.
+        llm = _make_fake_chat_openai("gpt-5.5")
+        twin = struct_mod._build_structured_twin(llm)
+        assert twin is llm
+
+    def test_chat_anthropic_with_suffix_returns_stripped_twin(self):
+        # Direct Anthropic provider also encodes effort in newer langchain
+        # versions — make sure we handle that too.
+        llm = _make_fake_chat_anthropic("claude-opus-4.7-xhigh")
+        twin = struct_mod._build_structured_twin(llm)
+        assert twin is not llm
+        assert getattr(twin, "model", None) == "claude-opus-4.7"
+
+    def test_failure_to_clone_falls_back_to_original_llm(self):
+        # If model_copy itself blows up, we must not propagate — log and
+        # return the original so the call site degrades to free-text
+        # rather than crashing.
+        llm = _make_fake_chat_openai("claude-opus-4.7-xhigh")
+        llm.model_copy = MagicMock(side_effect=RuntimeError("clone failed"))
+        twin = struct_mod._build_structured_twin(llm)
+        assert twin is llm
+
+    def test_llm_with_no_model_attribute_returns_original(self):
+        llm = MagicMock(spec=["with_structured_output"])  # no model/model_name
+        # Strip out auto-attributes from MagicMock so getattr returns None.
+        twin = struct_mod._build_structured_twin(llm)
+        assert twin is llm
+
+
+# ---------------------------------------------------------------------------
+# bind_structured integration
+# ---------------------------------------------------------------------------
+
+
+class TestBindStructuredAnthropicTwin:
+    def test_thinking_enabled_claude_binds_structured_via_twin(self):
+        """The bug-fix path: claude-opus-4.7-xhigh must produce a structured
+        binding sourced from the *twin* (claude-opus-4.7), not the original."""
+        llm = _make_fake_chat_openai("claude-opus-4.7-xhigh")
+        bound = struct_mod.bind_structured(llm, _DummyPlan, "Research Manager")
+        # Twin's with_structured_output sentinel — must be the value used.
+        assert bound == "STRUCTURED_TWIN_OUTPUT"
+        # Original LLM's with_structured_output must NOT have been called.
+        assert llm.with_structured_output.call_count == 0
+
+    def test_non_thinking_claude_uses_original_llm(self):
+        llm = _make_fake_chat_openai("claude-opus-4.7")
+        bound = struct_mod.bind_structured(llm, _DummyPlan, "Research Manager")
+        assert bound == "STRUCTURED_ORIGINAL_OUTPUT"
+        assert llm.with_structured_output.call_count == 1
+
+    def test_gpt5_uses_original_llm(self):
+        llm = _make_fake_chat_openai("gpt-5.5")
+        bound = struct_mod.bind_structured(llm, _DummyPlan, "Research Manager")
+        assert bound == "STRUCTURED_ORIGINAL_OUTPUT"
+        assert llm.with_structured_output.call_count == 1
+
+    def test_unsupported_provider_returns_none(self):
+        # Some older Ollama models don't support structured output at all
+        # — the helper must return None so the agent uses free text.
+        llm = MagicMock()
+        llm.model_name = "llama-3.2"
+        llm.with_structured_output = MagicMock(side_effect=NotImplementedError)
+        bound = struct_mod.bind_structured(llm, _DummyPlan, "Trader")
+        assert bound is None

--- a/tests/test_polygon_finance.py
+++ b/tests/test_polygon_finance.py
@@ -1,0 +1,381 @@
+"""Polygon vendor module tests.
+
+Mocks :func:`tradingagents.dataflows.polygon_common._make_request` and
+:func:`paginated_results` so no live network calls are made. Validates:
+
+* PIT visibility rule (filing_date + period_of_report fallback)
+* Strict TTM aggregation (returns None when any quarter missing)
+* Statement-to-CSV shape (rows=concepts, columns=periods)
+* End-to-end ``get_fundamentals`` integration with mocked endpoints
+* Vendor router fallback when Polygon raises
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from tradingagents.dataflows import polygon_finance as pf
+from tradingagents.dataflows.polygon_common import (
+    PolygonError,
+    PolygonNotFoundError,
+    PolygonRateLimitError,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_pit_visible
+# ---------------------------------------------------------------------------
+
+
+class TestIsPitVisible:
+    """Filings with filing_date < curr_date are visible. Filings without
+    filing_date fall back to a period_of_report + 90-day lag rule.
+    """
+
+    @staticmethod
+    def _curr() -> datetime:
+        return datetime(2024, 5, 10)
+
+    def test_filing_date_strictly_before_curr_date_is_visible(self):
+        entry = {"filing_date": "2024-05-09", "end_date": "2024-04-28"}
+        assert pf._is_pit_visible(entry, self._curr()) is True
+
+    def test_filing_date_equal_to_curr_date_is_not_visible(self):
+        # Strictly less-than: a filing made today wasn't on the wire when the
+        # market opened, so we exclude it from "visible at curr_date".
+        entry = {"filing_date": "2024-05-10", "end_date": "2024-04-28"}
+        assert pf._is_pit_visible(entry, self._curr()) is False
+
+    def test_filing_date_after_curr_date_is_not_visible(self):
+        entry = {"filing_date": "2024-05-29", "end_date": "2024-04-28"}
+        assert pf._is_pit_visible(entry, self._curr()) is False
+
+    def test_null_filing_date_with_old_period_is_visible_via_lag(self):
+        # period_of_report + 90 days <= curr_date → assume the SEC filing
+        # window has elapsed and the data is publicly available.
+        entry = {"filing_date": None, "end_date": "2024-01-31"}  # +90d = 2024-04-30
+        assert pf._is_pit_visible(entry, self._curr()) is True
+
+    def test_null_filing_date_with_recent_period_is_not_visible(self):
+        # period_of_report = curr_date - 30d → still inside the typical filing
+        # window, no filing_date evidence, so we treat it as not yet public.
+        entry = {"filing_date": None, "end_date": "2024-04-10"}
+        assert pf._is_pit_visible(entry, self._curr()) is False
+
+    def test_no_dates_at_all_is_not_visible(self):
+        # Defensive: row with neither filing_date nor period_of_report is
+        # excluded — better to drop than risk look-ahead.
+        entry = {"filing_date": None, "end_date": None}
+        assert pf._is_pit_visible(entry, self._curr()) is False
+
+
+# ---------------------------------------------------------------------------
+# _ttm_sum
+# ---------------------------------------------------------------------------
+
+
+def _quarter(value, concept="revenues", section="income_statement"):
+    """Build a Polygon-shaped financials entry with a single concept value."""
+    return {
+        "timeframe": "quarterly",
+        "financials": {
+            section: {
+                concept: {"value": value, "label": concept},
+            }
+        }
+    }
+
+
+class TestTtmSum:
+    def test_strict_ttm_sums_four_quarters(self):
+        quarters = [_quarter(100), _quarter(200), _quarter(150), _quarter(250)]
+        assert pf._ttm_sum(quarters, "income_statement", "revenues") == 700
+
+    def test_ttm_returns_none_when_fewer_than_four_quarters(self):
+        quarters = [_quarter(100), _quarter(200), _quarter(150)]
+        assert pf._ttm_sum(quarters, "income_statement", "revenues") is None
+
+    def test_ttm_returns_none_when_any_quarter_missing_value(self):
+        # All four entries present but one has no value for the concept.
+        quarters = [
+            _quarter(100),
+            _quarter(200),
+            {"timeframe": "quarterly", "financials": {"income_statement": {}}},  # missing concept
+            _quarter(250),
+        ]
+        assert pf._ttm_sum(quarters, "income_statement", "revenues") is None
+
+    def test_ttm_uses_only_first_four_quarters(self):
+        # If 5 are passed, only the most recent 4 (caller's responsibility
+        # to order) are summed.
+        quarters = [_quarter(100), _quarter(200), _quarter(150), _quarter(250), _quarter(999)]
+        assert pf._ttm_sum(quarters, "income_statement", "revenues") == 700
+
+
+# ---------------------------------------------------------------------------
+# _statement_to_csv
+# ---------------------------------------------------------------------------
+
+
+class TestStatementToCsv:
+    def test_csv_shape_has_concepts_as_rows_and_periods_as_columns(self):
+        entries = [
+            {
+                "end_date": "2024-04-28",
+                "financials": {
+                    "income_statement": {
+                        "revenues": {"value": 26044000000.0, "label": "Revenue"},
+                        "gross_profit": {"value": 20407000000.0, "label": "Gross Profit"},
+                    }
+                },
+            },
+            {
+                "end_date": "2024-01-28",
+                "financials": {
+                    "income_statement": {
+                        "revenues": {"value": 22103000000.0, "label": "Revenue"},
+                        "gross_profit": {"value": 16791000000.0, "label": "Gross Profit"},
+                    }
+                },
+            },
+        ]
+        csv = pf._statement_to_csv(entries, "income_statement")
+        # Headers: concept column + each period
+        assert "concept" in csv.lower() or "metric" in csv.lower() or "label" in csv.lower()
+        assert "2024-04-28" in csv
+        assert "2024-01-28" in csv
+        # Both concepts represented
+        assert "revenues" in csv.lower() or "revenue" in csv.lower()
+        assert "gross_profit" in csv.lower() or "gross profit" in csv.lower()
+
+    def test_csv_handles_empty_entries(self):
+        csv = pf._statement_to_csv([], "income_statement")
+        assert csv == "" or "no data" in csv.lower() or csv.startswith("concept") or csv.startswith("metric") or csv.startswith("label")
+
+
+# ---------------------------------------------------------------------------
+# get_fundamentals end-to-end (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+_NVDA_TICKER_REF = {
+    "results": {
+        "name": "Nvidia Corp",
+        "market_cap": 2247000000000.0,
+        "share_class_shares_outstanding": 2500000000,
+        "weighted_shares_outstanding": 2495000000,
+        "sic_description": "SEMICONDUCTORS & RELATED DEVICES",
+        "primary_exchange": "XNAS",
+    }
+}
+
+_NVDA_BARS = {
+    "results": [
+        {"t": 1715040000000, "o": 89.48, "h": 91.19, "l": 89.42, "c": 90.41, "v": 325721020},
+        {"t": 1715126400000, "o": 90.53, "h": 91.07, "l": 88.23, "c": 88.75, "v": 378012680},
+        {"t": 1715212800000, "o": 90.30, "h": 91.40, "l": 89.23, "c": 89.88, "v": 335325410},
+    ]
+}
+
+
+def _fin_quarter(end_date, filing_date, revenues, net_income=None, gross_profit=None):
+    inc = {"revenues": {"value": revenues, "label": "Revenues"}}
+    if gross_profit is not None:
+        inc["gross_profit"] = {"value": gross_profit, "label": "Gross Profit"}
+    if net_income is not None:
+        inc["net_income_loss"] = {"value": net_income, "label": "Net Income"}
+    return {
+        "filing_date": filing_date,
+        "end_date": end_date,
+        "timeframe": "quarterly",
+        "financials": {
+            "income_statement": inc,
+            "balance_sheet": {
+                "assets": {"value": 65728000000.0, "label": "Total Assets"},
+                "equity": {"value": 42978000000.0, "label": "Equity"},
+                "long_term_debt": {"value": 9709000000.0, "label": "Long-Term Debt"},
+            },
+            "cash_flow_statement": {
+                "net_cash_flow_from_operating_activities": {"value": 7000000000.0, "label": "OCF"},
+            },
+        },
+    }
+
+
+_NVDA_FINANCIALS = [
+    _fin_quarter("2024-01-28", "2024-02-21", 22103000000, 12285000000, 16791000000),
+    _fin_quarter("2023-10-29", "2023-11-21", 18120000000, 9243000000, 13400000000),
+    _fin_quarter("2023-07-30", "2023-08-23", 13507000000, 6188000000, 9462000000),
+    _fin_quarter("2023-04-30", "2023-05-24", 7192000000, 2043000000, 4648000000),
+]
+
+
+class TestGetFundamentalsIntegration:
+    """Full get_fundamentals call with mocked Polygon endpoints."""
+
+    def _route(self, endpoint, params=None):
+        """Mock dispatcher: route calls based on URL prefix."""
+        if endpoint.startswith("/v3/reference/tickers/"):
+            return _NVDA_TICKER_REF
+        if endpoint.startswith("/v2/aggs/ticker/"):
+            return _NVDA_BARS
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    def test_get_fundamentals_returns_correct_market_cap_for_nvda(self):
+        with patch.object(pf, "_make_request", side_effect=self._route), \
+             patch.object(pf, "paginated_results", return_value=_NVDA_FINANCIALS):
+            report = pf.get_fundamentals("NVDA", "2024-05-10")
+
+        # Critical: market cap must be in trillions, not buggy $224B
+        assert "$2.25T" in report or "$2.24T" in report
+        assert "Nvidia" in report
+        assert "SEMICONDUCTORS" in report.upper()
+        # PIT date appears in header
+        assert "2024-05-10" in report
+
+    def test_get_fundamentals_filters_out_post_curr_date_filings(self):
+        """A row with filing_date AFTER curr_date must not influence the
+        report — this is the guarantee that yf_pit_derivations Path D failed."""
+        leaked_future = _fin_quarter("2024-04-28", "2026-01-25", 99999999999)
+        all_financials = [leaked_future] + _NVDA_FINANCIALS
+
+        with patch.object(pf, "_make_request", side_effect=self._route), \
+             patch.object(pf, "paginated_results", return_value=all_financials):
+            report = pf.get_fundamentals("NVDA", "2024-05-10")
+
+        # The leaked future-filed row's revenues (99,999,999,999) must not
+        # appear; only the legitimate ~$60B TTM should.
+        assert "99999999999" not in report
+        assert "$99.9B" not in report
+
+    def test_get_fundamentals_handles_no_visible_filings(self):
+        """If every filing has filing_date >= curr_date, get_fundamentals
+        must still return a useful response (degraded but not crashing)."""
+        all_in_future = [
+            _fin_quarter("2024-04-28", "2030-01-01", 22103000000),
+        ]
+        with patch.object(pf, "_make_request", side_effect=self._route), \
+             patch.object(pf, "paginated_results", return_value=all_in_future):
+            report = pf.get_fundamentals("NVDA", "2024-05-10")
+
+        # Should still include the price-derived bits (close, 52w range)
+        # and metadata even when no PIT financials are visible.
+        assert "Nvidia" in report
+        # No TTM revenue can be computed → label should reflect missing data
+        # (we just want this to not raise)
+
+
+# ---------------------------------------------------------------------------
+# get_news / get_global_news / get_insider_transactions
+# ---------------------------------------------------------------------------
+
+
+class TestPolygonNews:
+    def test_get_news_returns_formatted_string(self):
+        sample = [
+            {
+                "published_utc": "2024-05-09T14:30:00Z",
+                "title": "NVDA up on AI demand",
+                "publisher": {"name": "Reuters"},
+                "article_url": "https://example.com/1",
+                "description": "NVIDIA shares rose ahead of earnings.",
+            }
+        ]
+        from tradingagents.dataflows import polygon_news as pn
+        with patch.object(pn, "paginated_results", return_value=sample):
+            out = pn.get_news("NVDA", "2024-05-01", "2024-05-10")
+        assert "NVDA up on AI demand" in out
+        assert "Reuters" in out
+
+    def test_get_news_handles_no_results(self):
+        from tradingagents.dataflows import polygon_news as pn
+        with patch.object(pn, "paginated_results", side_effect=PolygonNotFoundError("none")):
+            out = pn.get_news("NVDA", "2024-05-01", "2024-05-10")
+        assert "No news found" in out
+
+    def test_get_insider_transactions_raises_to_trigger_fallback(self):
+        """Polygon Stocks Starter doesn't include insider transactions —
+        the function must raise PolygonError so route_to_vendor falls
+        through to the next configured vendor."""
+        from tradingagents.dataflows import polygon_news as pn
+        with pytest.raises(PolygonError):
+            pn.get_insider_transactions("NVDA")
+
+
+# ---------------------------------------------------------------------------
+# Vendor router fallback
+# ---------------------------------------------------------------------------
+
+
+class TestVendorRouterFallback:
+    """Confirm route_to_vendor falls back from Polygon to yfinance on
+    PolygonError, and from any vendor missing API key to the next."""
+
+    def test_polygon_error_triggers_fallback_to_yfinance(self):
+        from tradingagents.dataflows import interface
+
+        def boom(*args, **kwargs):
+            raise PolygonRateLimitError("simulated 429")
+
+        sentinel = "FALLBACK_TO_YFINANCE_REPORT"
+        # Patch the configured chain to be exactly polygon→yfinance so we
+        # can reason about the fallback deterministically (avoids ordering
+        # dependencies on alpha_vantage, which sits between them in the
+        # registration order and would otherwise be tried second).
+        with patch.object(interface, "get_vendor", return_value="polygon,yfinance"), \
+             patch.dict(
+                 interface.VENDOR_METHODS["get_fundamentals"],
+                 {
+                     "polygon": boom,
+                     "yfinance": lambda *a, **kw: sentinel,
+                 },
+             ):
+            result = interface.route_to_vendor(
+                "get_fundamentals", "NVDA", "2024-05-10"
+            )
+            assert result == sentinel
+
+    def test_missing_api_key_value_error_triggers_fallback(self):
+        from tradingagents.dataflows import interface
+
+        def missing_key(*args, **kwargs):
+            raise ValueError("ALPHA_VANTAGE_API_KEY environment variable is not set.")
+
+        sentinel = "FALLBACK_AFTER_MISSING_KEY"
+        with patch.object(interface, "get_vendor", return_value="polygon,yfinance"), \
+             patch.dict(
+                 interface.VENDOR_METHODS["get_fundamentals"],
+                 {
+                     "polygon": missing_key,
+                     "yfinance": lambda *a, **kw: sentinel,
+                 },
+             ):
+            result = interface.route_to_vendor(
+                "get_fundamentals", "NVDA", "2024-05-10"
+            )
+            assert result == sentinel
+
+    def test_unrelated_value_error_does_not_swallow(self):
+        """ValueError that isn't about API keys (e.g. bad input args) must
+        propagate — we only fall through on missing-key signals."""
+        from tradingagents.dataflows import interface
+
+        def bad_input(*args, **kwargs):
+            raise ValueError("ticker must be a non-empty string")
+
+        with patch.object(interface, "get_vendor", return_value="polygon,yfinance,alpha_vantage"), \
+             patch.dict(
+                 interface.VENDOR_METHODS["get_fundamentals"],
+                 {
+                     "polygon": bad_input,
+                     "yfinance": bad_input,
+                     "alpha_vantage": bad_input,
+                 },
+             ):
+            with pytest.raises(ValueError, match="non-empty string"):
+                interface.route_to_vendor(
+                    "get_fundamentals", "NVDA", "2024-05-10"
+                )

--- a/tests/test_yfinance_pit.py
+++ b/tests/test_yfinance_pit.py
@@ -1,0 +1,472 @@
+"""Point-in-time correctness tests for yfinance fundamentals.
+
+yfinance's ``Ticker.info`` always returns *live* snapshot values (current
+market cap, TTM ratios, 52-week ranges) regardless of any historical date
+supplied by the caller. ``get_fundamentals`` therefore reconstructs those
+fields point-in-time from historical statements + price bars when
+``curr_date`` is in the past, and preserves the prior behaviour for live
+(None / today) calls.
+
+These tests mock ``yfinance.Ticker`` so they do not hit the network.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tradingagents.dataflows import y_finance
+
+
+# A representative subset of the live-snapshot field labels the function
+# is expected to *suppress* on historical calls. (Picked to span price-
+# derived, TTM, and rolling-window categories.)
+_LIVE_FIELD_LABELS = (
+    "Market Cap",
+    "PE Ratio (TTM)",
+    "Forward PE",
+    "Price to Book",
+    "52 Week High",
+    "50 Day Average",
+    "200 Day Average",
+    "Dividend Yield",
+    "Revenue (TTM)",
+    "EBITDA",
+    "Free Cash Flow",
+    "EPS (TTM)",
+)
+
+_STABLE_FIELD_LABELS = ("Name", "Sector", "Industry", "Beta")
+
+
+def _fake_info():
+    """Realistic-shaped yfinance Ticker.info payload (NVDA-like, April 2026)."""
+    return {
+        "longName": "NVIDIA Corporation",
+        "sector": "Technology",
+        "industry": "Semiconductors",
+        "marketCap": 5_090_000_000_000,
+        "trailingPE": 45.6,
+        "forwardPE": 18.6,
+        "pegRatio": 1.2,
+        "priceToBook": 38.0,
+        "trailingEps": 4.90,
+        "forwardEps": 11.24,
+        "dividendYield": 0.0002,
+        "beta": 2.34,
+        "fiftyTwoWeekHigh": 216.83,
+        "fiftyTwoWeekLow": 104.08,
+        "fiftyDayAverage": 186.23,
+        "twoHundredDayAverage": 183.35,
+        "totalRevenue": 215_940_000_000,
+        "grossProfits": 156_000_000_000,
+        "ebitda": 130_000_000_000,
+        "netIncomeToCommon": 90_000_000_000,
+        "profitMargins": 0.42,
+        "operatingMargins": 0.55,
+        "returnOnEquity": 0.95,
+        "returnOnAssets": 0.45,
+        "debtToEquity": 22.0,
+        "currentRatio": 4.5,
+        "bookValue": 2.5,
+        "freeCashflow": 58_100_000_000,
+    }
+
+
+def _patch_ticker(info, **statement_overrides):
+    """Patch yf.Ticker so that ``.info`` returns ``info`` and yf_retry passes through.
+
+    Optional ``statement_overrides`` lets tests inject:
+        history=DataFrame, quarterly_income_stmt=DataFrame,
+        quarterly_balance_sheet=DataFrame, quarterly_cashflow=DataFrame,
+        get_shares_full=Series, dividends=Series.
+    Anything not passed is left as a default MagicMock attribute so the
+    derivation module's ``_safe_attr`` / ``_safe_call`` swallow it cleanly.
+    """
+    fake_ticker = MagicMock()
+    fake_ticker.info = info
+
+    if "history" in statement_overrides:
+        fake_ticker.history.return_value = statement_overrides["history"]
+    if "get_shares_full" in statement_overrides:
+        fake_ticker.get_shares_full.return_value = statement_overrides["get_shares_full"]
+    for attr in (
+        "quarterly_income_stmt",
+        "quarterly_balance_sheet",
+        "quarterly_cashflow",
+        "dividends",
+    ):
+        if attr in statement_overrides:
+            setattr(fake_ticker, attr, statement_overrides[attr])
+
+    return patch.object(y_finance.yf, "Ticker", return_value=fake_ticker)
+
+
+def _fake_history_2024():
+    """One trading year of synthetic NVDA-like daily bars ending 2024-05-10."""
+    end = pd.Timestamp("2024-05-10")
+    idx = pd.bdate_range(end=end, periods=260)
+    n = len(idx)
+    closes = pd.Series(
+        [40 + (i / n) * 50 for i in range(n)],
+        index=idx,
+    )
+    return pd.DataFrame({
+        "Open":   closes - 0.5,
+        "High":   closes + 1.0,
+        "Low":    closes - 1.0,
+        "Close":  closes,
+        "Volume": [50_000_000] * n,
+    })
+
+
+def _fake_income_stmt():
+    """Quarterly income statement keyed on fiscal-period end dates ≤ 2024-05-10."""
+    cols = [
+        pd.Timestamp("2024-04-30"),  # Q1 FY25
+        pd.Timestamp("2024-01-31"),  # Q4 FY24
+        pd.Timestamp("2023-10-31"),  # Q3 FY24
+        pd.Timestamp("2023-07-31"),  # Q2 FY24
+        pd.Timestamp("2023-04-30"),  # extra older quarter
+    ]
+    return pd.DataFrame({
+        cols[0]: [26_000_000_000, 18_000_000_000, 16_000_000_000, 14_500_000_000],
+        cols[1]: [22_103_000_000, 16_791_000_000, 14_000_000_000, 12_840_000_000],
+        cols[2]: [18_120_000_000, 13_400_000_000, 11_300_000_000, 10_417_000_000],
+        cols[3]: [13_510_000_000,  9_462_000_000,  7_640_000_000,  6_188_000_000],
+        cols[4]: [ 7_192_000_000,  4_648_000_000,  3_490_000_000,  2_043_000_000],
+    }, index=["Total Revenue", "Gross Profit", "Operating Income", "Net Income"])
+
+
+def _fake_balance_sheet():
+    cols = [
+        pd.Timestamp("2024-04-30"),
+        pd.Timestamp("2024-01-31"),
+        pd.Timestamp("2023-10-31"),
+    ]
+    return pd.DataFrame({
+        cols[0]: [70_000_000_000, 50_000_000_000, 12_000_000_000, 30_000_000_000, 11_000_000_000],
+        cols[1]: [65_700_000_000, 42_980_000_000,  9_700_000_000, 28_000_000_000,  9_500_000_000],
+        cols[2]: [54_152_000_000, 36_500_000_000,  9_500_000_000, 23_000_000_000,  8_400_000_000],
+    }, index=[
+        "Total Assets",
+        "Stockholders Equity",
+        "Total Debt",
+        "Current Assets",
+        "Current Liabilities",
+    ])
+
+
+def _fake_cashflow():
+    cols = [
+        pd.Timestamp("2024-04-30"),
+        pd.Timestamp("2024-01-31"),
+        pd.Timestamp("2023-10-31"),
+        pd.Timestamp("2023-07-31"),
+    ]
+    return pd.DataFrame({
+        cols[0]: [14_000_000_000],
+        cols[1]: [11_217_000_000],
+        cols[2]: [ 7_040_000_000],
+        cols[3]: [ 6_345_000_000],
+    }, index=["Free Cash Flow"])
+
+
+def _fake_shares_full():
+    """Daily share-count series ending 2024-05-10."""
+    end = pd.Timestamp("2024-05-10")
+    idx = pd.bdate_range(end=end, periods=260)
+    return pd.Series([2_460_000_000] * len(idx), index=idx)
+
+
+def _fake_dividends_none():
+    """NVDA-style: minimal/no dividends in window."""
+    return pd.Series([], dtype=float)
+
+
+def _full_pit_overrides():
+    return dict(
+        history=_fake_history_2024(),
+        quarterly_income_stmt=_fake_income_stmt(),
+        quarterly_balance_sheet=_fake_balance_sheet(),
+        quarterly_cashflow=_fake_cashflow(),
+        get_shares_full=_fake_shares_full(),
+        dividends=_fake_dividends_none(),
+    )
+
+
+@pytest.mark.unit
+def test_historical_curr_date_reconstructs_pit_snapshot():
+    """A past curr_date must reconstruct snapshot fields from PIT data, NOT
+    return the live ``info`` snapshot."""
+    past = "2024-05-10"
+    with _patch_ticker(_fake_info(), **_full_pit_overrides()):
+        out = y_finance.get_fundamentals("NVDA", curr_date=past)
+
+    assert "Market Cap:" in out, "Market Cap should be reconstructed for historical"
+    # Reconstructed market cap must NOT match the poisoned live info value.
+    # Live info has Market Cap = 5,090,000,000,000 (April 2026).
+    # PIT-reconstructed = close × shares_out = ~89.5 × 2.46B ≈ ~220B (synthetic).
+    assert "5090000000000" not in out
+    assert "Revenue (TTM):" in out
+    assert "EPS (TTM):" in out
+    assert "PE Ratio (TTM):" in out
+
+    for label in _STABLE_FIELD_LABELS:
+        assert f"{label}:" in out, f"stable field {label!r} missing from output"
+
+    assert "Point-in-time mode" in out
+    assert past in out
+    assert "reconstructed" in out
+    assert "Forward EPS:" not in out
+    assert "Forward PE:" not in out
+    assert "PEG Ratio:" not in out
+
+
+@pytest.mark.unit
+def test_historical_uses_only_quarters_at_or_before_curr_date():
+    """Reconstructed TTM Revenue must equal the sum of the 4 quarters ending
+    on or before curr_date, never including any later filing."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    fake_ticker.history.return_value = _fake_history_2024()
+    fake_ticker.quarterly_income_stmt = _fake_income_stmt()
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = _fake_dividends_none()
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+
+    # Last 4 quarters ≤ 2024-05-10:
+    # 2024-04-30: 26.0B, 2024-01-31: 22.103B, 2023-10-31: 18.120B, 2023-07-31: 13.510B
+    expected_ttm_rev = 26_000_000_000 + 22_103_000_000 + 18_120_000_000 + 13_510_000_000
+    assert derived["Revenue (TTM)"] == expected_ttm_rev
+
+    # Quarter at 2023-04-30 (7.192B) MUST NOT be included even though it's in the data.
+    assert 7_192_000_000 not in [v for v in derived.values() if isinstance(v, (int, float))]
+
+
+@pytest.mark.unit
+def test_historical_market_cap_uses_close_at_curr_date_not_live():
+    """Reconstructed Market Cap must = close[curr_date] × shares_outstanding[curr_date],
+    not the live info snapshot."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    history = _fake_history_2024()
+    fake_ticker.history.return_value = history
+    fake_ticker.quarterly_income_stmt = _fake_income_stmt()
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = _fake_dividends_none()
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+
+    expected_close = float(history.loc[history.index <= pd.Timestamp("2024-05-10")]["Close"].iloc[-1])
+    expected_shares = 2_460_000_000
+    expected_mcap = int(round(expected_close * expected_shares))
+
+    assert derived["Market Cap"] == expected_mcap
+    assert derived["Market Cap"] != 5_090_000_000_000
+
+
+@pytest.mark.unit
+def test_historical_52_week_range_from_history_window():
+    """52-week H/L must derive from the 365-day window ending at curr_date."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    h = _fake_history_2024()
+    fake_ticker.history.return_value = h
+    fake_ticker.quarterly_income_stmt = _fake_income_stmt()
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = _fake_dividends_none()
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+
+    cutoff = pd.Timestamp("2024-05-10")
+    window = h[(h.index <= cutoff) & (h.index >= cutoff - pd.Timedelta(days=365))]
+    expected_high = round(float(window["High"].max()), 2)
+    expected_low = round(float(window["Low"].min()), 2)
+
+    assert derived["52 Week High"] == expected_high
+    assert derived["52 Week Low"] == expected_low
+    # Live info has 52 Week High = 216.83 (2026 figure). Synthetic 2024 series
+    # tops out at ~91; the live value must NOT be reused.
+    assert derived["52 Week High"] != 216.83
+
+
+@pytest.mark.unit
+def test_historical_sparse_quarters_omit_ttm_gracefully():
+    """If fewer than 4 quarters are available ≤ curr_date, TTM fields are omitted
+    rather than a partial sum being published as if it were full-year data."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    sparse_income = pd.DataFrame({
+        pd.Timestamp("2024-04-30"): [26_000_000_000, 18_000_000_000, 16_000_000_000, 14_500_000_000],
+        pd.Timestamp("2024-01-31"): [22_103_000_000, 16_791_000_000, 14_000_000_000, 12_840_000_000],
+    }, index=["Total Revenue", "Gross Profit", "Operating Income", "Net Income"])
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    fake_ticker.history.return_value = _fake_history_2024()
+    fake_ticker.quarterly_income_stmt = sparse_income
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = _fake_dividends_none()
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+
+    assert "Revenue (TTM)" not in derived
+    assert "Net Income" not in derived
+    assert "EPS (TTM)" not in derived
+    assert "PE Ratio (TTM)" not in derived
+    # But price-derived ranges and book value (single-period) should still come through.
+    assert "52 Week High" in derived
+    assert "Book Value" in derived
+
+
+@pytest.mark.unit
+def test_historical_dividend_yield_uses_ttm_dividends_in_window():
+    """Dividend yield = sum of dividends paid in the trailing 365 days ÷ close at curr_date."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    div_dates = [
+        pd.Timestamp("2024-03-15"),
+        pd.Timestamp("2023-12-15"),
+        pd.Timestamp("2023-09-15"),
+        pd.Timestamp("2023-06-15"),
+    ]
+    dividends = pd.Series([0.50, 0.50, 0.50, 0.50], index=div_dates)
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    h = _fake_history_2024()
+    fake_ticker.history.return_value = h
+    fake_ticker.quarterly_income_stmt = _fake_income_stmt()
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = dividends
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+
+    expected_close = float(h.loc[h.index <= pd.Timestamp("2024-05-10")]["Close"].iloc[-1])
+    expected_yield = round(2.00 / expected_close, 4)
+    assert derived["Dividend Yield"] == expected_yield
+
+
+@pytest.mark.unit
+def test_historical_no_dividend_history_omits_yield():
+    """A ticker with no dividends in the trailing window does not emit Dividend Yield."""
+    from tradingagents.dataflows.yf_pit_derivations import derive_pit_fundamentals
+
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+    fake_ticker.history.return_value = _fake_history_2024()
+    fake_ticker.quarterly_income_stmt = _fake_income_stmt()
+    fake_ticker.quarterly_balance_sheet = _fake_balance_sheet()
+    fake_ticker.quarterly_cashflow = _fake_cashflow()
+    fake_ticker.get_shares_full.return_value = _fake_shares_full()
+    fake_ticker.dividends = _fake_dividends_none()
+
+    derived = derive_pit_fundamentals(fake_ticker, "2024-05-10")
+    assert "Dividend Yield" not in derived
+
+
+@pytest.mark.unit
+def test_derivation_failure_does_not_crash_get_fundamentals():
+    """If the derivation module raises mid-run, get_fundamentals must still return
+    a valid (degraded) report with the stable structural fields."""
+    fake_ticker = MagicMock()
+    fake_ticker.info = _fake_info()
+
+    fake_ticker.history.side_effect = RuntimeError("yfinance exploded")
+
+    type(fake_ticker).quarterly_income_stmt = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("statements unavailable"))
+    )
+    type(fake_ticker).quarterly_balance_sheet = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("statements unavailable"))
+    )
+    type(fake_ticker).quarterly_cashflow = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("statements unavailable"))
+    )
+    fake_ticker.get_shares_full.side_effect = RuntimeError("shares unavailable")
+    type(fake_ticker).dividends = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("dividends unavailable"))
+    )
+
+    with patch.object(y_finance.yf, "Ticker", return_value=fake_ticker):
+        out = y_finance.get_fundamentals("NVDA", curr_date="2024-05-10")
+
+    for label in _STABLE_FIELD_LABELS:
+        assert f"{label}:" in out
+    assert "Point-in-time mode" in out
+    assert "Market Cap:" not in out
+
+
+@pytest.mark.unit
+def test_no_curr_date_preserves_live_snapshot_fields():
+    """Backwards compatibility: curr_date=None returns the full live snapshot."""
+    with _patch_ticker(_fake_info()):
+        out = y_finance.get_fundamentals("NVDA", curr_date=None)
+
+    for label in _LIVE_FIELD_LABELS + _STABLE_FIELD_LABELS:
+        assert f"{label}:" in out, f"{label!r} missing from live (no-curr_date) output"
+
+    assert "Point-in-time mode" not in out
+
+
+@pytest.mark.unit
+def test_today_preserves_live_snapshot_fields():
+    """curr_date == today is a *live* call and must not trip the historical guard."""
+    today = datetime.now().date().strftime("%Y-%m-%d")
+    with _patch_ticker(_fake_info()):
+        out = y_finance.get_fundamentals("NVDA", curr_date=today)
+
+    assert "Market Cap:" in out
+    assert "Point-in-time mode" not in out
+
+
+@pytest.mark.unit
+def test_future_curr_date_treated_as_live():
+    """A curr_date in the future is degenerate — fall back to live snapshot rather
+    than silently returning an empty 'point-in-time' view."""
+    future = (datetime.now().date() + timedelta(days=30)).strftime("%Y-%m-%d")
+    with _patch_ticker(_fake_info()):
+        out = y_finance.get_fundamentals("NVDA", curr_date=future)
+
+    assert "Market Cap:" in out
+    assert "Point-in-time mode" not in out
+
+
+@pytest.mark.unit
+def test_malformed_curr_date_treated_as_live():
+    """Invalid curr_date strings must not silently suppress fields — fall back to live."""
+    with _patch_ticker(_fake_info()):
+        out = y_finance.get_fundamentals("NVDA", curr_date="not-a-date")
+
+    assert "Market Cap:" in out
+    assert "Point-in-time mode" not in out
+
+
+@pytest.mark.unit
+def test_empty_info_payload():
+    """A None / empty info dict still produces a clean error string, not a crash."""
+    with _patch_ticker({}):
+        out = y_finance.get_fundamentals("NVDA", curr_date="2024-05-10")
+
+    assert "No fundamentals data found" in out

--- a/tradingagents/agents/utils/structured.py
+++ b/tradingagents/agents/utils/structured.py
@@ -14,11 +14,37 @@ canonical pattern:
 
 Centralising the pattern here keeps the agent factories small and ensures
 all three agents log the same warnings when fallback fires.
+
+----
+
+**Anthropic extended-thinking compatibility**
+
+Claude models served via Anthropic's API (directly or proxied through
+GitHub Copilot's OpenAI-compatible endpoint) reject any request that
+combines ``extended_thinking`` with a forced ``tool_choice``. Structured
+output via LangChain imposes ``tool_choice="any"`` to guarantee the model
+emits the schema, so the two features are mutually exclusive at the
+provider level — every structured call from a thinking-enabled Claude
+fails with::
+
+    400 - Thinking may not be enabled when tool_choice forces tool use.
+
+To preserve the structured plan (rather than silently degrading to free
+text), we detect this combination at bind time and build a *non-thinking
+twin* of the LLM specifically for structured calls. The original
+thinking-enabled LLM remains in use for everything else.
+
+The twin is built by copying the LLM with a model id that omits the
+effort suffix (``claude-opus-4.7-xhigh`` → ``claude-opus-4.7``). For
+direct ``ChatAnthropic`` instances we drop the ``thinking`` kwarg
+instead. If neither path applies we fall through to the original
+behaviour.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Callable, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -28,14 +54,87 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+# Effort suffixes Copilot encodes into Claude model ids. Order matters: we
+# strip the longest match first so ``claude-opus-4.7-xhigh`` doesn't get
+# truncated to ``claude-opus-4.7-x``.
+_THINKING_SUFFIXES = ("-xhigh", "-high", "-medium", "-low", "-minimal")
+
+_THINKING_SUFFIX_RE = re.compile(
+    r"-(?:xhigh|high|medium|low|minimal)$",
+    flags=re.IGNORECASE,
+)
+
+
+def _strip_thinking_suffix(model_name: str) -> str:
+    """Return ``model_name`` with any trailing effort suffix removed.
+
+    ``claude-opus-4.7-xhigh`` → ``claude-opus-4.7``. Returns the input
+    unchanged when no recognised suffix is present.
+    """
+    if not isinstance(model_name, str):
+        return model_name
+    return _THINKING_SUFFIX_RE.sub("", model_name)
+
+
+def _build_structured_twin(llm: Any) -> Any:
+    """Return a copy of ``llm`` configured to accept forced ``tool_choice``.
+
+    For Claude models served via Copilot (``ChatOpenAI`` with a
+    ``claude-*-{effort}`` model id) the twin uses the same model with the
+    effort suffix stripped, which causes Copilot to omit the
+    ``extended_thinking`` flag when proxying to Anthropic.
+
+    For direct ``ChatAnthropic`` instances the twin drops the ``thinking``
+    kwarg if present.
+
+    Returns the original LLM unchanged if no remediation applies.
+    """
+    model_attr = getattr(llm, "model_name", None) or getattr(llm, "model", None)
+    if not isinstance(model_attr, str):
+        return llm
+
+    is_claude = "claude" in model_attr.lower()
+    if not is_claude:
+        return llm
+
+    stripped = _strip_thinking_suffix(model_attr)
+    if stripped == model_attr:
+        # No effort suffix — assume thinking isn't forced on, leave LLM alone.
+        return llm
+
+    # pydantic v2 models expose ``model_copy``; LangChain LLMs are pydantic
+    # BaseModels so this works for both ChatOpenAI and ChatAnthropic.
+    try:
+        # ChatOpenAI uses ``model_name``; ChatAnthropic uses ``model``. Update
+        # whichever attribute the underlying LLM uses.
+        update_field = "model_name" if hasattr(llm, "model_name") else "model"
+        twin = llm.model_copy(update={update_field: stripped})
+        logger.info(
+            "Structured-output twin built for thinking-enabled Claude: %s -> %s",
+            model_attr, stripped,
+        )
+        return twin
+    except Exception as exc:  # noqa: BLE001 — fail-open to original LLM
+        logger.warning(
+            "Failed to build non-thinking twin for %s (%s); structured output "
+            "will likely fall back to free text on Anthropic provider.",
+            model_attr, exc,
+        )
+        return llm
+
+
 def bind_structured(llm: Any, schema: type[T], agent_name: str) -> Optional[Any]:
     """Return ``llm.with_structured_output(schema)`` or ``None`` if unsupported.
+
+    For thinking-enabled Claude models, transparently builds a
+    non-thinking twin so structured output works (see module docstring).
 
     Logs a warning when the binding fails so the user understands the agent
     will use free-text generation for every call instead of one-shot fallback.
     """
+    target = _build_structured_twin(llm)
     try:
-        return llm.with_structured_output(schema)
+        return target.with_structured_output(schema)
     except (NotImplementedError, AttributeError) as exc:
         logger.warning(
             "%s: provider does not support with_structured_output (%s); "

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -23,6 +23,20 @@ from .alpha_vantage import (
     get_global_news as get_alpha_vantage_global_news,
 )
 from .alpha_vantage_common import AlphaVantageRateLimitError
+from .polygon_finance import (
+    get_stock_data as get_polygon_stock_data,
+    get_indicators as get_polygon_indicators,
+    get_fundamentals as get_polygon_fundamentals,
+    get_balance_sheet as get_polygon_balance_sheet,
+    get_cashflow as get_polygon_cashflow,
+    get_income_statement as get_polygon_income_statement,
+)
+from .polygon_news import (
+    get_news as get_polygon_news,
+    get_global_news as get_polygon_global_news,
+    get_insider_transactions as get_polygon_insider_transactions,
+)
+from .polygon_common import PolygonError, PolygonRateLimitError
 
 # Configuration and routing logic
 from .config import get_config
@@ -61,6 +75,7 @@ TOOLS_CATEGORIES = {
 }
 
 VENDOR_LIST = [
+    "polygon",
     "yfinance",
     "alpha_vantage",
 ]
@@ -69,41 +84,50 @@ VENDOR_LIST = [
 VENDOR_METHODS = {
     # core_stock_apis
     "get_stock_data": {
+        "polygon": get_polygon_stock_data,
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
     },
     # technical_indicators
     "get_indicators": {
+        "polygon": get_polygon_indicators,
         "alpha_vantage": get_alpha_vantage_indicator,
         "yfinance": get_stock_stats_indicators_window,
     },
     # fundamental_data
     "get_fundamentals": {
+        "polygon": get_polygon_fundamentals,
         "alpha_vantage": get_alpha_vantage_fundamentals,
         "yfinance": get_yfinance_fundamentals,
     },
     "get_balance_sheet": {
+        "polygon": get_polygon_balance_sheet,
         "alpha_vantage": get_alpha_vantage_balance_sheet,
         "yfinance": get_yfinance_balance_sheet,
     },
     "get_cashflow": {
+        "polygon": get_polygon_cashflow,
         "alpha_vantage": get_alpha_vantage_cashflow,
         "yfinance": get_yfinance_cashflow,
     },
     "get_income_statement": {
+        "polygon": get_polygon_income_statement,
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
     },
     # news_data
     "get_news": {
+        "polygon": get_polygon_news,
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
     },
     "get_global_news": {
+        "polygon": get_polygon_global_news,
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
     },
     "get_insider_transactions": {
+        "polygon": get_polygon_insider_transactions,
         "alpha_vantage": get_alpha_vantage_insider_transactions,
         "yfinance": get_yfinance_insider_transactions,
     },
@@ -158,5 +182,21 @@ def route_to_vendor(method: str, *args, **kwargs):
             return impl_func(*args, **kwargs)
         except AlphaVantageRateLimitError:
             continue  # Only rate limits trigger fallback
+        except (PolygonRateLimitError, PolygonError):
+            # Polygon hard failures (rate limit, auth, network) trigger fallback
+            # to the next configured vendor so a transient outage doesn't kill
+            # an active run. Local data shape errors (e.g. missing concept keys)
+            # are caught inside the polygon module itself and returned as
+            # informative strings — those don't propagate as exceptions.
+            continue
+        except ValueError as exc:
+            # Missing API keys (e.g. ALPHA_VANTAGE_API_KEY not set) raise
+            # ValueError. Treat these as "vendor unavailable" and continue
+            # the fallback chain rather than crashing the whole call. Other
+            # ValueError causes (bad input args) would still surface from
+            # the final vendor in the chain.
+            if "API_KEY" in str(exc) or "api key" in str(exc).lower():
+                continue
+            raise
 
     raise RuntimeError(f"No available vendor for '{method}'")

--- a/tradingagents/dataflows/polygon_common.py
+++ b/tradingagents/dataflows/polygon_common.py
@@ -1,0 +1,173 @@
+"""Shared utilities for Polygon REST API access.
+
+Polygon is the preferred provider for point-in-time fundamentals (as-reported
+SEC filings filtered by ``filing_date.lt``) and split-adjusted historical bars.
+This module hosts the request helper, key resolution, in-process caching,
+rate-limit handling, and the shared error classes consumed by callers and the
+vendor router in :mod:`tradingagents.dataflows.interface`.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import threading
+import time
+from typing import Any
+
+import requests
+
+API_BASE_URL = "https://api.polygon.io"
+
+_TRANSIENT_HTTP_STATUSES = {429, 500, 502, 503, 504}
+_DEFAULT_TIMEOUT = 30
+_MAX_RETRIES = 4
+
+
+class PolygonError(Exception):
+    """Base error class for Polygon REST failures."""
+
+
+class PolygonRateLimitError(PolygonError):
+    """Raised when Polygon returns 429 or signals rate limit exhaustion.
+
+    Mirrors :class:`AlphaVantageRateLimitError` so the vendor router can
+    treat it as a fallback trigger.
+    """
+
+
+class PolygonAuthError(PolygonError):
+    """Raised when Polygon returns 401/403 — usually a bad/expired API key."""
+
+
+class PolygonNotFoundError(PolygonError):
+    """Raised when the requested resource (ticker, page) is missing."""
+
+
+def get_api_key() -> str:
+    api_key = os.getenv("POLYGON_API_KEY")
+    if not api_key:
+        raise PolygonError(
+            "POLYGON_API_KEY environment variable is not set. "
+            "Add it to .env or export it before invoking the agent pipeline."
+        )
+    return api_key
+
+
+_session_lock = threading.Lock()
+_session: requests.Session | None = None
+
+
+def _get_session() -> requests.Session:
+    global _session
+    with _session_lock:
+        if _session is None:
+            session = requests.Session()
+            session.headers.update({
+                "User-Agent": "trading_agents/polygon-client",
+                "Accept": "application/json",
+            })
+            _session = session
+        return _session
+
+
+def _sleep_backoff(attempt: int) -> None:
+    base = min(2 ** attempt, 16)
+    time.sleep(base + random.random())
+
+
+def _make_request(
+    path: str,
+    params: dict[str, Any] | None = None,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+    max_retries: int = _MAX_RETRIES,
+) -> dict[str, Any]:
+    """Issue a GET against ``API_BASE_URL + path``.
+
+    Retries on transient 5xx and 429 with exponential backoff. Returns the
+    JSON-decoded payload (Polygon always returns JSON).
+    """
+    api_params: dict[str, Any] = dict(params or {})
+    api_params["apiKey"] = get_api_key()
+    url = f"{API_BASE_URL}{path}"
+
+    session = _get_session()
+
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            response = session.get(url, params=api_params, timeout=timeout)
+        except requests.RequestException as exc:
+            last_exc = exc
+            _sleep_backoff(attempt)
+            continue
+
+        status = response.status_code
+
+        if status == 200:
+            try:
+                return response.json()
+            except ValueError as exc:
+                raise PolygonError(
+                    f"Polygon returned non-JSON 200 for {path}: {exc}"
+                ) from exc
+
+        if status in (401, 403):
+            raise PolygonAuthError(
+                f"Polygon auth failed for {path}: {status} {response.text[:200]}"
+            )
+
+        if status == 404:
+            raise PolygonNotFoundError(f"Polygon 404 for {path}: {response.text[:200]}")
+
+        if status in _TRANSIENT_HTTP_STATUSES:
+            if status == 429 and attempt == max_retries - 1:
+                raise PolygonRateLimitError(
+                    f"Polygon rate limit hit on {path} after {max_retries} attempts"
+                )
+            _sleep_backoff(attempt)
+            continue
+
+        raise PolygonError(
+            f"Polygon error {status} on {path}: {response.text[:200]}"
+        )
+
+    raise PolygonError(f"Polygon request failed after {max_retries} retries: {last_exc}")
+
+
+def paginated_results(
+    initial_path: str,
+    initial_params: dict[str, Any] | None = None,
+    *,
+    max_pages: int = 10,
+) -> list[dict[str, Any]]:
+    """Iterate Polygon's ``next_url``-style cursor pagination.
+
+    Returns the union of ``results`` arrays across all visited pages. Caps
+    at ``max_pages`` to bound runaway crawls (financials/news for a single
+    ticker rarely need more than 2-3 pages).
+    """
+    from urllib.parse import urlparse, parse_qs
+
+    out: list[dict[str, Any]] = []
+    payload = _make_request(initial_path, initial_params)
+    out.extend(payload.get("results") or [])
+
+    next_url = payload.get("next_url")
+    pages_visited = 1
+    while next_url and pages_visited < max_pages:
+        parsed = urlparse(next_url)
+        if not parsed.path:
+            break
+        # Strip apiKey from any prior url; _make_request will append a fresh one.
+        next_params: dict[str, Any] = {
+            k: v[0] if isinstance(v, list) and len(v) == 1 else v
+            for k, v in parse_qs(parsed.query).items()
+            if k != "apiKey"
+        }
+        payload = _make_request(parsed.path, next_params)
+        out.extend(payload.get("results") or [])
+        next_url = payload.get("next_url")
+        pages_visited += 1
+    return out

--- a/tradingagents/dataflows/polygon_finance.py
+++ b/tradingagents/dataflows/polygon_finance.py
@@ -1,0 +1,552 @@
+"""Polygon REST implementations for the trading-agents data layer.
+
+This module is the production-default replacement for the yfinance-based
+fundamentals path. Polygon's ``/vX/reference/financials`` endpoint returns
+as-reported SEC filings with both ``filing_date`` (when the filing became
+public) and ``period_of_report_date`` (the fiscal period end), enabling
+strict point-in-time semantics that yfinance's snapshot ``info`` cannot
+provide.
+
+Public surface intentionally mirrors :mod:`y_finance` so the vendor router
+in :mod:`interface` can swap between providers without touching call sites:
+
+* :func:`get_stock_data` — daily OHLCV bars over a date range (CSV string)
+* :func:`get_fundamentals` — overview/snapshot fundamentals at ``curr_date``
+* :func:`get_balance_sheet`, :func:`get_cashflow`, :func:`get_income_statement`
+  — point-in-time financial statements filtered by both filing date and
+  period end date
+* :func:`get_indicators` — technical indicators computed off Polygon bars
+  via ``stockstats``
+
+Forward-looking analyst projections (Forward EPS / PE / PEG) have no
+PIT-correct source on Polygon either; we omit them rather than fabricate.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from io import StringIO
+from typing import Annotated, Any
+
+import pandas as pd
+
+from .polygon_common import (
+    PolygonError,
+    PolygonNotFoundError,
+    _make_request,
+    paginated_results,
+)
+
+# --- helpers ----------------------------------------------------------------
+
+# When Polygon returns a financials row without a filing_date, fall back to
+# this many days after period_of_report_date as a conservative upper bound on
+# when the filing would have been public. SEC large-accelerated 10-Q deadline
+# is 40 days, 10-K is 60 days; 90 gives a safety margin while still excluding
+# rows whose period ended within the last quarter.
+_FILING_LAG_FALLBACK_DAYS = 90
+
+
+def _parse_date(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.strptime(s[:10], "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _is_pit_visible(entry: dict, curr_dt: datetime) -> bool:
+    """Decide whether a Polygon financials entry was public at ``curr_dt``.
+
+    Rule: filing_date strictly before curr_dt. If filing_date is missing,
+    accept only when period_of_report_date + 90d <= curr_dt (conservative).
+    Period-of-report alone is never sufficient — the filing happens later.
+    """
+    filing = _parse_date(entry.get("filing_date"))
+    if filing is not None:
+        return filing < curr_dt
+
+    period = _parse_date(entry.get("end_date") or entry.get("period_of_report_date"))
+    if period is None:
+        return False
+    return period + timedelta(days=_FILING_LAG_FALLBACK_DAYS) <= curr_dt
+
+
+def _financials_facts(
+    ticker: str,
+    *,
+    curr_date: str | None,
+    timeframe: str,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    """Fetch and PIT-filter financials entries.
+
+    timeframe: 'quarterly' or 'annual'
+    """
+    params: dict[str, Any] = {
+        "ticker": ticker.upper(),
+        "order": "desc",
+        "limit": str(limit),
+        "timeframe": timeframe,
+    }
+    if curr_date:
+        params["period_of_report_date.lt"] = curr_date
+        params["filing_date.lt"] = curr_date
+
+    try:
+        results = paginated_results("/vX/reference/financials", params, max_pages=2)
+    except PolygonNotFoundError:
+        return []
+
+    if not curr_date:
+        return results
+
+    curr_dt = _parse_date(curr_date)
+    if curr_dt is None:
+        return results
+
+    return [r for r in results if _is_pit_visible(r, curr_dt)]
+
+
+def _statement_to_csv(entries: list[dict[str, Any]], section: str) -> str:
+    """Convert a list of financials entries' ``section`` (e.g. 'balance_sheet')
+    into a CSV string with periods as columns and concept labels as rows.
+    """
+    if not entries:
+        return ""
+
+    columns: list[str] = []
+    by_concept: dict[str, dict[str, Any]] = {}
+
+    for entry in entries:
+        period_end = entry.get("end_date") or entry.get("period_of_report_date") or "unknown"
+        timeframe = entry.get("timeframe", "")
+        col_name = f"{period_end} ({timeframe})" if timeframe else period_end
+        columns.append(col_name)
+
+        section_data = (entry.get("financials") or {}).get(section) or {}
+        for concept_key, concept_payload in section_data.items():
+            if not isinstance(concept_payload, dict):
+                continue
+            label = concept_payload.get("label") or concept_key
+            value = concept_payload.get("value")
+            row = by_concept.setdefault(label, {})
+            row[col_name] = value
+
+    if not by_concept:
+        return ""
+
+    df = pd.DataFrame.from_dict(by_concept, orient="index", columns=columns)
+    df.index.name = "concept"
+    return df.to_csv()
+
+
+def _format_money(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if abs(v) >= 1e12:
+        return f"${v / 1e12:.2f}T"
+    if abs(v) >= 1e9:
+        return f"${v / 1e9:.2f}B"
+    if abs(v) >= 1e6:
+        return f"${v / 1e6:.2f}M"
+    return f"${v:,.2f}"
+
+
+def _ttm_sum(entries: list[dict[str, Any]], section: str, concept: str, n: int = 4) -> float | None:
+    """Sum the most recent ``n`` quarterly values of ``concept`` in ``section``.
+    Returns None if any value is missing (strict TTM)."""
+    quarterly = [e for e in entries if e.get("timeframe") == "quarterly"]
+    quarterly = quarterly[:n]
+    if len(quarterly) < n:
+        return None
+    total = 0.0
+    for e in quarterly:
+        s = (e.get("financials") or {}).get(section) or {}
+        v = (s.get(concept) or {}).get("value")
+        if v is None:
+            return None
+        try:
+            total += float(v)
+        except (TypeError, ValueError):
+            return None
+    return total
+
+
+def _latest_value(entries: list[dict[str, Any]], section: str, concept: str) -> float | None:
+    """Return the value of ``concept`` from the most recent entry, if present."""
+    for e in entries:
+        s = (e.get("financials") or {}).get(section) or {}
+        v = (s.get(concept) or {}).get("value")
+        if v is not None:
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _close_at(ticker: str, curr_date: str) -> float | None:
+    """Daily close at or before ``curr_date`` (split-adjusted)."""
+    curr_dt = _parse_date(curr_date)
+    if curr_dt is None:
+        return None
+    start = (curr_dt - timedelta(days=14)).strftime("%Y-%m-%d")
+    end = curr_date
+    try:
+        payload = _make_request(
+            f"/v2/aggs/ticker/{ticker.upper()}/range/1/day/{start}/{end}",
+            {"adjusted": "true", "sort": "desc", "limit": 30},
+        )
+    except PolygonError:
+        return None
+    bars = payload.get("results") or []
+    if not bars:
+        return None
+    return float(bars[0].get("c"))
+
+
+def _high_low_window(ticker: str, curr_date: str, days: int) -> tuple[float | None, float | None]:
+    curr_dt = _parse_date(curr_date)
+    if curr_dt is None:
+        return None, None
+    start = (curr_dt - timedelta(days=days)).strftime("%Y-%m-%d")
+    end = curr_date
+    try:
+        payload = _make_request(
+            f"/v2/aggs/ticker/{ticker.upper()}/range/1/day/{start}/{end}",
+            {"adjusted": "true", "sort": "asc", "limit": 50000},
+        )
+    except PolygonError:
+        return None, None
+    bars = payload.get("results") or []
+    if not bars:
+        return None, None
+    highs = [float(b.get("h")) for b in bars if b.get("h") is not None]
+    lows = [float(b.get("l")) for b in bars if b.get("l") is not None]
+    return (max(highs) if highs else None, min(lows) if lows else None)
+
+
+def _moving_average(ticker: str, curr_date: str, window: int) -> float | None:
+    curr_dt = _parse_date(curr_date)
+    if curr_dt is None:
+        return None
+    # Pad backwards to cover non-trading days
+    start = (curr_dt - timedelta(days=int(window * 1.6) + 14)).strftime("%Y-%m-%d")
+    end = curr_date
+    try:
+        payload = _make_request(
+            f"/v2/aggs/ticker/{ticker.upper()}/range/1/day/{start}/{end}",
+            {"adjusted": "true", "sort": "desc", "limit": int(window * 2 + 60)},
+        )
+    except PolygonError:
+        return None
+    bars = payload.get("results") or []
+    closes = [float(b.get("c")) for b in bars if b.get("c") is not None]
+    if len(closes) < window:
+        return None
+    return sum(closes[:window]) / window
+
+
+# --- public API -------------------------------------------------------------
+
+
+def get_stock_data(
+    symbol: Annotated[str, "ticker symbol of the company"],
+    start_date: Annotated[str, "Start date in yyyy-mm-dd format"],
+    end_date: Annotated[str, "End date in yyyy-mm-dd format"],
+) -> str:
+    """Fetch daily OHLCV bars from Polygon and return as CSV (yfinance-shape).
+
+    Bars are split-adjusted (``adjusted=true``) so historical highs/lows align
+    with current share counts — necessary for moving-average and 52-week
+    range calculations to be meaningful across split events.
+    """
+    datetime.strptime(start_date, "%Y-%m-%d")
+    datetime.strptime(end_date, "%Y-%m-%d")
+
+    try:
+        payload = _make_request(
+            f"/v2/aggs/ticker/{symbol.upper()}/range/1/day/{start_date}/{end_date}",
+            {"adjusted": "true", "sort": "asc", "limit": 50000},
+        )
+    except PolygonNotFoundError:
+        return f"No data found for symbol '{symbol}' between {start_date} and {end_date}"
+    except PolygonError as exc:
+        return f"Error retrieving data for {symbol}: {exc}"
+
+    bars = payload.get("results") or []
+    if not bars:
+        return f"No data found for symbol '{symbol}' between {start_date} and {end_date}"
+
+    rows = []
+    for bar in bars:
+        ts = bar.get("t")
+        if ts is None:
+            continue
+        date = datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d")
+        rows.append({
+            "Date": date,
+            "Open": round(float(bar.get("o", 0)), 2),
+            "High": round(float(bar.get("h", 0)), 2),
+            "Low": round(float(bar.get("l", 0)), 2),
+            "Close": round(float(bar.get("c", 0)), 2),
+            "Adj Close": round(float(bar.get("c", 0)), 2),
+            "Volume": int(bar.get("v", 0)),
+        })
+
+    df = pd.DataFrame(rows)
+    df.set_index("Date", inplace=True)
+
+    header = (
+        f"# Stock data for {symbol.upper()} from {start_date} to {end_date}\n"
+        f"# Total records: {len(df)}\n"
+        f"# Source: Polygon (split-adjusted)\n"
+        f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    )
+    return header + df.to_csv()
+
+
+def get_fundamentals(
+    ticker: Annotated[str, "ticker symbol of the company"],
+    curr_date: Annotated[
+        str,
+        "current date in YYYY-MM-DD format. Snapshot fields (Market Cap, P/E, "
+        "TTM ratios, 52-week ranges, moving averages) are computed point-in-time "
+        "from filings and bars available on or before this date.",
+    ] = None,
+) -> str:
+    """Build an overview fundamentals report for ``ticker`` at ``curr_date``.
+
+    Combines Polygon's ``/v3/reference/tickers`` (company metadata, shares,
+    SIC code), the latest PIT-visible financials, daily bar history (52w
+    range + moving averages), and derived TTM ratios. The market cap shown
+    is the as-of value from Polygon's reference data, which uses the share
+    count and price valid on ``curr_date`` — eliminating the split-adjustment
+    pitfalls the yfinance-derived path had on tickers like NVDA.
+    """
+    if not curr_date:
+        curr_date = datetime.utcnow().strftime("%Y-%m-%d")
+
+    out_lines: list[str] = []
+    derived_count = 0
+
+    # Reference data (name, sector, market cap, shares at date)
+    try:
+        ref = _make_request(
+            f"/v3/reference/tickers/{ticker.upper()}",
+            {"date": curr_date},
+        )
+        results = ref.get("results") or {}
+    except PolygonNotFoundError:
+        return f"No fundamentals data found for symbol '{ticker}'"
+    except PolygonError as exc:
+        return f"Error retrieving fundamentals for {ticker}: {exc}"
+
+    name = results.get("name")
+    if name:
+        out_lines.append(f"Name: {name}")
+    sic_desc = results.get("sic_description")
+    if sic_desc:
+        out_lines.append(f"Sector / SIC: {sic_desc}")
+    primary_exchange = results.get("primary_exchange")
+    if primary_exchange:
+        out_lines.append(f"Primary Exchange: {primary_exchange}")
+
+    market_cap = results.get("market_cap")
+    if market_cap:
+        out_lines.append(f"Market Cap: {_format_money(market_cap)}")
+        derived_count += 1
+    shares = results.get("share_class_shares_outstanding") or results.get("weighted_shares_outstanding")
+    if shares:
+        out_lines.append(f"Shares Outstanding: {int(shares):,}")
+        derived_count += 1
+
+    # Price + 52-week range
+    last_close = _close_at(ticker, curr_date)
+    if last_close is not None:
+        out_lines.append(f"Last Close (≤ {curr_date}): ${last_close:.2f}")
+        derived_count += 1
+    high52, low52 = _high_low_window(ticker, curr_date, 365)
+    if high52 is not None and low52 is not None:
+        out_lines.append(f"52-Week High: ${high52:.2f}")
+        out_lines.append(f"52-Week Low: ${low52:.2f}")
+        derived_count += 2
+    sma50 = _moving_average(ticker, curr_date, 50)
+    sma200 = _moving_average(ticker, curr_date, 200)
+    if sma50 is not None:
+        out_lines.append(f"50-Day Moving Average: ${sma50:.2f}")
+        derived_count += 1
+    if sma200 is not None:
+        out_lines.append(f"200-Day Moving Average: ${sma200:.2f}")
+        derived_count += 1
+
+    # Quarterly financials (TTM)
+    quarterlies = _financials_facts(ticker, curr_date=curr_date, timeframe="quarterly", limit=8)
+
+    revenue_ttm = _ttm_sum(quarterlies, "income_statement", "revenues")
+    net_income_ttm = _ttm_sum(quarterlies, "income_statement", "net_income_loss")
+    op_income_ttm = _ttm_sum(quarterlies, "income_statement", "operating_income_loss")
+    diluted_eps_ttm = _ttm_sum(quarterlies, "income_statement", "diluted_earnings_per_share")
+    basic_eps_ttm = _ttm_sum(quarterlies, "income_statement", "basic_earnings_per_share")
+    op_cash_ttm = _ttm_sum(quarterlies, "cash_flow_statement", "net_cash_flow_from_operating_activities")
+    capex_ttm = _ttm_sum(quarterlies, "cash_flow_statement", "net_cash_flow_from_investing_activities_continuing")
+    gross_profit_ttm = _ttm_sum(quarterlies, "income_statement", "gross_profit")
+
+    if revenue_ttm is not None:
+        out_lines.append(f"Revenue (TTM): {_format_money(revenue_ttm)}")
+        derived_count += 1
+    if gross_profit_ttm is not None:
+        out_lines.append(f"Gross Profit (TTM): {_format_money(gross_profit_ttm)}")
+        if revenue_ttm:
+            out_lines.append(f"Gross Margin (TTM): {gross_profit_ttm / revenue_ttm * 100:.1f}%")
+        derived_count += 1
+    if op_income_ttm is not None:
+        out_lines.append(f"Operating Income (TTM): {_format_money(op_income_ttm)}")
+        if revenue_ttm:
+            out_lines.append(f"Operating Margin (TTM): {op_income_ttm / revenue_ttm * 100:.1f}%")
+        derived_count += 1
+    if net_income_ttm is not None:
+        out_lines.append(f"Net Income (TTM): {_format_money(net_income_ttm)}")
+        if revenue_ttm:
+            out_lines.append(f"Profit Margin (TTM): {net_income_ttm / revenue_ttm * 100:.1f}%")
+        derived_count += 1
+
+    # Diluted EPS TTM and PE
+    eps_ttm = diluted_eps_ttm if diluted_eps_ttm is not None else basic_eps_ttm
+    if eps_ttm is not None:
+        out_lines.append(f"EPS (TTM): {eps_ttm:.2f}")
+        derived_count += 1
+        if last_close and eps_ttm > 0:
+            out_lines.append(f"P/E (TTM): {last_close / eps_ttm:.2f}")
+            derived_count += 1
+
+    # Cash flow detail
+    if op_cash_ttm is not None:
+        out_lines.append(f"Operating Cash Flow (TTM): {_format_money(op_cash_ttm)}")
+        derived_count += 1
+
+    # Latest balance sheet snapshot (most recent quarterly)
+    cash = _latest_value(quarterlies, "balance_sheet", "cash_and_equivalents") \
+        or _latest_value(quarterlies, "balance_sheet", "cash")
+    debt = _latest_value(quarterlies, "balance_sheet", "long_term_debt") \
+        or _latest_value(quarterlies, "balance_sheet", "noncurrent_liabilities")
+    total_equity = _latest_value(quarterlies, "balance_sheet", "equity") \
+        or _latest_value(quarterlies, "balance_sheet", "stockholders_equity")
+    total_assets = _latest_value(quarterlies, "balance_sheet", "assets")
+
+    if cash is not None:
+        out_lines.append(f"Cash & Equivalents (latest): {_format_money(cash)}")
+        derived_count += 1
+    if debt is not None:
+        out_lines.append(f"Long-Term Debt (latest): {_format_money(debt)}")
+        derived_count += 1
+    if total_assets is not None:
+        out_lines.append(f"Total Assets (latest): {_format_money(total_assets)}")
+        derived_count += 1
+    if total_equity is not None:
+        out_lines.append(f"Stockholders' Equity (latest): {_format_money(total_equity)}")
+        derived_count += 1
+        if net_income_ttm is not None and total_equity > 0:
+            out_lines.append(f"Return on Equity (TTM/avg equity ≈ latest): {net_income_ttm / total_equity * 100:.1f}%")
+            derived_count += 1
+
+    # Reporting period reference
+    if quarterlies:
+        latest = quarterlies[0]
+        period_end = latest.get("end_date") or latest.get("period_of_report_date")
+        filing_date = latest.get("filing_date")
+        if filing_date:
+            out_lines.append(
+                f"Most recent fiscal period: {period_end} (filed {filing_date})"
+            )
+        else:
+            out_lines.append(
+                f"Most recent fiscal period: {period_end} "
+                f"(filing date not reported by Polygon — visibility inferred from "
+                f"period_of_report + 90-day filing-lag fallback)"
+            )
+
+    header = (
+        f"# Company Fundamentals for {ticker.upper()}\n"
+        f"# Source: Polygon (point-in-time as of {curr_date})\n"
+        f"# {derived_count} fields derived from filings & bars available on or before {curr_date}\n"
+        f"# Forward-looking analyst projections (Forward EPS / PE / PEG) intentionally omitted —\n"
+        f"#   no PIT-correct source.\n"
+        f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    )
+    return header + "\n".join(out_lines)
+
+
+def _statement_report(
+    ticker: str,
+    section: str,
+    label: str,
+    freq: str,
+    curr_date: str | None,
+) -> str:
+    timeframe = "annual" if (freq or "").lower() == "annual" else "quarterly"
+    entries = _financials_facts(ticker, curr_date=curr_date, timeframe=timeframe, limit=8)
+    csv_string = _statement_to_csv(entries, section)
+    if not csv_string:
+        return f"No {label.lower()} data found for symbol '{ticker}'"
+    header = (
+        f"# {label} data for {ticker.upper()} ({timeframe})\n"
+        f"# Source: Polygon (point-in-time, filings public on or before {curr_date or 'latest'})\n"
+        f"# Periods returned: {len(entries)}\n"
+        f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    )
+    return header + csv_string
+
+
+def get_balance_sheet(
+    ticker: Annotated[str, "ticker symbol of the company"],
+    freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    return _statement_report(ticker, "balance_sheet", "Balance Sheet", freq, curr_date)
+
+
+def get_cashflow(
+    ticker: Annotated[str, "ticker symbol of the company"],
+    freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    return _statement_report(ticker, "cash_flow_statement", "Cash Flow", freq, curr_date)
+
+
+def get_income_statement(
+    ticker: Annotated[str, "ticker symbol of the company"],
+    freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    return _statement_report(ticker, "income_statement", "Income Statement", freq, curr_date)
+
+
+def get_indicators(
+    symbol: Annotated[str, "ticker symbol"],
+    indicator: Annotated[str, "technical indicator key"],
+    curr_date: Annotated[str, "current trading date in YYYY-MM-DD"],
+    look_back_days: Annotated[int, "how many days to look back"],
+) -> str:
+    """Compute indicators by reusing the stockstats path against Polygon bars.
+
+    The stockstats indicator window report itself is vendor-agnostic — it
+    delegates to :func:`stockstats_utils.load_ohlcv`, which we patched to
+    dispatch on the configured vendor. So we just call the existing
+    ``get_stock_stats_indicators_window`` helper; bars come from Polygon
+    automatically when ``core_stock_apis = polygon``.
+    """
+    from .y_finance import get_stock_stats_indicators_window
+
+    return get_stock_stats_indicators_window(
+        symbol=symbol,
+        indicator=indicator,
+        curr_date=curr_date,
+        look_back_days=look_back_days,
+    )

--- a/tradingagents/dataflows/polygon_news.py
+++ b/tradingagents/dataflows/polygon_news.py
@@ -1,0 +1,132 @@
+"""Polygon news + insider-transactions endpoints.
+
+Both endpoints accept date-range filters and date-stamped responses, making
+them strict-PIT for backtest replay. ``get_news`` and ``get_global_news``
+mirror the yfinance-side signatures so the vendor router can swap providers
+without touching agent code.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Annotated, Any
+
+from .polygon_common import (
+    PolygonError,
+    PolygonNotFoundError,
+    _make_request,
+    paginated_results,
+)
+
+
+def _format_news_entries(entries: list[dict[str, Any]], header_label: str) -> str:
+    if not entries:
+        return f"# {header_label}\n# No news found in the requested window\n"
+
+    lines = [f"# {header_label}", f"# Source: Polygon", f"# Total items: {len(entries)}\n"]
+    for item in entries:
+        published = item.get("published_utc", "")
+        title = item.get("title", "(untitled)")
+        publisher_obj = item.get("publisher") or {}
+        publisher = publisher_obj.get("name", "Unknown") if isinstance(publisher_obj, dict) else str(publisher_obj)
+        url = item.get("article_url") or item.get("url") or ""
+        description = item.get("description", "") or ""
+        # Trim long descriptions to keep the prompt reasonably sized
+        if len(description) > 500:
+            description = description[:500].rsplit(" ", 1)[0] + "..."
+        keywords = ", ".join(item.get("keywords", []) or [])
+
+        lines.append(f"## {title}")
+        lines.append(f"- Published: {published}")
+        lines.append(f"- Publisher: {publisher}")
+        if keywords:
+            lines.append(f"- Keywords: {keywords}")
+        if url:
+            lines.append(f"- URL: {url}")
+        if description:
+            lines.append(f"- Summary: {description}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _date_window(curr_date: str | None, lookback_days: int = 7) -> tuple[str, str]:
+    """Default to a 7-day window ending on curr_date (or today)."""
+    if curr_date:
+        end_dt = datetime.strptime(curr_date[:10], "%Y-%m-%d")
+    else:
+        end_dt = datetime.utcnow()
+    start_dt = end_dt - timedelta(days=lookback_days)
+    return start_dt.strftime("%Y-%m-%d"), end_dt.strftime("%Y-%m-%d")
+
+
+def get_news(
+    ticker: Annotated[str, "ticker symbol"],
+    start_date: Annotated[str, "Start date in yyyy-mm-dd format"],
+    end_date: Annotated[str, "End date in yyyy-mm-dd format"],
+) -> str:
+    """Fetch ticker-specific news from Polygon's news endpoint.
+
+    Filters to articles published in ``[start_date, end_date)`` (PIT-safe
+    when the caller passes a backtest-aware end_date).
+    """
+    params: dict[str, Any] = {
+        "ticker": ticker.upper(),
+        "published_utc.gte": start_date,
+        "published_utc.lt": end_date,
+        "order": "desc",
+        "limit": 50,
+    }
+    try:
+        results = paginated_results("/v2/reference/news", params, max_pages=2)
+    except PolygonNotFoundError:
+        return f"No news found for {ticker} between {start_date} and {end_date}"
+    except PolygonError as exc:
+        return f"Error retrieving news for {ticker}: {exc}"
+
+    return _format_news_entries(
+        results,
+        f"News for {ticker.upper()} from {start_date} to {end_date}",
+    )
+
+
+def get_global_news(
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"],
+    look_back_days: Annotated[int, "how many days of news to fetch"] = 7,
+    limit: Annotated[int, "max articles to return"] = 10,
+) -> str:
+    """Fetch broad market news (no ticker filter) from Polygon."""
+    start_date, end_date = _date_window(curr_date, look_back_days)
+
+    params: dict[str, Any] = {
+        "published_utc.gte": start_date,
+        "published_utc.lt": end_date,
+        "order": "desc",
+        "limit": min(int(limit) * 5, 50),  # over-fetch then trim to limit
+    }
+    try:
+        results = paginated_results("/v2/reference/news", params, max_pages=2)
+    except PolygonError as exc:
+        return f"Error retrieving global news: {exc}"
+
+    return _format_news_entries(
+        results[: int(limit)],
+        f"Global market news from {start_date} to {end_date}",
+    )
+
+
+def get_insider_transactions(
+    ticker: Annotated[str, "ticker symbol"],
+) -> str:
+    """Insider Form-4 transactions from Polygon.
+
+    Polygon's Stocks Starter plan does not include the SEC insider
+    transactions endpoint; this raises :class:`PolygonError` so the vendor
+    router transparently falls through to alpha_vantage / yfinance instead
+    of returning an empty payload that downstream agents would have to
+    parse around.
+    """
+    raise PolygonError(
+        "Polygon insider transactions endpoint requires Insider Transactions "
+        "add-on — falling back to next vendor"
+    )

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -44,40 +44,104 @@ def _clean_dataframe(data: pd.DataFrame) -> pd.DataFrame:
     return data
 
 
+def _load_ohlcv_polygon(symbol: str, curr_date_dt: pd.Timestamp) -> pd.DataFrame:
+    """Fetch OHLCV bars from Polygon for the cached historical window.
+
+    Returns a DataFrame in the same shape as yfinance: ``Date, Open, High,
+    Low, Close, Volume`` columns. Bars are split-adjusted; bars on or after
+    ``curr_date_dt`` are filtered by the caller.
+    """
+    from .polygon_common import _make_request, PolygonError
+
+    today_date = pd.Timestamp.today()
+    start_date = today_date - pd.DateOffset(years=5)
+    start_str = start_date.strftime("%Y-%m-%d")
+    end_str = today_date.strftime("%Y-%m-%d")
+
+    payload = _make_request(
+        f"/v2/aggs/ticker/{symbol.upper()}/range/1/day/{start_str}/{end_str}",
+        {"adjusted": "true", "sort": "asc", "limit": 50000},
+    )
+    bars = payload.get("results") or []
+
+    rows = []
+    for bar in bars:
+        ts = bar.get("t")
+        if ts is None:
+            continue
+        rows.append({
+            "Date": pd.Timestamp(ts, unit="ms"),
+            "Open": bar.get("o"),
+            "High": bar.get("h"),
+            "Low": bar.get("l"),
+            "Close": bar.get("c"),
+            "Volume": bar.get("v"),
+        })
+    return pd.DataFrame(rows)
+
+
 def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     """Fetch OHLCV data with caching, filtered to prevent look-ahead bias.
 
-    Downloads 15 years of data up to today and caches per symbol. On
-    subsequent calls the cache is reused. Rows after curr_date are
-    filtered out so backtests never see future prices.
+    Dispatches on the configured ``core_stock_apis`` vendor: ``polygon`` uses
+    Polygon's split-adjusted aggregates endpoint, ``yfinance`` uses
+    ``yf.download``. Both paths cache to disk per ``(symbol, vendor)`` and
+    filter rows after ``curr_date`` so backtests never see future prices.
     """
     config = get_config()
     curr_date_dt = pd.to_datetime(curr_date)
 
-    # Cache uses a fixed window (15y to today) so one file per symbol
+    # Determine vendor for bars. Tool-level override takes precedence, then
+    # the core_stock_apis category.
+    vendor = (
+        config.get("tool_vendors", {}).get("get_stock_data")
+        or config.get("data_vendors", {}).get("core_stock_apis", "yfinance")
+    )
+    primary_vendor = vendor.split(",")[0].strip() if isinstance(vendor, str) else "yfinance"
+
     today_date = pd.Timestamp.today()
     start_date = today_date - pd.DateOffset(years=5)
     start_str = start_date.strftime("%Y-%m-%d")
     end_str = today_date.strftime("%Y-%m-%d")
 
     os.makedirs(config["data_cache_dir"], exist_ok=True)
+    # Cache key includes vendor so switching providers doesn't return stale
+    # files written by the other one.
+    cache_tag = "Polygon" if primary_vendor == "polygon" else "YFin"
     data_file = os.path.join(
         config["data_cache_dir"],
-        f"{symbol}-YFin-data-{start_str}-{end_str}.csv",
+        f"{symbol}-{cache_tag}-data-{start_str}-{end_str}.csv",
     )
 
     if os.path.exists(data_file):
         data = pd.read_csv(data_file, on_bad_lines="skip", encoding="utf-8")
     else:
-        data = yf_retry(lambda: yf.download(
-            symbol,
-            start=start_str,
-            end=end_str,
-            multi_level_index=False,
-            progress=False,
-            auto_adjust=True,
-        ))
-        data = data.reset_index()
+        if primary_vendor == "polygon":
+            try:
+                data = _load_ohlcv_polygon(symbol, curr_date_dt)
+            except Exception as exc:
+                logger.warning(
+                    f"Polygon bar fetch failed for {symbol} ({exc}); falling back to yfinance"
+                )
+                data = yf_retry(lambda: yf.download(
+                    symbol,
+                    start=start_str,
+                    end=end_str,
+                    multi_level_index=False,
+                    progress=False,
+                    auto_adjust=True,
+                ))
+                data = data.reset_index()
+        else:
+            data = yf_retry(lambda: yf.download(
+                symbol,
+                start=start_str,
+                end=end_str,
+                multi_level_index=False,
+                progress=False,
+                auto_adjust=True,
+            ))
+            data = data.reset_index()
         data.to_csv(data_file, index=False, encoding="utf-8")
 
     data = _clean_dataframe(data)

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -5,6 +5,7 @@ import pandas as pd
 import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
+from .yf_pit_derivations import derive_pit_fundamentals
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
@@ -245,11 +246,91 @@ def get_stockstats_indicator(
     return str(indicator_value)
 
 
+# Fields in `Ticker.info` that yfinance always returns at *live* values
+# (current price-derived, current market cap, TTM ratios computed off the
+# trailing window ending today). When the caller requests a historical
+# `curr_date`, these are look-ahead data and must be omitted.
+_YF_LIVE_SNAPSHOT_FIELDS = (
+    ("Market Cap", "marketCap"),
+    ("PE Ratio (TTM)", "trailingPE"),
+    ("Forward PE", "forwardPE"),
+    ("PEG Ratio", "pegRatio"),
+    ("Price to Book", "priceToBook"),
+    ("EPS (TTM)", "trailingEps"),
+    ("Forward EPS", "forwardEps"),
+    ("Dividend Yield", "dividendYield"),
+    ("52 Week High", "fiftyTwoWeekHigh"),
+    ("52 Week Low", "fiftyTwoWeekLow"),
+    ("50 Day Average", "fiftyDayAverage"),
+    ("200 Day Average", "twoHundredDayAverage"),
+    ("Revenue (TTM)", "totalRevenue"),
+    ("Gross Profit", "grossProfits"),
+    ("EBITDA", "ebitda"),
+    ("Net Income", "netIncomeToCommon"),
+    ("Profit Margin", "profitMargins"),
+    ("Operating Margin", "operatingMargins"),
+    ("Return on Equity", "returnOnEquity"),
+    ("Return on Assets", "returnOnAssets"),
+    ("Debt to Equity", "debtToEquity"),
+    ("Current Ratio", "currentRatio"),
+    ("Book Value", "bookValue"),
+    ("Free Cash Flow", "freeCashflow"),
+)
+
+# Structural facts that don't materially change across historical dates.
+_YF_STABLE_FIELDS = (
+    ("Name", "longName"),
+    ("Sector", "sector"),
+    ("Industry", "industry"),
+    ("Beta", "beta"),
+)
+
+
+def _is_historical_curr_date(curr_date):
+    """Return True iff curr_date is a parseable date strictly before today."""
+    if not curr_date:
+        return False
+    try:
+        curr_dt = datetime.strptime(curr_date, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return False
+    return curr_dt < datetime.now().date()
+
+
 def get_fundamentals(
     ticker: Annotated[str, "ticker symbol of the company"],
-    curr_date: Annotated[str, "current date (not used for yfinance)"] = None
+    curr_date: Annotated[
+        str,
+        "current date in YYYY-MM-DD format. When in the past, live snapshot "
+        "fields (Market Cap, P/E, TTM ratios, 52-week ranges) are reconstructed "
+        "point-in-time from historical statements and price bars to prevent "
+        "look-ahead bias.",
+    ] = None,
 ):
-    """Get company fundamentals overview from yfinance."""
+    """Get company fundamentals overview from yfinance.
+
+    yfinance's ``Ticker.info`` always returns *live* values (current price,
+    current market cap, TTM ratios computed off the trailing window ending
+    today) regardless of the requested ``curr_date``. When ``curr_date`` is
+    in the past this function returns:
+
+    * stable structural fields (name, sector, industry, beta) from
+      ``Ticker.info`` — these don't materially vary across historical dates;
+    * snapshot fields (Market Cap, P/E, TTM revenue/income/FCF, margins,
+      ROE/ROA, 52-week ranges, moving averages, dividend yield) reconstructed
+      PIT-correctly from ``Ticker.history``, the quarterly statements, and
+      ``get_shares_full`` — see :mod:`yf_pit_derivations`.
+
+    Forward-looking fields (Forward EPS, Forward P/E, PEG Ratio) are not
+    reconstructed: they are analyst projections, not historical fact, and
+    have no PIT-correct yfinance source.
+
+    A header note flags PIT mode so downstream agents can reason about the
+    reconstruction explicitly. For point-in-time financial *statements*, use
+    :func:`get_income_statement`, :func:`get_balance_sheet`, and
+    :func:`get_cashflow`, which already filter by fiscal period via
+    ``filter_financials_by_date``.
+    """
     try:
         ticker_obj = yf.Ticker(ticker.upper())
         info = yf_retry(lambda: ticker_obj.info)
@@ -257,44 +338,48 @@ def get_fundamentals(
         if not info:
             return f"No fundamentals data found for symbol '{ticker}'"
 
-        fields = [
-            ("Name", info.get("longName")),
-            ("Sector", info.get("sector")),
-            ("Industry", info.get("industry")),
-            ("Market Cap", info.get("marketCap")),
-            ("PE Ratio (TTM)", info.get("trailingPE")),
-            ("Forward PE", info.get("forwardPE")),
-            ("PEG Ratio", info.get("pegRatio")),
-            ("Price to Book", info.get("priceToBook")),
-            ("EPS (TTM)", info.get("trailingEps")),
-            ("Forward EPS", info.get("forwardEps")),
-            ("Dividend Yield", info.get("dividendYield")),
-            ("Beta", info.get("beta")),
-            ("52 Week High", info.get("fiftyTwoWeekHigh")),
-            ("52 Week Low", info.get("fiftyTwoWeekLow")),
-            ("50 Day Average", info.get("fiftyDayAverage")),
-            ("200 Day Average", info.get("twoHundredDayAverage")),
-            ("Revenue (TTM)", info.get("totalRevenue")),
-            ("Gross Profit", info.get("grossProfits")),
-            ("EBITDA", info.get("ebitda")),
-            ("Net Income", info.get("netIncomeToCommon")),
-            ("Profit Margin", info.get("profitMargins")),
-            ("Operating Margin", info.get("operatingMargins")),
-            ("Return on Equity", info.get("returnOnEquity")),
-            ("Return on Assets", info.get("returnOnAssets")),
-            ("Debt to Equity", info.get("debtToEquity")),
-            ("Current Ratio", info.get("currentRatio")),
-            ("Book Value", info.get("bookValue")),
-            ("Free Cash Flow", info.get("freeCashflow")),
-        ]
+        is_historical = _is_historical_curr_date(curr_date)
 
         lines = []
-        for label, value in fields:
+
+        for label, key in _YF_STABLE_FIELDS:
+            value = info.get(key)
             if value is not None:
                 lines.append(f"{label}: {value}")
 
+        derived: dict = {}
+        if is_historical:
+            try:
+                derived = derive_pit_fundamentals(ticker_obj, curr_date) or {}
+            except Exception:
+                derived = {}
+
+            for label, _key in _YF_LIVE_SNAPSHOT_FIELDS:
+                if label in derived:
+                    lines.append(f"{label}: {derived[label]}")
+        else:
+            for label, key in _YF_LIVE_SNAPSHOT_FIELDS:
+                value = info.get(key)
+                if value is not None:
+                    lines.append(f"{label}: {value}")
+
         header = f"# Company Fundamentals for {ticker.upper()}\n"
-        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        if is_historical:
+            num_derived = sum(1 for label, _ in _YF_LIVE_SNAPSHOT_FIELDS if label in derived)
+            header += (
+                f"# Point-in-time mode (curr_date={curr_date}): snapshot fields "
+                f"reconstructed\n"
+                f"#   from historical price bars, quarterly statements, and "
+                f"share-count series\n"
+                f"#   ({num_derived} of {len(_YF_LIVE_SNAPSHOT_FIELDS)} fields "
+                f"derived; missing entries\n"
+                f"#   indicate sparse data for this date).\n"
+                f"# Forward-looking analyst projections (Forward EPS, Forward "
+                f"P/E, PEG Ratio)\n"
+                f"#   are intentionally omitted — no PIT-correct source.\n"
+            )
+        header += "\n"
 
         return header + "\n".join(lines)
 

--- a/tradingagents/dataflows/yf_pit_derivations.py
+++ b/tradingagents/dataflows/yf_pit_derivations.py
@@ -1,0 +1,288 @@
+"""Point-in-time reconstruction of yfinance ``Ticker.info`` snapshot fields.
+
+``yfinance.Ticker.info`` always returns *live* values (current market cap,
+TTM ratios, 52-week ranges, moving averages, dividend yield) regardless of
+the historical date a backtest is simulating. ``y_finance.get_fundamentals``
+addresses the look-ahead bug by omitting those fields on historical calls.
+
+This module *reconstructs* the same fields PIT-correctly from data
+yfinance does expose with proper time indexing:
+
+* ``Ticker.history(start, end)`` — daily OHLCV bars (price-derived ranges,
+  moving averages, market cap close).
+* ``Ticker.quarterly_income_stmt`` / ``.quarterly_balance_sheet`` /
+  ``.quarterly_cashflow`` — fiscal-period-indexed statements (TTM sums,
+  point-in-time stocks, derived ratios).
+* ``Ticker.get_shares_full(start, end)`` — historical share count series.
+* ``Ticker.dividends`` — date-indexed per-share dividend payments.
+
+Forward-looking fields (Forward EPS, Forward P/E, PEG Ratio) are
+intentionally not reconstructed — they are analyst projections, not
+historical fact, and have no PIT-correct yfinance source.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+
+# yfinance row labels for each statement line item often vary by ticker /
+# statement vintage. We accept the first match against a list of synonyms.
+_INCOME_KEYS = {
+    "revenue": ["Total Revenue", "TotalRevenue"],
+    "gross_profit": ["Gross Profit", "GrossProfit"],
+    "operating_income": [
+        "Operating Income",
+        "OperatingIncome",
+        "Total Operating Income As Reported",
+    ],
+    "net_income": [
+        "Net Income",
+        "Net Income Common Stockholders",
+        "NetIncome",
+        "Net Income From Continuing Operation Net Minority Interest",
+        "Net Income Continuous Operations",
+    ],
+    "ebitda": ["EBITDA", "Normalized EBITDA"],
+}
+
+_BALANCE_KEYS = {
+    "total_assets": ["Total Assets"],
+    "total_equity": [
+        "Stockholders Equity",
+        "Common Stock Equity",
+        "Total Equity Gross Minority Interest",
+    ],
+    "total_debt": ["Total Debt", "Net Debt"],
+    "current_assets": ["Current Assets", "Total Current Assets"],
+    "current_liabilities": ["Current Liabilities", "Total Current Liabilities"],
+}
+
+_CASHFLOW_KEYS = {
+    "free_cash_flow": ["Free Cash Flow", "FreeCashFlow"],
+}
+
+
+def _strip_tz(idx):
+    """yfinance sometimes returns tz-aware indexes; PIT comparisons need naive."""
+    try:
+        if getattr(idx, "tz", None) is not None:
+            return idx.tz_localize(None)
+    except (AttributeError, TypeError):
+        pass
+    return idx
+
+
+def _first_match(df: Optional[pd.DataFrame], keys):
+    if df is None or not isinstance(df, pd.DataFrame) or df.empty:
+        return None
+    for k in keys:
+        if k in df.index:
+            return df.loc[k]
+    return None
+
+
+def _ttm_sum(df, synonyms, curr_date) -> Optional[float]:
+    """Sum the four most-recent quarterly values whose period ends on or
+    before ``curr_date``. Returns ``None`` if fewer than four are available
+    or any of those four are NaN — partial TTM is worse than no TTM."""
+    row = _first_match(df, synonyms)
+    if row is None:
+        return None
+    cutoff = pd.Timestamp(curr_date)
+    cols = [pd.Timestamp(c) for c in row.index if pd.notna(c)]
+    cols = [c for c in cols if c <= cutoff]
+    if len(cols) < 4:
+        return None
+    last4 = sorted(cols, reverse=True)[:4]
+    vals = [row[c] for c in last4]
+    if any(pd.isna(v) for v in vals):
+        return None
+    return float(sum(vals))
+
+
+def _latest_le(df, synonyms, curr_date) -> Optional[float]:
+    """Most recent point-in-time value of a balance-sheet line item with
+    period ending on or before ``curr_date``."""
+    row = _first_match(df, synonyms)
+    if row is None:
+        return None
+    cutoff = pd.Timestamp(curr_date)
+    cols = [pd.Timestamp(c) for c in row.index if pd.notna(c) and pd.Timestamp(c) <= cutoff]
+    if not cols:
+        return None
+    latest = max(cols)
+    val = row[latest]
+    return float(val) if pd.notna(val) else None
+
+
+def _close_at(history: pd.DataFrame, curr_date) -> Optional[float]:
+    """Most recent close on or before ``curr_date``."""
+    if history is None or history.empty or "Close" not in history.columns:
+        return None
+    h = history.copy()
+    h.index = _strip_tz(h.index)
+    cutoff = pd.Timestamp(curr_date)
+    bars = h[h.index <= cutoff]
+    if bars.empty:
+        return None
+    val = bars["Close"].iloc[-1]
+    return float(val) if pd.notna(val) else None
+
+
+def _shares_at(shares, curr_date) -> Optional[float]:
+    """Share count on or before ``curr_date``. yfinance's ``get_shares_full``
+    returns a Series indexed by datetime."""
+    if shares is None or len(shares) == 0:
+        return None
+    s = shares.copy()
+    s.index = _strip_tz(s.index)
+    cutoff = pd.Timestamp(curr_date)
+    s = s[s.index <= cutoff]
+    if s.empty:
+        return None
+    val = s.iloc[-1]
+    return float(val) if pd.notna(val) else None
+
+
+def _safe_div(num, den):
+    if num is None or den is None or den == 0:
+        return None
+    return num / den
+
+
+def derive_pit_fundamentals(ticker_obj, curr_date: str) -> dict:
+    """Reconstruct fundamental snapshot fields PIT-correctly.
+
+    Returns a dict keyed by the same human-readable labels
+    ``y_finance.get_fundamentals`` uses for live mode. Only fields that
+    could be successfully derived appear; sparse/missing inputs degrade
+    gracefully (one missing field does not poison the rest).
+
+    Forward-looking analyst projections (Forward EPS, Forward P/E, PEG)
+    are intentionally absent — there is no PIT-correct yfinance source
+    for analyst estimates as-of a historical date.
+    """
+    cutoff = pd.Timestamp(curr_date)
+    lookback_start = cutoff - pd.Timedelta(days=400)
+
+    def _safe_call(fn, *args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception:
+            return None
+
+    def _safe_attr(name):
+        try:
+            return getattr(ticker_obj, name)
+        except Exception:
+            return None
+
+    history = _safe_call(
+        ticker_obj.history,
+        start=lookback_start.strftime("%Y-%m-%d"),
+        end=(cutoff + pd.Timedelta(days=1)).strftime("%Y-%m-%d"),
+    )
+    if history is None:
+        history = pd.DataFrame()
+
+    income = _safe_attr("quarterly_income_stmt")
+    balance = _safe_attr("quarterly_balance_sheet")
+    cashflow = _safe_attr("quarterly_cashflow")
+    shares = _safe_call(
+        ticker_obj.get_shares_full,
+        start=lookback_start,
+        end=cutoff + pd.Timedelta(days=1),
+    )
+    dividends = _safe_attr("dividends")
+
+    close_px = _close_at(history, curr_date)
+    shares_out = _shares_at(shares, curr_date)
+
+    revenue_ttm = _ttm_sum(income, _INCOME_KEYS["revenue"], curr_date)
+    gross_profit_ttm = _ttm_sum(income, _INCOME_KEYS["gross_profit"], curr_date)
+    operating_income_ttm = _ttm_sum(income, _INCOME_KEYS["operating_income"], curr_date)
+    net_income_ttm = _ttm_sum(income, _INCOME_KEYS["net_income"], curr_date)
+    ebitda_ttm = _ttm_sum(income, _INCOME_KEYS["ebitda"], curr_date)
+    fcf_ttm = _ttm_sum(cashflow, _CASHFLOW_KEYS["free_cash_flow"], curr_date)
+
+    total_assets = _latest_le(balance, _BALANCE_KEYS["total_assets"], curr_date)
+    total_equity = _latest_le(balance, _BALANCE_KEYS["total_equity"], curr_date)
+    total_debt = _latest_le(balance, _BALANCE_KEYS["total_debt"], curr_date)
+    current_assets = _latest_le(balance, _BALANCE_KEYS["current_assets"], curr_date)
+    current_liab = _latest_le(balance, _BALANCE_KEYS["current_liabilities"], curr_date)
+
+    out: dict = {}
+
+    if not (history is None or history.empty):
+        h = history.copy()
+        h.index = _strip_tz(h.index)
+        h = h[h.index <= cutoff]
+        if not h.empty:
+            year_window = h[h.index >= cutoff - pd.Timedelta(days=365)]
+            if not year_window.empty and "High" in year_window.columns:
+                out["52 Week High"] = round(float(year_window["High"].max()), 2)
+                out["52 Week Low"] = round(float(year_window["Low"].min()), 2)
+            window_50 = h.tail(50)
+            if len(window_50) >= 10:
+                out["50 Day Average"] = round(float(window_50["Close"].mean()), 2)
+            window_200 = h.tail(200)
+            if len(window_200) >= 50:
+                out["200 Day Average"] = round(float(window_200["Close"].mean()), 2)
+
+    if close_px is not None and shares_out is not None and shares_out > 0:
+        out["Market Cap"] = int(round(close_px * shares_out))
+
+    if revenue_ttm is not None:
+        out["Revenue (TTM)"] = int(round(revenue_ttm))
+    if gross_profit_ttm is not None:
+        out["Gross Profit"] = int(round(gross_profit_ttm))
+    if ebitda_ttm is not None:
+        out["EBITDA"] = int(round(ebitda_ttm))
+    if net_income_ttm is not None:
+        out["Net Income"] = int(round(net_income_ttm))
+    if fcf_ttm is not None:
+        out["Free Cash Flow"] = int(round(fcf_ttm))
+
+    margin = _safe_div(net_income_ttm, revenue_ttm)
+    if margin is not None:
+        out["Profit Margin"] = round(margin, 4)
+    op_margin = _safe_div(operating_income_ttm, revenue_ttm)
+    if op_margin is not None:
+        out["Operating Margin"] = round(op_margin, 4)
+
+    if net_income_ttm is not None and shares_out and shares_out > 0:
+        eps_ttm = net_income_ttm / shares_out
+        out["EPS (TTM)"] = round(eps_ttm, 2)
+        if close_px is not None and eps_ttm > 0:
+            out["PE Ratio (TTM)"] = round(close_px / eps_ttm, 2)
+
+    roe = _safe_div(net_income_ttm, total_equity)
+    if roe is not None:
+        out["Return on Equity"] = round(roe, 4)
+    roa = _safe_div(net_income_ttm, total_assets)
+    if roa is not None:
+        out["Return on Assets"] = round(roa, 4)
+
+    if total_debt is not None and total_equity and total_equity != 0:
+        out["Debt to Equity"] = round(total_debt / total_equity * 100, 2)
+    if current_assets is not None and current_liab and current_liab != 0:
+        out["Current Ratio"] = round(current_assets / current_liab, 2)
+
+    if total_equity is not None and shares_out and shares_out > 0:
+        bvps = total_equity / shares_out
+        out["Book Value"] = round(bvps, 2)
+        if close_px is not None and bvps > 0:
+            out["Price to Book"] = round(close_px / bvps, 2)
+
+    if dividends is not None and len(dividends) > 0 and close_px:
+        d = dividends.copy()
+        d.index = _strip_tz(d.index)
+        ttm_div_window = d[(d.index <= cutoff) & (d.index > cutoff - pd.Timedelta(days=365))]
+        ttm_div = float(ttm_div_window.sum()) if len(ttm_div_window) > 0 else 0.0
+        if ttm_div > 0:
+            out["Dividend Yield"] = round(ttm_div / close_px, 4)
+
+    return out

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -38,13 +38,16 @@ DEFAULT_CONFIG = {
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "core_stock_apis": "polygon",       # Options: polygon, alpha_vantage, yfinance
+        "technical_indicators": "polygon",  # Options: polygon, alpha_vantage, yfinance
+        "fundamental_data": "polygon",      # Options: polygon, alpha_vantage, yfinance
+        "news_data": "polygon",             # Options: polygon, alpha_vantage, yfinance
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {
-        # Example: "get_stock_data": "alpha_vantage",  # Override category default
+        # Polygon Stocks Starter plan does not include SEC insider transactions.
+        # Route this single tool to yfinance (free, always available) with
+        # alpha_vantage as backup when ALPHA_VANTAGE_API_KEY is configured.
+        "get_insider_transactions": "yfinance,alpha_vantage",
     },
 }


### PR DESCRIPTION
## Summary

Replaces yfinance with Polygon as the default vendor for fundamentals, bars, indicators, and news. yfinance + alpha_vantage remain as automatic fallbacks via the existing `route_to_vendor` chain. Also bundles the Anthropic extended-thinking + structured-output incompatibility fix surfaced in the 3-way 2024-05-10 run.

## Bugs fixed

### Bug 1: Path D NVDA market cap was $224.6B (10x low)
The yfinance Path D derivation multiplied split-adjusted historical price by pre-split share count, producing a 10x-low market cap on NVDA at 2024-05-10. Polygon's `/v3/reference/tickers?date=X` endpoint returns the as-of market_cap pre-computed correctly, eliminating the bug class.

**Verified:** `route_to_vendor('get_fundamentals', 'NVDA', '2024-05-10')` now returns Market Cap **$2.25T** (matches reality).

### Bug 2: Anthropic thinking + structured output rejected
`claude-opus-4.7-xhigh` (and other thinking-enabled Claude variants) fail with `400 - Thinking may not be enabled when tool_choice forces tool use` when LangChain's `with_structured_output` imposes `tool_choice='any'`. Affected the Research Manager during persona-aligned runs, silently degrading to free-text plans.

**Fix:** `bind_structured` detects Claude models with effort suffixes (`-xhigh`, `-high`, `-medium`, `-low`, `-minimal`) and builds a non-thinking *twin* via `model_copy` for structured calls only. The original thinking-enabled LLM remains in use for free-text and other paths.

## Polygon-specific design decisions

- **PIT visibility filter** (`_is_pit_visible`): `filing_date.lt` does not exclude null filing_date rows, so we combine with `period_of_report_date.lt` AND a Python-side filter using a 90-day filing-lag fallback when filing_date is null.
- **Strict TTM** (`_ttm_sum`): returns None if any of 4 most-recent quarters is missing the concept value, preventing partial-window misleading aggregates.
- **Cache key versioned by vendor**: `{symbol}-{Polygon|YFin}-data-{start}-{end}.csv` so switching vendors invalidates stale files.
- **Insider transactions**: not on Stocks Starter plan; `get_insider_transactions` raises `PolygonError` so the router falls through to yfinance.

## Tests

143 passing (+ 38 subtests).

- `tests/test_polygon_finance.py` — 21 tests: PIT rule, TTM strictness, statement-to-CSV, integration with mocked endpoints, vendor fallback chain.
- `tests/test_anthropic_thinking_structured.py` — 18 tests: suffix stripping, twin construction (ChatOpenAI + ChatAnthropic shapes), clone-failure fallback, bind_structured integration.