### PR TITLE
Fix Docker volume permissions for TradingAgents data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser \
+    && install -d -m 0755 -o appuser -g appuser /home/appuser/.tradingagents
 USER appuser
 WORKDIR /home/appuser/app
 


### PR DESCRIPTION
## Summary

Fix a Docker startup permission error by pre-creating the TradingAgents data directory in the image and assigning it to `appuser`.

This affects the documented Docker flow:

```bash
docker compose run --rm tradingagents
```

Without this change, the container can fail on startup with:

```text
PermissionError: [Errno 13] Permission denied: '/home/appuser/.tradingagents/cache'
```

## Root Cause

The container runs as the non-root user `appuser`, and the application writes runtime state under `~/.tradingagents` by default.

The compose setup mounts a volume at:

```text
/home/appuser/.tradingagents
```

but the image did not guarantee that directory existed with writable ownership for `appuser` before runtime.

## Change

In the Docker image:

- create `/home/appuser/.tradingagents`
- assign ownership of that directory to `appuser`

This keeps the fix local to container provisioning and avoids changing application behavior.

## Validation

Validated locally with:

```bash
docker compose config
docker compose build tradingagents
docker compose run --rm --entrypoint python tradingagents -c "from tradingagents.default_config import DEFAULT_CONFIG; import os; os.makedirs(DEFAULT_CONFIG['data_cache_dir'], exist_ok=True); print(DEFAULT_CONFIG['data_cache_dir']); print('writable')"
```

The final runtime check successfully created:

```text
/home/appuser/.tradingagents/cache
```

and printed:

```text
writable
```

## Notes

If an existing Docker named volume was created with the old image state, users may need to recreate it once:

```bash
docker compose down -v
docker compose up
```
