### PR TITLE
fix: configurable benchmark for non-US tickers in reflection alpha (#628)

### DIFF
--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -483,12 +483,79 @@ class TestDeferredReflection:
         assert "-5.0%" in human_content
         assert "Exit position immediately." in human_content
 
+    def test_reflect_default_benchmark_is_spy(self):
+        """When benchmark is not passed, the prompt still says 'Alpha vs SPY'."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = "ok"
+        reflector = Reflector(mock_llm)
+        reflector.reflect_on_final_decision(
+            final_decision=DECISION_BUY, raw_return=0.04, alpha_return=0.02
+        )
+        human_content = next(
+            c for r, c in mock_llm.invoke.call_args[0][0] if r == "human"
+        )
+        assert "Alpha vs SPY:" in human_content
+
+    def test_reflect_uses_provided_benchmark(self):
+        """A custom benchmark name flows into the human prompt."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = "ok"
+        reflector = Reflector(mock_llm)
+        reflector.reflect_on_final_decision(
+            final_decision=DECISION_BUY,
+            raw_return=0.04,
+            alpha_return=0.02,
+            benchmark="^NSEI",
+        )
+        human_content = next(
+            c for r, c in mock_llm.invoke.call_args[0][0] if r == "human"
+        )
+        assert "Alpha vs ^NSEI:" in human_content
+        assert "Alpha vs SPY:" not in human_content
+
+    # TradingAgentsGraph._resolve_benchmark
+
+    def test_resolve_benchmark_default_us_ticker(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = DEFAULT_CONFIG
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "NVDA") == "SPY"
+
+    def test_resolve_benchmark_nse_suffix(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = DEFAULT_CONFIG
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "RELIANCE.NS") == "^NSEI"
+
+    def test_resolve_benchmark_hk_suffix(self):
+        from tradingagents.default_config import DEFAULT_CONFIG
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = DEFAULT_CONFIG
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "0700.HK") == "^HSI"
+
+    def test_resolve_benchmark_explicit_override_wins(self):
+        """benchmark_ticker beats the suffix map entirely."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {
+            "benchmark_ticker": "QQQ",
+            "benchmark_map": {".NS": "^NSEI", "": "SPY"},
+        }
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "RELIANCE.NS") == "QQQ"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "NVDA") == "QQQ"
+
+    def test_resolve_benchmark_falls_back_when_map_missing(self):
+        """No benchmark_ticker, no benchmark_map → SPY."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {}
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "NVDA") == "SPY"
+
     # TradingAgentsGraph._fetch_returns
 
     def test_fetch_returns_valid_ticker(self):
         stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
         spy_prices   = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
         mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph._resolve_benchmark.return_value = "SPY"
         with patch("yfinance.Ticker") as mock_ticker_cls:
             def _make_ticker(sym):
                 m = MagicMock()
@@ -521,10 +588,11 @@ class TestDeferredReflection:
         assert raw is None and alpha is None and days is None
 
     def test_fetch_returns_spy_shorter_than_stock(self):
-        """SPY having fewer rows than the stock must not raise IndexError."""
+        """Benchmark having fewer rows than the stock must not raise IndexError."""
         stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
         spy_prices   = [400.0, 402.0, 403.0]
         mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph._resolve_benchmark.return_value = "SPY"
         with patch("yfinance.Ticker") as mock_ticker_cls:
             def _make_ticker(sym):
                 m = MagicMock()
@@ -534,6 +602,30 @@ class TestDeferredReflection:
             raw, alpha, days = TradingAgentsGraph._fetch_returns(mock_graph, "NVDA", "2026-01-05")
         assert raw is not None and alpha is not None and days is not None
         assert days == 2
+
+    def test_fetch_returns_uses_resolved_benchmark(self):
+        """_fetch_returns must request the benchmark resolved by _resolve_benchmark, not SPY."""
+        stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
+        nifty_prices = [20000.0, 20100.0, 20200.0, 20150.0, 20250.0, 20300.0]
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph._resolve_benchmark.return_value = "^NSEI"
+        requested = []
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            def _make_ticker(sym):
+                requested.append(sym)
+                m = MagicMock()
+                m.history.return_value = _price_df(
+                    nifty_prices if sym == "^NSEI" else stock_prices
+                )
+                return m
+            mock_ticker_cls.side_effect = _make_ticker
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "RELIANCE.NS", "2026-01-05"
+            )
+        assert raw is not None and alpha is not None and days is not None
+        assert "^NSEI" in requested
+        assert "SPY" not in requested
+        mock_graph._resolve_benchmark.assert_called_once_with("RELIANCE.NS")
 
     # TradingAgentsGraph._resolve_pending_entries
 

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -627,6 +627,45 @@ class TestDeferredReflection:
         assert "SPY" not in requested
         mock_graph._resolve_benchmark.assert_called_once_with("RELIANCE.NS")
 
+    def test_fetch_returns_skips_resolution_when_benchmark_passed(self):
+        """Caller-provided benchmark must skip _resolve_benchmark entirely."""
+        stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
+        spy_prices   = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            def _make_ticker(sym):
+                m = MagicMock()
+                m.history.return_value = _price_df(
+                    spy_prices if sym == "SPY" else stock_prices
+                )
+                return m
+            mock_ticker_cls.side_effect = _make_ticker
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "NVDA", "2026-01-05", benchmark="SPY"
+            )
+        assert raw is not None and alpha is not None and days is not None
+        mock_graph._resolve_benchmark.assert_not_called()
+
+    def test_fetch_returns_reuses_stock_when_ticker_is_benchmark(self):
+        """Analysing the benchmark itself (e.g. SPY vs SPY) must not duplicate the yfinance call."""
+        spy_prices = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        requested = []
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            def _make_ticker(sym):
+                requested.append(sym)
+                m = MagicMock()
+                m.history.return_value = _price_df(spy_prices)
+                return m
+            mock_ticker_cls.side_effect = _make_ticker
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "SPY", "2026-01-05", benchmark="SPY"
+            )
+        assert raw is not None and alpha == 0.0 and days == 5
+        assert requested == ["SPY"], (
+            f"expected exactly one yfinance request when ticker == benchmark, got {requested}"
+        )
+
     # TradingAgentsGraph._resolve_pending_entries
 
     def test_resolve_skips_other_tickers(self, tmp_path):
@@ -658,6 +697,25 @@ class TestDeferredReflection:
         assert entries[0]["reflection"] == "Momentum confirmed."
         assert "+5.0%" in entries[0]["raw"]
         assert "+2.0%" in entries[0]["alpha"]
+
+    def test_resolve_resolves_benchmark_once_per_run(self, tmp_path):
+        """Benchmark is resolved once per run and forwarded to every _fetch_returns call,
+        instead of being recomputed for each pending entry."""
+        log = make_log(tmp_path)
+        log.store_decision("NVDA", "2026-01-05", DECISION_BUY)
+        log.store_decision("NVDA", "2026-01-12", DECISION_SELL)
+        mock_reflector = MagicMock()
+        mock_reflector.reflect_on_final_decision.return_value = "ok"
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.memory_log = log
+        mock_graph.reflector = mock_reflector
+        mock_graph._resolve_benchmark = MagicMock(return_value="SPY")
+        mock_graph._fetch_returns = MagicMock(return_value=(0.05, 0.02, 5))
+        TradingAgentsGraph._resolve_pending_entries(mock_graph, "NVDA")
+        mock_graph._resolve_benchmark.assert_called_once_with("NVDA")
+        assert mock_graph._fetch_returns.call_count == 2
+        for call in mock_graph._fetch_returns.call_args_list:
+            assert call.kwargs.get("benchmark") == "SPY"
 
 
 # ---------------------------------------------------------------------------

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -31,6 +31,20 @@ DEFAULT_CONFIG = {
     # Output language for analyst reports and final decision
     # Internal agent debate stays in English for reasoning quality
     "output_language": "English",
+    # Benchmark used for alpha calculation in deferred reflection.
+    # When `benchmark_ticker` is set, it wins for every analysis.
+    # Otherwise the longest matching suffix in `benchmark_map` is used,
+    # falling back to the "" entry for tickers without a known suffix.
+    "benchmark_ticker": None,
+    "benchmark_map": {
+        ".NS": "^NSEI",     # Nifty 50 (NSE India)
+        ".BO": "^BSESN",    # Sensex (BSE India)
+        ".T":  "^N225",     # Nikkei 225 (Japan)
+        ".HK": "^HSI",      # Hang Seng (Hong Kong)
+        ".L":  "^FTSE",     # FTSE 100 (London)
+        ".TO": "^GSPTSE",   # TSX Composite (Toronto)
+        "":    "SPY",       # default for US-listed tickers
+    },
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -33,6 +33,7 @@ class Reflector:
         final_decision: str,
         raw_return: float,
         alpha_return: float,
+        benchmark: str = "SPY",
     ) -> str:
         """Single reflection call on the final trade decision with outcome context.
 
@@ -45,7 +46,7 @@ class Reflector:
                 "human",
                 (
                     f"Raw return: {raw_return:+.1%}\n"
-                    f"Alpha vs SPY: {alpha_return:+.1%}\n\n"
+                    f"Alpha vs {benchmark}: {alpha_return:+.1%}\n\n"
                     f"Final Decision:\n{final_decision}"
                 ),
             ),

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -187,6 +187,23 @@ class TradingAgentsGraph:
             ),
         }
 
+    def _resolve_benchmark(self, ticker: str) -> str:
+        """Resolve the benchmark symbol for a ticker.
+
+        Explicit ``benchmark_ticker`` config wins for every analysis. Otherwise
+        the longest matching suffix in ``benchmark_map`` is picked (so ``.BO``
+        beats ``""``), falling back to the ``""`` entry, and finally ``SPY``
+        if neither config key is set.
+        """
+        explicit = self.config.get("benchmark_ticker")
+        if explicit:
+            return explicit
+        benchmark_map = self.config.get("benchmark_map") or {}
+        for suffix in sorted((s for s in benchmark_map if s), key=len, reverse=True):
+            if ticker.endswith(suffix):
+                return benchmark_map[suffix]
+        return benchmark_map.get("", "SPY")
+
     def _fetch_returns(
         self, ticker: str, trade_date: str, holding_days: int = 5
     ) -> Tuple[Optional[float], Optional[float], Optional[int]]:
@@ -201,22 +218,23 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
+            benchmark = self._resolve_benchmark(ticker)
             stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
-            spy = yf.Ticker("SPY").history(start=trade_date, end=end_str)
+            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
 
-            if len(stock) < 2 or len(spy) < 2:
+            if len(stock) < 2 or len(bench) < 2:
                 return None, None, None
 
-            actual_days = min(holding_days, len(stock) - 1, len(spy) - 1)
+            actual_days = min(holding_days, len(stock) - 1, len(bench) - 1)
             raw = float(
                 (stock["Close"].iloc[actual_days] - stock["Close"].iloc[0])
                 / stock["Close"].iloc[0]
             )
-            spy_ret = float(
-                (spy["Close"].iloc[actual_days] - spy["Close"].iloc[0])
-                / spy["Close"].iloc[0]
+            bench_ret = float(
+                (bench["Close"].iloc[actual_days] - bench["Close"].iloc[0])
+                / bench["Close"].iloc[0]
             )
-            alpha = raw - spy_ret
+            alpha = raw - bench_ret
             return raw, alpha, actual_days
         except Exception as e:
             logger.warning(
@@ -239,6 +257,7 @@ class TradingAgentsGraph:
         if not pending:
             return
 
+        benchmark = self._resolve_benchmark(ticker)
         updates = []
         for entry in pending:
             raw, alpha, days = self._fetch_returns(ticker, entry["date"])
@@ -248,6 +267,7 @@ class TradingAgentsGraph:
                 final_decision=entry.get("decision", ""),
                 raw_return=raw,
                 alpha_return=alpha,
+                benchmark=benchmark,
             )
             updates.append({
                 "ticker": ticker,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -205,9 +205,18 @@ class TradingAgentsGraph:
         return benchmark_map.get("", "SPY")
 
     def _fetch_returns(
-        self, ticker: str, trade_date: str, holding_days: int = 5
+        self,
+        ticker: str,
+        trade_date: str,
+        holding_days: int = 5,
+        benchmark: Optional[str] = None,
     ) -> Tuple[Optional[float], Optional[float], Optional[int]]:
         """Fetch raw and alpha return for ticker over holding_days from trade_date.
+
+        ``benchmark`` may be passed by callers that already resolved it (e.g.
+        :meth:`_resolve_pending_entries` does so once per ticker), avoiding
+        redundant resolution work in batch loops. When ``None`` it is resolved
+        from the ticker.
 
         Returns (raw_return, alpha_return, actual_holding_days) or
         (None, None, None) if price data is unavailable (too recent, delisted,
@@ -218,9 +227,14 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            benchmark = self._resolve_benchmark(ticker)
+            if benchmark is None:
+                benchmark = self._resolve_benchmark(ticker)
             stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
-            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+            # Skip the duplicate request when the user analyses the benchmark
+            # itself (e.g. SPY vs SPY → alpha is 0 by definition).
+            bench = stock if benchmark == ticker else yf.Ticker(benchmark).history(
+                start=trade_date, end=end_str
+            )
 
             if len(stock) < 2 or len(bench) < 2:
                 return None, None, None
@@ -260,7 +274,9 @@ class TradingAgentsGraph:
         benchmark = self._resolve_benchmark(ticker)
         updates = []
         for entry in pending:
-            raw, alpha, days = self._fetch_returns(ticker, entry["date"])
+            raw, alpha, days = self._fetch_returns(
+                ticker, entry["date"], benchmark=benchmark
+            )
             if raw is None:
                 continue  # price not available yet — try again next run
             reflection = self.reflector.reflect_on_final_decision(


### PR DESCRIPTION
Closes #628.

## Summary
- `_fetch_returns()` hardcoded `SPY` as the alpha benchmark, producing misleading alpha for non-US tickers (e.g. `RELIANCE.NS` vs `SPY` mixes an INR single-stock return with a USD index return). `reflection.py` echoed the same hardcoding in the prompt (`Alpha vs SPY`).
- Adds two config keys (Option B from the issue):
  - `benchmark_ticker` — explicit override; wins everywhere when set.
  - `benchmark_map` — suffix → index map with sensible defaults: `.NS → ^NSEI`, `.BO → ^BSESN`, `.T → ^N225`, `.HK → ^HSI`, `.L → ^FTSE`, `.TO → ^GSPTSE`, `"" → SPY`.
- New `_resolve_benchmark(ticker)` picks the longest matching suffix (so `.BO` isn't swallowed by `""`), then `_fetch_returns` uses it and `_resolve_pending_entries` threads the name through to `Reflector.reflect_on_final_decision`, which now formats `f"Alpha vs {benchmark}"`.
- US-listed tickers keep the existing zero-config experience; international tickers now compute meaningful alpha out of the box; advanced users can pin any benchmark via `benchmark_ticker`.

## Scope
Strictly the benchmark, as agreed in #628. Out of scope (each its own follow-up):
- Currency normalization for `TraderAction` price targets
- News source localization (Moneycontrol, Economic Times, etc.)
- Region-specific insider/disclosure feeds (SEBI for India, etc.)

## Test plan
- [x] Existing `_fetch_returns` tests updated to mock `_resolve_benchmark` (no behavior change for SPY/US path).
- [x] New: `_resolve_benchmark` returns SPY for US tickers under default config.
- [x] New: `_resolve_benchmark` returns `^NSEI` for `RELIANCE.NS`, `^HSI` for `0700.HK`.
- [x] New: explicit `benchmark_ticker` beats the suffix map.
- [x] New: missing/empty `benchmark_map` falls back to SPY.
- [x] New: `_fetch_returns` requests the resolved benchmark (verified by capturing `yf.Ticker` calls — `^NSEI` requested, `SPY` not).
- [x] New: `Reflector.reflect_on_final_decision` defaults to `Alpha vs SPY` and substitutes a custom benchmark name (e.g. `Alpha vs ^NSEI`) into the human prompt.
- [x] Full suite: `pytest tests/` → **100 passed**.