### PR TITLE
fix: add yf_retry to _fetch_returns, per-entry error handling, remove dead entitlement code

### DIFF
--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -53,10 +53,9 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
         "source": "trading_agents",
     })
     
-    # Handle entitlement parameter if present in params or global variable
-    current_entitlement = globals().get('_current_entitlement')
-    entitlement = api_params.get("entitlement") or current_entitlement
-    
+    # Handle entitlement parameter if present in params
+    entitlement = api_params.get("entitlement")
+
     if entitlement:
         api_params["entitlement"] = entitlement
     elif "entitlement" in api_params:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -24,6 +24,7 @@ from tradingagents.agents.utils.agent_states import (
     RiskDebateState,
 )
 from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows.stockstats_utils import yf_retry
 
 # Import the new abstract tool methods from agent_utils
 from tradingagents.agents.utils.agent_utils import (
@@ -201,8 +202,8 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
-            spy = yf.Ticker("SPY").history(start=trade_date, end=end_str)
+            stock = yf_retry(lambda: yf.Ticker(ticker).history(start=trade_date, end=end_str))
+            spy = yf_retry(lambda: yf.Ticker("SPY").history(start=trade_date, end=end_str))
 
             if len(stock) < 2 or len(spy) < 2:
                 return None, None, None
@@ -244,11 +245,18 @@ class TradingAgentsGraph:
             raw, alpha, days = self._fetch_returns(ticker, entry["date"])
             if raw is None:
                 continue  # price not available yet — try again next run
-            reflection = self.reflector.reflect_on_final_decision(
-                final_decision=entry.get("decision", ""),
-                raw_return=raw,
-                alpha_return=alpha,
-            )
+            try:
+                reflection = self.reflector.reflect_on_final_decision(
+                    final_decision=entry.get("decision", ""),
+                    raw_return=raw,
+                    alpha_return=alpha,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to reflect on pending entry for %s on %s (will retry next run)",
+                    ticker, entry["date"], exc_info=True,
+                )
+                continue
             updates.append({
                 "ticker": ticker,
                 "trade_date": entry["date"],


### PR DESCRIPTION
## Summary

Three small fixes that improve error resilience and remove dead code:

- **Add `yf_retry` to `_fetch_returns` yfinance calls.** The rest of the dataflows layer uses `yf_retry` with exponential backoff to handle Yahoo Finance HTTP 429 rate limits, but `_fetch_returns` called `yf.Ticker(...).history()` directly. A rate-limit response during memory log resolution would crash the entire `propagate()` call.

- **Add per-entry error handling in `_resolve_pending_entries`.** The `reflect_on_final_decision` call (which invokes an LLM) was outside any try/except, so a single failing reflection discarded the entire batch of pending updates. Now a failed reflection logs a warning and skips to the next entry, matching the existing resilience pattern used for `_fetch_returns`.

- **Remove dead `_current_entitlement` global lookup in `alpha_vantage_common.py`.** `_make_api_request` called `globals().get('_current_entitlement')` but `_current_entitlement` is never defined anywhere in the project. Removed the dead code and simplified the entitlement logic.

## Test plan

- [x] Existing tests pass (no regressions)
- [ ] Manual: run `tradingagents analyze` with yfinance data vendor to confirm `propagate()` still works
- [ ] Manual: trigger a rate limit during memory log resolution to confirm retry kicks in