### PR TITLE
feat: Add MiniMax LLM client support

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,53 @@
+"""MiniMax + TradingAgents demo (backtest mode).
+
+Run:
+    python demo.py
+"""
+
+import os
+from datetime import datetime
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from tradingagents.agents.agent import Agent
+from tradingagents.llm_clients.factory import create_llm_client
+
+
+def main():
+    print("=" * 60)
+    print("TradingAgents — MiniMax M2.7 Demo (NVDA Backtest)")
+    print("=" * 60)
+
+    llm_provider = "minimax"
+    deep_think_llm = "MiniMax-M2.7"
+    quick_think_llm = "MiniMax-M2.7"
+
+    deep_client = create_llm_client(provider=llm_provider, model=deep_think_llm)
+    quick_client = create_llm_client(provider=llm_provider, model=quick_think_llm)
+
+    print(f"\nLLM provider : {llm_provider}")
+    print(f"Deep think   : {deep_think_llm}")
+    print(f"Quick think  : {quick_think_llm}")
+
+    agent = Agent(deep_think_client=deep_client, quick_think_client=quick_client)
+
+    ticker = "NVDA"
+    backtest_date = "2024-05-10"
+    agent_type = "analyst"
+
+    print(f"\nTicker       : {ticker}")
+    print(f"Date         : {backtest_date}")
+    print(f"Agent type   : {agent_type}")
+    print("-" * 60)
+
+    result = agent.run(ticker=ticker, agent_type=agent_type, backtest_date=backtest_date)
+
+    print("\n" + "=" * 60)
+    print("RESULT")
+    print("=" * 60)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -50,4 +50,8 @@ def create_llm_client(
         from .azure_client import AzureOpenAIClient
         return AzureOpenAIClient(model, base_url, **kwargs)
 
+    if provider_lower == "minimax":
+        from .minimax_client import MiniMaxClient
+        return MiniMaxClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/llm_clients/minimax_client.py
+++ b/tradingagents/llm_clients/minimax_client.py
@@ -1,0 +1,37 @@
+"""MiniMax LLM client for TradingAgents.
+
+Uses LangChain's built-in MiniMaxChatOpenAI which handles
+MiniMax's non-standard /chatcompletion_v2 endpoint automatically.
+"""
+
+from typing import Any, Optional
+
+from langchain_community.chat_models.minimax import MiniMaxChatOpenAI
+
+from .base_client import BaseLLMClient, normalize_content
+from .validators import validate_model
+
+
+class MiniMaxClient(BaseLLMClient):
+    """TradingAgents LLM client for MiniMax.
+
+    Leverages LangChain's MiniMaxChatOpenAI which already knows how to
+    route requests to MiniMax's API at /chatcompletion_v2.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(model, base_url, **kwargs)
+        self._model = model
+
+    def get_llm(self) -> Any:
+        """Return configured MiniMaxChatOpenAI instance."""
+        return MiniMaxChatOpenAI(model=self._model)
+
+    def validate_model(self) -> bool:
+        """Validate model for MiniMax (accepts any model name)."""
+        return True

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -17,7 +17,7 @@ def validate_model(provider: str, model: str) -> bool:
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in ("ollama", "openrouter", "minimax"):
         return True
 
     if provider_lower not in VALID_MODELS:


### PR DESCRIPTION
## Summary

Add MiniMax as a supported LLM provider in TradingAgents.

MiniMax uses a non-standard API endpoint path (`/chatcompletion_v2` instead of `/chat/completions`). This PR uses LangChain's built-in `MiniMaxChatOpenAI` which already handles this path translation.

## Changes

- **minimax_client.py**: New client using `langchain_community.chat_models.minimax.MiniMaxChatOpenAI`
- **factory.py**: Register `minimax` provider in `create_llm_client()`
- **validators.py**: Add `minimax` to providers that accept any model name

## Usage

```python
from tradingagents.llm_clients.factory import create_llm_client

client = create_llm_client(provider="minimax", model="MiniMax-M2.7")
```

Set `MINIMAX_API_KEY` in environment.

## Testing

Run `python demo.py` (NVDA backtest) with `llm_provider="minimax"`.