### PR TITLE
Allow OLLAMA_BASE_URL env var to override hardcoded localhost

### DIFF
--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -116,7 +116,7 @@ _PROVIDER_CONFIG = {
     "qwen": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "DASHSCOPE_API_KEY"),
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
-    "ollama": (os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1"), None),
+    "ollama": (os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1", None),
 }
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -116,7 +116,7 @@ _PROVIDER_CONFIG = {
     "qwen": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "DASHSCOPE_API_KEY"),
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
-    "ollama": ("http://localhost:11434/v1", None),
+    "ollama": (os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1"), None),
 }
 
 


### PR DESCRIPTION
The ollama provider was hardcoded to http://localhost:11434/v1, which prevented running TradingAgents on a remote machine while serving Ollama on a different host (e.g., a separate VM, a Mac with Apple Silicon GPU acceleration, or any non-localhost setup).

This change reads OLLAMA_BASE_URL from the environment when set, falling back to the existing localhost default. No behavior change for existing users; opt-in via env var for remote setups.

Tested with Ollama running on a remote Mac while TradingAgents executed in a Linux VM.