### PR TITLE
Fix CLI display of literal-looking message text

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -855,20 +855,12 @@ def extract_content_string(content):
     """Extract string content from various message formats.
     Returns None if no meaningful text content is found.
     """
-    import ast
-
     def is_empty(val):
         """Check if value is empty using Python's truthiness."""
         if val is None or val == '':
             return True
         if isinstance(val, str):
-            s = val.strip()
-            if not s:
-                return True
-            try:
-                return not bool(ast.literal_eval(s))
-            except (ValueError, SyntaxError):
-                return False  # Can't parse = real text
+            return not val.strip()
         return not bool(val)
 
     if is_empty(content):

--- a/tests/test_cli_message_content.py
+++ b/tests/test_cli_message_content.py
@@ -4,13 +4,20 @@ from cli.main import extract_content_string
 
 
 @pytest.mark.unit
-def test_extract_content_string_preserves_literal_looking_text():
-    assert extract_content_string("0") == "0"
-    assert extract_content_string("False") == "False"
-
-
-@pytest.mark.unit
-def test_extract_content_string_treats_empty_containers_as_empty():
-    assert extract_content_string([]) is None
-    assert extract_content_string({}) is None
-    assert extract_content_string("") is None
+@pytest.mark.parametrize(
+    ("input_value", "expected"),
+    [
+        ("0", "0"),
+        ("False", "False"),
+        ("None", "None"),
+        ("[]", "[]"),
+        ([], None),
+        ({}, None),
+        ("", None),
+        ("   ", None),
+        (0, None),
+        (False, None),
+    ],
+)
+def test_extract_content_string(input_value, expected):
+    assert extract_content_string(input_value) == expected

--- a/tests/test_cli_message_content.py
+++ b/tests/test_cli_message_content.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cli.main import extract_content_string
+
+
+@pytest.mark.unit
+def test_extract_content_string_preserves_literal_looking_text():
+    assert extract_content_string("0") == "0"
+    assert extract_content_string("False") == "False"
+
+
+@pytest.mark.unit
+def test_extract_content_string_treats_empty_containers_as_empty():
+    assert extract_content_string([]) is None
+    assert extract_content_string({}) is None
+    assert extract_content_string("") is None


### PR DESCRIPTION
What I changed
- Keep string message content as text in the CLI display, even when it looks like a Python falsy literal such as `0` or `False`.
- Still treats real empty containers and blank strings as empty.
- Adds focused unit coverage for the display helper.

How to verify
- `python -m pytest`