### PR TITLE
feat(deepseek): V4 models, reasoning_content via ChatDeepSeek

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "langchain-experimental>=0.3.4",
     "langchain-google-genai>=4.0.0",
     "langchain-openai>=0.3.23",
+    "langchain-deepseek>=1.0.0",
     "langgraph>=0.4.8",
     "langgraph-checkpoint-sqlite>=2.0.0",
     "pandas>=2.3.0",

--- a/tradingagents/llm_clients/deepseek_client.py
+++ b/tradingagents/llm_clients/deepseek_client.py
@@ -1,0 +1,127 @@
+"""DeepSeek LLM client using langchain_deepseek's ChatDeepSeek.
+
+Handles DeepSeek's reasoning_content requirement: when thinking mode is used,
+the reasoning_content from the response must be preserved and passed back in
+subsequent API requests. langchain_openai's ChatOpenAI does not support this.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_deepseek import ChatDeepSeek
+
+from .base_client import BaseLLMClient, normalize_content
+from .validators import validate_model
+
+# Kwargs forwarded from user config to ChatDeepSeek
+_PASSTHROUGH_KWARGS = (
+    "timeout",
+    "max_retries",
+    "api_key",
+    "callbacks",
+    "http_client",
+    "http_async_client",
+)
+
+
+class NormalizedChatDeepSeek(ChatDeepSeek):
+    """ChatDeepSeek with normalized content and reasoning_content preservation.
+
+    DeepSeek's API requires reasoning_content to be preserved across turns
+    when using thinking/reasoning models. This class handles it in both
+    directions: capturing reasoning_content from responses and injecting it
+    back into request payloads.
+    """
+
+    def invoke(self, input, config=None, **kwargs):
+        return normalize_content(super().invoke(input, config, **kwargs))
+
+    def with_structured_output(self, schema, *, method=None, **kwargs):
+        if method is None:
+            method = "function_calling"
+        return super().with_structured_output(schema, method=method, **kwargs)
+
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Include reasoning_content from additional_kwargs in the request.
+
+        DeepSeek's API requires that reasoning_content be passed back in
+        subsequent requests when thinking mode is used. ChatDeepSeek stores
+        it in additional_kwargs but doesn't include it in request payloads
+        by default.
+        """
+        # Build a position-ordered list of reasoning_content values from
+        # original AIMessages before super() converts them to dicts.
+        reasoning_values: list[Optional[str]] = []
+        if isinstance(input_, list):
+            for msg in input_:
+                if isinstance(msg, AIMessage):
+                    reasoning_values.append(
+                        msg.additional_kwargs.get("reasoning_content")
+                    )
+                else:
+                    reasoning_values.append(None)
+        elif isinstance(input_, BaseMessage):
+            if isinstance(input_, AIMessage):
+                reasoning_values = [
+                    input_.additional_kwargs.get("reasoning_content")
+                ]
+            else:
+                reasoning_values = [None]
+
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+
+        # Apply reasoning_content to corresponding assistant message dicts.
+        # super() processed messages 1:1, so index positions are preserved.
+        if reasoning_values:
+            for i, msg_dict in enumerate(payload["messages"]):
+                if i < len(reasoning_values) and reasoning_values[i]:
+                    msg_dict["reasoning_content"] = reasoning_values[i]
+
+        return payload
+
+
+class DeepSeekClient(BaseLLMClient):
+    """Client for DeepSeek provider using ChatDeepSeek.
+
+    Uses langchain_deepseek's ChatDeepSeek which properly handles
+    reasoning_content and other DeepSeek-specific API requirements.
+    """
+
+    # ChatDeepSeek default includes /v1 suffix, but CLI passes base_url without it.
+    # Only override api_base for non-default URLs.
+    _DEFAULT_BASE = "https://api.deepseek.com"
+
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(model, base_url, **kwargs)
+
+    def get_llm(self) -> Any:
+        self.warn_if_unknown_model()
+        llm_kwargs: dict[str, Any] = {"model": self.model}
+
+        # Only set api_base if the user provided a custom (non-default) URL.
+        # ChatDeepSeek handles its own default (https://api.deepseek.com/v1).
+        if self.base_url and self.base_url.rstrip("/") != self._DEFAULT_BASE.rstrip("/"):
+            llm_kwargs["api_base"] = self.base_url
+
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs:
+                llm_kwargs[key] = self.kwargs[key]
+
+        return NormalizedChatDeepSeek(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        return validate_model("deepseek", self.model)

--- a/tradingagents/llm_clients/deepseek_client.py
+++ b/tradingagents/llm_clients/deepseek_client.py
@@ -39,6 +39,9 @@ class NormalizedChatDeepSeek(ChatDeepSeek):
     def invoke(self, input, config=None, **kwargs):
         return normalize_content(super().invoke(input, config, **kwargs))
 
+    async def ainvoke(self, input, config=None, **kwargs):
+        return normalize_content(await super().ainvoke(input, config, **kwargs))
+
     def with_structured_output(self, schema, *, method=None, **kwargs):
         if method is None:
             method = "function_calling"
@@ -58,24 +61,22 @@ class NormalizedChatDeepSeek(ChatDeepSeek):
         it in additional_kwargs but doesn't include it in request payloads
         by default.
         """
-        # Build a position-ordered list of reasoning_content values from
-        # original AIMessages before super() converts them to dicts.
-        reasoning_values: list[Optional[str]] = []
+        messages: list[BaseMessage]
         if isinstance(input_, list):
-            for msg in input_:
-                if isinstance(msg, AIMessage):
-                    reasoning_values.append(
-                        msg.additional_kwargs.get("reasoning_content")
-                    )
-                else:
-                    reasoning_values.append(None)
+            messages = input_
         elif isinstance(input_, BaseMessage):
-            if isinstance(input_, AIMessage):
-                reasoning_values = [
-                    input_.additional_kwargs.get("reasoning_content")
-                ]
-            else:
-                reasoning_values = [None]
+            messages = [input_]
+        elif hasattr(input_, "to_messages"):
+            messages = input_.to_messages()
+        else:
+            messages = self._convert_input(input_).to_messages()
+
+        reasoning_values: list[Optional[str]] = [
+            msg.additional_kwargs.get("reasoning_content")
+            if isinstance(msg, AIMessage)
+            else None
+            for msg in messages
+        ]
 
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -4,7 +4,7 @@ from .base_client import BaseLLMClient
 
 # Providers that use the OpenAI-compatible chat completions API
 _OPENAI_COMPATIBLE = (
-    "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
+    "openai", "xai", "qwen", "glm", "ollama", "openrouter",
 )
 
 
@@ -33,6 +33,10 @@ def create_llm_client(
         ValueError: If provider is not supported
     """
     provider_lower = provider.lower()
+
+    if provider_lower == "deepseek":
+        from .deepseek_client import DeepSeekClient
+        return DeepSeekClient(model, base_url, **kwargs)
 
     if provider_lower in _OPENAI_COMPATIBLE:
         from .openai_client import OpenAIClient

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -65,10 +65,12 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "deepseek": {
         "quick": [
+            ("DeepSeek V4 Flash - Fast", "deepseek-v4-flash"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),
         ],
         "deep": [
+            ("DeepSeek V4 Pro - Reasoning/thinking", "deepseek-v4-pro"),
             ("DeepSeek V3.2 (thinking)", "deepseek-reasoner"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -65,12 +65,12 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "deepseek": {
         "quick": [
-            ("DeepSeek V4 Flash - Fast", "deepseek-v4-flash"),
+            ("DeepSeek V4 Flash - Latest V4 fast model", "deepseek-v4-flash"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),
         ],
         "deep": [
-            ("DeepSeek V4 Pro - Reasoning/thinking", "deepseek-v4-pro"),
+            ("DeepSeek V4 Pro - Latest V4 flagship model", "deepseek-v4-pro"),
             ("DeepSeek V3.2 (thinking)", "deepseek-reasoner"),
             ("DeepSeek V3.2", "deepseek-chat"),
             ("Custom model ID", "custom"),


### PR DESCRIPTION
## Summary
Adds first-class DeepSeek support for **thinking/reasoning models** (e.g. `deepseek-v4-pro`) by using `langchain-deepseek` and echoing `reasoning_content` on follow-up requests. Registers **V4 Flash / V4 Pro** in the CLI model catalog.

## Problem
DeepSeek returns `reasoning_content` in thinking mode and requires it on subsequent turns. `ChatOpenAI` does not preserve that field → `400` `reasoning_content must be passed back`.

## Changes
- **`tradingagents/llm_clients/deepseek_client.py`**: `DeepSeekClient` + `NormalizedChatDeepSeek` (normalize content + inject `reasoning_content` in `_get_request_payload`).
- **`tradingagents/llm_clients/factory.py`**: route `deepseek` to `DeepSeekClient`.
- **`tradingagents/llm_clients/model_catalog.py`**: quick `deepseek-v4-flash`, deep `deepseek-v4-pro`.
- **`pyproject.toml`**: `langchain-deepseek>=1.0.0`.

## Testing
- Manual: DeepSeek provider + V4 Flash / V4 Pro, full CLI analysis without `reasoning_content` errors.

Closes #651

Made with [Cursor](https://cursor.com)