### PR TITLE
Remove checkpoint SQLite sidecars

### DIFF
--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -11,6 +11,7 @@ from langgraph.graph import END, StateGraph
 
 from tradingagents.graph.checkpointer import (
     checkpoint_step,
+    clear_all_checkpoints,
     clear_checkpoint,
     get_checkpointer,
     has_checkpoint,
@@ -106,6 +107,24 @@ class TestCheckpointResume(unittest.TestCase):
             result = graph.invoke({"count": 0}, config=cfg)
 
         self.assertEqual(result["count"], 11)
+
+    def test_clear_all_removes_sqlite_sidecar_files(self):
+        """Clearing all checkpoints removes SQLite WAL/SHM sidecar files too."""
+        cp_dir = Path(self.tmpdir) / "checkpoints"
+        cp_dir.mkdir(parents=True)
+        db = cp_dir / "TEST.db"
+        wal = cp_dir / "TEST.db-wal"
+        shm = cp_dir / "TEST.db-shm"
+
+        for path in (db, wal, shm):
+            path.write_text("", encoding="utf-8")
+
+        cleared = clear_all_checkpoints(self.tmpdir)
+
+        self.assertEqual(cleared, 1)
+        self.assertFalse(db.exists())
+        self.assertFalse(wal.exists())
+        self.assertFalse(shm.exists())
 
 
     def test_different_date_starts_fresh(self):

--- a/tradingagents/graph/checkpointer.py
+++ b/tradingagents/graph/checkpointer.py
@@ -69,7 +69,8 @@ def clear_all_checkpoints(data_dir: str | Path) -> int:
         return 0
     dbs = list(cp_dir.glob("*.db"))
     for db in dbs:
-        db.unlink()
+        for path in (db, db.with_name(f"{db.name}-wal"), db.with_name(f"{db.name}-shm")):
+            path.unlink(missing_ok=True)
     return len(dbs)
 
 


### PR DESCRIPTION
## Summary

Removes SQLite checkpoint sidecar files when clearing all saved checkpoints.

## Changes

- Delete `*.db-wal` and `*.db-shm` files alongside each checkpoint `*.db`.
- Keep the existing return value as the number of checkpoint databases cleared.
- Add focused unit coverage for SQLite sidecar cleanup.