### PR TITLE
fix: add .DS_Store and reports to .gitignore and persist generated reports to repository reports folder in Docker runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,5 @@ __marimo__/
 
 # Cache
 **/data_cache/
+reports/.DS_Store
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -217,5 +217,5 @@ __marimo__/
 
 # Cache
 **/data_cache/
-reports
+reports/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -217,5 +217,5 @@ __marimo__/
 
 # Cache
 **/data_cache/
-reports/.DS_Store
+reports
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - .env
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
+      - ./reports:/home/appuser/app/reports
     tty: true
     stdin_open: true
 
@@ -23,6 +24,7 @@ services:
       - LLM_PROVIDER=ollama
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
+      - ./reports:/home/appuser/app/reports
     depends_on:
       - ollama
     tty: true


### PR DESCRIPTION
**Summary**

This update ensures reports generated by TradingAgents inside Docker are saved directly into the repository-level reports directory on the host machine.

**What changed**

Added a bind mount in [docker-compose.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for the tradingagents service:

- ./reports -> /home/appuser/app/reports

Added the same bind mount for the tradingagents-ollama service:

- ./reports -> /home/appuser/app/reports

**Why**

Previously, report output from container runs remained inside Docker volumes and required manual extraction to access from the host machine.

With this change, saved reports are immediately written to the [reports](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) directory on the host filesystem via a Docker bind mount — making them accessible directly from your working directory after each run.

> Note: [reports](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is excluded from Git via [.gitignore](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — reports are intentionally kept local to each developer's machine and are not committed to the repository. "Track" here refers to the host filesystem bind mount, not Git tracking.


**Result**

- Running docker compose run --rm tradingagents now writes report folders/files to the host repo at [reports](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- The existing structured report layout is preserved (for example, per-run timestamped folders with complete_report.md and subfolders).

**Validation**

- Docker Compose configuration validated successfully after mount updates.

- Verified report output appears in the repository reports directory after a run.