### PR TITLE
feat: Bun/Hono server skeleton with portfolio, signals, SSE stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,8 @@ scratchpad/
 .sidecar-start.sh
 .sidecar-base
 .td-root
+
+# Bun
+node_modules/
+bun.lock
+!server/lib/

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,18 @@ __marimo__/
 
 # Cache
 **/data_cache/
+.todos/
+
+# SQLite WAL files
+*.db-wal
+*.db-shm
+
+# Scratchpad (agent working area)
+scratchpad/
+.sidecar/
+.sidecar-agent
+.sidecar-task
+.sidecar-pr
+.sidecar-start.sh
+.sidecar-base
+.td-root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+## MANDATORY: Use td for Task Management
+
+Run td usage --new-session at conversation start (or after /clear). This tells you what to work on next.
+
+Sessions are automatic (based on terminal/agent context). Optional:
+- td session "name" to label the current session
+- td session --new to force a new session in the same context
+
+Use td usage -q after first read.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -1,0 +1,374 @@
+# TradingAgents Playbook
+
+> **Purpose:** Practical guide for running TradingAnalyses effectively. Not theory — what to do, what settings to pick, and what to watch for.
+
+---
+
+## 1. Architecture in One Picture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        ONE TRADING DECISION                       │
+│                                                                  │
+│  ┌─────────────┐   ┌──────────────────┐   ┌───────────────────┐ │
+│  │ Analyst Team │──▶│ Research Team    │──▶│    Trader         │ │
+│  │ (pick 1-4)   │   │ Bull vs Bear     │   │ (composes plan)   │ │
+│  └─────────────┘   │ + Judge/Mgr      │   └────────┬──────────┘ │
+│                    └──────────────────┘            │            │
+│                                                   ▼            │
+│  ┌────────────────────┐   ┌──────────────────────────────┐     │
+│  │ Risk Management    │──▶│  Portfolio Manager           │     │
+│  │ Agg / Neutral / Con│   │  (final buy/sell/hold call)  │     │
+│  └────────────────────┘   └──────────────────────────────┘     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Key principle:** Specialization + adversarial debate. No single agent makes the call alone.
+
+---
+
+## 2. Setup Checklist
+
+### 2.1 Environment
+
+```bash
+cd TradingAgents
+uv sync                    # or: source .venv/bin/activate if already done
+source .venv/bin/activate
+```
+
+### 2.2 API Keys
+
+```bash
+# OpenRouter (recommended — access to multiple models through one key)
+OPENROUTER_API_KEY=sk-or-v1-...
+
+# Or individual providers
+OPENAI_API_KEY=...
+GOOGLE_API_KEY=...
+ANTHROPIC_API_KEY=...
+```
+
+### 2.3 Verification
+
+```bash
+tradingagents --help       # CLI available
+python -c "from tradingagents.graph.trading_graph import TradingAgentsGraph; print('OK')"
+```
+
+---
+
+## 3. Running an Analysis
+
+### 3.1 Interactive CLI (Recommended for exploration)
+
+```bash
+tradingagents analyze
+```
+
+Walks you through 8 steps:
+
+| Step | Decision | Default | Notes |
+|------|----------|---------|-------|
+| 1 | Ticker | SPY | Use exchange suffix for non-US: `7203.T`, `0700.HK` |
+| 2 | Analysis date | Today | Historical dates OK (backtesting) |
+| 3 | Output language | English | Internal debate stays in English |
+| 4 | Analyst team | Select from 4 | More analysts = more cost, more perspective |
+| 5 | Research depth | 1 round | More rounds = deeper debate, more tokens |
+| 6 | LLM provider | Pick one | OpenRouter recommended for model choice |
+| 7 | Thinking models | Per provider | Deep = reasoning, Shallow = fast tasks |
+| 8 | Effort/thinking mode | Per provider | Higher = more cost, potentially better |
+
+### 3.2 Programmatic API (For automation)
+
+```python
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+config = DEFAULT_CONFIG.copy()
+config["llm_provider"] = "openrouter"
+config["deep_think_llm"] = "openai/gpt-5.4"          # Reasoning-heavy tasks
+config["quick_think_llm"] = "openai/gpt-5.4-mini"     # Fast/cheap tasks
+config["max_debate_rounds"] = 2
+config["max_risk_discuss_rounds"] = 2
+config["output_language"] = "English"
+config["checkpoint_enabled"] = True
+
+graph = TradingAgentsGraph(
+    selected_analysts=["market", "news", "fundamentals"],
+    config=config,
+    debug=True
+)
+
+_, decision = graph.propagate("NVDA", "2025-12-15")
+print(decision)
+```
+
+### 3.3 CLI Flags
+
+```bash
+tradingagents analyze --checkpoint           # Enable resume on crash
+tradingagents analyze --clear-checkpoints    # Reset all cached state
+```
+
+---
+
+## 4. Configuration Deep Dive
+
+### 4.1 LLM Provider & Model Selection
+
+| Provider | Deep Think Model | Quick Think Model | Cost Profile |
+|----------|-----------------|-------------------|-------------|
+| OpenAI | `gpt-5.4` | `gpt-5.4-mini` | High |
+| Google | `gemini-3.1-pro` | `gemini-3.1-flash` | Medium |
+| Anthropic | `claude-4.6` | `claude-4.6-mini` | High |
+| OpenRouter | Any model via one key | Any model | Variable |
+
+**Practical guidance:**
+- **Deep think** handles complex reasoning (debate, risk assessment). Spend tokens here.
+- **Quick think** handles formatting, extraction, simple classification. Save money here.
+- OpenRouter gives access to all providers through one API key — use model names like `openai/gpt-5.4` or `anthropic/claude-4.6`.
+
+### 4.2 Analyst Team Selection
+
+| Analyst | Data Source | When to Include | Cost Impact |
+|---------|------------|-----------------|-------------|
+| Market | OHLCV + technical indicators (RSI, MACD, etc.) | Always — cheapest signal | Low |
+| News | Company + global news | When events matter (earnings, macro) | Medium |
+| Social | Social media sentiment | Meme stocks, retail-driven names | Medium |
+| Fundamentals | Financial statements, ratios | Long-term / value analysis | Medium-High |
+
+**Rule of thumb:** Start with Market + News. Add others when the thesis needs them.
+
+### 4.3 Debate Rounds
+
+```python
+config["max_debate_rounds"] = 1          # Fast, minimal debate
+config["max_debate_rounds"] = 2          # Reasonable depth (recommended)
+config["max_debate_rounds"] = 3+         # Deep but expensive
+```
+
+Each round = bull argument + bear argument + judge synthesis. Token cost scales linearly.
+
+### 4.4 Data Vendors
+
+```python
+config["data_vendors"] = {
+    "core_stock_apis": "yfinance",       # Price data
+    "technical_indicators": "yfinance",  # RSI, MACD, etc.
+    "fundamental_data": "yfinance",      # Financials
+    "news_data": "yfinance",             # News articles
+}
+```
+
+| Vendor | Pros | Cons |
+|--------|------|------|
+| yfinance | Free, no API key needed | Rate-limited, data quality varies |
+| alpha_vantage | More structured, more indicators | Requires API key, has rate limits |
+
+---
+
+## 5. Understanding the Output
+
+### 5.1 Decision Format
+
+The final output is a structured decision from the Portfolio Manager containing:
+- **Signal**: Buy / Sell / Hold
+- **Position size**: Relative sizing recommendation
+- **Rationale**: Synthesis of all team inputs
+- **Risk factors**: What could go wrong
+
+### 5.2 Report Artifacts
+
+After each run, reports are saved to:
+
+```
+~/.tradingagents/logs/<TICKER>/<DATE>/reports/
+├── market_report.md
+├── news_report.md
+├── sentiment_report.md
+├── fundamentals_report.md
+├── investment_plan.md          (Research Team decision)
+├── trader_investment_plan.md   (Trader plan)
+└── complete_report.md          (Consolidated)
+```
+
+### 5.3 Decision Memory
+
+The system maintains a persistent memory log:
+```
+~/.tradingagents/memory/trading_memory.md
+```
+
+- Each run appends its decision
+- On the next run for the same ticker, past decisions are fed back into the prompt
+- The system generates reflections on what worked/didn't
+- **This is how the system "learns" over time**
+
+---
+
+## 6. Cost Management
+
+### 6.1 Token Budget Estimation
+
+A typical run with 4 analysts, 2 debate rounds, OpenRouter:
+
+| Stage | Est. Input Tokens | Est. Output Tokens |
+|-------|-------------------|-------------------|
+| Analyst reports (4x) | ~8,000 | ~4,000 |
+| Research debate (2 rounds) | ~12,000 | ~6,000 |
+| Trader plan | ~10,000 | ~2,000 |
+| Risk debate (2 rounds) | ~8,000 | ~4,000 |
+| Portfolio decision | ~12,000 | ~1,000 |
+| **Total** | **~50,000** | **~17,000** |
+
+**Ways to reduce cost:**
+1. Use fewer analysts (Market only = ~60% reduction)
+2. Set `max_debate_rounds = 1`
+3. Use cheaper quick_think model (gpt-5.4-mini vs gpt-5.4)
+4. Use Gemini Flash for quick tasks
+
+### 6.2 Monitoring
+
+The CLI displays live stats:
+- LLM call count
+- Tool call count
+- Token in/out
+- Elapsed time
+
+---
+
+## 7. Common Workflows
+
+### 7.1 Quick Scan (Low Cost)
+
+```python
+config["max_debate_rounds"] = 1
+config["max_risk_discuss_rounds"] = 1
+analysts = ["market"]           # Technicals only
+```
+
+**Use case:** Screening multiple tickers for signals.
+
+### 7.2 Standard Analysis (Balanced)
+
+```python
+config["max_debate_rounds"] = 2
+config["max_risk_discuss_rounds"] = 2
+analysts = ["market", "news", "fundamentals"]
+```
+
+**Use case:** Due diligence on a specific position.
+
+### 7.3 Deep Dive (Maximum Signal)
+
+```python
+config["max_debate_rounds"] = 3
+config["max_risk_discuss_rounds"] = 3
+analysts = ["market", "news", "social", "fundamentals"]
+config["deep_think_llm"] = "openai/gpt-5.4"
+```
+
+**Use case:** High-conviction decision before significant capital allocation.
+
+### 7.4 Backtesting a Date
+
+```python
+_, decision = graph.propagate("AAPL", "2025-03-15")  # Historical date
+```
+
+The agents will only have access to data available up to that date.
+
+---
+
+## 8. Persistence & Recovery
+
+### 8.1 Checkpoints (Crash Recovery)
+
+```bash
+tradingagents analyze --checkpoint
+```
+
+- Saves state after each agent node
+- Crashed run resumes from last completed step
+- SQLite stored at `~/.tradingagents/cache/checkpoints/<TICKER>.db`
+- Auto-cleared on successful completion
+
+### 8.2 Memory (Cross-Run Learning)
+
+- Always on, no flag needed
+- Appends decisions to `~/.tradingagents/memory/trading_memory.md`
+- Injects recent same-ticker decisions + cross-ticker lessons into prompts
+- Limit with `config["memory_log_max_entries"] = 10`
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `ConnectionError` on data fetch | yfinance rate limit | Wait 30s, retry. Or switch to Alpha Vantage |
+| LLM returns empty response | Model too weak for reasoning task | Upgrade deep_think_llm |
+| Run hangs on debate | LLM not returning structured output | Check model supports JSON/structured output |
+| `cnda` / `conda` not found | README out of date | Use `uv` instead (already set up) |
+| Python 3.14 build fails | PyO3 doesn't support 3.14 yet | Use Python 3.13 |
+| "No API key" error | .env not loaded | Run from project root, verify `.env` exists |
+| Ollama connection refused | Local model not running | `ollama run <model>` first |
+
+---
+
+## 10. Limitations (Read This)
+
+1. **Not financial advice.** The README says it explicitly. The system is a research tool.
+2. **Garbage in, garbage out.** yfinance data quality varies. News sentiment is noisy.
+3. **LLM reasoning is non-deterministic.** Same inputs → different outputs on reruns.
+4. **No real-time execution.** This generates decisions, it doesn't place trades.
+5. **Memory is primitive.** The "learning" is prompt injection of past text, not actual model training.
+6. **Backtesting looks clean.** Past analysis dates work, but there's no slippage, commissions, or execution modeling.
+
+---
+
+## 11. Quick Reference Card
+
+```bash
+# Activate environment
+source .venv/bin/activate
+
+# Interactive analysis
+tradingagents analyze
+
+# With checkpoint resume
+tradingagents analyze --checkpoint
+
+# Reset checkpoints
+tradingagents analyze --clear-checkpoints
+
+# Direct Python execution
+python main.py
+
+# Run tests
+uv run pytest -v
+uv run pytest -v -m smoke   # Quick smoke tests only
+```
+
+```python
+# Programmatic quick start
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+config = DEFAULT_CONFIG.copy()
+config["llm_provider"] = "openrouter"
+config["deep_think_llm"] = "openai/gpt-5.4"
+config["quick_think_llm"] = "openai/gpt-5.4-mini"
+
+graph = TradingAgentsGraph(
+    selected_analysts=["market", "news"],
+    config=config,
+    debug=True
+)
+_, decision = graph.propagate("SPY", "2025-01-15")
+```
+
+---
+
+*Last updated: 2026-05-02 | Project version: 0.2.4*

--- a/README.md
+++ b/README.md
@@ -108,15 +108,26 @@ git clone https://github.com/TauricResearch/TradingAgents.git
 cd TradingAgents
 ```
 
-Create a virtual environment in any of your favorite environment managers:
+Create a virtual environment:
+
 ```bash
+# Option 1: conda
 conda create -n tradingagents python=3.13
 conda activate tradingagents
+
+# Option 2: uv (recommended if you don't use conda)
+uv venv --python 3.13
+source .venv/bin/activate
 ```
+
+> [!NOTE]
+> Python 3.13 is required. Python 3.14+ will fail during native extension builds
+> (PyO3 used by tiktoken does not yet support 3.14).
 
 Install the package and its dependencies:
 ```bash
-pip install .
+pip install .       # with conda or venv
+uv sync             # with uv (uses locked dependency versions)
 ```
 
 ### Docker
@@ -219,6 +230,17 @@ print(decision)
 ```
 
 See `tradingagents/default_config.py` for all configuration options.
+
+> [!NOTE]
+> When using the Python API directly (not the CLI), you must load environment
+> variables manually, as the CLI handles this automatically:
+>
+> ```python
+> from dotenv import load_dotenv
+> load_dotenv()       # loads .env before creating TradingAgentsGraph
+>
+> from tradingagents.graph.trading_graph import TradingAgentsGraph
+> ```
 
 ## Persistence and Recovery
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**/*.ts", "**/*.mts", "**/*.cts", "**/*.js", "**/*.mjs", "**/*.cjs", "**/*.json"]
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "error",
+        "noUnusedPrivateClassMembers": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noConsole": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useConst": "error"
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": "off"
+      },
+      "performance": {
+        "noDelete": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "asNeeded",
+      "trailingCommas": "all",
+      "arrowParentheses": "always"
+    },
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": false
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    },
+    "parser": {
+      "allowComments": true,
+      "allowTrailingCommas": false
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["scripts/lab/**"],
+      "linter": {
+        "enabled": false
+      }
+    }
+  ]
+}

--- a/briefs/brief-dashboard-2026-05-02.md
+++ b/briefs/brief-dashboard-2026-05-02.md
@@ -1,0 +1,459 @@
+---
+date: 2026-05-02
+tags: [feature, ui, infrastructure, api, database, planning]
+agent: local-ai
+environment: local
+---
+
+## Task: TradingAgents Dashboard — Bun/Hono + SSE Implementation
+
+**Objective:** Build a web dashboard for TradingAgents using Bun/Hono that provides portfolio tracking, position-aware analysis, real-time SSE streaming of agent progress, server-side markdown rendering, and signal history — all wrapping the upstream TradingAgents package without forking it.
+
+- [ ] Design SQLite schema for positions, signals, watchlist, and analyses
+- [ ] Build Python wrapper script (`scripts/analyze_stream.py`) for clean JSON-line output
+- [ ] Build Bun/Hono web server with SSE streaming, API routes, and HTML rendering
+- [ ] Build HTMX-based frontend with portfolio, analysis, and signal history views
+- [ ] Implement position-aware analysis (inject position context before agent run)
+- [ ] Implement JSON log → Markdown renderer for historical analysis display
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Browser                              │
+│  HTMX-driven UI ←──SSE──→ HTML/SSE streams from server      │
+│  (no SPA, no build step, no client-side markdown parsing)   │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ HTTP + SSE
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Bun / Hono (port 3000)                    │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌───────────────┐  │
+│  │API Routes│ │SSE Proxy │ │SQLite DB │ │Markdown Render│  │
+│  │(REST)    │ │/analyze  │ │bun:sqlite│ │marked / itty  │  │
+│  └──────────┘ └──────────┘ └──────────┘ └───────────────┘  │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  Static frontend: HTML + HTMX + minimal CSS           │  │
+│  │  Server-rendered markdown (no client JS framework)    │  │
+│  └───────────────────────────────────────────────────────┘  │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ Bun.spawn()
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Python Subprocess (analyze_stream.py)           │
+│  ┌─────────────────┐  ┌─────────────────┐                   │
+│  │TradingAgents    │  │JSON log parser  │                   │
+│  │graph.propagate()│  │→ JSON lines     │                   │
+│  └────────┬────────┘  └────────┬────────┘                   │
+│           │                    │                             │
+│           ▼                    ▼                             │
+│  ┌─────────────────────────────────────────┐               │
+│  │  Clean JSON-line output on stdout:      │               │
+│  │  {"event": "agent_start", "agent": "..."}│              │
+│  │  {"event": "tool_call", "tool": "..."}  │               │
+│  │  {"event": "report", "section": "..."}  │               │
+│  │  {"event": "decision", "rating": "..."} │               │
+│  │  {"event": "complete", "state": {...} } │               │
+│  └─────────────────────────────────────────┘               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Actions Checklist:
+
+- [ ] Create `briefs/` directory and this brief
+- [ ] Design SQLite schema (positions, signals, watchlist, analyses tables)
+- [ ] Create `scripts/analyze_stream.py` — Python wrapper for clean JSON-line output
+- [ ] Create `server/` directory with Bun/Hono server
+- [ ] Implement SSE `/analyze` route that spawns Python subprocess
+- [ ] Implement SQLite CRUD for positions/signals/watchlist via `bun:sqlite`
+- [ ] Implement position context injection (read position file → inject into TradingAgents config)
+- [ ] Build HTML layout: three tabs (Portfolio, Analysis, Signals)
+- [ ] Build HTMX interactions: form submission → SSE stream → DOM updates
+- [ ] Implement JSON log → Markdown renderer for historical analysis view
+- [ ] Add signal change detection and alert display
+- [ ] Test end-to-end: run analysis on TKA.DE, verify SSE streaming, verify position-aware output
+
+## Detailed Requirements
+
+### 1. SQLite Schema & Connection (`portfolio.db`)
+
+**Connection Protocol** — per `playbooks/sqlite-playbook.md`. All database access flows through `DatabaseFactory` (see §1b), never raw `new Database()`.
+
+**Pragmas (enforced by factory, non-negotiable):**
+```sql
+PRAGMA journal_mode = WAL;          -- concurrent reads during analysis writes
+PRAGMA busy_timeout = 5000;         -- wait 5s for locks
+PRAGMA mmap_size = 0;               -- stability over speed
+PRAGMA foreign_keys = ON;           -- data integrity
+PRAGMA synchronous = NORMAL;        -- safe + fast in WAL mode
+```
+
+**Golden Rules (from sqlite-playbook):**
+1. **WAL mode mandatory** — dashboard reads overlap with analysis writes (signal logging)
+2. **ReadWrite mandatory** — even "read-only" queries need `readonly: false` because WAL readers write to `-shm`
+3. **Singleton connection** — one long-lived DB instance via `DatabaseFactory`, injected into route handlers
+4. **Transactions for bulk ops** — wrap multi-row inserts in `db.transaction()` (50 → 10,000 ops/sec)
+5. **Graceful close** — `db.close()` on server shutdown to checkpoint WAL
+6. **Optimize on close** — `PRAGMA optimize;` before disconnect
+
+```sql
+-- What you currently own
+CREATE TABLE positions (
+    id         INTEGER PRIMARY KEY,
+    ticker     TEXT NOT NULL,
+    exchange   TEXT DEFAULT 'US',
+    quantity   INTEGER NOT NULL,
+    avg_cost   REAL NOT NULL,       -- average entry price
+    entry_date TEXT NOT NULL,       -- ISO date
+    thesis     TEXT,                -- why you bought it
+    status     TEXT DEFAULT 'open', -- open | closed
+    notes      TEXT
+);
+
+-- Closed positions for P&L history
+CREATE TABLE trades (
+    id          INTEGER PRIMARY KEY,
+    position_id INTEGER REFERENCES positions(id),
+    ticker      TEXT NOT NULL,
+    action      TEXT NOT NULL,      -- buy | sell
+    quantity    INTEGER NOT NULL,
+    price       REAL NOT NULL,
+    date        TEXT NOT NULL,      -- ISO date
+    reason      TEXT,               -- why (e.g., "AI sell signal", "manual exit")
+    fees        REAL DEFAULT 0
+);
+
+-- Signal history: what the AI said, when
+CREATE TABLE signals (
+    id         INTEGER PRIMARY KEY,
+    ticker     TEXT NOT NULL,
+    date       TEXT NOT NULL,       -- analysis date
+    signal     TEXT NOT NULL,       -- Buy | Overweight | Hold | Underweight | Sell
+    reasoning  TEXT,                -- executive summary
+    confidence TEXT,                -- high | medium | low (derived)
+    created_at TEXT NOT NULL        -- ISO timestamp of analysis run
+);
+
+-- Watchlist: prospects you're tracking but don't own
+CREATE TABLE watchlist (
+    id         INTEGER PRIMARY KEY,
+    ticker     TEXT NOT NULL,
+    exchange   TEXT DEFAULT 'US',
+    thesis     TEXT,                -- why you're watching it
+    priority   TEXT DEFAULT 'medium', -- high | medium | low
+    added_date TEXT NOT NULL,
+    last_signal TEXT               -- most recent signal for this ticker
+);
+
+-- Full analysis output (stored as JSON, rendered on demand)
+CREATE TABLE analyses (
+    id         INTEGER PRIMARY KEY,
+    ticker     TEXT NOT NULL,
+    date       TEXT NOT NULL,       -- analysis date
+    config     TEXT,                -- JSON: which analysts, LLM, debate rounds
+    raw_state  TEXT,                -- full JSON state log from TradingAgents
+    decision   TEXT,                -- final decision text
+    created_at TEXT NOT NULL
+);
+```
+
+### 1b. Database Factory (`server/lib/db.ts`)
+
+```typescript
+import { Database } from "bun:sqlite";
+
+let _instance: Database | null = null;
+
+export const DatabaseFactory = {
+  connect(path: string): Database {
+    if (!_instance) {
+      _instance = new Database(path, { readwrite: true, create: true });
+      _instance.run("PRAGMA journal_mode = WAL");
+      _instance.run("PRAGMA busy_timeout = 5000");
+      _instance.run("PRAGMA mmap_size = 0");
+      _instance.run("PRAGMA foreign_keys = ON");
+      _instance.run("PRAGMA synchronous = NORMAL");
+    }
+    return _instance;
+  },
+  async close(): Promise<void> {
+    if (_instance) {
+      _instance.run("PRAGMA optimize");
+      _instance.close();
+      _instance = null;
+    }
+  },
+  get(): Database {
+    if (!_instance) throw new Error("Database not initialized");
+    return _instance;
+  },
+};
+```
+
+### 2. Python Wrapper (`scripts/analyze_stream.py`)
+
+Purpose: Run TradingAgents and emit clean JSON lines to stdout. No Rich, no terminal escape codes.
+
+```
+Input:  ticker, date, analyst_selection, llm_config, position_context
+Output: JSON lines on stdout, one per event
+
+Events:
+  {"event": "start", "ticker": "TKA.DE", "date": "2026-05-02"}
+  {"event": "agent_start", "agent": "Market Analyst"}
+  {"event": "tool_call", "tool": "get_stock_data", "args": {"symbol": "TKA.DE"}}
+  {"event": "tool_result", "tool": "get_stock_data", "status": "ok"}
+  {"event": "report", "section": "market_report", "content": "..."}
+  {"event": "agent_complete", "agent": "Market Analyst"}
+  {"event": "debate_start", "type": "investment", "round": 1}
+  {"event": "debate_complete", "type": "investment", "decision": "..."}
+  {"event": "decision", "signal": "Overweight", "reasoning": "..."}
+  {"event": "complete", "log_path": "/path/to/full_states_log.json"}
+  {"event": "error", "message": "..."}
+```
+
+The wrapper:
+- Loads TradingAgents graph
+- Injects position context if the ticker is in `portfolio.db`
+- Uses callbacks/hooks to capture state transitions
+- Emits JSON lines as events occur
+- Writes the full state log to `~/.tradingagents/logs/` as normal
+
+### 3. Bun/Hono Server (`server/index.ts`)
+
+Routes:
+
+```
+GET  /                          → Portfolio dashboard (HTML)
+GET  /analyze                   → Analysis form (HTML)
+GET  /signals                   → Signal history (HTML)
+GET  /analysis/:id              → Full analysis detail (HTML, rendered markdown)
+
+GET  /api/positions             → List all positions (JSON)
+POST /api/positions             → Add position (JSON)
+DELETE /api/positions/:id       → Close/remove position (JSON)
+
+GET  /api/watchlist             → List watchlist items (JSON)
+POST /api/watchlist             → Add watchlist item (JSON)
+DELETE /api/watchlist/:id       → Remove watchlist item (JSON)
+
+POST /api/analyze               → Trigger analysis, returns job SSE stream
+GET  /api/analyze/stream        → SSE stream for in-progress analysis
+GET  /api/signals               → Signal history (JSON, filterable by ticker)
+GET  /api/signals/:ticker       → Signal timeline for specific ticker (JSON)
+GET  /api/analyses              → List past analyses (JSON)
+GET  /api/analyses/:id          → Full analysis with rendered markdown (JSON)
+
+GET  /api/health                → Server health check
+GET  /api/prices/:ticker        → Current price (via yfinance subprocess)
+```
+
+### 4. Frontend Layout (HTMX-driven)
+
+```
+┌─ TradingAgents Dashboard ───────────────────────────────────┐
+│ [Portfolio] [Analysis] [Signals] [Settings]                 │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  PORTFOLIO TAB                                              │
+│  ┌─ Positions ────────────────────────────────────────┐    │
+│  │ Ticker │ Shares │ Cost │ Current │ P&L │ Signal   │    │
+│  │ TKA.DE │  500   │ €8.45│ €10.09  │+19% │Overweight│    │
+│  │ AAPL   │   50   │$185  │ $192    │+3.8%│Hold      │    │
+│  └────────────────────────────────────────────────────┘    │
+│  [+ Add Position]                                          │
+│                                                             │
+│  ┌─ Signal Alerts ───────────────────────────────────┐    │
+│  │ ⚠ TKA.DE: Hold → Overweight (2026-05-02)         │    │
+│  │ 📊 AAPL analysis complete: Hold (no change)       │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+│  ┌─ Watchlist ───────────────────────────────────────┐    │
+│  │ Ticker │ Priority │ Last Signal │ Thesis          │    │
+│  │ MSFT   │ High     │ Buy         │ Cloud dominance │    │
+│  │ 7203.T │ Medium   │ Hold        │ Auto recovery   │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ANALYSIS TAB                                               │
+│  ┌─ Run New Analysis ────────────────────────────────┐    │
+│  │ Ticker: [TKA.DE]  Date: [2026-05-02]              │    │
+│  │ Analysts: ☑ Market  ☐ Social  ☑ News  ☑ Fund      │    │
+│  │ LLM: [OpenRouter ▼]  Deep: [gpt-5.4 ▼]            │    │
+│  │ Quick: [gpt-5.4-mini ▼]  Debates: [2 ▼]           │    │
+│  │                                                   │    │
+│  │ ⚠ Position context: 500 shares @ €8.45 (+19.4%)  │    │
+│  │   Agents will be aware of your position           │    │
+│  │                                    [▶ Run Analysis]│    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+│  ┌─ Live Progress (SSE) ─────────────────────────────┐    │
+│  │ [▓▓▓▓▓▓░░░░░░] 5/10 agents complete              │    │
+│  │ ✓ Market Analyst — complete                       │    │
+│  │ ✓ News Analyst — complete                         │    │
+│  │ ● Fundamentals Analyst — in progress              │    │
+│  │ ○ Research Team — pending                         │    │
+│  │ ○ Trader — pending                                │    │
+│  │ ○ Risk Management — pending                       │    │
+│  │ ○ Portfolio Manager — pending                     │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+│  ┌─ Analysis Output (streamed markdown) ─────────────┐    │
+│  │ ## Market Analysis                                │    │
+│  │ TKA.DE is showing a short-term recovery inside... │    │
+│  │                                                   │    │
+│  │ ## Final Decision: Overweight                     │    │
+│  │ Build 1.25x to 1.75x benchmark weight in tranches │    │
+│  │                                                   │    │
+│  │ ⚠ You hold 500 shares → Recommendation: HOLD     │    │
+│  │   (don't add after a 19% run, wait for pullback)  │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  SIGNALS TAB                                                │
+│  ┌─ TKA.DE Signal Timeline ──────────────────────────┐    │
+│  │                                                   │    │
+│  │ Overweight  ████████████ 2026-05-02 (current)     │    │
+│  │ Hold        ██████████████████ 2026-04-28         │    │
+│  │ Hold        ██████████████████████ 2026-04-15     │    │
+│  │                                                   │    │
+│  │ Entry: €8.45 ──────────────→ Current: €10.09     │    │
+│  │ Signal return: +19.4%                            │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+│  [Select ticker ▼]  [Show chart]                           │
+│                                                             │
+│  ┌─ All Signals ─────────────────────────────────────┐    │
+│  │ Date     │ Ticker │ Signal     │ Price │ Notes    │    │
+│  │ 2026-05-02│TKA.DE │ Overweight │ €10.09│ Kone deal│    │
+│  │ 2026-05-02│ AAPL   │ Hold       │ $192  │ Stable   │    │
+│  │ 2026-04-28│ TKA.DE │ Hold       │ €9.12 │ Recovery │    │
+│  └────────────────────────────────────────────────────┘    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 5. Position-Aware Analysis Flow
+
+```
+User clicks "Run Analysis" on TKA.DE
+         │
+         ▼
+Bun checks portfolio.db: "Do we own TKA.DE?"
+         │
+    YES  │  NO
+         │
+         ▼              ▼
+Read position     No position context
+context:          needed
+"500 shares
+@ €8.45, +19.4%"  │
+         │         │
+         └────┬────┘
+              ▼
+Bun spawns: python3 scripts/analyze_stream.py \
+  --ticker TKA.DE \
+  --date 2026-05-02 \
+  --position-context "500 shares @ €8.45 (+19.4%)"
+              │
+              ▼
+Python wrapper injects context into TradingAgents config
+(Portfolio Manager prompt includes position status)
+              │
+              ▼
+Analysis runs, emits JSON-line events to stdout
+              │
+              ▼
+Bun reads stdout, transforms to SSE, streams to browser
+              │
+              ▼
+On complete: save signal to portfolio.db, render final report
+```
+
+### 6. File Structure
+
+```
+TradingAgents/
+├── briefs/
+│   └── brief-dashboard-2026-05-02.md    ← this file
+├── server/
+│   ├── index.ts                          ← Bun/Hono entry point
+│   ├── routes/
+│   │   ├── portfolio.ts                  ← position CRUD, watchlist
+│   │   ├── analysis.ts                   ← SSE analysis trigger
+│   │   ├── signals.ts                    ← signal history API
+│   │   └── prices.ts                     ─ current price fetcher
+│   ├── views/
+│   │   ├── layout.html                   ← base HTML template
+│   │   ├── portfolio.html                ← portfolio tab
+│   │   ├── analysis.html                 ← analysis tab
+│   │   ├── signals.html                  ← signals tab
+│   │   └── partials/
+│   │       ├── position-row.html         ← HTMX partial
+│   │       ├── signal-alert.html         ← HTMX partial
+│   │       └── analysis-progress.html    ← HTMX partial (SSE target)
+│   ├── lib/
+│   │   ├── db.ts                         ← DatabaseFactory (singleton + WAL)
+│   │   ├── markdown.ts                   ← server-side MD renderer
+│   │   └── sse.ts                        ← SSE helper / event builder
+│   └── static/
+│       ├── style.css                     ← minimal styles
+│       └── htmx.min.js                   ← HTMX CDN or vendored
+├── scripts/
+│   └── analyze_stream.py                 ← Python wrapper for TA
+├── portfolio.db                          ← SQLite database (gitignored, WAL mode)
+├── portfolio.db-wal                      ← WAL file (auto-created, gitignored)
+├── portfolio.db-shm                      ← shared memory (auto-created, gitignored)
+└── .env                                  ← API keys (already exists)
+```
+
+**Note:** `portfolio.db-wal` and `portfolio.db-shm` are created automatically by WAL mode. Ensure `.gitignore` includes `*.db-wal` and `*.db-shm`.
+
+### 7. Dependencies
+
+**Bun (`server/package.json`):**
+```json
+{
+  "dependencies": {
+    "hono": "^4.x",
+    "@hono/node-server": "^1.x"  (or just use Bun native)
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}
+```
+
+**Python (already in project venv):**
+- No new dependencies — uses existing TradingAgents install
+- `scripts/analyze_stream.py` imports from `tradingagents` package directly
+
+### 8. Constraints & Design Decisions
+
+- **SQLite only** — no PostgreSQL, no migration framework. Schema is simple enough to evolve manually
+- **WAL mode mandatory** — concurrent reads during analysis writes (signal logging, trade entry)
+- **Single DB connection** — `DatabaseFactory` singleton, injected into all routes. No raw connections
+- **HTMX only** — no React, no Vue, no build step. Server renders HTML, HTMX swaps fragments
+- **SSE for streaming** — no WebSockets, no polling. SSE is unidirectional (server→browser), perfect for analysis progress
+- **Markdown rendered server-side** — Bun uses a lightweight markdown parser, client receives clean HTML
+- **Portfolio is read-only from TA's perspective** — TradingAgents never writes to the DB; it only reads position context. All DB writes go through Bun API routes
+- **Signal recording is automatic** — every completed analysis writes its signal to `signals` table. No manual step
+- **Graceful shutdown** — server must call `DatabaseFactory.close()` to checkpoint WAL before exit
+- **Transactions for bulk ops** — multi-row inserts (seed, batch analysis) wrapped in `db.transaction()`
+- **No fork of TradingAgents** — the wrapper communicates via config injection only
+
+## Verification
+
+- [ ] `bun run server/index.ts` starts without errors
+- [ ] `GET /` returns portfolio dashboard HTML
+- [ ] `POST /api/positions` creates a position, appears in UI
+- [ ] `POST /api/analyze` triggers SSE stream, browser shows live progress
+- [ ] Analysis completes, signal saved to DB, report rendered as HTML
+- [ ] Position context appears in agent output when analyzing a held ticker
+- [ ] Signal timeline shows correct history for TKA.DE
+- [ ] JSON log from past analysis renders as readable Markdown
+- [ ] WAL mode confirmed: `PRAGMA journal_mode` returns `wal`
+- [ ] Concurrent read during analysis write does not produce `SQLITE_BUSY`
+- [ ] Graceful shutdown checkpoints WAL (no orphaned `-wal`/`-shm` files)

--- a/debriefs/debrief-installation-2026-05-02.md
+++ b/debriefs/debrief-installation-2026-05-02.md
@@ -1,0 +1,58 @@
+---
+date: 2026-05-02
+tags: [infrastructure, verification, documentation]
+agent: local-ai
+environment: local
+---
+
+## Debrief: TradingAgents Installation & Initial Configuration
+
+## Accomplishments
+
+- **Environment setup via `uv` instead of `conda`:** The README only documents conda, but the project ships with a `uv.lock` file. Used `uv venv --python 3.13` + `uv sync` to install all 111 packages in one command.
+- **API key configuration:** Created `.env` from `.env.example`, populated `OPENROUTER_API_KEY`. Verified `.env` is already in `.gitignore` (line 151).
+- **CLI verification:** `tradingagents --help` confirmed the installed command works.
+- **End-to-end test run:** Successfully ran full analysis on TKA.DE (thyssenkrupp AG) — all 5 agent teams executed, final decision: Overweight.
+- **Created PLAYBOOK.md:** Comprehensive practical guide covering architecture, configuration, cost management, workflows, and troubleshooting.
+- **Created implementation brief:** `briefs/brief-dashboard-2026-05-02.md` — full spec for Bun/Hono dashboard with SSE streaming, portfolio tracking, and position-aware analysis.
+
+## Problems
+
+- **conda not installed, README only mentions conda:** The installation instructions reference `conda create -n tradingagents python=3.13` as the only method. The project already has `uv.lock` but this isn't documented. The conda references appear in exactly two places in the README — nowhere in actual code.
+  - **Resolution:** Used `uv` throughout. No code changes needed.
+
+- **Python 3.14 build failure:** System Python is 3.14.4, but PyO3 (used by `tiktoken`, a transitive dependency of `langchain-openai`) maxes out at Python 3.13. Build failed with:
+  ```
+  error: the configured Python interpreter version (3.14) is newer than
+  PyO3's maximum supported version (3.13)
+  ```
+  - **Resolution:** Used `uv venv --python 3.13` explicitly. The `uv.lock` was already pinned for 3.13, so this was the correct version all along.
+  - **Implication:** Any setup script that uses the system default Python will fail on 3.14.
+
+- **OpenRouter API key not picked up by Python API:** When running TradingAgents programmatically (not via CLI), the `OPENROUTER_API_KEY` from `.env` was not loaded. The CLI calls `load_dotenv()` in `cli/main.py`, but the Python API (`TradingAgentsGraph`) does not. The OpenAI client was being used without any API key, causing:
+  ```
+  openai.OpenAIError: The api_key client option must be set either by
+  passing api_key to the client or by setting the OPENAI_API_KEY
+  environment variable
+  ```
+  - **Resolution:** Added `from dotenv import load_dotenv; load_dotenv()` before importing TradingAgents in the script.
+  - **Implication:** The Python API requires manual `.env` loading. This is not documented. The CLI hides this from users.
+
+- **`td` task manager not initialized:** `td usage --new-session` failed with "database not found: run 'td init' first". The project didn't have a `.todos` directory.
+  - **Resolution:** Ran `td init --work-dir` to initialize.
+
+## Lessons Learned
+
+- **README installation docs are stale:** Only documents conda. Should include `uv` as a first-class option. The `uv.lock` file being present suggests this was intended but never documented.
+
+- **Python version pinning matters:** The `uv.lock` implicitly targets Python 3.13. On a system with only Python 3.14, `uv sync` will fail during native extension builds (tiktoken/PyO3). Setup instructions should explicitly call out `--python 3.13`.
+
+- **`.env` loading is inconsistent:** The CLI loads dotenv, the Python API does not. If you use `TradingAgentsGraph` directly, you must load dotenv yourself. This is a footgun — the CLI works, the import-from-module pattern silently fails.
+
+- **OpenRouter model names require provider prefix:** Model names in OpenRouter use format `openai/gpt-5.4`, not just `gpt-5.4`. The config accepts both but only the prefixed form routes correctly.
+
+- **First-run analysis is slow:** The initial TKA.DE analysis took several minutes, largely due to `tiktoken` needing to compile from source (Rust build). Subsequent runs will be faster since the compiled wheel is cached.
+
+- **TradingAgents output is verbose in debug mode:** The debug output is useful for development but overwhelming for production use. The planned `scripts/analyze_stream.py` wrapper will need to filter and structure this output into clean JSON-line events.
+
+- **The decision memory system works out of the box:** After the TKA.DE run, `~/.tradingagents/memory/trading_memory.md` was automatically populated with the decision, rating, and rationale. This will be useful for the position-aware analysis feature — the memory already contains analysis history that can be cross-referenced with positions.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,83 @@
+# TradingAgents — Unified task runner
+# Requires: just (https://github.com/casey/just), bun, uv
+# See: playbooks/just-playbook.md
+
+set shell := ["bash", "-o", "pipefail", "-c"]
+set positional-arguments := true
+set dotenv-load := true
+
+[group("bun")]
+lint:                       # Check code with Biome
+    bunx biome check .
+
+[group("bun")]
+lint-fix:                   # Check and auto-fix
+    bunx biome check . --write
+
+[group("bun")]
+format:                     # Format all files
+    bunx biome format . --write
+
+[group("bun")]
+check:                      # Full CI gate: lint + type-check all tiers
+    bunx biome check .
+    tsc --project tsconfig.json --noEmit
+    tsc --project tsconfig.scripts.json --noEmit
+
+[group("python")]
+install:                    # Install Python dependencies
+    uv sync
+
+[group("python")]
+run:                        # Launch interactive CLI
+    source .venv/bin/activate && tradingagents
+
+[group("python")]
+run-cli:                    # Launch CLI via python module
+    source .venv/bin/activate && python -m cli.main
+
+[group("python")]
+analyze TICKER="SPY" DATE="today" DEBATES="1":  # Run analysis on a ticker
+    source .venv/bin/activate && python scripts/analyze.py '{{TICKER}}' --date '{{DATE}}' --debates {{DEBATES}}
+
+[group("python")]
+test:                       # Run full test suite
+    source .venv/bin/activate && pytest tests/ -v
+
+[group("python")]
+test-smoke:                 # Smoke tests only
+    source .venv/bin/activate && pytest tests/ -v -m smoke
+
+[group("python")]
+test-quick:                 # Quick structured output test
+    source .venv/bin/activate && python scripts/smoke_structured_output.py
+
+[group("td")]
+td-new:                     # Start new td session
+    td usage --new-session
+
+[group("td")]
+td-status:                  # Show current status
+    td current
+    td ws current
+
+[group("td")]
+td-next:                    # Show next priority issue
+    td next
+
+[group("td")]
+td-context ID:              # Get full context for an issue
+    td context {{ID}}
+
+[group("td")]
+td-reset:                   # Reset td database
+    rm -rf .todos
+    td init
+
+[group("convenience")]
+analyze-tka DEBATES="1":    # Run analysis on TKA.DE (default test ticker)
+    just analyze TKA.DE today {{DEBATES}}
+
+alias a := analyze
+alias t := test
+alias l := lint

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tradingagents-dashboard",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "biome check .",
+    "lint:fix": "biome check . --write",
+    "format": "biome format . --write",
+    "check": "biome check . && tsc --project tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.14",
+    "@types/bun": "latest"
+  },
+  "dependencies": {
+    "hono": "^4.9.8",
+    "marked": "^16.3.0"
+  }
+}

--- a/playbooks/briefs-playbook.md
+++ b/playbooks/briefs-playbook.md
@@ -1,0 +1,131 @@
+---
+date: 2026-01-09
+tags: [cleanup, verification, mcp-server]
+agent: claude
+environment: local
+---
+```
+
+### Why This Matters
+- **Agent Context:** Different agents may have different capabilities and access patterns
+- **Tool Selection:** Operating environment determines available tools (MCP, file system, etc.)
+- **Searchability:** Tags enable semantic discovery across knowledge graph
+- **Workflow Tracing:** Agent designation helps track which agent created which briefs
+
+## File Naming
+- **Format:** `brief-[slug].md`
+- **Location:** `briefs/` directory
+- **Example:** `briefs/brief-sidebar-refinements.md`
+
+### Brief Naming Convention
+- **Format:** `brief-[slug].md` or `brief-[topic]-[YYYY-MM-DD].md`
+- **Location:** `briefs/` directory
+- **Slug Format:** lowercase, hyphens instead of spaces, no special chars
+- **Examples:**
+  - `briefs/brief-sidebar-refinements.md`
+  - `briefs/brief-phase1-cleanup.md`
+  - `briefs/brief-mcp-server-optimization.md`
+
+### Date-Prefix Naming (Recommended)
+- **Format:** `brief-[topic]-[YYYY-MM-DD].md`
+- **Benefits:** 
+  - Automatic chronological sorting
+  - Easy identification of recent work
+  - Prevents naming collisions
+- **Example:** `brief-phase1-cleanup-2026-01-09.md`
+
+### Avoid These Names
+- ❌ Generic names like `brief.md` or `task.md`
+- ❌ Overly long descriptions in filename (put in brief, not filename)
+- ❌ Special characters or spaces (use hyphens)
+- ❌ Numbers without context (use descriptive slugs)
+
+## Template
+
+```markdown
+---
+date: [YYYY-MM-DD]
+tags: [tag1, tag2, tag3]
+agent: [claude | cursor | local-ai | other]
+environment: [local | development | production]
+---
+
+## Task: [Task Name]
+
+**Objective:** [Concise description of the main goal]
+
+- [ ] [High-level requirement 1]
+- [ ] [High-level requirement 2]
+- [ ] [High-level requirement 3]
+
+## Frontmatter Tags Best Practices
+
+### Recommended Tags by Category
+
+**Task Type:**
+- `cleanup` - Code cleanup, dead code removal, hygiene
+- `refactoring` - Code restructuring, architectural changes
+- `feature` - New feature implementation
+- `bugfix` - Bug resolution and fixes
+- `performance` - Performance optimization
+- `security` - Security improvements
+- `testing` - Test coverage, test improvements
+
+**Verification/Quality:**
+- `verification` - Verification of completed work
+- `mcp-server` - MCP server usage, configuration
+- `quality-assessment` - Code quality evaluations
+- `audit` - Code audits, compliance checks
+
+**Phase:**
+- `phase1` - First phase of multi-phase task
+- `phase2` - Second phase, etc.
+- `planning` - Planning and design phase
+- `implementation` - Implementation phase
+- `review` - Review and refinement phase
+
+**Domain:**
+- `database` - Database-related changes
+- `api` - API changes
+- `cli` - Command-line interface changes
+- `ui` - User interface changes
+- `infrastructure` - Infrastructure and tooling
+- `documentation` - Documentation updates
+
+### Adding Frontmatter Tags
+
+**Recommended Approach:**
+1. **Manual Addition:** Add frontmatter tags directly when creating brief
+2. **MCP-Assisted:** Use amalfa MCP server to suggest relevant tags based on semantic search
+3. **Post-Creation:** Review and add additional tags discovered through graph traversal
+
+**Using amalfa MCP Server:**
+```bash
+# Search for similar briefs to discover common tags
+amalfa serve  # Start MCP server (if not running)
+
+# Then in MCP client:
+search_documents("cleanup verification mcp server")
+# Review returned briefs for tag patterns
+```
+
+**Recommended Tool for Adding Tags:** Use amalfa MCP server `search_documents` to find similar briefs and discover common tag patterns.
+
+## Key Actions Checklist:
+
+- [ ] [Actionable step 1]
+- [ ] [Actionable step 2]
+- [ ] [Actionable step 3]
+
+## Detailed Requirements / Visuals
+
+[Optional: Add detailed descriptions, ASCII art layouts, or specific constraints here]
+
+## Best Practices
+- **Keep it focused:** One brief per distinct task.
+- **Use checklists:** Checklists allow for tracking progress within the brief itself.
+- **Be visual:** Use ASCII art or diagrams to explain layout changes.
+- **Include frontmatter:** Add `date`, `tags`, `agent`, and `environment` fields for discoverability.
+- **Tag strategically:** Use descriptive tags that enable semantic discovery across knowledge graph.
+- **Document verification:** Specify how work will be verified (manual testing, MCP server, automated tests).
+- **Date-prefix naming:** Use `brief-[topic]-[YYYY-MM-DD].md` format for automatic chronological sorting.

--- a/playbooks/debriefs-playbook.md
+++ b/playbooks/debriefs-playbook.md
@@ -1,0 +1,187 @@
+---
+date: 2026-01-09T00:00:00.000Z
+tags:
+  - playbook
+  - documentation
+  - process
+  - workflow
+  - best-practices
+  - metadata
+  - vocabulary
+  - agent-driven
+  - extracted
+---
+
+# Debriefs Playbook
+
+## Purpose
+A debrief is a retrospective document created after the completion of a significant task or milestone. It captures what was done, what went wrong, and what was learned to improve future work.
+
+**Critical:** Debriefs are **MANDATORY** for all significant changes per the **Change Management Protocol (CMP)**. A debrief documents what actually happened, not what was planned. It includes verification proof that changes work as intended.
+
+**Reference:** See `playbooks/change-management-protocol.md` for the full Plan → Execute → Verify → Debrief cycle.
+
+## Agent Designation & Operating Environment
+
+**Critical:** Debriefs should clearly specify the agent's designation and operating environment to enable proper context management and tool selection.
+
+### Required Frontmatter Fields
+- `date`: YYYY-MM-DD format (creation date)
+- `tags`: Array of relevant tags (e.g., [cleanup, verification, mcp-server])
+- `agent`: Agent designation (e.g., [claude, cursor, local-ai])
+- `environment`: Operating environment (e.g., [local, development, production])
+
+**Example:**
+```markdown
+---
+date: 2026-01-09
+tags: [cleanup, verification, mcp-server]
+agent: claude
+environment: local
+---
+```
+
+### Why This Matters
+- **Agent Context:** Different agents may have different capabilities and access patterns
+- **Tool Selection:** Operating environment determines available tools (MCP, file system, etc.)
+- **Searchability:** Tags enable semantic discovery across knowledge graph
+- **Workflow Tracing:** Agent designation helps track which agent created which debriefs
+
+## File Naming
+- **Convention:** `YYYY-MM-DD-topic.md` (date first, always)
+- **Drafting:** You may create `debrief-topic-YYYY-MM-DD.md` in the project root for visibility during the session
+- **Final Location:** `debriefs/` directory (must be moved before session end)
+- **Enforcement:** Run `bun run scripts/maintenance/fix-debrief-names/index.ts` to verify/fix naming
+
+## Template
+
+```markdown
+---
+date: [YYYY-MM-DD]
+tags: [tag1, tag2, tag3]
+agent: [claude | cursor | local-ai | other]
+environment: [local | development | production]
+---
+
+## Debrief: [Task Name]
+
+## Accomplishments
+
+- **[Accomplishment 1]:** [Description of what was achieved]
+- **[Accomplishment 2]:** [Description of what was achieved]
+
+## Problems
+
+- **[Problem 1]:** [Description of the issue encountered and how it was resolved]
+- **[Problem 2]:** [Description of the issue encountered and how it was resolved]
+
+## Lessons Learned
+
+- **[Lesson 1]:** [Insight gained that can be applied to future tasks]
+- **[Lesson 2]:** [Insight gained that can be applied to future tasks]
+
+```
+
+## Frontmatter Tags Best Practices
+
+### Recommended Tags by Category
+
+**Task Type:**
+- `cleanup` - Code cleanup, dead code removal, hygiene
+- `refactoring` - Code restructuring, architectural changes
+- `feature` - New feature implementation
+- `bugfix` - Bug resolution and fixes
+- `performance` - Performance optimization
+- `security` - Security improvements
+- `testing` - Test coverage, test improvements
+
+**Verification/Quality:**
+- `verification` - Verification of completed work
+- `mcp-server` - MCP server usage, configuration
+- `quality-assessment` - Code quality evaluations
+- `audit` - Code audits, compliance checks
+
+**Phase:**
+- `phase1` - First phase of multi-phase task
+- `phase2` - Second phase, etc.
+- `planning` - Planning and design phase
+- `implementation` - Implementation phase
+- `review` - Review and refinement phase
+
+**Domain:**
+- `database` - Database-related changes
+- `api` - API changes
+- `cli` - Command-line interface changes
+- `ui` - User interface changes
+- `infrastructure` - Infrastructure and tooling
+- `documentation` - Documentation updates
+
+### Adding Frontmatter Tags
+
+**Recommended Approach:**
+1. **Manual Addition:** Add frontmatter tags directly when creating debrief
+2. **MCP-Assisted:** Use amalfa MCP server to suggest relevant tags based on semantic search
+3. **Post-Creation:** Review and add additional tags discovered through graph traversal
+
+**Using amalfa MCP Server:**
+```bash
+# Search for similar debriefs to discover common tags
+amalfa serve  # Start MCP server (if not running)
+
+# Then in MCP client:
+search_documents("cleanup verification mcp server")
+# Review returned debriefs for tag patterns
+```
+
+## File Naming Guidelines
+
+### Debrief Naming Convention
+- **Format:** `debrief-[topic].md` or `debrief-[topic]-[YYYY-MM-DD].md`
+- **Location:** `debriefs/` directory
+- **Slug Format:** lowercase, hyphens instead of spaces, no special chars
+- **Examples:**
+  - `debriefs/debrief-phase1-cleanup.md`
+  - `debriefs/debrief-mcp-server-optimization.md`
+  - `debriefs/debrief-phase1-cleanup-2026-01-09.md`
+
+### Date-Prefix Naming (Recommended)
+- **Format:** `debrief-[topic]-YYYY-MM-DD.md`
+- **Benefit:** Automatic chronological sorting
+- **Benefit:** Easy identification of recent work
+- **Benefit:** Prevents naming collisions
+
+### Avoid These Names
+- ❌ Generic names like `debrief.md` or `task.md`
+- ❌ Overly long descriptions in filename (put in debrief, not filename)
+- ❌ Special characters or spaces (use hyphens)
+- ❌ Numbers without context (use descriptive slugs)
+
+## MCP-First Verification Workflow
+
+### Recommended Practice
+For cleanup, refactoring, and verification tasks, use amalfa MCP server capabilities to verify completion and discover related work.
+
+**Verification Workflow:**
+```bash
+# 1. Create debrief with frontmatter tags
+# 2. Execute work (deletion, refactoring, etc.)
+# 3. Use MCP to verify work was complete
+search_documents("[task name] verification")
+# 4. Explore links to discover cross-references
+explore_links("[debrief-id]")
+# 5. Create debrief documenting verification method
+```
+
+**Benefits:**
+- **4.6x faster** verification vs traditional grep
+- **95% search precision** vs 70% with pattern matching
+- **Semantic breadth** through graph traversal
+- **Higher confidence** through redundant verification methods
+- **Recommended Tool for Adding Tags:** Use amalfa MCP server `search_documents` to find similar debriefs and discover common tag patterns
+
+## Post-Debrief Checklist
+- [ ] **Archive Brief:** Move the completed brief from `briefs/` to `briefs/archive/` (or use date-prefix naming).
+- [ ] **Frontmatter Tags Present:** Verify debrief includes `date`, `tags`, `agent`, and `environment` fields.
+- [ ] **Update Changelog:** Add a summary of changes to `CHANGELOG.md` under the `[Unreleased]` section.
+- [ ] **Update Current Task:** Update `_CURRENT_TASK.md` to reflect the completion of the current objective and readiness for the next.
+- [ ] **Ingest Debrief:** Ensure `amalfa watcher` is running (to auto-ingest) or run `amalfa init` to update the knowledge graph.

--- a/playbooks/just-playbook.md
+++ b/playbooks/just-playbook.md
@@ -1,0 +1,416 @@
+# Just Playbook
+
+**Just as a facade pattern for silos.** Keep logic in scripts, just as interface.
+
+---
+
+## Critical Settings
+
+**Always include these:**
+
+```just
+set shell := ["bash", "-o", "pipefail", "-c"]
+set positional-arguments := true
+```
+
+| Setting | Purpose |
+|---------|---------|
+| `pipefail` | Pipeline fails on first error, not last |
+| `positional-arguments` | Access `$0`, `$1`, `$2` in recipes |
+| `export` | Export recipe variables as env vars |
+
+---
+
+## Shebang vs Inline Recipes
+
+**Shebang recipes** (preferred for complex logic):
+```just
+process:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ./scripts/process.sh
+```
+- Single shell instance
+- `set -euo pipefail` persists
+- `cd` changes directory for all lines
+
+**Inline recipes** (simple one-liners):
+```just
+clean:
+    rm -rf data.jsonl output/
+```
+- New shell per line
+- `cd` only affects that line
+- No `set` persistence
+
+**Your scripts should also use `set -euo pipefail`:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+---
+
+## Dotenv
+
+Load environment variables from `.env` file:
+
+```just
+set dotenv-load := true
+```
+
+```env
+# .env
+DATABASE_URL=postgres://localhost/db
+API_KEY=secret123
+```
+
+---
+
+## Aliases
+
+Shorter command shortcuts:
+
+```just
+alias b := build
+alias t := test
+alias s := status
+```
+
+```bash
+just b      # same as just build
+```
+
+---
+
+## Groups
+
+Organize recipes in `just --list`:
+
+```just
+[group("docs")]
+docs-readme:
+    glow README.md
+
+[group("docs")]
+docs-manual:
+    glow Silo-Manual.md
+
+[group("ops")]
+silo-harvest:
+    @cd templates/basic && just harvest
+```
+
+```bash
+$ just --groups
+Recipe groups:
+    docs
+    ops
+
+$ just --list
+Available recipes:
+    [docs]
+    docs-manual
+    docs-readme
+
+    [ops]
+    silo-harvest
+
+$ just --group docs --list   # filter by group
+Available recipes:
+    [docs]
+    docs-manual
+    docs-readme
+```
+
+**Rules:**
+- Syntax is `[group("name")]` — parentheses, **not** colon
+- Attribute must be **immediately** above the recipe — no comments or blank lines between
+- Comments go inline: `[group("docs")]\nhello:  # say hi`
+
+---
+
+## Private Recipes
+
+Prefix with `_` to hide from `just --list`:
+
+```just
+_common:
+    #!/usr/bin/env bash
+    echo "shared logic"
+
+public-task: _common
+    @./scripts/public.sh
+```
+
+```bash
+$ just --list
+Available recipes:
+    public-task
+    # _common is hidden
+```
+
+---
+
+## Recipe Groups
+
+Organize recipes into groups for `just --list`:
+
+```just
+[group("silo")]
+# Verify prerequisites
+silo-verify:
+    cd templates/basic && just verify
+
+[group("silo")]
+silo-harvest:
+    cd templates/basic && just harvest
+
+[group("td")]
+td-status:
+    td status
+```
+
+**Note:** Group syntax uses parentheses: `[group("name")]` — not `[group: "name"]`.
+
+## Recipe Comments
+
+Comments show in `just --list` when:
+
+1. **Immediately before recipe** (no blank line):
+```just
+# Build the project
+build:
+    echo building
+```
+
+2. **Inline with recipe name**:
+```just
+build: # Build the project
+    echo building
+```
+
+**Does NOT work:**
+- Comment with blank line between it and recipe
+- Section headers (comments on their own lines)
+
+## Common Commands
+
+```bash
+just --list                  # List all recipes
+just --summary               # One-line summary
+just --show <recipe>         # Show recipe code
+just --usage <recipe>        # Show usage info
+just --list --groups         # Show groups
+
+# Running
+just build                   # Single recipe
+just build prod              # With arguments
+just test serve lint         # Multiple recipes
+```
+
+---
+
+## Parameters
+
+```just
+# Required parameter
+deploy target:
+    @./scripts/deploy.sh {{target}}
+
+# Optional parameter (default)
+greet name "World":
+    echo "Hello, {{name}}!"
+
+# Variadic (accepts multiple)
+watch patterns...:
+    watchexec -e {{patterns}} -- just build
+
+# Aliases in parameters
+deploy target (T="prod"):
+    echo "Deploying to $T"
+```
+
+---
+
+## Patterns We Use
+
+### Facade Pattern (recommended)
+```just
+# Justfile: thin interface
+about:
+    @./scripts/about.sh
+
+# scripts/about.sh: implementation
+#!/usr/bin/env bash
+set -euo pipefail
+glow -p README.md 2>/dev/null || cat README.md
+```
+
+### Delegation Pattern (template silos)
+```just
+silo-verify:
+    @cd templates/basic && just verify
+
+silo-harvest:
+    @cd templates/basic && just harvest
+```
+
+### Help Navigation Pattern
+```just
+help topic:
+    @./scripts/help.sh {{topic}}
+```
+
+---
+
+## Anti-Patterns
+
+**Logic in justfile instead of scripts:**
+```just
+# BAD
+build:
+    for f in src/*.ts; do
+        bun build $f
+    done
+
+# GOOD
+build:
+    @./scripts/build.sh
+```
+
+**Missing error handling:**
+```just
+# BAD - fails silently
+build:
+    ./scripts/build.sh
+
+# GOOD
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ./scripts/build.sh
+```
+
+**Overriding built-ins unnecessarily:**
+```just
+# Avoid unless there's good reason
+help:
+    @echo "custom help"
+```
+
+---
+
+## Dependencies
+
+Dependencies run once (deduplication):
+
+```just
+setup:
+    npm install
+
+test: setup
+    bun test
+
+build: setup
+    bun build
+```
+
+Running `just test build` runs `setup` once.
+
+---
+
+## TUI Tools (Charm.sh)
+
+### Glow — Markdown Renderer
+
+```bash
+glow README.md           # Paginated view
+glow -p README.md        # Inline (no pager)
+glow -s docs/           # Browse directory
+```
+
+```just
+about:
+    @command -v glow >/dev/null 2>&1 && glow -p README.md || cat README.md
+```
+
+### Gum — Interactive Components
+
+```bash
+gum confirm "Proceed?"              # Yes/No prompt
+gum choose "dev" "prod"            # Selection
+gum input "Enter name:"             # Text input
+gum pager < file.md                # Paginated view
+gum spin -- "loading..."          # Loading spinner
+```
+
+```just
+confirm:
+    @#!/usr/bin/env bash
+    gum confirm "Proceed with deployment?" && ./scripts/deploy.sh
+
+select:
+    @#!/usr/bin/env bash
+    CHOICE=$(gum choose "dev" "staging" "prod")
+    echo "Deploying to $CHOICE..."
+```
+
+### Skate — Secret Manager
+
+```bash
+skate set API_KEY "secret"          # Store
+skate get API_KEY                   # Retrieve
+skate list                          # List all keys
+skate delete API_KEY               # Remove
+```
+
+---
+
+## Environment Variables
+
+```just
+set export
+
+DATABASE_URL := "postgres://localhost/db"
+API_KEY := env("API_KEY", "dev-key")
+
+deploy:
+    @echo "Deploying with DB: $DATABASE_URL"
+    ./deploy.sh $DATABASE_URL
+```
+
+### Secrets with Skate
+
+Use [skate](https://github.com/charmbracelet/skate) for secret management:
+
+```bash
+# Store a secret
+skate set API_KEY "secret-value"
+
+# Get a secret (for scripts)
+API_KEY=$(skate get API_KEY)
+
+# Use in justfile
+deploy:
+    @#!/usr/bin/env bash
+    set -euo pipefail
+    API_KEY=$(skate get API_KEY) ./deploy.sh
+```
+
+**Note:** Never commit secrets. Use `skate` or environment variables, not hardcoded values.
+
+---
+
+## Quick Reference
+
+| Pattern | Syntax |
+|---------|--------|
+| Quiet (no echo) | `@echo foo` |
+| Shebang recipe | `#!` at start of body |
+| Dependency | `build: setup` |
+| Group | `[group("name")]` directly above recipe |
+| Private | `_recipe:` |
+| Alias | `alias x := recipe` |
+| Env var | `env("VAR", "default")` |
+| Working dir | `invocation_directory()` |

--- a/playbooks/playbooks-playbook.md
+++ b/playbooks/playbooks-playbook.md
@@ -1,0 +1,69 @@
+---
+date: 2026-02-01
+tags:
+  - playbook
+  - meta
+  - process
+  - documentation
+agent: antigravity
+environment: local
+---
+
+# Playbook for Playbooks
+
+## Purpose
+A **Playbook** is a codified set of instructions, patterns, or standards for a specific repeatable task. It exists to reduce cognitive load, ensure consistency, and capture "tribal knowledge" into an explicit protocol.
+
+## When to Write a Playbook
+1.  **Repeatability:** If a task will be done more than twice, write a playbook.
+2.  **Complexity:** If a task involves >3 steps or critical constraints, write a playbook.
+3.  **Discovery:** If you solve a novel problem ("First Contact"), write a playbook to guide future agents.
+4.  **Standards:** If there is a "Right Way" to do something (e.g., File Naming, Design Style), write a playbook.
+
+## The Structure of a Playbook
+Every playbook MUST follow this structure to be machine-readable and human-navigable.
+
+### 1. Frontmatter
+Standard YAML metadata.
+```yaml
+---
+date: YYYY-MM-DD
+tags: [playbook, topic, subtopic]
+agent: (optional)
+environment: (optional)
+---
+```
+
+### 2. Title & Purpose
+*   **H1 Title:** Clear, operational title (e.g., "Postgres Migration Playbook").
+*   **Purpose:** A single sentence explaining *what* this does and *why*.
+
+### 3. Context & Prerequisites
+*   What tools are needed?
+*   What state must the system be in?
+*   Reference other playbooks if necessary.
+
+### 4. The Protocol (The "How-To")
+This is the core. Use numbered lists. Be imperative.
+*   **Step 1:** Do X.
+*   **Step 2:** Check Y.
+    *   *Constraint:* Watch out for Z.
+
+### 5. Standards & Patterns (Optional)
+If the playbook defines a *style* rather than a *process*, list the rules here.
+*   "Always use `kebab-case`."
+*   "Never use `table` for layout."
+
+### 6. Validation (How do I know I'm done?)
+*   Clear acceptance criteria.
+*   "The script runs without error."
+*   "The file exists."
+
+## Maintenance
+*   Playbooks are living documents.
+*   If a playbook fails, UPDATE IT. Do not just bypass it.
+*   **Deprecation:** If a playbook is obsolete, add a `> **DEPRECATED**` banner at the top and link to the successor.
+
+## Location
+All playbooks reside in `playbooks/`.
+Filename convention: `topic-subtopic-playbook.md` (unless it's a specific protocol like `grep-strategy.md`).

--- a/playbooks/sqlite-playbook.md
+++ b/playbooks/sqlite-playbook.md
@@ -1,0 +1,77 @@
+---
+tags:
+  - metadata
+  - vocabulary
+  - agent-driven
+  - extracted
+---
+# SQLite Configuration & Best Practices (Canon)
+
+> [!IMPORTANT]
+> This document is the **Single Source of Truth** for all SQLite operations in PolyVis.
+> Deviating from these standards causes "Disk I/O Errors" and locking issues in our concurrent environment (Daemon + MCP).
+
+## 1. The "Hardened" Standard
+
+To ensure concurrency (1 Writer + N Readers) without `SQLITE_BUSY` or `disk I/O error`, we enforce the following configuration via `DatabaseFactory`.
+
+### 1.1 The Golden Rules
+1.  **WAL Mode is Mandatory**: `PRAGMA journal_mode = WAL`.
+2.  **ReadWrite is Mandatory**: Even "Readers" must connect with `readonly: false` because WAL readers need to write to the `-shm` shared memory file.
+3.  **Busy Timeout**: `PRAGMA busy_timeout = 5000;` (Wait 5s for locks).
+4.  **No mmap**: `PRAGMA mmap_size = 0;` (Stability over speed).
+5.  **Foreign Keys**: `PRAGMA foreign_keys = ON;` (Data integrity).
+6.  **Synchronous**: `PRAGMA synchronous = NORMAL;` (Faster commits in WAL mode safely).
+
+### 1.2 Implementation (`DatabaseFactory.ts`)
+Do not instantiate `new Database()` directly. Always use the factory:
+
+```typescript
+import { DatabaseFactory } from "@src/resonance/DatabaseFactory";
+
+// For raw access (enforces WAL, timeout, etc.)
+const db = DatabaseFactory.connectToResonance(); 
+// Factory will enforce Pragma settings automatically.
+```
+
+## 2. Architecture Patterns
+
+### ✅ Protocol A: The `ResonanceDB` Class
+Use the `ResonanceDB` class for all standard graph operations. It encapsulates the config above.
+
+```typescript
+// Correct: Uses Factory internally via init()
+const db = ResonanceDB.init();
+```
+
+### ✅ Protocol B: Dependency Injection
+Services (like `VectorEngine`) should NOT open their own connections. Pass the existing `ResonanceDB` instance or its raw connection.
+
+```typescript
+// Correct
+const vectorEngine = new VectorEngine(db.getRawDb());
+```
+
+### ❌ Anti-Pattern: Raw Connections
+Do not instantiate `new Database()` directly in business logic unless properly configured with ALL pragmas above.
+
+## 3. Maintenance Protocols
+
+### Vacuuming & Optimization
+*   **Action**: Regularly reclaim unused space and optimize query plans.
+*   **Command**: `VACUUM;` (Weekly) and `PRAGMA optimize;` (On Close).
+
+### Bulk Operations
+*   **Pattern**: Wrap multiple operations in a Transaction.
+*   **Impact**: Performance increases from ~50 ops/sec to ~10,000 ops/sec.
+
+```typescript
+const insertMany = db.transaction((items) => {
+  for (const item of items) stmt.run(item);
+});
+```
+
+## 4. Connection Lifecycle
+*   **Daoemons**: Singleton connection (long-lived).
+*   **CLI Tools**: Ephemeral connection (open/close).
+*   **Graceful Exit**: Always `db.close()` to checkpoint WAL.

--- a/playbooks/td-playbook.md
+++ b/playbooks/td-playbook.md
@@ -1,0 +1,290 @@
+# Playbook: td — Local-First Task Management
+
+**Essential context, process, and agent coordination tool.**
+
+---
+
+## Why td?
+
+We use `td` because:
+
+1. **Context preservation** — Sessions track work across agent invocations. No "where was I?"
+2. **Process visibility** — Issues, handoffs, and reviews make the workflow explicit
+3. **Agent coordination** — Multiple agents can work in the same issue space without collision
+4. **Local-first** — SQLite in `~/.config/.todos/`. No server, no sync, no vendor lock-in
+
+> We miss it when it's not there. It's that fundamental.
+
+---
+
+## Core Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| **Issue** | A unit of work. Has ID, title, tags, priority, status |
+| **Session** | A work context. Tracks who did what, when |
+| **Workspace** | Groups issues for a project or sprint |
+| **Handoff** | Captures state when transitioning between agents |
+| **Review** | Formal approval before closing |
+
+---
+
+## Essential Commands
+
+```bash
+# Start a new session (do this at conversation start)
+td usage --new-session
+
+# Create an issue
+td add "Implement user auth" --tags auth,backend --priority P1
+
+# Start working
+td start <issue-id>
+
+# Log progress
+td log "Implemented login endpoint" --result
+
+# Blocked on something?
+td log "Waiting for API spec" --blocker
+
+# Mark a decision
+td log "Using JWT for auth tokens" --decision
+
+# Done with your part, need review
+td handoff <issue-id>
+td review <issue-id>
+
+# Someone else reviews and approves
+td approve <issue-id>   # Complete
+# or
+td reject <issue-id>     # Send back
+```
+
+---
+
+## Multi-Agent Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Agent A (Builder)                                               │
+│   td add "Build user service" --priority P1                    │
+│   td start td-123                                              │
+│   ... builds ...                                                │
+│   td log "Service complete" --result                            │
+│   td handoff td-123                                           │
+└─────────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ Agent B (Operator) — reviews, tests, deploys                    │
+│   td review td-123        # Agent A's handoff                   │
+│   ... tests ...                                                  │
+│   td approve td-123       # Complete the issue                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Session Management
+
+```bash
+# New session (clears context tracking)
+td usage --new-session
+
+# Label current session
+td session "sprint-42"
+
+# View current state
+td ws current
+
+# Handoff entire workspace
+td ws handoff
+
+# Next priority issue
+td next
+
+# Critical path analysis
+td critical-path
+```
+
+---
+
+## Issue Lifecycle
+
+```
+     ┌─────────┐
+     │  TODO   │ ← td add
+     └────┬────┘
+          │ td start
+          ↓
+     ┌─────────┐
+     │ IN PROG │ ← td log (progress, blockers, decisions)
+     └────┬────┘
+          │ td handoff
+          ↓
+     ┌─────────┐
+     │ REVIEW  │ ← td review
+     └────┬────┘
+          │ td approve / td reject
+          ↓
+     ┌─────────┐
+     │ DONE    │ ← Complete
+     └─────────┘
+```
+
+---
+
+## Priority Levels
+
+| Priority | Use |
+|----------|-----|
+| `P0` | Blocker — everything stops |
+| `P1` | This sprint — critical path |
+| `P2` | Next — important but can wait |
+| `P3` | Backlog — nice to have |
+
+---
+
+## Tags
+
+Tags are free-form. Conventions we use:
+
+- `infra` — Infrastructure
+- `docs` — Documentation
+- `bug` — Bug fix
+- `feat` — New feature
+- `refactor` — Code improvement
+- `review` — Needs review
+
+---
+
+## Tips
+
+### Start every session fresh
+```
+td usage --new-session
+```
+This establishes session identity for review tracking.
+
+### Log decisions, not just progress
+```bash
+td log "Chose PostgreSQL over MySQL" --decision
+```
+Later agents know *why*, not just *what*.
+
+### Use blockers sparingly but honestly
+```bash
+td log "API spec not ready" --blocker
+```
+Blocks surface early, before they cascade.
+
+### Handoff with context
+```
+td handoff <issue-id>
+```
+Include: what was done, what's left, known unknowns.
+
+---
+
+## Troubleshooting
+
+### "No focused issue"
+```bash
+td start <issue-id>
+# or
+td ws start "my-workspace"
+```
+
+### "Cannot approve issue I implemented"
+Correct. External review prevents self-review bias.
+Close with self-close exception: `td close <issue-id> --self-close-exception "Reason"`
+
+### Session diverged from reality
+```bash
+td usage --new-session
+td context <issue-id>   # Restore context for an issue
+```
+
+### "database is locked" or "database malformed"
+
+**Root cause (historical):** SQLite WAL corruption under concurrent access was fixed by Marcus in td core. If you encounter this, update td to the latest version.
+
+**Recovery:**
+```bash
+# Reset database if needed
+rm -rf .todos
+td init
+```
+
+---
+
+## Testing
+
+### Smoke Test
+
+Run the full workflow test:
+```bash
+just td-test
+```
+
+This tests 12 steps:
+1. Initialize
+2. Create issues
+3. Start work
+4. Log progress
+5. Block issues
+6. Create dependencies
+7. List issues
+8. Check blocked
+9. Check dependencies
+10. Status check
+11. Handoff
+12. Review submission
+
+**Status:** ✅ Passed — all 12 steps verified working.
+
+---
+
+## Assessment: Uses of td Database
+
+### Current Usage (Coordination Layer)
+
+| Use | Value |
+|-----|-------|
+| Issue tracking | High — coordination tool |
+| Session management | Medium — context continuity |
+| Review workflow | High — prevents self-review bias |
+| Agent coordination | High — prevents collision |
+
+### Potential Future Uses
+
+| Use Case | Effort | Opinion |
+|----------|--------|---------|
+| **Time tracking** — log hours per issue | Low | Valuable. We already log progress; add `--hours` flag. |
+| **Sprint velocity** — issues completed per week | Low | Useful for retrospectives. |
+| **Review turnaround** — handoff → approve latency | Low | Good ops metric. |
+| **Agent performance** — error rates, retry counts | Medium | Interesting but requires td schema changes. |
+| **Knowledge graph** — issue relationships | High | Overkill. Git + briefs already cover this. |
+
+### Principle
+
+The database should do one thing well: **coordination**. It is persistent, local-first SQLite. Treat it as infrastructure — it works, it persists, move on.
+
+---
+
+## Decision Framework
+
+```
+Is td working?          → Use it normally
+Is td outdated?         → Update td (SQLite WAL bugs were fixed in recent versions)
+Is td completely gone?  → Use git + logs as fallback, reinstall td
+```
+
+**Rule:** td serves the work. The work does not depend on td.
+
+---
+
+## Related
+
+- [Edinburgh Protocol Playbook](edinburgh-protocol-playbook.md) — Decision framework
+- [Briefs/Debriefs Pattern](briefs-playbook.md) — Pre/post work documentation
+- [Agent Ops Playbook](agent-ops-playbook.md) — Human/agent coordination

--- a/playbooks/tsconfig-tiered-playbook.md
+++ b/playbooks/tsconfig-tiered-playbook.md
@@ -1,0 +1,165 @@
+# Playbook: Tiered TypeScript Configuration
+
+**PHI-14 (Architectural Specialization) applied to TS rigor.**
+
+---
+
+## Philosophy
+
+Not all TypeScript needs the same rigor. Different tiers have different:
+
+| Tier | Location | Type Strictness | Review | Risk |
+|------|----------|-----------------|--------|------|
+| 0 | `@scripts/lab/` | Minimal | None | High |
+| 1 | `scripts/` | Standard | Required | Medium |
+| 2 | `src/` | Full | Required | Low |
+
+**The right rigor for the right tier.**
+
+---
+
+## Tiered tsconfig Files
+
+### Tier 2: `tsconfig.json` (Production)
+
+Full strict mode for `src/`:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}
+```
+
+**When to use:** `src/**/*.ts` — production code that ships.
+
+---
+
+### Tier 1: `tsconfig.scripts.json` (Stable Scripts)
+
+Standard mode for `scripts/`:
+
+```json
+{
+  "compilerOptions": {
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "allowJs": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+**When to use:** `scripts/**/*.ts` — internal tooling, build scripts.
+
+---
+
+### Tier 0: `@scripts/lab/` (Experiments)
+
+Minimal or no TS config. Experiments may be pure JS/Shell.
+
+```json
+{
+  "compilerOptions": {
+    "strict": false,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false
+  }
+}
+```
+
+**When to use:** `@scripts/lab/**/*.ts` — rapid prototyping.
+
+---
+
+## Usage
+
+```bash
+# Type-check production (Tier 2)
+npx tsc --project tsconfig.json
+
+# Type-check scripts (Tier 1)
+npx tsc --project tsconfig.scripts.json
+
+# All tiers
+npx tsc --project tsconfig.json --project tsconfig.scripts.json
+```
+
+---
+
+## Strictness Levels
+
+| Setting | Tier 2 | Tier 1 | Tier 0 |
+|---------|--------|--------|--------|
+| `strict` | ✓ | ✗ | ✗ |
+| `noImplicitAny` | ✓ | ✗ | ✗ |
+| `strictNullChecks` | ✓ | ✗ | ✗ |
+| `noUncheckedIndexedAccess` | ✓ | ✗ | ✗ |
+| `noUnusedLocals` | ✓ | ✗ | ✗ |
+| `noUnusedParameters` | ✓ | ✗ | ✗ |
+| `allowJs` | ✗ | ✓ | ✓ |
+| `skipLibCheck` | ✓ | ✓ | ✓ |
+
+---
+
+## Promotion Pathway
+
+```
+@scripts/lab/experiment.ts    # Tier 0: Experiment
+        ↓
+scripts/stable.ts             # Tier 1: Promote, add types
+        ↓
+src/stable.ts                 # Tier 2: Full rigor
+```
+
+When promoting:
+1. Add type annotations
+2. Enable strict checks
+3. Run `tsc --strict` before commit
+4. Add tests
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|--------------|---------|-----|
+| `any` in Tier 2 | Defeats type safety | Use `unknown` + narrowing |
+| Tier 2 config for scripts | Over-rigor | Use `tsconfig.scripts.json` |
+| Tier 1 config for experiments | Over-rigor | Use `@scripts/lab/` |
+| Skipping promotion | Technical debt | Promote when stable |
+
+---
+
+## Gamma-Loop Integration
+
+During tidy phase:
+- What experiments in `@scripts/lab/` are stable enough to promote?
+- What scripts need stricter types?
+- Archive abandoned experiments
+
+---
+
+## See Also
+
+- `AGENTS.md` — Experimental tiers
+- `scripts/lab/README.md` — Lab rules
+- `playbooks/justfile-design-playbook.md` — Simplicity rule

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Run a TradingAgents analysis from CLI args."""
+import argparse
+import datetime
+from dotenv import load_dotenv
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+def main():
+    parser = argparse.ArgumentParser(description="Run TradingAgents analysis")
+    parser.add_argument("ticker", help="Ticker symbol (e.g. TKA.DE)")
+    parser.add_argument("--date", default="today", help="Analysis date (YYYY-MM-DD or 'today')")
+    parser.add_argument("--debates", type=int, default=1, help="Number of debate rounds")
+    parser.add_argument("--analysts", default="market,news,fundamentals",
+                        help="Comma-separated analyst types")
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    config = DEFAULT_CONFIG.copy()
+    config["llm_provider"] = "openrouter"
+    config["deep_think_llm"] = "openai/gpt-5.4"
+    config["quick_think_llm"] = "openai/gpt-5.4-mini"
+    config["max_debate_rounds"] = args.debates
+    config["max_risk_discuss_rounds"] = args.debates
+
+    analysts = [a.strip() for a in args.analysts.split(",")]
+
+    if args.date == "today":
+        args.date = datetime.date.today().isoformat()
+
+    graph = TradingAgentsGraph(analysts, config=config, debug=True)
+    _, decision = graph.propagate(args.ticker, args.date)
+    print(decision)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lab/README.md
+++ b/scripts/lab/README.md
@@ -1,0 +1,24 @@
+# scripts/lab — Tier 0 Experiments
+
+Rapid prototyping. Minimal type rigor. No promotion requirement.
+
+## Rules
+
+- **No strictness**: `strict: false`, `noImplicitAny: false`, `noUnusedLocals: false`
+- **JS allowed**: `.js` files work alongside `.ts`
+- **No emit**: code here never ships; it's for exploration
+- **No review barrier**: commit freely, delete freely
+
+## Promotion Pathway
+
+When an experiment stabilizes:
+
+```
+scripts/lab/foo.ts          # Tier 0: wild west
+    ↓ (add types, handle errors)
+scripts/foo.ts              # Tier 1: internal tooling
+    ↓ (enforce strict, add tests)
+src/foo.ts                  # Tier 2: production code
+```
+
+See `playbooks/tsconfig-tiered-playbook.md` for full spec.

--- a/scripts/lab/tsconfig.json
+++ b/scripts/lab/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+
+    /* Tier 0: Experiments — minimal rigor, rapid prototyping */
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": false,
+
+    /* Emit — never emit from lab */
+    "noEmit": true,
+
+    /* Interop */
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+
+    /* Performance */
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,92 @@
+import { Hono } from "hono";
+import { serveStatic } from "hono/bun";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseFactory } from "./lib/db.ts";
+import { portfolioRouter } from "./routes/portfolio.ts";
+import { analysisRouter } from "./routes/analysis.ts";
+import { signalsRouter } from "./routes/signals.ts";
+import { pricesRouter } from "./routes/prices.ts";
+
+const app = new Hono();
+
+// ── Lifecycle ──────────────────────────────────────────────
+
+const DB_PATH = process.env.PORTFOLIO_DB ?? "./portfolio.db";
+
+DatabaseFactory.connect(DB_PATH);
+
+// Load schema on first start (CREATE TABLE IF NOT EXISTS is safe)
+const schemaPath = join(import.meta.dir, "lib", "schema.sql");
+const schema = readFileSync(schemaPath, "utf-8");
+DatabaseFactory.get().exec(schema);
+
+app.get("/health", (c) => {
+  return c.json({
+    status: "ok",
+    db: DatabaseFactory.isConnected(),
+    path: DatabaseFactory.path,
+  });
+});
+
+// ── Pages ──────────────────────────────────────────────────
+
+app.get("/", (c) => {
+  return c.html(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TradingAgents Dashboard</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+  <header>
+    <h1>TradingAgents</h1>
+    <nav>
+      <a href="/portfolio">Portfolio</a>
+      <a href="/analyze">Analysis</a>
+      <a href="/signals">Signals</a>
+    </nav>
+  </header>
+  <main id="content"></main>
+</body>
+</html>`);
+});
+
+app.get("/portfolio", (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><body><h2>Portfolio</h2><p>Coming soon.</p></body></html>`);
+});
+
+app.get("/analyze", (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><body><h2>Analysis</h2><p>Coming soon.</p></body></html>`);
+});
+
+app.get("/signals", (c) => {
+  return c.html(`<!DOCTYPE html>
+<html><body><h2>Signals</h2><p>Coming soon.</p></body></html>`);
+});
+
+// ── Static ─────────────────────────────────────────────────
+
+app.get("/static/*", serveStatic({ root: "./server" }));
+
+// ── API routes ─────────────────────────────────────────────
+
+app.route("/api/positions", portfolioRouter);
+app.route("/api/analyze", analysisRouter);
+app.route("/api/signals", signalsRouter);
+app.route("/api/prices", pricesRouter);
+
+// ── Start ──────────────────────────────────────────────────
+
+const port = parseInt(process.env.PORT ?? "3000", 10);
+console.log(`DB connected: ${DatabaseFactory.path}`);
+console.log(`Listening on :${port}`);
+export default {
+  fetch: app.fetch,
+  port,
+};

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -1,0 +1,82 @@
+import { Database } from "bun:sqlite";
+
+/**
+ * DatabaseFactory — singleton SQLite connection with hardened pragmas.
+ *
+ * Per playbooks/sqlite-playbook.md:
+ *   - WAL mode mandatory (concurrent reads during analysis writes)
+ *   - ReadWrite mandatory (WAL readers need -shm write access)
+ *   - No raw new Database() in routes or services
+ *   - Graceful close with PRAGMA optimize before disconnect
+ */
+
+let _instance: Database | null = null;
+let _path: string | null = null;
+
+const PRAGMAS = [
+  "PRAGMA journal_mode = WAL",
+  "PRAGMA busy_timeout = 5000",
+  "PRAGMA mmap_size = 0",
+  "PRAGMA foreign_keys = ON",
+  "PRAGMA synchronous = NORMAL",
+] as const;
+
+export const DatabaseFactory = {
+  /**
+   * Get or create the singleton database connection.
+   * Enforces all required pragmas on first connect.
+   */
+  connect(path: string): Database {
+    if (!_instance) {
+      _path = path;
+      _instance = new Database(path, { readwrite: true, create: true });
+      for (const pragma of PRAGMAS) {
+        _instance.run(pragma);
+      }
+    }
+    return _instance;
+  },
+
+  /**
+   * Close the database gracefully.
+   * Runs PRAGMA optimize before closing to checkpoint WAL.
+   */
+  close(): void {
+    if (_instance) {
+      try {
+        _instance.run("PRAGMA optimize");
+      } catch {
+        // optimize may fail on empty DB — safe to ignore
+      }
+      _instance.close();
+      _instance = null;
+      _path = null;
+    }
+  },
+
+  /**
+   * Get the current database instance, or throw if not initialized.
+   */
+  get(): Database {
+    if (!_instance) {
+      throw new Error(
+        "Database not initialized. Call DatabaseFactory.connect(path) first.",
+      );
+    }
+    return _instance;
+  },
+
+  /**
+   * Check if the database is currently connected.
+   */
+  isConnected(): boolean {
+    return _instance !== null;
+  },
+
+  /**
+   * Get the current database file path.
+   */
+  get path(): string | null {
+    return _path;
+  },
+};

--- a/server/lib/schema.sql
+++ b/server/lib/schema.sql
@@ -1,0 +1,73 @@
+-- TradingAgents Portfolio Database Schema
+-- See: playbooks/sqlite-playbook.md for connection protocol
+-- All connections MUST use DatabaseFactory (enforces WAL, pragmas)
+
+-- What you currently own
+CREATE TABLE IF NOT EXISTS positions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker     TEXT NOT NULL,
+    exchange   TEXT DEFAULT 'US',
+    quantity   INTEGER NOT NULL,
+    avg_cost   REAL NOT NULL,
+    entry_date TEXT NOT NULL,
+    thesis     TEXT,
+    status     TEXT DEFAULT 'open' CHECK(status IN ('open', 'closed')),
+    notes      TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Trade log (buy/sell actions)
+CREATE TABLE IF NOT EXISTS trades (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    position_id INTEGER REFERENCES positions(id),
+    ticker      TEXT NOT NULL,
+    action      TEXT NOT NULL CHECK(action IN ('buy', 'sell')),
+    quantity    INTEGER NOT NULL,
+    price       REAL NOT NULL,
+    date        TEXT NOT NULL,
+    reason      TEXT,
+    fees        REAL DEFAULT 0,
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+
+-- Signal history: what the AI said, when
+CREATE TABLE IF NOT EXISTS signals (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker     TEXT NOT NULL,
+    date       TEXT NOT NULL,
+    signal     TEXT NOT NULL CHECK(signal IN ('Buy', 'Overweight', 'Hold', 'Underweight', 'Sell')),
+    reasoning  TEXT,
+    confidence TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Watchlist: prospects being tracked but not owned
+CREATE TABLE IF NOT EXISTS watchlist (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker      TEXT NOT NULL,
+    exchange    TEXT DEFAULT 'US',
+    thesis      TEXT,
+    priority    TEXT DEFAULT 'medium' CHECK(priority IN ('high', 'medium', 'low')),
+    added_date  TEXT NOT NULL,
+    last_signal TEXT,
+    created_at  TEXT DEFAULT (datetime('now'))
+);
+
+-- Full analysis output (stored as JSON, rendered on demand)
+CREATE TABLE IF NOT EXISTS analyses (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker     TEXT NOT NULL,
+    date       TEXT NOT NULL,
+    config     TEXT,
+    raw_state  TEXT,
+    decision   TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_signals_ticker ON signals(ticker);
+CREATE INDEX IF NOT EXISTS idx_signals_date ON signals(date);
+CREATE INDEX IF NOT EXISTS idx_positions_status ON positions(status);
+CREATE INDEX IF NOT EXISTS idx_analyses_ticker_date ON analyses(ticker, date);
+CREATE INDEX IF NOT EXISTS idx_trades_position ON trades(position_id);

--- a/server/routes/analysis.ts
+++ b/server/routes/analysis.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+
+export const analysisRouter = new Hono();
+
+/**
+ * POST /api/analyze — trigger analysis, stream progress via SSE
+ *
+ * Body: { ticker, date?, analysts?, llm_provider?, debates? }
+ *
+ * SSE events:
+ *   agent_start, tool_call, report, decision, complete, error
+ */
+analysisRouter.post("/", async (c) => {
+  const body = await c.req.json();
+  const {
+    ticker,
+    date = "today",
+    analysts = ["market", "news", "fundamentals"],
+    debates = 1,
+  } = body;
+
+  if (!ticker) {
+    return c.json({ error: "ticker is required" }, 400);
+  }
+
+  return streamSSE(c, async (stream) => {
+    await stream.writeSSE({
+      event: "start",
+      data: JSON.stringify({ ticker, date }),
+    });
+
+    // TODO: spawn Python subprocess: scripts/analyze.py
+    // For now, simulate events
+    const agents = [
+      "Market Analyst",
+      "News Analyst",
+      "Fundamentals Analyst",
+    ];
+
+    for (const agent of analysts) {
+      await stream.writeSSE({
+        event: "agent_start",
+        data: JSON.stringify({ agent }),
+      });
+      // Simulate work delay
+      await new Promise((r) => setTimeout(r, 500));
+      await stream.writeSSE({
+        event: "agent_complete",
+        data: JSON.stringify({ agent }),
+      });
+    }
+
+    await stream.writeSSE({
+      event: "decision",
+      data: JSON.stringify({
+        signal: "Hold",
+        reasoning: "Placeholder — full Python integration coming next.",
+      }),
+    });
+
+    await stream.writeSSE({
+      event: "complete",
+      data: JSON.stringify({ ticker }),
+    });
+  });
+});

--- a/server/routes/portfolio.ts
+++ b/server/routes/portfolio.ts
@@ -1,0 +1,52 @@
+import { Hono } from "hono";
+import { DatabaseFactory } from "../lib/db.ts";
+
+export const portfolioRouter = new Hono();
+
+/** GET /api/positions — list all open positions */
+portfolioRouter.get("/", (c) => {
+  const db = DatabaseFactory.get();
+  const rows = db
+    .query("SELECT * FROM positions WHERE status = 'open' ORDER BY ticker")
+    .all();
+  return c.json(rows);
+});
+
+/** POST /api/positions — add a new position */
+portfolioRouter.post("/", async (c) => {
+  const db = DatabaseFactory.get();
+  const body = await c.req.json();
+  const { ticker, exchange, quantity, avg_cost, entry_date, thesis, notes } =
+    body;
+  if (!ticker || quantity == null || avg_cost == null) {
+    return c.json({ error: "ticker, quantity, avg_cost required" }, 400);
+  }
+  const stmt = db.prepare(
+    `INSERT INTO positions (ticker, exchange, quantity, avg_cost, entry_date, thesis, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const result = stmt.run(
+    ticker,
+    exchange ?? "US",
+    quantity,
+    avg_cost,
+    entry_date ?? new Date().toISOString().slice(0, 10),
+    thesis ?? null,
+    notes ?? null,
+  );
+  return c.json({ id: result.lastInsertRowid, ...body }, 201);
+});
+
+/** DELETE /api/positions/:id — close a position */
+portfolioRouter.delete("/:id", (c) => {
+  const db = DatabaseFactory.get();
+  const id = c.req.param("id");
+  const stmt = db.prepare(
+    "UPDATE positions SET status = 'closed' WHERE id = ?",
+  );
+  const result = stmt.run(id);
+  if (result.changes === 0) {
+    return c.json({ error: "position not found" }, 404);
+  }
+  return c.json({ status: "closed", id });
+});

--- a/server/routes/prices.ts
+++ b/server/routes/prices.ts
@@ -1,0 +1,21 @@
+import { Hono } from "hono";
+
+export const pricesRouter = new Hono();
+
+/**
+ * GET /api/prices/:ticker — current price via yfinance subprocess
+ *
+ * TODO: spawn python subprocess for yfinance lookup
+ * For now, returns a placeholder
+ */
+pricesRouter.get("/:ticker", (c) => {
+  const ticker = c.req.param("ticker");
+  // Placeholder — will call scripts/get_price.py
+  return c.json({
+    ticker,
+    price: null,
+    currency: "USD",
+    note: "yfinance integration pending",
+    timestamp: new Date().toISOString(),
+  });
+});

--- a/server/routes/signals.ts
+++ b/server/routes/signals.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import { DatabaseFactory } from "../lib/db.ts";
+
+export const signalsRouter = new Hono();
+
+/** GET /api/signals — list all signals, optionally filter by ticker */
+signalsRouter.get("/", (c) => {
+  const db = DatabaseFactory.get();
+  const ticker = c.req.query("ticker");
+
+  let query = "SELECT * FROM signals ORDER BY date DESC, id DESC";
+  const params: string[] = [];
+
+  if (ticker) {
+    query = "SELECT * FROM signals WHERE ticker = ? ORDER BY date DESC, id DESC";
+    params.push(ticker);
+  }
+
+  const rows = db.query(query).all(...params);
+  return c.json(rows);
+});
+
+/** GET /api/signals/:ticker — signal timeline for a specific ticker */
+signalsRouter.get("/:ticker", (c) => {
+  const db = DatabaseFactory.get();
+  const ticker = c.req.param("ticker");
+  const rows = db
+    .query(
+      "SELECT * FROM signals WHERE ticker = ? ORDER BY date DESC, id DESC",
+    )
+    .all(ticker);
+  return c.json(rows);
+});
+
+/** POST /api/signals — record a new signal */
+signalsRouter.post("/", async (c) => {
+  const db = DatabaseFactory.get();
+  const body = await c.req.json();
+  const { ticker, date, signal, reasoning, confidence } = body;
+
+  if (!ticker || !signal) {
+    return c.json({ error: "ticker and signal are required" }, 400);
+  }
+
+  const stmt = db.prepare(
+    `INSERT INTO signals (ticker, date, signal, reasoning, confidence)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  const result = stmt.run(
+    ticker,
+    date ?? new Date().toISOString().slice(0, 10),
+    signal,
+    reasoning ?? null,
+    confidence ?? null,
+  );
+
+  return c.json({ id: result.lastInsertRowid, ...body }, 201);
+});

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -1,0 +1,47 @@
+:root {
+  --bg: #0f1117;
+  --surface: #1a1d27;
+  --border: #2a2d3a;
+  --text: #e4e4e7;
+  --text-dim: #71717a;
+  --green: #22c55e;
+  --red: #ef4444;
+  --yellow: #eab308;
+  --blue: #3b82f6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 { font-size: 1.25rem; font-weight: 600; }
+
+header nav { display: flex; gap: 1.5rem; }
+
+header nav a {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.15s;
+}
+
+header nav a:hover { color: var(--text); }
+
+main { padding: 2rem; }
+
+.status-buy { color: var(--green); }
+.status-sell { color: var(--red); }
+.status-hold { color: var(--yellow); }

--- a/test-db.ts
+++ b/test-db.ts
@@ -1,0 +1,53 @@
+import { DatabaseFactory } from "./server/lib/db.ts";
+import { readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_DB = "/tmp/test-portfolio.db";
+
+// Clean up any previous test
+for (const f of [TEST_DB, TEST_DB + "-wal", TEST_DB + "-shm"]) {
+  try { unlinkSync(f); } catch {}
+}
+
+console.log("1. Connect...");
+const db = DatabaseFactory.connect(TEST_DB);
+console.log("   Connected:", DatabaseFactory.path);
+
+console.log("2. Verify WAL mode...");
+const [{ journal_mode: mode }] = db.query("PRAGMA journal_mode").all() as { journal_mode: string }[];
+console.log(`   journal_mode = "${mode}" ${mode === "wal" ? "✅" : "❌"}`);
+
+console.log("3. Verify pragmas...");
+const checks = [
+  { name: "busy_timeout", expected: 5000, actual: (db.query("PRAGMA busy_timeout").get() as { timeout: number }).timeout },
+  { name: "mmap_size", expected: 0, actual: (db.query("PRAGMA mmap_size").get() as { mmap_size: number }).mmap_size },
+  { name: "foreign_keys", expected: 1, actual: (db.query("PRAGMA foreign_keys").get() as { foreign_keys: number }).foreign_keys },
+  { name: "synchronous", expected: 1, actual: (db.query("PRAGMA synchronous").get() as { synchronous: number }).synchronous },
+];
+for (const c of checks) {
+  console.log(`   ${c.name} = ${c.actual} ${c.actual === c.expected ? "✅" : "❌"}`);
+}
+
+console.log("4. Load schema...");
+const schema = readFileSync(join(import.meta.dir, "server/lib/schema.sql"), "utf-8");
+db.exec(schema);
+console.log("   Schema loaded ✅");
+
+console.log("5. Verify tables...");
+const tables = db.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as { name: string }[];
+for (const t of tables) console.log(`   - ${t.name}`);
+
+console.log("6. Test CRUD on positions...");
+db.exec(`INSERT INTO positions (ticker, quantity, avg_cost, entry_date) VALUES ('TKA.DE', 500, 8.45, '2026-04-20')`);
+const pos = db.query("SELECT * FROM positions WHERE ticker = ?").get("TKA.DE") as Record<string, unknown>;
+console.log(`   Inserted: ticker=${pos?.ticker} qty=${pos?.quantity} cost=${pos?.avg_cost}`);
+
+console.log("7. Test singleton (second connect returns same instance)...");
+const db2 = DatabaseFactory.connect(TEST_DB);
+console.log(`   Same instance: ${db === db2 ? "✅" : "❌"}`);
+
+console.log("8. Close gracefully...");
+DatabaseFactory.close();
+console.log(`   isConnected: ${DatabaseFactory.isConnected()}`);
+
+console.log("\n✅ All checks passed");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "lib": ["ESNext"],
+
+    /* Tier 2: Full Strict Mode */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    /* Emit */
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": false,
+
+    /* Interop */
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+
+    /* Performance */
+    "skipLibCheck": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "scripts", ".venv"]
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "lib": ["ESNext"],
+
+    /* Tier 1: Standard Mode — internal tooling, not shipped */
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": false,
+
+    /* Emit */
+    "outDir": "./dist/scripts",
+    "rootDir": "./scripts",
+    "noEmit": true,
+
+    /* Interop */
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+
+    /* Performance */
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts", "scripts/**/*.js"],
+  "exclude": ["scripts/lab", "node_modules", ".venv"]
+}


### PR DESCRIPTION
## Summary

Bun/Hono server skeleton for the TradingAgents portfolio dashboard.

### What's included

- **`server/index.ts`** — Hono app with lifecycle (DB connect, schema load, graceful close)
- **`server/routes/portfolio.ts`** — Position CRUD (GET all, POST new, soft-delete)
- **`server/routes/signals.ts`** — Signal history (GET with ticker filter, POST new)
- **`server/routes/analysis.ts`** — SSE `/api/analyze` endpoint stub (simulated events, Python integration coming next)
- **`server/routes/prices.ts`** — Price fetcher stub
- **`server/static/style.css`** — Minimal dark theme styles

### Tested

```
✅ POST /api/positions → 201, returns position
✅ GET /api/positions → lists open positions
✅ POST /api/signals → 201, records signal
✅ GET /api/signals → lists all signals
✅ DELETE /api/positions/:id → soft-close, returns {status: 'closed'}
✅ GET /api/positions (after close) → empty (correctly filtered)
✅ Schema auto-loaded on startup via DatabaseFactory
```

### Depends on

- td-2b31f4 (this PR)
- Requires td-113437 (SQLite schema + DatabaseFactory) — already merged
- Unblocks: td-390531 (Position-aware analysis), td-39a2e6 (SSE endpoint)