### PR TITLE
feat(cli): scrollable Textual TUI for live analyze view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ __marimo__/
 # Enterprise env file (secrets) and generated run reports
 .env.enterprise
 reports/
+
+# macOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Scrollable Textual TUI** for `tradingagents analyze`, now the default live
+  view. It uses a [Textual](https://textual.textualize.io/) app with scrollable
+  Messages & Tools and Current Report panes (mouse wheel, arrow keys, `g`/`G`
+  for top/bottom, `Tab`/`Shift-Tab` to switch panes), so long reports and
+  earlier tool calls are no longer truncated. The classic fixed-height Rich
+  `Live` renderer is preserved behind `--classic` (or
+  `TRADINGAGENTS_CLASSIC_TUI=1`) for one release.
+- `handle_stream_chunk(buffer, chunk, wall_time_tracker=None)` extracted from
+  `run_analysis` so the chunk → buffer mapping has a single home shared by both
+  renderers, and `ALL_TEAMS` consolidated as the canonical team → agent map for
+  the progress pane.
+
+### Changed
+
+- The `update_research_team_status` helper now takes a buffer argument instead
+  of relying on the module-global `message_buffer`, so the chunk handler is safe
+  to call from the TUI worker thread.
+
 ## [0.3.0] — 2026-06-22
 
 Stabilization and extensibility release: a CI gate, a unified verified
@@ -71,7 +93,6 @@ structured output.
 Thanks to everyone who shaped this release through code, design, and reports:
 
 [@CadeYu](https://github.com/CadeYu), [@Zavianx](https://github.com/Zavianx), [@weijianz-opc](https://github.com/weijianz-opc), [@naltun](https://github.com/naltun), [@brahmasky](https://github.com/brahmasky), [@nik2208](https://github.com/nik2208), [@thieucong98](https://github.com/thieucong98), [@Derekko-web](https://github.com/Derekko-web), [@LukiPrince](https://github.com/LukiPrince), [@Eddieargenal](https://github.com/Eddieargenal), [@Ghraven](https://github.com/Ghraven), [@ms32035](https://github.com/ms32035), [@yting27](https://github.com/yting27), [@nyxst4ck](https://github.com/nyxst4ck), [@KenCheung-AIxFinance](https://github.com/KenCheung-AIxFinance), [@yangyusheng2n](https://github.com/yangyusheng2n), [@fareloj](https://github.com/fareloj), [@haosenwang1018](https://github.com/haosenwang1018), [@octo-patch](https://github.com/octo-patch), [@seifenk](https://github.com/seifenk), [@CaoYuhaoCarl](https://github.com/CaoYuhaoCarl), [@mihailnica10](https://github.com/mihailnica10), [@Dado-hash](https://github.com/Dado-hash), [@Handsomemikezzz](https://github.com/Handsomemikezzz), [@ydhawesome](https://github.com/ydhawesome), [@macd2](https://github.com/macd2), [@AyushKar2005](https://github.com/AyushKar2005), [@wildhuman](https://github.com/wildhuman), [@robert23kim](https://github.com/robert23kim), [@bngness](https://github.com/bngness), [@tedix-rodrigo](https://github.com/tedix-rodrigo), [@malaccan](https://github.com/malaccan), [@rfalken78](https://github.com/rfalken78), [@dengli1971-droid](https://github.com/dengli1971-droid), [@proofconcept39](https://github.com/proofconcept39), [@prasta1](https://github.com/prasta1), [@liximin](https://github.com/liximin), [@jeffhuen](https://github.com/jeffhuen), [@mazar](https://github.com/mazar), [@soyangelromero](https://github.com/soyangelromero), [@CNQQC](https://github.com/CNQQC), [@dovetaill](https://github.com/dovetaill), [@fperdigon](https://github.com/fperdigon), [@gyx09212214-prog](https://github.com/gyx09212214-prog), [@RSXLX](https://github.com/RSXLX).
-
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/cli/main.py
+++ b/cli/main.py
@@ -52,6 +52,27 @@ from tradingagents.reporting import write_report_tree
 
 console = Console()
 
+# Canonical team → agent mapping for the progress pane. Shared by the classic
+# Rich `Live` renderer (`update_display`) and the Textual TUI so the two views
+# never drift. `MessageBuffer.FIXED_AGENTS` is a related but narrower view
+# (omits the Analyst Team since analysts are user-selected).
+ALL_TEAMS = {
+    "Analyst Team": [
+        "Market Analyst",
+        "Sentiment Analyst",
+        "News Analyst",
+        "Fundamentals Analyst",
+    ],
+    "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
+    "Trading Team": ["Trader"],
+    "Risk Management": [
+        "Aggressive Analyst",
+        "Neutral Analyst",
+        "Conservative Analyst",
+    ],
+    "Portfolio Management": ["Portfolio Manager"],
+}
+
 app = typer.Typer(
     name="TradingAgents",
     help="TradingAgents CLI: Multi-Agents LLM Financial Trading Framework",
@@ -300,22 +321,9 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     progress_table.add_column("Status", style="yellow", justify="center", width=20)
 
     # Group agents by team - filter to only include agents in agent_status
-    all_teams = {
-        "Analyst Team": [
-            "Market Analyst",
-            "Sentiment Analyst",
-            "News Analyst",
-            "Fundamentals Analyst",
-        ],
-        "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
-        "Trading Team": ["Trader"],
-        "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
-        "Portfolio Management": ["Portfolio Manager"],
-    }
-
     # Filter teams to only include agents that are in agent_status
     teams = {}
-    for team, agents in all_teams.items():
+    for team, agents in ALL_TEAMS.items():
         active_agents = [a for a in agents if a in message_buffer.agent_status]
         if active_agents:
             teams[team] = active_agents
@@ -813,11 +821,11 @@ def display_complete_report(final_state):
             console.print(Panel(Markdown(risk["judge_decision"]), title="Portfolio Manager", border_style="blue", padding=(1, 2)))
 
 
-def update_research_team_status(status):
+def update_research_team_status(buffer, status):
     """Update status for research team members (not Trader)."""
     research_team = ["Bull Researcher", "Bear Researcher", "Research Manager"]
     for agent in research_team:
-        message_buffer.update_agent_status(agent, status)
+        buffer.update_agent_status(agent, status)
 
 
 # Ordered list of analysts for status transitions
@@ -958,6 +966,108 @@ def format_tool_args(args, max_length=80) -> str:
         return result[:max_length - 3] + "..."
     return result
 
+
+def handle_stream_chunk(buffer, chunk, wall_time_tracker=None):
+    """Apply a single graph stream chunk to the message buffer.
+
+    Pure state mutation — no rendering side effects. Safe to call from a
+    worker thread; render layers (Rich `Live` or the Textual TUI) refresh on
+    their own cadence. Shared by both renderers so the chunk → buffer mapping
+    has a single home.
+    """
+    # Process all messages in chunk, deduplicating by message ID
+    for message in chunk.get("messages", []):
+        msg_id = getattr(message, "id", None)
+        if msg_id is not None:
+            if msg_id in buffer._processed_message_ids:
+                continue
+            buffer._processed_message_ids.add(msg_id)
+
+        msg_type, content = classify_message_type(message)
+        if content and content.strip():
+            buffer.add_message(msg_type, content)
+
+        if hasattr(message, "tool_calls") and message.tool_calls:
+            for tool_call in message.tool_calls:
+                if isinstance(tool_call, dict):
+                    buffer.add_tool_call(tool_call["name"], tool_call["args"])
+                else:
+                    buffer.add_tool_call(tool_call.name, tool_call.args)
+
+    # Update analyst statuses based on report state (runs on every chunk)
+    update_analyst_statuses(buffer, chunk, wall_time_tracker=wall_time_tracker)
+
+    # Research Team - Handle Investment Debate State
+    if chunk.get("investment_debate_state"):
+        debate_state = chunk["investment_debate_state"]
+        bull_hist = debate_state.get("bull_history", "").strip()
+        bear_hist = debate_state.get("bear_history", "").strip()
+        judge = debate_state.get("judge_decision", "").strip()
+
+        # Only update status when there's actual content
+        if bull_hist or bear_hist:
+            update_research_team_status(buffer, "in_progress")
+        if bull_hist:
+            buffer.update_report_section(
+                "investment_plan", f"### Bull Researcher Analysis\n{bull_hist}"
+            )
+        if bear_hist:
+            buffer.update_report_section(
+                "investment_plan", f"### Bear Researcher Analysis\n{bear_hist}"
+            )
+        if judge:
+            buffer.update_report_section(
+                "investment_plan", f"### Research Manager Decision\n{judge}"
+            )
+            update_research_team_status(buffer, "completed")
+            buffer.update_agent_status("Trader", "in_progress")
+
+    # Trading Team
+    if chunk.get("trader_investment_plan"):
+        buffer.update_report_section(
+            "trader_investment_plan", chunk["trader_investment_plan"]
+        )
+        if buffer.agent_status.get("Trader") != "completed":
+            buffer.update_agent_status("Trader", "completed")
+            buffer.update_agent_status("Aggressive Analyst", "in_progress")
+
+    # Risk Management Team - Handle Risk Debate State
+    if chunk.get("risk_debate_state"):
+        risk_state = chunk["risk_debate_state"]
+        agg_hist = risk_state.get("aggressive_history", "").strip()
+        con_hist = risk_state.get("conservative_history", "").strip()
+        neu_hist = risk_state.get("neutral_history", "").strip()
+        judge = risk_state.get("judge_decision", "").strip()
+
+        if agg_hist:
+            if buffer.agent_status.get("Aggressive Analyst") != "completed":
+                buffer.update_agent_status("Aggressive Analyst", "in_progress")
+            buffer.update_report_section(
+                "final_trade_decision", f"### Aggressive Analyst Analysis\n{agg_hist}"
+            )
+        if con_hist:
+            if buffer.agent_status.get("Conservative Analyst") != "completed":
+                buffer.update_agent_status("Conservative Analyst", "in_progress")
+            buffer.update_report_section(
+                "final_trade_decision", f"### Conservative Analyst Analysis\n{con_hist}"
+            )
+        if neu_hist:
+            if buffer.agent_status.get("Neutral Analyst") != "completed":
+                buffer.update_agent_status("Neutral Analyst", "in_progress")
+            buffer.update_report_section(
+                "final_trade_decision", f"### Neutral Analyst Analysis\n{neu_hist}"
+            )
+        if judge and buffer.agent_status.get("Portfolio Manager") != "completed":
+            buffer.update_agent_status("Portfolio Manager", "in_progress")
+            buffer.update_report_section(
+                "final_trade_decision", f"### Portfolio Manager Decision\n{judge}"
+            )
+            buffer.update_agent_status("Aggressive Analyst", "completed")
+            buffer.update_agent_status("Conservative Analyst", "completed")
+            buffer.update_agent_status("Neutral Analyst", "completed")
+            buffer.update_agent_status("Portfolio Manager", "completed")
+
+
 def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     """Assemble the run config from interactive selections, honoring env precedence.
 
@@ -988,7 +1098,7 @@ def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     return config
 
 
-def run_analysis(checkpoint: bool | None = None):
+def run_analysis(checkpoint: bool | None = None, classic: bool = False):
     # First get all user selections
     selections = get_user_selections()
 
@@ -1065,158 +1175,100 @@ def run_analysis(checkpoint: bool | None = None):
     message_buffer.add_tool_call = save_tool_call_decorator(message_buffer, "add_tool_call")
     message_buffer.update_report_section = save_report_section_decorator(message_buffer, "update_report_section")
 
-    # Now start the display layout
-    layout = create_layout()
+    # Seed initial buffer state (rendered identically by both display modes)
+    message_buffer.add_message("System", f"Selected ticker: {selections['ticker']}")
+    if selections["asset_type"] != "stock":
+        message_buffer.add_message("System", f"Detected asset type: {selections['asset_type']}")
+    message_buffer.add_message(
+        "System", f"Analysis date: {selections['analysis_date']}"
+    )
+    message_buffer.add_message(
+        "System",
+        f"Selected analysts: {', '.join(analyst.value for analyst in selections['analysts'])}",
+    )
 
-    with Live(layout, refresh_per_second=4):
-        # Initial display
-        update_display(layout, stats_handler=stats_handler, start_time=start_time)
+    # Update agent status to in_progress for the first analyst
+    first_analyst = get_initial_analyst_node(analyst_execution_plan)
+    message_buffer.update_agent_status(first_analyst, "in_progress")
+    analyst_wall_time_tracker.mark_started(selected_analyst_keys[0])
 
-        # Add initial messages
-        message_buffer.add_message("System", f"Selected ticker: {selections['ticker']}")
-        if selections["asset_type"] != "stock":
-            message_buffer.add_message("System", f"Detected asset type: {selections['asset_type']}")
-        message_buffer.add_message(
-            "System", f"Analysis date: {selections['analysis_date']}"
-        )
-        message_buffer.add_message(
-            "System",
-            f"Selected analysts: {', '.join(analyst.value for analyst in selections['analysts'])}",
-        )
-        update_display(layout, stats_handler=stats_handler, start_time=start_time)
+    # Initialize state and get graph args with callbacks.
+    # Resolve the instrument identity once here so all agents anchor to
+    # the real company (#814); the CLI builds state directly rather than
+    # going through propagate(), so this must happen on the CLI path too.
+    instrument_context = graph.resolve_instrument_context(
+        selections["ticker"], selections["asset_type"]
+    )
+    init_agent_state = graph.propagator.create_initial_state(
+        selections["ticker"],
+        selections["analysis_date"],
+        asset_type=selections["asset_type"],
+        instrument_context=instrument_context,
+    )
+    # Pass callbacks to graph config for tool execution tracking
+    # (LLM tracking is handled separately via LLM constructor)
+    args = graph.propagator.get_graph_args(callbacks=[stats_handler])
 
-        # Update agent status to in_progress for the first analyst
-        first_analyst = get_initial_analyst_node(analyst_execution_plan)
-        message_buffer.update_agent_status(first_analyst, "in_progress")
-        analyst_wall_time_tracker.mark_started(selected_analyst_keys[0])
-        update_display(layout, stats_handler=stats_handler, start_time=start_time)
-
-        # Create spinner text
-        spinner_text = (
-            f"Analyzing {selections['ticker']} on {selections['analysis_date']}..."
-        )
-        update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
-
-        # Initialize state and get graph args with callbacks.
-        # Resolve the instrument identity once here so all agents anchor to
-        # the real company (#814); the CLI builds state directly rather than
-        # going through propagate(), so this must happen on the CLI path too.
-        instrument_context = graph.resolve_instrument_context(
-            selections["ticker"], selections["asset_type"]
-        )
-        init_agent_state = graph.propagator.create_initial_state(
-            selections["ticker"],
-            selections["analysis_date"],
-            asset_type=selections["asset_type"],
-            instrument_context=instrument_context,
-        )
-        # Pass callbacks to graph config for tool execution tracking
-        # (LLM tracking is handled separately via LLM constructor)
-        args = graph.propagator.get_graph_args(callbacks=[stats_handler])
-
-        # Stream the analysis
-        trace = []
-        for chunk in graph.graph.stream(init_agent_state, **args):
-            # Process all messages in chunk, deduplicating by message ID
-            for message in chunk.get("messages", []):
-                msg_id = getattr(message, "id", None)
-                if msg_id is not None:
-                    if msg_id in message_buffer._processed_message_ids:
-                        continue
-                    message_buffer._processed_message_ids.add(msg_id)
-
-                msg_type, content = classify_message_type(message)
-                if content and content.strip():
-                    message_buffer.add_message(msg_type, content)
-
-                if hasattr(message, "tool_calls") and message.tool_calls:
-                    for tool_call in message.tool_calls:
-                        if isinstance(tool_call, dict):
-                            message_buffer.add_tool_call(tool_call["name"], tool_call["args"])
-                        else:
-                            message_buffer.add_tool_call(tool_call.name, tool_call.args)
-
-            # Update analyst statuses based on report state (runs on every chunk)
-            update_analyst_statuses(
-                message_buffer,
-                chunk,
-                wall_time_tracker=analyst_wall_time_tracker,
-            )
-
-            # Research Team - Handle Investment Debate State
-            if chunk.get("investment_debate_state"):
-                debate_state = chunk["investment_debate_state"]
-                bull_hist = debate_state.get("bull_history", "").strip()
-                bear_hist = debate_state.get("bear_history", "").strip()
-                judge = debate_state.get("judge_decision", "").strip()
-
-                # Only update status when there's actual content
-                if bull_hist or bear_hist:
-                    update_research_team_status("in_progress")
-                if bull_hist:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Bull Researcher Analysis\n{bull_hist}"
-                    )
-                if bear_hist:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Bear Researcher Analysis\n{bear_hist}"
-                    )
-                if judge:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Research Manager Decision\n{judge}"
-                    )
-                    update_research_team_status("completed")
-                    message_buffer.update_agent_status("Trader", "in_progress")
-
-            # Trading Team
-            if chunk.get("trader_investment_plan"):
-                message_buffer.update_report_section(
-                    "trader_investment_plan", chunk["trader_investment_plan"]
-                )
-                if message_buffer.agent_status.get("Trader") != "completed":
-                    message_buffer.update_agent_status("Trader", "completed")
-                    message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
-
-            # Risk Management Team - Handle Risk Debate State
-            if chunk.get("risk_debate_state"):
-                risk_state = chunk["risk_debate_state"]
-                agg_hist = risk_state.get("aggressive_history", "").strip()
-                con_hist = risk_state.get("conservative_history", "").strip()
-                neu_hist = risk_state.get("neutral_history", "").strip()
-                judge = risk_state.get("judge_decision", "").strip()
-
-                if agg_hist:
-                    if message_buffer.agent_status.get("Aggressive Analyst") != "completed":
-                        message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Aggressive Analyst Analysis\n{agg_hist}"
-                    )
-                if con_hist:
-                    if message_buffer.agent_status.get("Conservative Analyst") != "completed":
-                        message_buffer.update_agent_status("Conservative Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Conservative Analyst Analysis\n{con_hist}"
-                    )
-                if neu_hist:
-                    if message_buffer.agent_status.get("Neutral Analyst") != "completed":
-                        message_buffer.update_agent_status("Neutral Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Neutral Analyst Analysis\n{neu_hist}"
-                    )
-                if judge and message_buffer.agent_status.get("Portfolio Manager") != "completed":
-                    message_buffer.update_agent_status("Portfolio Manager", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Portfolio Manager Decision\n{judge}"
-                    )
-                    message_buffer.update_agent_status("Aggressive Analyst", "completed")
-                    message_buffer.update_agent_status("Conservative Analyst", "completed")
-                    message_buffer.update_agent_status("Neutral Analyst", "completed")
-                    message_buffer.update_agent_status("Portfolio Manager", "completed")
-
-            # Update the display
+    if classic:
+        # Classic Rich Live renderer (kept for one release, behind --classic).
+        layout = create_layout()
+        with Live(layout, refresh_per_second=4):
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
+            spinner_text = (
+                f"Analyzing {selections['ticker']} on {selections['analysis_date']}..."
+            )
+            update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
 
-            trace.append(chunk)
+            # Stream the analysis
+            trace = []
+            for chunk in graph.graph.stream(init_agent_state, **args):
+                handle_stream_chunk(
+                    message_buffer, chunk, wall_time_tracker=analyst_wall_time_tracker
+                )
+                update_display(layout, stats_handler=stats_handler, start_time=start_time)
+                trace.append(chunk)
+
+            # Streamed chunks are per-node deltas, not full state. Merge them
+            # so every report field populated across the run is present.
+            final_state = {}
+            for chunk in trace:
+                final_state.update(chunk)
+
+            # Update all agent statuses to completed
+            for agent in message_buffer.agent_status:
+                message_buffer.update_agent_status(agent, "completed")
+
+            message_buffer.add_message(
+                "System", f"Completed analysis for {selections['analysis_date']}"
+            )
+            message_buffer.add_message("System", analyst_wall_time_tracker.format_summary())
+
+            # Update final report sections
+            for section in message_buffer.report_sections:
+                if section in final_state:
+                    message_buffer.update_report_section(section, final_state[section])
+
+            update_display(layout, stats_handler=stats_handler, start_time=start_time)
+    else:
+        # Scrollable Textual TUI (default). The blocking graph stream runs in a
+        # worker thread inside the app; control returns here when it finishes.
+        from cli.tui import TradingApp
+
+        tui = TradingApp(
+            buffer=message_buffer,
+            graph=graph,
+            init_agent_state=init_agent_state,
+            graph_args=args,
+            stats_handler=stats_handler,
+            start_time=start_time,
+            ticker=selections["ticker"],
+            analysis_date=selections["analysis_date"],
+            wall_time_tracker=analyst_wall_time_tracker,
+        )
+        tui.run()
+        if tui._stream_error is not None:
+            raise tui._stream_error
+        trace = tui.trace
 
         # Streamed chunks are per-node deltas, not full state. Merge them
         # so every report field populated across the run is present.
@@ -1224,23 +1276,11 @@ def run_analysis(checkpoint: bool | None = None):
         for chunk in trace:
             final_state.update(chunk)
 
-        # Update all agent statuses to completed
-        for agent in message_buffer.agent_status:
-            message_buffer.update_agent_status(agent, "completed")
+    if not trace:
+        console.print("[red]Analysis ended before producing any output.[/red]")
+        return
 
-        message_buffer.add_message(
-            "System", f"Completed analysis for {selections['analysis_date']}"
-        )
-        message_buffer.add_message("System", analyst_wall_time_tracker.format_summary())
-
-        # Update final report sections
-        for section in message_buffer.report_sections:
-            if section in final_state:
-                message_buffer.update_report_section(section, final_state[section])
-
-        update_display(layout, stats_handler=stats_handler, start_time=start_time)
-
-    # Post-analysis prompts (outside Live context for clean interaction)
+    # Post-analysis prompts (outside the live view for clean interaction)
     console.print("\n[bold cyan]Analysis Complete![/bold cyan]\n")
     console.print(f"[dim]{analyst_wall_time_tracker.format_summary()}[/dim]")
 
@@ -1280,12 +1320,19 @@ def analyze(
         "--clear-checkpoints",
         help="Delete all saved checkpoints before running (force fresh start).",
     ),
+    classic: bool = typer.Option(
+        False,
+        "--classic",
+        help="Use the classic fixed-height Rich Live renderer instead of the "
+        "new scrollable Textual TUI.",
+        envvar="TRADINGAGENTS_CLASSIC_TUI",
+    ),
 ):
     if clear_checkpoints:
         from tradingagents.graph.checkpointer import clear_all_checkpoints
         n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
         console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
-    run_analysis(checkpoint=checkpoint)
+    run_analysis(checkpoint=checkpoint, classic=classic)
 
 
 if __name__ == "__main__":

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -1,0 +1,306 @@
+"""Textual-based live view for `tradingagents analyze`.
+
+Mirrors the panes of the classic Rich Live renderer (header / progress /
+messages / report / footer) but routes them through Textual widgets so the
+report and message panes are scrollable. Selected via the absence of
+`--classic`; the classic path remains in `cli.main.run_analysis` for one
+release.
+
+The graph stream loop is blocking, so it runs in a Textual worker thread
+(`@work(thread=True)`). Buffer mutations are funnelled back to the UI via
+`app.call_from_thread(...)` and a fixed-cadence refresh interval, matching
+the `refresh_per_second=4` of the classic renderer.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+from rich import box
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+from textual import work
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Footer, Header, Markdown, Static
+
+# --- Rich renderable builders -------------------------------------------------
+# Pure functions of buffer state. No Textual coupling, easy to unit-test, and
+# reusable from the classic renderer if we ever consolidate.
+
+_STATUS_COLORS = {"pending": "yellow", "completed": "green", "error": "red"}
+
+
+def _status_cell(status: str):
+    if status == "in_progress":
+        return Spinner("dots", text="[blue]in_progress[/blue]", style="bold cyan")
+    color = _STATUS_COLORS.get(status, "white")
+    return f"[{color}]{status}[/{color}]"
+
+
+def build_progress_table(buffer) -> Table:
+    from cli.main import ALL_TEAMS  # canonical mapping; defined in cli.main
+
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        show_footer=False,
+        box=box.SIMPLE_HEAD,
+        padding=(0, 2),
+        expand=True,
+    )
+    table.add_column("Team", style="cyan", justify="center", width=20)
+    table.add_column("Agent", style="green", justify="center", width=20)
+    table.add_column("Status", style="yellow", justify="center", width=20)
+
+    teams = {}
+    for team, agents in ALL_TEAMS.items():
+        active = [a for a in agents if a in buffer.agent_status]
+        if active:
+            teams[team] = active
+
+    for team, agents in teams.items():
+        first = agents[0]
+        table.add_row(
+            team, first, _status_cell(buffer.agent_status.get(first, "pending"))
+        )
+        for agent in agents[1:]:
+            table.add_row(
+                "", agent, _status_cell(buffer.agent_status.get(agent, "pending"))
+            )
+        table.add_row("─" * 20, "─" * 20, "─" * 20, style="dim")
+    return table
+
+
+def build_messages_table(buffer, limit: int | None = None) -> Table:
+    """Build the messages & tools table.
+
+    `limit=None` shows everything (TUI mode — outer VerticalScroll handles
+    overflow). The classic renderer passes `limit=12`.
+    """
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        show_footer=False,
+        expand=True,
+        box=box.MINIMAL,
+        show_lines=True,
+        padding=(0, 1),
+    )
+    table.add_column("Time", style="cyan", width=8, justify="center")
+    table.add_column("Type", style="green", width=10, justify="center")
+    table.add_column("Content", style="white", no_wrap=False, ratio=1)
+
+    rows: list[tuple[str, str, str]] = []
+    from cli.main import format_tool_args  # avoid circular import at module load
+
+    for timestamp, tool_name, args in buffer.tool_calls:
+        rows.append((timestamp, "Tool", f"{tool_name}: {format_tool_args(args)}"))
+    for timestamp, msg_type, content in buffer.messages:
+        s = str(content) if content else ""
+        if len(s) > 200:
+            s = s[:197] + "..."
+        rows.append((timestamp, msg_type, s))
+
+    rows.sort(key=lambda r: r[0], reverse=True)
+    if limit is not None:
+        rows = rows[:limit]
+
+    for timestamp, msg_type, content in rows:
+        table.add_row(timestamp, msg_type, Text(content, overflow="fold"))
+    return table
+
+
+def _format_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def build_stats_text(buffer, stats_handler=None, start_time: float | None = None) -> str:
+    completed = sum(1 for s in buffer.agent_status.values() if s == "completed")
+    total = len(buffer.agent_status)
+    parts = [f"Agents: {completed}/{total}"]
+
+    if stats_handler is not None:
+        stats = stats_handler.get_stats()
+        parts.append(f"LLM: {stats['llm_calls']}")
+        parts.append(f"Tools: {stats['tool_calls']}")
+        if stats["tokens_in"] > 0 or stats["tokens_out"] > 0:
+            parts.append(
+                f"Tokens: {_format_tokens(stats['tokens_in'])}↑ "
+                f"{_format_tokens(stats['tokens_out'])}↓"
+            )
+        else:
+            parts.append("Tokens: --")
+
+    parts.append(
+        f"Reports: {buffer.get_completed_reports_count()}/{len(buffer.report_sections)}"
+    )
+
+    if start_time is not None:
+        elapsed = time.time() - start_time
+        parts.append(f"⏱ {int(elapsed // 60):02d}:{int(elapsed % 60):02d}")
+
+    return " | ".join(parts)
+
+
+# --- Textual app --------------------------------------------------------------
+
+
+class TradingApp(App):
+    """Live view with scrollable report and message panes."""
+
+    CSS_PATH = "tui.tcss"
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("ctrl+c", "quit", "Quit"),
+        ("tab", "focus_next", "Next pane"),
+        ("shift+tab", "focus_previous", "Prev pane"),
+        ("g", "scroll_top", "Top"),
+        ("G", "scroll_bottom", "Bottom"),
+    ]
+
+    def __init__(
+        self,
+        buffer,
+        graph,
+        init_agent_state: Any,
+        graph_args: dict,
+        stats_handler,
+        start_time: float,
+        ticker: str,
+        analysis_date: str,
+        wall_time_tracker=None,
+        on_complete: Callable[[list[Any]], None] | None = None,
+    ):
+        super().__init__()
+        self.buffer = buffer
+        self.graph = graph
+        self.init_agent_state = init_agent_state
+        self.graph_args = graph_args
+        self.stats_handler = stats_handler
+        self.start_time = start_time
+        self.ticker = ticker
+        self.analysis_date = analysis_date
+        self.wall_time_tracker = wall_time_tracker
+        self.on_complete = on_complete
+        self.trace: list[Any] = []
+        self._stream_error: BaseException | None = None
+        self.title = "TradingAgents"
+        self.sub_title = f"{ticker} · {analysis_date}"
+
+    # --- composition ---------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="body"):
+            with Vertical(id="left"):
+                with VerticalScroll(id="progress-scroll"):
+                    yield Static(id="progress")
+                with VerticalScroll(id="messages-scroll"):
+                    yield Static(id="messages")
+            with VerticalScroll(id="report-scroll"):
+                yield Markdown("*Waiting for analysis report...*", id="report")
+        yield Static(id="footer-stats")
+        yield Footer()
+
+    # --- lifecycle -----------------------------------------------------------
+
+    def on_mount(self) -> None:
+        self.query_one("#progress-scroll").border_title = "Progress"
+        self.query_one("#messages-scroll").border_title = "Messages & Tools"
+        self.query_one("#report-scroll").border_title = "Current Report"
+        self._refresh_panes()
+        self.set_interval(0.25, self._refresh_panes)
+        self.run_stream()
+
+    # --- worker --------------------------------------------------------------
+
+    @work(thread=True, exclusive=True)
+    def run_stream(self) -> None:
+        from cli.main import handle_stream_chunk
+
+        try:
+            for chunk in self.graph.graph.stream(
+                self.init_agent_state, **self.graph_args
+            ):
+                handle_stream_chunk(
+                    self.buffer, chunk, wall_time_tracker=self.wall_time_tracker
+                )
+                self.trace.append(chunk)
+        except BaseException as exc:  # noqa: BLE001 — re-raised on main thread
+            self._stream_error = exc
+        finally:
+            self.call_from_thread(self._on_stream_done)
+
+    def _on_stream_done(self) -> None:
+        if self._stream_error is not None:
+            self.buffer.add_message("System", f"Error: {self._stream_error!r}")
+            self._refresh_panes()
+            return
+
+        # Mark all agents complete and copy final-state report sections back.
+        for agent in list(self.buffer.agent_status):
+            self.buffer.update_agent_status(agent, "completed")
+        self.buffer.add_message(
+            "System", f"Completed analysis for {self.analysis_date}"
+        )
+        if self.wall_time_tracker is not None:
+            self.buffer.add_message(
+                "System", self.wall_time_tracker.format_summary()
+            )
+        # Streamed chunks are per-node deltas, not full state — merge them so
+        # every report field populated across the run is present (matches the
+        # classic renderer).
+        final_state: dict = {}
+        for chunk in self.trace:
+            final_state.update(chunk)
+        for section in list(self.buffer.report_sections):
+            if section in final_state:
+                self.buffer.update_report_section(section, final_state[section])
+        self._refresh_panes()
+        # Hand control back to the CLI for save/display prompts.
+        if self.on_complete is not None:
+            self.on_complete(self.trace)
+        self.exit()
+
+    # --- rendering -----------------------------------------------------------
+
+    def _refresh_panes(self) -> None:
+        self.query_one("#progress", Static).update(build_progress_table(self.buffer))
+        self.query_one("#messages", Static).update(
+            build_messages_table(self.buffer, limit=None)
+        )
+
+        report = self.buffer.current_report
+        md = self.query_one("#report", Markdown)
+        # Markdown.update is async; fire-and-forget — the next interval will
+        # paint over it if a newer report arrives mid-update.
+        if report:
+            md.update(report)
+        self.query_one("#footer-stats", Static).update(
+            build_stats_text(self.buffer, self.stats_handler, self.start_time)
+        )
+
+    # --- actions -------------------------------------------------------------
+
+    def action_scroll_top(self) -> None:
+        focused = self.focused
+        if focused is not None:
+            scroll = focused if hasattr(focused, "scroll_home") else focused.parent
+            if scroll is not None and hasattr(scroll, "scroll_home"):
+                scroll.scroll_home(animate=False)
+
+    def action_scroll_bottom(self) -> None:
+        focused = self.focused
+        if focused is not None:
+            scroll = focused if hasattr(focused, "scroll_end") else focused.parent
+            if scroll is not None and hasattr(scroll, "scroll_end"):
+                scroll.scroll_end(animate=False)

--- a/cli/tui.tcss
+++ b/cli/tui.tcss
@@ -1,0 +1,51 @@
+/* TradingAgents Textual layout. Mirrors the classic Rich Live panel colors:
+   cyan for progress, blue for messages, green for current report. */
+
+Screen {
+    background: $surface;
+}
+
+#body {
+    height: 1fr;
+}
+
+#left {
+    width: 3fr;
+}
+
+#report-scroll {
+    width: 5fr;
+}
+
+#progress-scroll {
+    height: 2fr;
+    border: round cyan;
+    padding: 0 1;
+}
+
+#messages-scroll {
+    height: 3fr;
+    border: round blue;
+    padding: 0 1;
+}
+
+#report-scroll {
+    border: round green;
+    padding: 0 1;
+}
+
+#footer-stats {
+    height: 1;
+    background: $panel;
+    color: $text-muted;
+    text-align: center;
+    padding: 0 2;
+}
+
+#progress, #messages {
+    width: 100%;
+}
+
+Markdown {
+    margin: 0 1;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "redis>=6.2.0",
     "requests>=2.32.4",
     "rich>=14.0.0",
+    "textual>=0.80",
     "typer>=0.21.0",
     "setuptools>=80.9.0",
     "stockstats>=0.6.5",
@@ -52,7 +53,7 @@ tradingagents = "cli.main:app"
 include = ["tradingagents*", "cli*"]
 
 [tool.setuptools.package-data]
-cli = ["static/*"]
+cli = ["static/*", "*.tcss"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Replace the fixed-height Rich Live layout with a Textual app that renders the same panes (header / progress / messages / current report / footer stats) but routes the messages and report through scrollable containers, so long reports and earlier tool calls are no longer truncated. Mouse wheel, arrow keys, g/G for top/bottom, and Tab/Shift-Tab to switch panes.

The graph stream loop is blocking, so it runs in a Textual worker thread (@work(thread=True)) and the UI refreshes on a 0.25s interval — same cadence as the classic refresh_per_second=4. The classic Rich Live renderer is preserved verbatim behind --classic (also TRADINGAGENTS_CLASSIC_TUI=1) for one release so any scripts depending on the previous output have a fallback.

Refactor: chunk → buffer mapping (~95 lines that lived inline in the stream loop) is extracted to handle_stream_chunk(buffer, chunk), shared by both renderers. update_research_team_status now takes a buffer arg instead of relying on the module global.

- New cli/tui.py: TradingApp + pure Rich-renderable builders (build_progress_table, build_messages_table, build_stats_text) exercised by a headless app.run_test smoke check.
- New cli/tui.tcss: layout + colours mirroring the classic panels (cyan progress, blue messages, green report).
- pyproject.toml: add textual>=0.80, ship *.tcss with the package.
- .gitignore: ignore .DS_Store on macOS.
- CHANGELOG: entry under [Unreleased].

All 108 existing tests still pass.