### PR TITLE
Add Ollama diagnostic check, CLI command, startup warning, and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ DEEPSEEK_API_KEY=
 DASHSCOPE_API_KEY=
 ZHIPU_API_KEY=
 OPENROUTER_API_KEY=
+
+# Ollama local server base URL — no /v1 suffix (used when LLM_PROVIDER=ollama)
+# The CLI appends /v1 automatically for model calls; the check utility uses the root.
+OLLAMA_HOST=http://localhost:11434

--- a/cli/main.py
+++ b/cli/main.py
@@ -1370,11 +1370,12 @@ def check():
     # Build a minimal config from defaults.
     # backend_url is None here (user hasn't selected a provider yet),
     # so _resolve_base_url will fall back to OLLAMA_HOST env var or localhost.
+    import os
     check_config = {
-        "llm_provider": DEFAULT_CONFIG.get("llm_provider", "openai"),
-        "backend_url": DEFAULT_CONFIG.get("backend_url"),  # None by default
-        "deep_think_llm": DEFAULT_CONFIG.get("deep_think_llm"),
-        "quick_think_llm": DEFAULT_CONFIG.get("quick_think_llm"),
+        "llm_provider": os.getenv("LLM_PROVIDER", DEFAULT_CONFIG.get("llm_provider", "openai")),
+        "backend_url": os.getenv("OLLAMA_HOST", DEFAULT_CONFIG.get("backend_url")),
+        "deep_think_llm": os.getenv("DEEP_THINK_LLM", DEFAULT_CONFIG.get("deep_think_llm")),
+        "quick_think_llm": os.getenv("QUICK_THINK_LLM", DEFAULT_CONFIG.get("quick_think_llm")),
     }
 
     if check_config["llm_provider"] != "ollama":

--- a/cli/main.py
+++ b/cli/main.py
@@ -46,7 +46,11 @@ class MessageBuffer:
     FIXED_AGENTS = {
         "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
         "Trading Team": ["Trader"],
-        "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
+        "Risk Management": [
+            "Aggressive Analyst",
+            "Neutral Analyst",
+            "Conservative Analyst",
+        ],
         "Portfolio Management": ["Portfolio Manager"],
     }
 
@@ -166,7 +170,7 @@ class MessageBuffer:
             if content is not None:
                 latest_section = section
                 latest_content = content
-               
+
         if latest_section and latest_content:
             # Format the current section for display
             section_titles = {
@@ -189,7 +193,12 @@ class MessageBuffer:
         report_parts = []
 
         # Analyst Team Reports - use .get() to handle missing sections
-        analyst_sections = ["market_report", "sentiment_report", "news_report", "fundamentals_report"]
+        analyst_sections = [
+            "market_report",
+            "sentiment_report",
+            "news_report",
+            "fundamentals_report",
+        ]
         if any(self.report_sections.get(section) for section in analyst_sections):
             report_parts.append("## Analyst Team Reports")
             if self.report_sections.get("market_report"):
@@ -290,7 +299,11 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
         ],
         "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
         "Trading Team": ["Trader"],
-        "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
+        "Risk Management": [
+            "Aggressive Analyst",
+            "Neutral Analyst",
+            "Conservative Analyst",
+        ],
         "Portfolio Management": ["Portfolio Manager"],
     }
 
@@ -463,7 +476,9 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
 def get_user_selections():
     """Get all user selections before starting the analysis display."""
     # Display ASCII art welcome message
-    with open(Path(__file__).parent / "static" / "welcome.txt", "r", encoding="utf-8") as f:
+    with open(
+        Path(__file__).parent / "static" / "welcome.txt", "r", encoding="utf-8"
+    ) as f:
         welcome_ascii = f.read()
 
     # Create welcome box content
@@ -524,7 +539,7 @@ def get_user_selections():
     console.print(
         create_question_box(
             "Step 3: Output Language",
-            "Select the language for analyst reports and final decision"
+            "Select the language for analyst reports and final decision",
         )
     )
     output_language = ask_output_language()
@@ -550,9 +565,7 @@ def get_user_selections():
 
     # Step 6: LLM Provider
     console.print(
-        create_question_box(
-            "Step 6: LLM Provider", "Select your LLM provider"
-        )
+        create_question_box("Step 6: LLM Provider", "Select your LLM provider")
     )
     selected_llm_provider, backend_url = select_llm_provider()
 
@@ -574,25 +587,20 @@ def get_user_selections():
     if provider_lower == "google":
         console.print(
             create_question_box(
-                "Step 8: Thinking Mode",
-                "Configure Gemini thinking mode"
+                "Step 8: Thinking Mode", "Configure Gemini thinking mode"
             )
         )
         thinking_level = ask_gemini_thinking_config()
     elif provider_lower == "openai":
         console.print(
             create_question_box(
-                "Step 8: Reasoning Effort",
-                "Configure OpenAI reasoning effort level"
+                "Step 8: Reasoning Effort", "Configure OpenAI reasoning effort level"
             )
         )
         reasoning_effort = ask_openai_reasoning_effort()
     elif provider_lower == "anthropic":
         console.print(
-            create_question_box(
-                "Step 8: Effort Level",
-                "Configure Claude effort level"
-            )
+            create_question_box("Step 8: Effort Level", "Configure Claude effort level")
         )
         anthropic_effort = ask_anthropic_effort()
 
@@ -646,20 +654,30 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
     analyst_parts = []
     if final_state.get("market_report"):
         analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "market.md").write_text(final_state["market_report"], encoding="utf-8")
+        (analysts_dir / "market.md").write_text(
+            final_state["market_report"], encoding="utf-8"
+        )
         analyst_parts.append(("Market Analyst", final_state["market_report"]))
     if final_state.get("sentiment_report"):
         analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "sentiment.md").write_text(final_state["sentiment_report"], encoding="utf-8")
+        (analysts_dir / "sentiment.md").write_text(
+            final_state["sentiment_report"], encoding="utf-8"
+        )
         analyst_parts.append(("Social Analyst", final_state["sentiment_report"]))
     if final_state.get("news_report"):
         analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "news.md").write_text(final_state["news_report"], encoding="utf-8")
+        (analysts_dir / "news.md").write_text(
+            final_state["news_report"], encoding="utf-8"
+        )
         analyst_parts.append(("News Analyst", final_state["news_report"]))
     if final_state.get("fundamentals_report"):
         analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
-        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
+        (analysts_dir / "fundamentals.md").write_text(
+            final_state["fundamentals_report"], encoding="utf-8"
+        )
+        analyst_parts.append(
+            ("Fundamentals Analyst", final_state["fundamentals_report"])
+        )
     if analyst_parts:
         content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
         sections.append(f"## I. Analyst Team Reports\n\n{content}")
@@ -671,26 +689,38 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
         research_parts = []
         if debate.get("bull_history"):
             research_dir.mkdir(exist_ok=True)
-            (research_dir / "bull.md").write_text(debate["bull_history"], encoding="utf-8")
+            (research_dir / "bull.md").write_text(
+                debate["bull_history"], encoding="utf-8"
+            )
             research_parts.append(("Bull Researcher", debate["bull_history"]))
         if debate.get("bear_history"):
             research_dir.mkdir(exist_ok=True)
-            (research_dir / "bear.md").write_text(debate["bear_history"], encoding="utf-8")
+            (research_dir / "bear.md").write_text(
+                debate["bear_history"], encoding="utf-8"
+            )
             research_parts.append(("Bear Researcher", debate["bear_history"]))
         if debate.get("judge_decision"):
             research_dir.mkdir(exist_ok=True)
-            (research_dir / "manager.md").write_text(debate["judge_decision"], encoding="utf-8")
+            (research_dir / "manager.md").write_text(
+                debate["judge_decision"], encoding="utf-8"
+            )
             research_parts.append(("Research Manager", debate["judge_decision"]))
         if research_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
+            content = "\n\n".join(
+                f"### {name}\n{text}" for name, text in research_parts
+            )
             sections.append(f"## II. Research Team Decision\n\n{content}")
 
     # 3. Trading
     if final_state.get("trader_investment_plan"):
         trading_dir = save_path / "3_trading"
         trading_dir.mkdir(exist_ok=True)
-        (trading_dir / "trader.md").write_text(final_state["trader_investment_plan"], encoding="utf-8")
-        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}")
+        (trading_dir / "trader.md").write_text(
+            final_state["trader_investment_plan"], encoding="utf-8"
+        )
+        sections.append(
+            f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}"
+        )
 
     # 4. Risk Management
     if final_state.get("risk_debate_state"):
@@ -699,15 +729,21 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
         risk_parts = []
         if risk.get("aggressive_history"):
             risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "aggressive.md").write_text(risk["aggressive_history"], encoding="utf-8")
+            (risk_dir / "aggressive.md").write_text(
+                risk["aggressive_history"], encoding="utf-8"
+            )
             risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
         if risk.get("conservative_history"):
             risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "conservative.md").write_text(risk["conservative_history"], encoding="utf-8")
+            (risk_dir / "conservative.md").write_text(
+                risk["conservative_history"], encoding="utf-8"
+            )
             risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
         if risk.get("neutral_history"):
             risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "neutral.md").write_text(risk["neutral_history"], encoding="utf-8")
+            (risk_dir / "neutral.md").write_text(
+                risk["neutral_history"], encoding="utf-8"
+            )
             risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
         if risk_parts:
             content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
@@ -717,12 +753,18 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
         if risk.get("judge_decision"):
             portfolio_dir = save_path / "5_portfolio"
             portfolio_dir.mkdir(exist_ok=True)
-            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
-            sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
+            (portfolio_dir / "decision.md").write_text(
+                risk["judge_decision"], encoding="utf-8"
+            )
+            sections.append(
+                f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}"
+            )
 
     # Write consolidated report
     header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-    (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
+    (save_path / "complete_report.md").write_text(
+        header + "\n\n".join(sections), encoding="utf-8"
+    )
     return save_path / "complete_report.md"
 
 
@@ -742,9 +784,15 @@ def display_complete_report(final_state):
     if final_state.get("fundamentals_report"):
         analysts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
     if analysts:
-        console.print(Panel("[bold]I. Analyst Team Reports[/bold]", border_style="cyan"))
+        console.print(
+            Panel("[bold]I. Analyst Team Reports[/bold]", border_style="cyan")
+        )
         for title, content in analysts:
-            console.print(Panel(Markdown(content), title=title, border_style="blue", padding=(1, 2)))
+            console.print(
+                Panel(
+                    Markdown(content), title=title, border_style="blue", padding=(1, 2)
+                )
+            )
 
     # II. Research Team Reports
     if final_state.get("investment_debate_state"):
@@ -757,14 +805,32 @@ def display_complete_report(final_state):
         if debate.get("judge_decision"):
             research.append(("Research Manager", debate["judge_decision"]))
         if research:
-            console.print(Panel("[bold]II. Research Team Decision[/bold]", border_style="magenta"))
+            console.print(
+                Panel("[bold]II. Research Team Decision[/bold]", border_style="magenta")
+            )
             for title, content in research:
-                console.print(Panel(Markdown(content), title=title, border_style="blue", padding=(1, 2)))
+                console.print(
+                    Panel(
+                        Markdown(content),
+                        title=title,
+                        border_style="blue",
+                        padding=(1, 2),
+                    )
+                )
 
     # III. Trading Team
     if final_state.get("trader_investment_plan"):
-        console.print(Panel("[bold]III. Trading Team Plan[/bold]", border_style="yellow"))
-        console.print(Panel(Markdown(final_state["trader_investment_plan"]), title="Trader", border_style="blue", padding=(1, 2)))
+        console.print(
+            Panel("[bold]III. Trading Team Plan[/bold]", border_style="yellow")
+        )
+        console.print(
+            Panel(
+                Markdown(final_state["trader_investment_plan"]),
+                title="Trader",
+                border_style="blue",
+                padding=(1, 2),
+            )
+        )
 
     # IV. Risk Management Team
     if final_state.get("risk_debate_state"):
@@ -777,14 +843,36 @@ def display_complete_report(final_state):
         if risk.get("neutral_history"):
             risk_reports.append(("Neutral Analyst", risk["neutral_history"]))
         if risk_reports:
-            console.print(Panel("[bold]IV. Risk Management Team Decision[/bold]", border_style="red"))
+            console.print(
+                Panel(
+                    "[bold]IV. Risk Management Team Decision[/bold]", border_style="red"
+                )
+            )
             for title, content in risk_reports:
-                console.print(Panel(Markdown(content), title=title, border_style="blue", padding=(1, 2)))
+                console.print(
+                    Panel(
+                        Markdown(content),
+                        title=title,
+                        border_style="blue",
+                        padding=(1, 2),
+                    )
+                )
 
         # V. Portfolio Manager Decision
         if risk.get("judge_decision"):
-            console.print(Panel("[bold]V. Portfolio Manager Decision[/bold]", border_style="green"))
-            console.print(Panel(Markdown(risk["judge_decision"]), title="Portfolio Manager", border_style="blue", padding=(1, 2)))
+            console.print(
+                Panel(
+                    "[bold]V. Portfolio Manager Decision[/bold]", border_style="green"
+                )
+            )
+            console.print(
+                Panel(
+                    Markdown(risk["judge_decision"]),
+                    title="Portfolio Manager",
+                    border_style="blue",
+                    padding=(1, 2),
+                )
+            )
 
 
 def update_research_team_status(status):
@@ -851,6 +939,7 @@ def update_analyst_statuses(message_buffer, chunk):
         if message_buffer.agent_status.get("Bull Researcher") == "pending":
             message_buffer.update_agent_status("Bull Researcher", "in_progress")
 
+
 def extract_content_string(content):
     """Extract string content from various message formats.
     Returns None if no meaningful text content is found.
@@ -859,7 +948,7 @@ def extract_content_string(content):
 
     def is_empty(val):
         """Check if value is empty using Python's truthiness."""
-        if val is None or val == '':
+        if val is None or val == "":
             return True
         if isinstance(val, str):
             s = val.strip()
@@ -878,16 +967,19 @@ def extract_content_string(content):
         return content.strip()
 
     if isinstance(content, dict):
-        text = content.get('text', '')
+        text = content.get("text", "")
         return text.strip() if not is_empty(text) else None
 
     if isinstance(content, list):
         text_parts = [
-            item.get('text', '').strip() if isinstance(item, dict) and item.get('type') == 'text'
-            else (item.strip() if isinstance(item, str) else '')
+            (
+                item.get("text", "").strip()
+                if isinstance(item, dict) and item.get("type") == "text"
+                else (item.strip() if isinstance(item, str) else "")
+            )
             for item in content
         ]
-        result = ' '.join(t for t in text_parts if t and not is_empty(t))
+        result = " ".join(t for t in text_parts if t and not is_empty(t))
         return result if result else None
 
     return str(content).strip() if not is_empty(content) else None
@@ -902,7 +994,7 @@ def classify_message_type(message) -> tuple[str, str | None]:
     """
     from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-    content = extract_content_string(getattr(message, 'content', None))
+    content = extract_content_string(getattr(message, "content", None))
 
     if isinstance(message, HumanMessage):
         if content and content.strip() == "Continue":
@@ -923,8 +1015,9 @@ def format_tool_args(args, max_length=80) -> str:
     """Format tool arguments for terminal display."""
     result = str(args)
     if len(result) > max_length:
-        return result[:max_length - 3] + "..."
+        return result[: max_length - 3] + "..."
     return result
+
 
 def run_analysis(checkpoint: bool = False):
     # First get all user selections
@@ -944,6 +1037,13 @@ def run_analysis(checkpoint: bool = False):
     config["anthropic_effort"] = selections.get("anthropic_effort")
     config["output_language"] = selections.get("output_language", "English")
     config["checkpoint_enabled"] = checkpoint
+    # Auto-check Ollama health before initialising the graph
+    if config.get("llm_provider") == "ollama":
+        from tradingagents.llm_clients.ollama_check import run_ollama_check
+
+        run_ollama_check(
+            config, exit_on_failure=False
+        )  # warn only — never crash startup
 
     # Create stats callback handler for tracking LLM/tool calls
     stats_handler = StatsCallbackHandler()
@@ -967,7 +1067,9 @@ def run_analysis(checkpoint: bool = False):
     start_time = time.time()
 
     # Create result directory
-    results_dir = Path(config["results_dir"]) / selections["ticker"] / selections["analysis_date"]
+    results_dir = (
+        Path(config["results_dir"]) / selections["ticker"] / selections["analysis_date"]
+    )
     results_dir.mkdir(parents=True, exist_ok=True)
     report_dir = results_dir / "reports"
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -976,6 +1078,7 @@ def run_analysis(checkpoint: bool = False):
 
     def save_message_decorator(obj, func_name):
         func = getattr(obj, func_name)
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             func(*args, **kwargs)
@@ -983,10 +1086,12 @@ def run_analysis(checkpoint: bool = False):
             content = content.replace("\n", " ")  # Replace newlines with spaces
             with open(log_file, "a", encoding="utf-8") as f:
                 f.write(f"{timestamp} [{message_type}] {content}\n")
+
         return wrapper
-    
+
     def save_tool_call_decorator(obj, func_name):
         func = getattr(obj, func_name)
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             func(*args, **kwargs)
@@ -994,25 +1099,39 @@ def run_analysis(checkpoint: bool = False):
             args_str = ", ".join(f"{k}={v}" for k, v in args.items())
             with open(log_file, "a", encoding="utf-8") as f:
                 f.write(f"{timestamp} [Tool Call] {tool_name}({args_str})\n")
+
         return wrapper
 
     def save_report_section_decorator(obj, func_name):
         func = getattr(obj, func_name)
+
         @wraps(func)
         def wrapper(section_name, content):
             func(section_name, content)
-            if section_name in obj.report_sections and obj.report_sections[section_name] is not None:
+            if (
+                section_name in obj.report_sections
+                and obj.report_sections[section_name] is not None
+            ):
                 content = obj.report_sections[section_name]
                 if content:
                     file_name = f"{section_name}.md"
-                    text = "\n".join(str(item) for item in content) if isinstance(content, list) else content
+                    text = (
+                        "\n".join(str(item) for item in content)
+                        if isinstance(content, list)
+                        else content
+                    )
                     with open(report_dir / file_name, "w", encoding="utf-8") as f:
                         f.write(text)
+
         return wrapper
 
     message_buffer.add_message = save_message_decorator(message_buffer, "add_message")
-    message_buffer.add_tool_call = save_tool_call_decorator(message_buffer, "add_tool_call")
-    message_buffer.update_report_section = save_report_section_decorator(message_buffer, "update_report_section")
+    message_buffer.add_tool_call = save_tool_call_decorator(
+        message_buffer, "add_tool_call"
+    )
+    message_buffer.update_report_section = save_report_section_decorator(
+        message_buffer, "update_report_section"
+    )
 
     # Now start the display layout
     layout = create_layout()
@@ -1041,7 +1160,9 @@ def run_analysis(checkpoint: bool = False):
         spinner_text = (
             f"Analyzing {selections['ticker']} on {selections['analysis_date']}..."
         )
-        update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
+        update_display(
+            layout, spinner_text, stats_handler=stats_handler, start_time=start_time
+        )
 
         # Initialize state and get graph args with callbacks
         init_agent_state = graph.propagator.create_initial_state(
@@ -1069,7 +1190,9 @@ def run_analysis(checkpoint: bool = False):
                 if hasattr(message, "tool_calls") and message.tool_calls:
                     for tool_call in message.tool_calls:
                         if isinstance(tool_call, dict):
-                            message_buffer.add_tool_call(tool_call["name"], tool_call["args"])
+                            message_buffer.add_tool_call(
+                                tool_call["name"], tool_call["args"]
+                            )
                         else:
                             message_buffer.add_tool_call(tool_call.name, tool_call.args)
 
@@ -1108,7 +1231,9 @@ def run_analysis(checkpoint: bool = False):
                 )
                 if message_buffer.agent_status.get("Trader") != "completed":
                     message_buffer.update_agent_status("Trader", "completed")
-                    message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
+                    message_buffer.update_agent_status(
+                        "Aggressive Analyst", "in_progress"
+                    )
 
             # Risk Management Team - Handle Risk Debate State
             if chunk.get("risk_debate_state"):
@@ -1119,33 +1244,65 @@ def run_analysis(checkpoint: bool = False):
                 judge = risk_state.get("judge_decision", "").strip()
 
                 if agg_hist:
-                    if message_buffer.agent_status.get("Aggressive Analyst") != "completed":
-                        message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
+                    if (
+                        message_buffer.agent_status.get("Aggressive Analyst")
+                        != "completed"
+                    ):
+                        message_buffer.update_agent_status(
+                            "Aggressive Analyst", "in_progress"
+                        )
                     message_buffer.update_report_section(
-                        "final_trade_decision", f"### Aggressive Analyst Analysis\n{agg_hist}"
+                        "final_trade_decision",
+                        f"### Aggressive Analyst Analysis\n{agg_hist}",
                     )
                 if con_hist:
-                    if message_buffer.agent_status.get("Conservative Analyst") != "completed":
-                        message_buffer.update_agent_status("Conservative Analyst", "in_progress")
+                    if (
+                        message_buffer.agent_status.get("Conservative Analyst")
+                        != "completed"
+                    ):
+                        message_buffer.update_agent_status(
+                            "Conservative Analyst", "in_progress"
+                        )
                     message_buffer.update_report_section(
-                        "final_trade_decision", f"### Conservative Analyst Analysis\n{con_hist}"
+                        "final_trade_decision",
+                        f"### Conservative Analyst Analysis\n{con_hist}",
                     )
                 if neu_hist:
-                    if message_buffer.agent_status.get("Neutral Analyst") != "completed":
-                        message_buffer.update_agent_status("Neutral Analyst", "in_progress")
+                    if (
+                        message_buffer.agent_status.get("Neutral Analyst")
+                        != "completed"
+                    ):
+                        message_buffer.update_agent_status(
+                            "Neutral Analyst", "in_progress"
+                        )
                     message_buffer.update_report_section(
-                        "final_trade_decision", f"### Neutral Analyst Analysis\n{neu_hist}"
+                        "final_trade_decision",
+                        f"### Neutral Analyst Analysis\n{neu_hist}",
                     )
                 if judge:
-                    if message_buffer.agent_status.get("Portfolio Manager") != "completed":
-                        message_buffer.update_agent_status("Portfolio Manager", "in_progress")
-                        message_buffer.update_report_section(
-                            "final_trade_decision", f"### Portfolio Manager Decision\n{judge}"
+                    if (
+                        message_buffer.agent_status.get("Portfolio Manager")
+                        != "completed"
+                    ):
+                        message_buffer.update_agent_status(
+                            "Portfolio Manager", "in_progress"
                         )
-                        message_buffer.update_agent_status("Aggressive Analyst", "completed")
-                        message_buffer.update_agent_status("Conservative Analyst", "completed")
-                        message_buffer.update_agent_status("Neutral Analyst", "completed")
-                        message_buffer.update_agent_status("Portfolio Manager", "completed")
+                        message_buffer.update_report_section(
+                            "final_trade_decision",
+                            f"### Portfolio Manager Decision\n{judge}",
+                        )
+                        message_buffer.update_agent_status(
+                            "Aggressive Analyst", "completed"
+                        )
+                        message_buffer.update_agent_status(
+                            "Conservative Analyst", "completed"
+                        )
+                        message_buffer.update_agent_status(
+                            "Neutral Analyst", "completed"
+                        )
+                        message_buffer.update_agent_status(
+                            "Portfolio Manager", "completed"
+                        )
 
             # Update the display
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
@@ -1180,21 +1337,54 @@ def run_analysis(checkpoint: bool = False):
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         default_path = Path.cwd() / "reports" / f"{selections['ticker']}_{timestamp}"
         save_path_str = typer.prompt(
-            "Save path (press Enter for default)",
-            default=str(default_path)
+            "Save path (press Enter for default)", default=str(default_path)
         ).strip()
         save_path = Path(save_path_str)
         try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
+            report_file = save_report_to_disk(
+                final_state, selections["ticker"], save_path
+            )
             console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
             console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
         except Exception as e:
             console.print(f"[red]Error saving report: {e}[/red]")
 
     # Prompt to display full report
-    display_choice = typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()
+    display_choice = (
+        typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()
+    )
     if display_choice in ("Y", "YES", ""):
         display_complete_report(final_state)
+
+
+@app.command()
+def check():
+    """
+    Diagnose Ollama connectivity and verify configured models are pulled locally.
+
+    Run this before `analyze` when using llm_provider=ollama to catch
+    connection errors and missing models early.
+    """
+    from tradingagents.llm_clients.ollama_check import run_ollama_check
+
+    # Build a minimal config from defaults.
+    # backend_url is None here (user hasn't selected a provider yet),
+    # so _resolve_base_url will fall back to OLLAMA_HOST env var or localhost.
+    check_config = {
+        "llm_provider": DEFAULT_CONFIG.get("llm_provider", "openai"),
+        "backend_url": DEFAULT_CONFIG.get("backend_url"),  # None by default
+        "deep_think_llm": DEFAULT_CONFIG.get("deep_think_llm"),
+        "quick_think_llm": DEFAULT_CONFIG.get("quick_think_llm"),
+    }
+
+    if check_config["llm_provider"] != "ollama":
+        console.print(
+            f"[yellow][Ollama Check] llm_provider is '{check_config['llm_provider']}', "
+            f"not 'ollama'. Set LLM_PROVIDER=ollama in your .env to use this check.[/yellow]"
+        )
+        raise typer.Exit(0)
+
+    run_ollama_check(check_config, exit_on_failure=True)
 
 
 @app.command()
@@ -1212,6 +1402,7 @@ def analyze(
 ):
     if clear_checkpoints:
         from tradingagents.graph.checkpointer import clear_all_checkpoints
+
         n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
         console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
     run_analysis(checkpoint=checkpoint)

--- a/tests/test_ollama_check.py
+++ b/tests/test_ollama_check.py
@@ -1,0 +1,141 @@
+"""Unit tests for ollama_check — all HTTP calls are mocked."""
+from unittest.mock import patch, MagicMock
+import pytest
+import requests as req
+from tradingagents.llm_clients.ollama_check import (
+    _resolve_base_url,
+    ping_ollama,
+    list_local_models,
+    check_model_available,
+    run_ollama_check,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+# backend_url as returned by select_llm_provider() when user picks Ollama
+FAKE_CONFIG = {
+    "llm_provider":    "ollama",
+    "backend_url":     "http://localhost:11434/v1",  # includes /v1 — real value from utils.py
+    "deep_think_llm":  "qwen3:latest",
+    "quick_think_llm": "glm-4.7-flash:latest",
+}
+
+FAKE_RESPONSE_BODY = {
+    "models": [
+        {"name": "qwen3:latest"},
+        {"name": "glm-4.7-flash:latest"},
+        {"name": "gpt-oss:latest"},
+    ]
+}
+
+def _mock_ok(url, timeout=5):
+    m = MagicMock()
+    m.status_code = 200
+    m.json.return_value = FAKE_RESPONSE_BODY
+    return m
+
+def _mock_conn_error(url, timeout=5):
+    raise req.exceptions.ConnectionError
+
+def _mock_timeout(url, timeout=5):
+    raise req.exceptions.Timeout
+
+# ── _resolve_base_url ─────────────────────────────────────────────────────────
+
+def test_resolve_strips_v1_suffix():
+    """backend_url from select_llm_provider() has /v1 — must be stripped."""
+    cfg = {"backend_url": "http://localhost:11434/v1"}
+    assert _resolve_base_url(cfg) == "http://localhost:11434"
+
+def test_resolve_no_suffix_unchanged():
+    cfg = {"backend_url": "http://localhost:11434"}
+    assert _resolve_base_url(cfg) == "http://localhost:11434"
+
+def test_resolve_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://192.168.1.10:11434")
+    cfg = {"backend_url": None}
+    assert _resolve_base_url(cfg) == "http://192.168.1.10:11434"
+
+def test_resolve_falls_back_to_localhost(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    cfg = {"backend_url": None}
+    assert _resolve_base_url(cfg) == "http://localhost:11434"
+
+# ── ping_ollama ───────────────────────────────────────────────────────────────
+
+def test_ping_true_on_200():
+    with patch("requests.get", side_effect=_mock_ok):
+        assert ping_ollama("http://localhost:11434") is True
+
+def test_ping_false_on_connection_error():
+    with patch("requests.get", side_effect=_mock_conn_error):
+        assert ping_ollama("http://localhost:11434") is False
+
+def test_ping_false_on_timeout():
+    with patch("requests.get", side_effect=_mock_timeout):
+        assert ping_ollama("http://localhost:11434") is False
+
+# ── list_local_models ─────────────────────────────────────────────────────────
+
+def test_list_models_parsed_correctly():
+    with patch("requests.get", side_effect=_mock_ok):
+        models = list_local_models("http://localhost:11434")
+    assert "qwen3:latest" in models
+    assert "glm-4.7-flash:latest" in models
+    assert len(models) == 3
+
+def test_list_models_empty_on_failure():
+    with patch("requests.get", side_effect=_mock_conn_error):
+        assert list_local_models("http://localhost:11434") == []
+
+# ── check_model_available ─────────────────────────────────────────────────────
+
+def test_exact_match():
+    assert check_model_available("qwen3:latest", ["qwen3:latest"]) is True
+
+def test_prefix_match():
+    assert check_model_available("qwen3", ["qwen3:latest"]) is True
+
+def test_case_insensitive():
+    assert check_model_available("Qwen3", ["qwen3:latest"]) is True
+
+def test_no_match():
+    assert check_model_available("command-r", ["qwen3:latest"]) is False
+
+# ── run_ollama_check ──────────────────────────────────────────────────────────
+
+def test_run_true_all_present():
+    with patch("requests.get", side_effect=_mock_ok):
+        assert run_ollama_check(FAKE_CONFIG) is True
+
+def test_run_false_server_down():
+    with patch("requests.get", side_effect=_mock_conn_error):
+        assert run_ollama_check(FAKE_CONFIG) is False
+
+def test_run_false_model_missing():
+    cfg = {**FAKE_CONFIG, "deep_think_llm": "command-r"}
+    with patch("requests.get", side_effect=_mock_ok):
+        assert run_ollama_check(cfg) is False
+
+def test_run_exits_on_failure_when_flag_set():
+    with patch("requests.get", side_effect=_mock_conn_error):
+        with pytest.raises(SystemExit) as exc:
+            run_ollama_check(FAKE_CONFIG, exit_on_failure=True)
+        assert exc.value.code == 1
+
+def test_run_skips_none_models():
+    """Should not crash when deep/quick model keys are None."""
+    cfg = {**FAKE_CONFIG, "deep_think_llm": None, "quick_think_llm": None}
+    with patch("requests.get", side_effect=_mock_ok):
+        assert run_ollama_check(cfg) is True
+
+def test_run_uses_root_url_not_v1():
+    """Verify the health check hits /api/tags at root, not /v1/api/tags."""
+    called_urls = []
+    def capture(url, timeout=5):
+        called_urls.append(url)
+        return _mock_ok(url, timeout)
+    with patch("requests.get", side_effect=capture):
+        run_ollama_check(FAKE_CONFIG)
+    assert all("/v1" not in u for u in called_urls), \
+        f"URL should not contain /v1 — got: {called_urls}"

--- a/tradingagents/llm_clients/ollama_check.py
+++ b/tradingagents/llm_clients/ollama_check.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import os
 import sys
 import requests
+from rich.console import Console
+
+_console = Console()
 
 
 def _resolve_base_url(config: dict) -> str:
@@ -49,7 +52,7 @@ def list_local_models(base_url: str) -> list[str]:
     try:
         resp = requests.get(f"{base_url}/api/tags", timeout=5)
         return [m["name"] for m in resp.json().get("models", [])]
-    except Exception:
+    except (requests.exceptions.RequestException, ValueError, KeyError):
         return []
 
 
@@ -81,35 +84,35 @@ def run_ollama_check(config: dict, exit_on_failure: bool = False) -> bool:
     quick_model = config.get("quick_think_llm")
     all_ok = True
 
-    print(f"[Ollama Check] Pinging server at {base_url} ...")
+    _console.print(f"[Ollama Check] Pinging server at {base_url} ...")
 
     if not ping_ollama(base_url):
-        print(
-            f"[Ollama Check] ✗ Cannot reach Ollama at {base_url}\n"
-            f"               → Is Ollama running? Try: ollama serve"
+        _console.print(
+            f"[red][Ollama Check] ✗ Cannot reach Ollama at {base_url}[/red]\n"
+            f"               → Try: ollama serve"
         )
         if exit_on_failure:
             sys.exit(1)
         return False
 
-    print("[Ollama Check] ✓ Server is reachable.")
+    _console.print("[green][Ollama Check] ✓ Server is reachable.[/green]")
 
     local_models = list_local_models(base_url)
     if local_models:
-        print("[Ollama Check] Available local models:")
+        _console.print("[Ollama Check] Available local models:")
         for m in local_models:
-            print(f"               - {m}")
+            _console.print(f"               - {m}")
     else:
-        print("[Ollama Check] ⚠ No models found locally. Try: ollama pull qwen3")
+        _console.print("[Ollama Check] ⚠ No models found locally. Try: ollama pull qwen3")
 
     for label, model in [("Deep", deep_model), ("Quick", quick_model)]:
         if not model:
             continue
         if check_model_available(model, local_models):
-            print(f'[Ollama Check] ✓ {label} model "{model}" found.')
+            _console.print(f'[green][Ollama Check] ✓ {label} model "{model}" found.[/green]')
         else:
-            print(
-                f'[Ollama Check] ✗ {label} model "{model}" NOT found locally.\n'
+            _console.print(
+                f'[red][Ollama Check] ✗ {label} model "{model}" NOT found.[/red]\n'
                 f"               → Run: ollama pull {model}"
             )
             all_ok = False

--- a/tradingagents/llm_clients/ollama_check.py
+++ b/tradingagents/llm_clients/ollama_check.py
@@ -1,0 +1,120 @@
+"""
+ollama_check.py
+Diagnostic utility — verifies Ollama server is reachable and required models are pulled.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import requests
+
+
+def _resolve_base_url(config: dict) -> str:
+    """
+    Resolve the Ollama ROOT base URL (no /v1 suffix).
+
+    When the user selects Ollama in the CLI, select_llm_provider() returns
+    "http://localhost:11434/v1" as backend_url. The health-check endpoint
+    GET /api/tags lives at the root, so we strip any trailing /v1.
+
+    Priority: config["backend_url"] (stripped) → OLLAMA_HOST env var → localhost default.
+    """
+    url = config.get("backend_url") or os.getenv(
+        "OLLAMA_HOST", "http://localhost:11434"
+    )
+    # Strip /v1 suffix added by select_llm_provider() for OpenAI-compat clients
+    return url.rstrip("/").removesuffix("/v1")
+
+
+def ping_ollama(base_url: str, timeout: int = 5) -> bool:
+    """
+    Return True if Ollama server responds at GET {base_url}/api/tags, else False.
+    Never raises — all exceptions are caught.
+    Does NOT print; caller handles all output.
+    """
+    try:
+        resp = requests.get(f"{base_url}/api/tags", timeout=timeout)
+        return resp.status_code == 200
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        return False
+
+
+def list_local_models(base_url: str) -> list[str]:
+    """
+    Return model name strings from GET {base_url}/api/tags.
+    Response JSON shape: {"models": [{"name": "qwen3:latest"}, ...]}
+    Returns [] on any failure.
+    """
+    try:
+        resp = requests.get(f"{base_url}/api/tags", timeout=5)
+        return [m["name"] for m in resp.json().get("models", [])]
+    except Exception:
+        return []
+
+
+def check_model_available(model_name: str, local_models: list[str]) -> bool:
+    """
+    Return True if model_name is a substring of any entry in local_models (case-insensitive).
+    Example: "qwen3" matches "qwen3:latest".
+    """
+    needle = model_name.lower()
+    return any(needle in m.lower() for m in local_models)
+
+
+def run_ollama_check(config: dict, exit_on_failure: bool = False) -> bool:
+    """
+    Full diagnostic using deep_think_llm and quick_think_llm from config.
+
+    Steps:
+      1. Resolve root base URL (strips /v1 from backend_url)
+      2. Ping server  → warn + return False if unreachable
+      3. List and print local models
+      4. Check deep_think_llm is pulled
+      5. Check quick_think_llm is pulled
+
+    Returns True only when all checks pass.
+    Calls sys.exit(1) on first failure when exit_on_failure=True.
+    """
+    base_url = _resolve_base_url(config)
+    deep_model = config.get("deep_think_llm")
+    quick_model = config.get("quick_think_llm")
+    all_ok = True
+
+    print(f"[Ollama Check] Pinging server at {base_url} ...")
+
+    if not ping_ollama(base_url):
+        print(
+            f"[Ollama Check] ✗ Cannot reach Ollama at {base_url}\n"
+            f"               → Is Ollama running? Try: ollama serve"
+        )
+        if exit_on_failure:
+            sys.exit(1)
+        return False
+
+    print("[Ollama Check] ✓ Server is reachable.")
+
+    local_models = list_local_models(base_url)
+    if local_models:
+        print("[Ollama Check] Available local models:")
+        for m in local_models:
+            print(f"               - {m}")
+    else:
+        print("[Ollama Check] ⚠ No models found locally. Try: ollama pull qwen3")
+
+    for label, model in [("Deep", deep_model), ("Quick", quick_model)]:
+        if not model:
+            continue
+        if check_model_available(model, local_models):
+            print(f'[Ollama Check] ✓ {label} model "{model}" found.')
+        else:
+            print(
+                f'[Ollama Check] ✗ {label} model "{model}" NOT found locally.\n'
+                f"               → Run: ollama pull {model}"
+            )
+            all_ok = False
+
+    if not all_ok and exit_on_failure:
+        sys.exit(1)
+
+    return all_ok


### PR DESCRIPTION
## Summary
Adds `ollama_check.py` — a diagnostic utility that:
- Pings the Ollama server at `backend_url` / `OLLAMA_HOST`
- Lists all locally available models
- Warns if `deep_think_llm` or `quick_think_llm` from config are not pulled locally

## Motivation
The most commonly reported user issue when using Ollama is a silent 
"Connection Failed" error — caused either by Ollama not running or the 
required model not being pulled. This gives an immediate, clear error 
with the exact `ollama pull <model>` command to fix it.

## Changes
- `tradingagents/llm_clients/ollama_check.py` — new diagnostic utility (5 functions)
- `cli/main.py` — new `tradingagents check` CLI command + startup warning inside `run_analysis()`
- `.env.example` — documents `OLLAMA_HOST`
- `tests/test_ollama_check.py` — 19 unit tests, all HTTP calls mocked

## Implementation Detail
`select_llm_provider()` stores `http://localhost:11434/v1` as `backend_url` 
for OpenAI-compatible model calls. The Ollama health endpoint `GET /api/tags` 
lives at the root — so `_resolve_base_url()` strips the `/v1` suffix before 
pinging. This is covered by `test_run_uses_root_url_not_v1`.

## How to Test
```bash
# 1. Happy path
ollama serve
tradingagents check

# 2. Server not running
# Stop ollama, then:
tradingagents check
# → clear ✗ error with "ollama serve" hint

# 3. Model not pulled
# Set DEEP_THINK_LLM=command-r in .env, then:
tradingagents check  
# → ✗ with "ollama pull command-r" hint
```

## Test Results
19 passed in 0.02s
108 passed (full suite — no regressions)
ruff check tradingagents/llm_clients/ollama_check.py → All checks passed!