### PR TITLE
feat(cli): add batch mode for multiple ticker analysis

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -23,6 +23,7 @@ from rich.tree import Tree
 from rich import box
 from rich.align import Align
 from rich.rule import Rule
+import questionary
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
@@ -460,8 +461,12 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     layout["footer"].update(Panel(stats_table, border_style="grey50"))
 
 
-def get_user_selections():
-    """Get all user selections before starting the analysis display."""
+def get_user_selections(batch_mode: bool = False):
+    """Get all user selections before starting the analysis display.
+
+    Args:
+        batch_mode: If True, skip the batch mode prompt and assume batch mode.
+    """
     # Display ASCII art welcome message
     with open(Path(__file__).parent / "static" / "welcome.txt", "r", encoding="utf-8") as f:
         welcome_ascii = f.read()
@@ -499,15 +504,48 @@ def get_user_selections():
             box_content += f"\n[dim]Default: {default}[/dim]"
         return Panel(box_content, border_style="blue", padding=(1, 2))
 
-    # Step 1: Ticker symbol
-    console.print(
-        create_question_box(
-            "Step 1: Ticker Symbol",
-            "Enter the exact ticker symbol to analyze, including exchange suffix when needed (examples: SPY, CNC.TO, 7203.T, 0700.HK)",
-            "SPY",
+    # Step 0: Batch mode selection
+    is_batch_mode = batch_mode
+    if not batch_mode:
+        console.print(
+            create_question_box(
+                "Step 0: Run Mode",
+                "Choose single ticker analysis or batch mode for multiple tickers"
+            )
         )
-    )
-    selected_ticker = get_ticker()
+        mode_choice = questionary.select(
+            "Select run mode:",
+            choices=[
+                questionary.Choice("Single ticker", "single"),
+                questionary.Choice("Batch mode (multiple tickers)", "batch"),
+            ],
+            style=questionary.Style([
+                ("selected", "fg:cyan noinherit"),
+                ("highlighted", "fg:cyan noinherit"),
+                ("pointer", "fg:cyan noinherit"),
+            ]),
+        ).ask()
+        is_batch_mode = (mode_choice == "batch")
+
+    # Step 1: Ticker symbol(s)
+    if is_batch_mode:
+        console.print(
+            create_question_box(
+                "Step 1: Ticker Symbols (Batch Mode)",
+                "Enter multiple ticker symbols separated by commas (examples: SPY,AAPL,MSFT)",
+            )
+        )
+        selected_tickers = get_batch_tickers()
+        console.print(f"[green]Tickers to analyze:[/green] {', '.join(selected_tickers)} ({len(selected_tickers)} total)")
+    else:
+        console.print(
+            create_question_box(
+                "Step 1: Ticker Symbol",
+                "Enter the exact ticker symbol to analyze, including exchange suffix when needed (examples: SPY, CNC.TO, 7203.T, 0700.HK)",
+                "SPY",
+            )
+        )
+        selected_tickers = [get_ticker()]
 
     # Step 2: Analysis date
     default_date = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -597,7 +635,8 @@ def get_user_selections():
         anthropic_effort = ask_anthropic_effort()
 
     return {
-        "ticker": selected_ticker,
+        "tickers": selected_tickers,
+        "batch_mode": is_batch_mode,
         "analysis_date": analysis_date,
         "analysts": selected_analysts,
         "research_depth": selected_research_depth,
@@ -926,33 +965,21 @@ def format_tool_args(args, max_length=80) -> str:
         return result[:max_length - 3] + "..."
     return result
 
-def run_analysis(checkpoint: bool = False):
-    # First get all user selections
-    selections = get_user_selections()
+def run_single_analysis(ticker: str, selections: dict, config: dict, auto_save: bool = False):
+    """Run analysis for a single ticker.
 
-    # Create config with selected research depth
-    config = DEFAULT_CONFIG.copy()
-    config["max_debate_rounds"] = selections["research_depth"]
-    config["max_risk_discuss_rounds"] = selections["research_depth"]
-    config["quick_think_llm"] = selections["shallow_thinker"]
-    config["deep_think_llm"] = selections["deep_thinker"]
-    config["backend_url"] = selections["backend_url"]
-    config["llm_provider"] = selections["llm_provider"].lower()
-    # Provider-specific thinking configuration
-    config["google_thinking_level"] = selections.get("google_thinking_level")
-    config["openai_reasoning_effort"] = selections.get("openai_reasoning_effort")
-    config["anthropic_effort"] = selections.get("anthropic_effort")
-    config["output_language"] = selections.get("output_language", "English")
-    config["checkpoint_enabled"] = checkpoint
-
-    # Create stats callback handler for tracking LLM/tool calls
+    Args:
+        ticker: The ticker symbol to analyze.
+        selections: User selections from get_user_selections().
+        config: Configuration dictionary.
+        auto_save: If True, skip prompts and auto-save the report.
+    """
+    global message_buffer
+    message_buffer = MessageBuffer()
     stats_handler = StatsCallbackHandler()
 
-    # Normalize analyst selection to predefined order (selection is a 'set', order is fixed)
-    selected_set = {analyst.value for analyst in selections["analysts"]}
-    selected_analyst_keys = [a for a in ANALYST_ORDER if a in selected_set]
+    selected_analyst_keys = [a for a in ANALYST_ORDER if a in {analyst.value for analyst in selections["analysts"]}]
 
-    # Initialize the graph with callbacks bound to LLMs
     graph = TradingAgentsGraph(
         selected_analyst_keys,
         config=config,
@@ -960,14 +987,11 @@ def run_analysis(checkpoint: bool = False):
         callbacks=[stats_handler],
     )
 
-    # Initialize message buffer with selected analysts
     message_buffer.init_for_analysis(selected_analyst_keys)
 
-    # Track start time for elapsed display
     start_time = time.time()
 
-    # Create result directory
-    results_dir = Path(config["results_dir"]) / selections["ticker"] / selections["analysis_date"]
+    results_dir = Path(config["results_dir"]) / ticker / selections["analysis_date"]
     results_dir.mkdir(parents=True, exist_ok=True)
     report_dir = results_dir / "reports"
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -980,11 +1004,11 @@ def run_analysis(checkpoint: bool = False):
         def wrapper(*args, **kwargs):
             func(*args, **kwargs)
             timestamp, message_type, content = obj.messages[-1]
-            content = content.replace("\n", " ")  # Replace newlines with spaces
+            content = content.replace("\n", " ")
             with open(log_file, "a", encoding="utf-8") as f:
                 f.write(f"{timestamp} [{message_type}] {content}\n")
         return wrapper
-    
+
     def save_tool_call_decorator(obj, func_name):
         func = getattr(obj, func_name)
         @wraps(func)
@@ -1014,15 +1038,12 @@ def run_analysis(checkpoint: bool = False):
     message_buffer.add_tool_call = save_tool_call_decorator(message_buffer, "add_tool_call")
     message_buffer.update_report_section = save_report_section_decorator(message_buffer, "update_report_section")
 
-    # Now start the display layout
     layout = create_layout()
 
     with Live(layout, refresh_per_second=4) as live:
-        # Initial display
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-        # Add initial messages
-        message_buffer.add_message("System", f"Selected ticker: {selections['ticker']}")
+        message_buffer.add_message("System", f"Selected ticker: {ticker}")
         message_buffer.add_message(
             "System", f"Analysis date: {selections['analysis_date']}"
         )
@@ -1032,29 +1053,20 @@ def run_analysis(checkpoint: bool = False):
         )
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-        # Update agent status to in_progress for the first analyst
         first_analyst = f"{selections['analysts'][0].value.capitalize()} Analyst"
         message_buffer.update_agent_status(first_analyst, "in_progress")
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-        # Create spinner text
-        spinner_text = (
-            f"Analyzing {selections['ticker']} on {selections['analysis_date']}..."
-        )
+        spinner_text = f"Analyzing {ticker} on {selections['analysis_date']}..."
         update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
 
-        # Initialize state and get graph args with callbacks
         init_agent_state = graph.propagator.create_initial_state(
-            selections["ticker"], selections["analysis_date"]
+            ticker, selections["analysis_date"]
         )
-        # Pass callbacks to graph config for tool execution tracking
-        # (LLM tracking is handled separately via LLM constructor)
         args = graph.propagator.get_graph_args(callbacks=[stats_handler])
 
-        # Stream the analysis
         trace = []
         for chunk in graph.graph.stream(init_agent_state, **args):
-            # Process all messages in chunk, deduplicating by message ID
             for message in chunk.get("messages", []):
                 msg_id = getattr(message, "id", None)
                 if msg_id is not None:
@@ -1073,17 +1085,14 @@ def run_analysis(checkpoint: bool = False):
                         else:
                             message_buffer.add_tool_call(tool_call.name, tool_call.args)
 
-            # Update analyst statuses based on report state (runs on every chunk)
             update_analyst_statuses(message_buffer, chunk)
 
-            # Research Team - Handle Investment Debate State
             if chunk.get("investment_debate_state"):
                 debate_state = chunk["investment_debate_state"]
                 bull_hist = debate_state.get("bull_history", "").strip()
                 bear_hist = debate_state.get("bear_history", "").strip()
                 judge = debate_state.get("judge_decision", "").strip()
 
-                # Only update status when there's actual content
                 if bull_hist or bear_hist:
                     update_research_team_status("in_progress")
                 if bull_hist:
@@ -1101,7 +1110,6 @@ def run_analysis(checkpoint: bool = False):
                     update_research_team_status("completed")
                     message_buffer.update_agent_status("Trader", "in_progress")
 
-            # Trading Team
             if chunk.get("trader_investment_plan"):
                 message_buffer.update_report_section(
                     "trader_investment_plan", chunk["trader_investment_plan"]
@@ -1110,7 +1118,6 @@ def run_analysis(checkpoint: bool = False):
                     message_buffer.update_agent_status("Trader", "completed")
                     message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
 
-            # Risk Management Team - Handle Risk Debate State
             if chunk.get("risk_debate_state"):
                 risk_state = chunk["risk_debate_state"]
                 agg_hist = risk_state.get("aggressive_history", "").strip()
@@ -1147,16 +1154,12 @@ def run_analysis(checkpoint: bool = False):
                         message_buffer.update_agent_status("Neutral Analyst", "completed")
                         message_buffer.update_agent_status("Portfolio Manager", "completed")
 
-            # Update the display
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
-
             trace.append(chunk)
 
-        # Get final state and decision
         final_state = trace[-1]
         decision = graph.process_signal(final_state["final_trade_decision"])
 
-        # Update all agent statuses to completed
         for agent in message_buffer.agent_status:
             message_buffer.update_agent_status(agent, "completed")
 
@@ -1164,37 +1167,96 @@ def run_analysis(checkpoint: bool = False):
             "System", f"Completed analysis for {selections['analysis_date']}"
         )
 
-        # Update final report sections
         for section in message_buffer.report_sections.keys():
             if section in final_state:
                 message_buffer.update_report_section(section, final_state[section])
 
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-    # Post-analysis prompts (outside Live context for clean interaction)
     console.print("\n[bold cyan]Analysis Complete![/bold cyan]\n")
 
-    # Prompt to save report
-    save_choice = typer.prompt("Save report?", default="Y").strip().upper()
-    if save_choice in ("Y", "YES", ""):
+    if auto_save:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        default_path = Path.cwd() / "reports" / f"{selections['ticker']}_{timestamp}"
-        save_path_str = typer.prompt(
-            "Save path (press Enter for default)",
-            default=str(default_path)
-        ).strip()
-        save_path = Path(save_path_str)
+        save_path = Path.cwd() / "reports" / f"{ticker}_{timestamp}"
         try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
-            console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
+            report_file = save_report_to_disk(final_state, ticker, save_path)
+            console.print(f"[green]✓ Report saved to:[/green] {save_path.resolve()}")
             console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
         except Exception as e:
             console.print(f"[red]Error saving report: {e}[/red]")
+    else:
+        save_choice = typer.prompt("Save report?", default="Y").strip().upper()
+        if save_choice in ("Y", "YES", ""):
+            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            default_path = Path.cwd() / "reports" / f"{ticker}_{timestamp}"
+            save_path_str = typer.prompt(
+                "Save path (press Enter for default)",
+                default=str(default_path)
+            ).strip()
+            save_path = Path(save_path_str)
+            try:
+                report_file = save_report_to_disk(final_state, ticker, save_path)
+                console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
+                console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
+            except Exception as e:
+                console.print(f"[red]Error saving report: {e}[/red]")
 
-    # Prompt to display full report
-    display_choice = typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()
-    if display_choice in ("Y", "YES", ""):
-        display_complete_report(final_state)
+        display_choice = typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()
+        if display_choice in ("Y", "YES", ""):
+            display_complete_report(final_state)
+
+    return final_state
+
+
+def run_analysis(checkpoint: bool = False):
+    selections = get_user_selections()
+
+    config = DEFAULT_CONFIG.copy()
+    config["max_debate_rounds"] = selections["research_depth"]
+    config["max_risk_discuss_rounds"] = selections["research_depth"]
+    config["quick_think_llm"] = selections["shallow_thinker"]
+    config["deep_think_llm"] = selections["deep_thinker"]
+    config["backend_url"] = selections["backend_url"]
+    config["llm_provider"] = selections["llm_provider"].lower()
+    config["google_thinking_level"] = selections.get("google_thinking_level")
+    config["openai_reasoning_effort"] = selections.get("openai_reasoning_effort")
+    config["anthropic_effort"] = selections.get("anthropic_effort")
+    config["output_language"] = selections.get("output_language", "English")
+    config["checkpoint_enabled"] = checkpoint
+
+    tickers = selections["tickers"]
+    batch_mode = selections["batch_mode"]
+
+    if batch_mode:
+        console.print(f"\n[bold cyan]Batch Mode: {len(tickers)} ticker(s) to analyze[/bold cyan]\n")
+        results = []
+        failed = []
+
+        for i, ticker in enumerate(tickers, 1):
+            console.print(f"\n[bold yellow]{'='*60}[/bold yellow]")
+            console.print(f"[bold yellow][{i}/{len(tickers)}] Processing {ticker}...[/bold yellow]")
+            console.print(f"[bold yellow]{'='*60}[/bold yellow]\n")
+
+            try:
+                run_single_analysis(ticker, selections, config, auto_save=True)
+                results.append(ticker)
+            except Exception as e:
+                console.print(f"\n[red]✗ Error analyzing {ticker}: {e}[/red]\n")
+                failed.append(ticker)
+                continue
+
+        console.print(f"\n[bold cyan]{'='*60}[/bold cyan]")
+        console.print(f"[bold cyan]Batch Analysis Summary[/bold cyan]")
+        console.print(f"[bold cyan]{'='*60}[/bold cyan]")
+        console.print(f"[green]Completed: {len(results)}/{len(tickers)}[/green]")
+        if results:
+            console.print(f"  [dim]{', '.join(results)}[/dim]")
+        if failed:
+            console.print(f"[red]Failed: {len(failed)}[/red]")
+            console.print(f"  [dim]{', '.join(failed)}[/dim]")
+        console.print(f"[bold cyan]{'='*60}[/bold cyan]\n")
+    else:
+        run_single_analysis(tickers[0], selections, config, auto_save=False)
 
 
 @app.command()

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -43,6 +43,37 @@ def normalize_ticker_symbol(ticker: str) -> str:
     return ticker.strip().upper()
 
 
+def get_batch_tickers() -> List[str]:
+    """Prompt the user to enter multiple ticker symbols (comma-separated)."""
+    tickers_input = questionary.text(
+        f"Enter tickers separated by commas ({TICKER_INPUT_EXAMPLES}):",
+        validate=lambda x: len(x.strip()) > 0 or "Please enter at least one ticker symbol.",
+        style=questionary.Style(
+            [
+                ("text", "fg:green"),
+                ("highlighted", "noinherit"),
+            ]
+        ),
+    ).ask()
+
+    if not tickers_input:
+        console.print("\n[red]No tickers provided. Exiting...[/red]")
+        exit(1)
+
+    raw_tickers = [t.strip() for t in tickers_input.split(",") if t.strip()]
+    if not raw_tickers:
+        console.print("\n[red]No valid tickers found. Exiting...[/red]")
+        exit(1)
+
+    normalized = [normalize_ticker_symbol(t) for t in raw_tickers]
+    unique_tickers = list(dict.fromkeys(normalized))
+
+    if len(unique_tickers) < len(normalized):
+        console.print(f"[yellow]Removed duplicate tickers. {len(unique_tickers)} unique ticker(s) to analyze.[/yellow]")
+
+    return unique_tickers
+
+
 def get_analysis_date() -> str:
     """Prompt the user to enter a date in YYYY-MM-DD format."""
     import re


### PR DESCRIPTION
- Add Step 0 prompt to select single or batch run mode
- Support comma-separated ticker input with normalization and dedup
- Auto-save reports in batch mode without user prompts
- Skip full report display in batch for clean terminal output
- Progress indicator [i/n] between tickers
- Error handling: log failure and continue to next ticker
- End-of-batch summary with completed/failed counts

PR Body:
## Summary
- Add Step 0 prompt at startup to select single ticker or batch mode
- Support comma-separated ticker input with normalization and automatic deduplication
- Auto-save reports in batch mode without user prompts (saves to `reports/{TICKER}_{timestamp}/`)
- Skip on-screen report display in batch mode for clean terminal output between runs
- Progress indicator `[i/n] Processing TICKER...` between tickers
- Error handling: log failure and continue to next ticker (does not stop the batch)
- End-of-batch summary showing completed vs failed tickers
## Changes
- **cli/utils.py**: Added `get_batch_tickers()` for comma-separated ticker input
- **cli/main.py**: 
  - Extracted analysis logic into `run_single_analysis()` reusable function
  - Added batch mode prompt as Step 0 before ticker entry
  - Modified `get_user_selections()` to return `tickers` list and `batch_mode` flag
  - `run_analysis()` loops over tickers in batch mode with progress tracking and summary
## Backward Compatibility
- Single mode is completely unchanged — identical prompts, save behavior, and display as before
- Batch mode is opt-in via the new Step 0 prompt
## Files Changed
- `cli/main.py` (+144 lines net)
- `cli/utils.py` (+31 lines)
To create the PR locally:
git push origin batch-mode-feature
gh pr create --base main --head batch-mode-feature --title "feat(cli): add batch mode for multiple ticker analysis" --body "$(cat <<'EOF'
## Summary
- Add Step 0 prompt at startup to select single ticker or batch mode
- Support comma-separated ticker input with normalization and automatic deduplication
- Auto-save reports in batch mode without user prompts (saves to `reports/{TICKER}_{timestamp}/`)
- Skip on-screen report display in batch mode for clean terminal output between runs
- Progress indicator `[i/n] Processing TICKER...` between tickers
- Error handling: log failure and continue to next ticker
- End-of-batch summary showing completed vs failed tickers
## Changes
- **cli/utils.py**: Added `get_batch_tickers()` for comma-separated ticker input
- **cli/main.py**: Extracted `run_single_analysis()`, added batch mode loop with progress tracking
## Backward Compatibility
Single mode is completely unchanged — identical prompts, save behavior, and display as before
EOF
)"