### PR TITLE
Parallelize analyst agents and add portfolio advisor

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -811,18 +811,8 @@ ANALYST_REPORT_MAP = {
 
 
 def update_analyst_statuses(message_buffer, chunk):
-    """Update analyst statuses based on accumulated report state.
-
-    Logic:
-    - Store new report content from the current chunk if present
-    - Check accumulated report_sections (not just current chunk) for status
-    - Analysts with reports = completed
-    - First analyst without report = in_progress
-    - Remaining analysts without reports = pending
-    - When all analysts done, set Bull Researcher to in_progress
-    """
     selected = message_buffer.selected_analysts
-    found_active = False
+    all_completed = True
 
     for analyst_key in ANALYST_ORDER:
         if analyst_key not in selected:
@@ -831,23 +821,18 @@ def update_analyst_statuses(message_buffer, chunk):
         agent_name = ANALYST_AGENT_NAMES[analyst_key]
         report_key = ANALYST_REPORT_MAP[analyst_key]
 
-        # Capture new report content from current chunk
         if chunk.get(report_key):
             message_buffer.update_report_section(report_key, chunk[report_key])
 
-        # Determine status from accumulated sections, not just current chunk
         has_report = bool(message_buffer.report_sections.get(report_key))
 
         if has_report:
             message_buffer.update_agent_status(agent_name, "completed")
-        elif not found_active:
-            message_buffer.update_agent_status(agent_name, "in_progress")
-            found_active = True
         else:
-            message_buffer.update_agent_status(agent_name, "pending")
+            message_buffer.update_agent_status(agent_name, "in_progress")
+            all_completed = False
 
-    # When all analysts complete, transition research team to in_progress
-    if not found_active and selected:
+    if all_completed and selected:
         if message_buffer.agent_status.get("Bull Researcher") == "pending":
             message_buffer.update_agent_status("Bull Researcher", "in_progress")
 
@@ -1032,9 +1017,9 @@ def run_analysis(checkpoint: bool = False):
         )
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-        # Update agent status to in_progress for the first analyst
-        first_analyst = f"{selections['analysts'][0].value.capitalize()} Analyst"
-        message_buffer.update_agent_status(first_analyst, "in_progress")
+        for analyst in selections["analysts"]:
+            analyst_name = ANALYST_AGENT_NAMES.get(analyst.value.lower(), f"{analyst.value.capitalize()} Analyst")
+            message_buffer.update_agent_status(analyst_name, "in_progress")
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
         # Create spinner text

--- a/portfolio_advisor.py
+++ b/portfolio_advisor.py
@@ -68,7 +68,8 @@ def parse_decision(decision_text: str) -> dict:
             result["rating"] = line.replace("**Rating**:", "").strip()
         elif line.startswith("**Price Target**:"):
             try:
-                result["price_target"] = float(line.replace("**Price Target**:", "").strip())
+                raw_val = line.replace("**Price Target**:", "").strip().replace("$", "").replace(",", "")
+                result["price_target"] = float(raw_val)
             except ValueError:
                 pass
         elif line.startswith("**Time Horizon**:"):
@@ -182,7 +183,7 @@ def main():
     portfolio_value = get_float_input("What is your total portfolio value in USD? $", min_val=1)
     ticker = get_ticker_input()
     shares = get_float_input(f"How many shares of {ticker} do you currently hold? ", min_val=0)
-    avg_price = get_float_input(f"What is your average cost per share for {ticker}? $", min_val=0)
+    avg_price = get_float_input(f"What is your average cost per share for {ticker}? $", min_val=0.01)
     trade_date = get_date_input()
 
     position = PortfolioPosition(ticker=ticker, shares=shares, avg_price=avg_price)
@@ -194,8 +195,8 @@ def main():
 
     config = DEFAULT_CONFIG.copy()
     config["llm_provider"] = "openai"
-    config["deep_think_llm"] = "gpt-5.1"
-    config["quick_think_llm"] = "gpt-5.1-mini"
+    config["deep_think_llm"] = "gpt-4o"
+    config["quick_think_llm"] = "gpt-4o-mini"
 
     ta = TradingAgentsGraph(debug=False, config=config)
     _, decision = ta.propagate(ticker, trade_date)

--- a/portfolio_advisor.py
+++ b/portfolio_advisor.py
@@ -1,0 +1,211 @@
+import datetime
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+
+@dataclass
+class PortfolioPosition:
+    ticker: str
+    shares: float
+    avg_price: float
+
+    @property
+    def cost_basis(self) -> float:
+        return self.shares * self.avg_price
+
+
+def get_float_input(prompt: str, min_val: float = 0) -> float:
+    while True:
+        try:
+            value = float(input(prompt))
+            if value < min_val:
+                print(f"Value must be at least {min_val}. Please try again.")
+                continue
+            return value
+        except ValueError:
+            print("Invalid number. Please try again.")
+
+
+def get_ticker_input() -> str:
+    while True:
+        ticker = input("Enter ticker symbol to analyze: ").strip().upper()
+        if ticker:
+            return ticker
+        print("Ticker cannot be empty. Please try again.")
+
+
+def get_date_input() -> str:
+    default_date = datetime.datetime.now().strftime("%Y-%m-%d")
+    user_input = input(f"Enter analysis date (YYYY-MM-DD) [default: {default_date}]: ").strip()
+    if not user_input:
+        return default_date
+    try:
+        datetime.datetime.strptime(user_input, "%Y-%m-%d")
+        return user_input
+    except ValueError:
+        print(f"Invalid date format. Using default: {default_date}")
+        return default_date
+
+
+def parse_decision(decision_text: str) -> dict:
+    result = {
+        "rating": None,
+        "price_target": None,
+        "time_horizon": None,
+        "summary": "",
+    }
+
+    for line in decision_text.split("\n"):
+        line = line.strip()
+        if line.startswith("**Rating**:"):
+            result["rating"] = line.replace("**Rating**:", "").strip()
+        elif line.startswith("**Price Target**:"):
+            try:
+                result["price_target"] = float(line.replace("**Price Target**:", "").strip())
+            except ValueError:
+                pass
+        elif line.startswith("**Time Horizon**:"):
+            result["time_horizon"] = line.replace("**Time Horizon**:", "").strip()
+        elif line.startswith("**Executive Summary**:"):
+            result["summary"] = line.replace("**Executive Summary**:", "").strip()
+
+    return result
+
+
+def calculate_recommendation(decision: dict, position: PortfolioPosition, portfolio_value: float) -> str:
+    rating = decision.get("rating", "Hold")
+    price_target = decision.get("price_target")
+    time_horizon = decision.get("time_horizon", "unknown timeframe")
+    summary = decision.get("summary", "")
+
+    current_value = position.cost_basis
+    allocation_pct = (current_value / portfolio_value * 100) if portfolio_value > 0 else 0
+
+    lines = []
+    lines.append("=" * 70)
+    lines.append("PORTFOLIO ANALYSIS & RECOMMENDATION")
+    lines.append("=" * 70)
+    lines.append(f"")
+    lines.append(f"Portfolio Value: ${portfolio_value:,.2f}")
+    lines.append(f"Position: {position.shares:.0f} shares of {position.ticker} @ ${position.avg_price:.2f} avg")
+    lines.append(f"Current Position Value: ${current_value:,.2f} ({allocation_pct:.1f}% of portfolio)")
+    lines.append(f"")
+    lines.append(f"Agent Consensus Rating: {rating}")
+    if price_target:
+        lines.append(f"Price Target: ${price_target:.2f}")
+    if time_horizon:
+        lines.append(f"Time Horizon: {time_horizon}")
+    if summary:
+        lines.append(f"Summary: {summary}")
+    lines.append(f"")
+
+    rating_lower = rating.lower() if rating else "hold"
+
+    if rating_lower == "buy" or rating_lower == "overweight":
+        lines.append("--- RECOMMENDED ACTION ---")
+        if allocation_pct < 20:
+            suggested_shares = int((portfolio_value * 0.10) / position.avg_price)
+            lines.append(f"INCREASE position: Buy approximately {suggested_shares} more shares")
+            lines.append(f"Target allocation: ~{allocation_pct + 10:.1f}% of portfolio")
+            if price_target:
+                lines.append(f"Buy below ${price_target:.2f} for optimal entry")
+        elif allocation_pct < 40:
+            suggested_shares = int((portfolio_value * 0.05) / position.avg_price)
+            lines.append(f"MODERATELY INCREASE: Add approximately {suggested_shares} shares")
+            if price_target:
+                lines.append(f"Accumulate on dips below ${price_target:.2f}")
+        else:
+            lines.append(f"HOLD current position but maintain bullish outlook")
+            lines.append(f"Consider trimming only if position exceeds 50% of portfolio")
+        lines[-1] += f". Time horizon: {time_horizon}."
+
+    elif rating_lower == "sell" or rating_lower == "underweight":
+        lines.append("--- RECOMMENDED ACTION ---")
+        if allocation_pct > 10:
+            sell_pct = 50 if rating_lower == "sell" else 25
+            shares_to_sell = int(position.shares * sell_pct / 100)
+            lines.append(f"REDUCE position: Sell approximately {shares_to_sell} shares ({sell_pct}%)")
+            if price_target:
+                lines.append(f"Place sell orders near ${price_target:.2f}")
+        elif position.shares > 0:
+            sell_pct = 100 if rating_lower == "sell" else 50
+            shares_to_sell = int(position.shares * sell_pct / 100)
+            lines.append(f"EXIT or REDUCE: Sell {shares_to_sell} shares")
+            if price_target:
+                lines.append(f"Target exit price: ${price_target:.2f}")
+        else:
+            lines.append(f"AVOID entry at current levels")
+
+    else:
+        lines.append("--- RECOMMENDED ACTION ---")
+        lines.append(f"HOLD: Maintain current position of {position.shares:.0f} shares")
+        lines.append(f"Do not add or reduce at this time")
+        if price_target:
+            if price_target > position.avg_price:
+                lines.append(f"Consider taking partial profits above ${price_target:.2f}")
+            elif price_target < position.avg_price:
+                lines.append(f"Set a stop-loss at ${price_target:.2f} to limit downside")
+        lines.append(f"Re-evaluate in {time_horizon}")
+
+    lines.append("")
+    lines.append("--- RISK MANAGEMENT ---")
+    if position.shares > 0:
+        stop_loss_price = position.avg_price * 0.92
+        lines.append(f"Stop-loss suggestion: ${stop_loss_price:.2f} (8% below your average cost)")
+        max_loss = position.shares * (position.avg_price - stop_loss_price)
+        lines.append(f"Maximum potential loss at stop: ${max_loss:,.2f} ({max_loss / portfolio_value * 100:.1f}% of portfolio)")
+    lines.append("")
+    lines.append("=" * 70)
+    lines.append("DISCLAIMER: This is AI-generated analysis, not financial advice.")
+    lines.append("Always consult a licensed financial advisor before making investment decisions.")
+    lines.append("=" * 70)
+
+    return "\n".join(lines)
+
+
+def main():
+    print("=" * 60)
+    print("  TradingAgents - Portfolio Advisor")
+    print("=" * 60)
+    print()
+    print("This tool analyzes a stock and gives personalized recommendations")
+    print("based on your portfolio position.")
+    print()
+
+    portfolio_value = get_float_input("What is your total portfolio value in USD? $", min_val=1)
+    ticker = get_ticker_input()
+    shares = get_float_input(f"How many shares of {ticker} do you currently hold? ", min_val=0)
+    avg_price = get_float_input(f"What is your average cost per share for {ticker}? $", min_val=0)
+    trade_date = get_date_input()
+
+    position = PortfolioPosition(ticker=ticker, shares=shares, avg_price=avg_price)
+
+    print()
+    print(f"Running multi-agent analysis for {ticker}...")
+    print(f"This may take a few minutes as agents research and debate.")
+    print()
+
+    config = DEFAULT_CONFIG.copy()
+    config["llm_provider"] = "openai"
+    config["deep_think_llm"] = "gpt-5.1"
+    config["quick_think_llm"] = "gpt-5.1-mini"
+
+    ta = TradingAgentsGraph(debug=False, config=config)
+    _, decision = ta.propagate(ticker, trade_date)
+
+    print()
+    print()
+    parsed = parse_decision(decision)
+    recommendation = calculate_recommendation(parsed, position, portfolio_value)
+    print(recommendation)
+
+
+if __name__ == "__main__":
+    main()

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -39,7 +39,7 @@ class GraphSetup:
         }
 
         def parallel_analyst_node(state):
-            max_tool_iterations = 10
+            max_tool_iterations = self.conditional_logic.max_debate_rounds * 5
 
             def run_single_analyst(analyst_type):
                 node_fn = factories[analyst_type](self.quick_thinking_llm)

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -1,6 +1,5 @@
-# TradingAgents/graph/setup.py
-
 from typing import Any, Dict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt import ToolNode
 
@@ -20,84 +19,87 @@ class GraphSetup:
         tool_nodes: Dict[str, ToolNode],
         conditional_logic: ConditionalLogic,
     ):
-        """Initialize with required components."""
         self.quick_thinking_llm = quick_thinking_llm
         self.deep_thinking_llm = deep_thinking_llm
         self.tool_nodes = tool_nodes
         self.conditional_logic = conditional_logic
 
+    def _create_parallel_analyst_node(self, selected_analysts):
+        factories = {
+            "market": create_market_analyst,
+            "social": create_social_media_analyst,
+            "news": create_news_analyst,
+            "fundamentals": create_fundamentals_analyst,
+        }
+        report_keys = {
+            "market": "market_report",
+            "social": "sentiment_report",
+            "news": "news_report",
+            "fundamentals": "fundamentals_report",
+        }
+
+        def parallel_analyst_node(state):
+            max_tool_iterations = 10
+
+            def run_single_analyst(analyst_type):
+                node_fn = factories[analyst_type](self.quick_thinking_llm)
+                tools_node = self.tool_nodes[analyst_type]
+                local_messages = list(state["messages"])
+
+                for _ in range(max_tool_iterations):
+                    local_state = {**state, "messages": local_messages}
+                    analyst_result = node_fn(local_state)
+                    new_messages = analyst_result.get("messages", [])
+                    local_messages.extend(new_messages)
+
+                    last_msg = new_messages[-1] if new_messages else None
+                    if not last_msg or not hasattr(last_msg, 'tool_calls') or not last_msg.tool_calls:
+                        return analyst_type, analyst_result
+
+                    tool_state = {"messages": [last_msg]}
+                    tool_result = tools_node.invoke(tool_state)
+                    local_messages.extend(tool_result["messages"])
+
+                return analyst_type, analyst_result
+
+            results = {}
+            with ThreadPoolExecutor(max_workers=len(selected_analysts)) as executor:
+                futures = {executor.submit(run_single_analyst, t): t for t in selected_analysts}
+                for future in as_completed(futures):
+                    analyst_type, analyst_result = future.result()
+                    results[analyst_type] = analyst_result
+
+            merged = {}
+            for analyst_type, analyst_result in results.items():
+                key = report_keys[analyst_type]
+                merged[key] = analyst_result.get(key, "")
+
+            return merged
+
+        return parallel_analyst_node
+
     def setup_graph(
         self, selected_analysts=["market", "social", "news", "fundamentals"]
     ):
-        """Set up and compile the agent workflow graph.
-
-        Args:
-            selected_analysts (list): List of analyst types to include. Options are:
-                - "market": Market analyst
-                - "social": Social media analyst
-                - "news": News analyst
-                - "fundamentals": Fundamentals analyst
-        """
         if len(selected_analysts) == 0:
             raise ValueError("Trading Agents Graph Setup Error: no analysts selected!")
 
-        # Create analyst nodes
-        analyst_nodes = {}
-        delete_nodes = {}
-        tool_nodes = {}
-
-        if "market" in selected_analysts:
-            analyst_nodes["market"] = create_market_analyst(
-                self.quick_thinking_llm
-            )
-            delete_nodes["market"] = create_msg_delete()
-            tool_nodes["market"] = self.tool_nodes["market"]
-
-        if "social" in selected_analysts:
-            analyst_nodes["social"] = create_social_media_analyst(
-                self.quick_thinking_llm
-            )
-            delete_nodes["social"] = create_msg_delete()
-            tool_nodes["social"] = self.tool_nodes["social"]
-
-        if "news" in selected_analysts:
-            analyst_nodes["news"] = create_news_analyst(
-                self.quick_thinking_llm
-            )
-            delete_nodes["news"] = create_msg_delete()
-            tool_nodes["news"] = self.tool_nodes["news"]
-
-        if "fundamentals" in selected_analysts:
-            analyst_nodes["fundamentals"] = create_fundamentals_analyst(
-                self.quick_thinking_llm
-            )
-            delete_nodes["fundamentals"] = create_msg_delete()
-            tool_nodes["fundamentals"] = self.tool_nodes["fundamentals"]
-
-        # Create researcher and manager nodes
         bull_researcher_node = create_bull_researcher(self.quick_thinking_llm)
         bear_researcher_node = create_bear_researcher(self.quick_thinking_llm)
         research_manager_node = create_research_manager(self.deep_thinking_llm)
         trader_node = create_trader(self.quick_thinking_llm)
 
-        # Create risk analysis nodes
         aggressive_analyst = create_aggressive_debator(self.quick_thinking_llm)
         neutral_analyst = create_neutral_debator(self.quick_thinking_llm)
         conservative_analyst = create_conservative_debator(self.quick_thinking_llm)
         portfolio_manager_node = create_portfolio_manager(self.deep_thinking_llm)
 
-        # Create workflow
+        parallel_analyst_node = self._create_parallel_analyst_node(selected_analysts)
+
         workflow = StateGraph(AgentState)
 
-        # Add analyst nodes to the graph
-        for analyst_type, node in analyst_nodes.items():
-            workflow.add_node(f"{analyst_type.capitalize()} Analyst", node)
-            workflow.add_node(
-                f"Msg Clear {analyst_type.capitalize()}", delete_nodes[analyst_type]
-            )
-            workflow.add_node(f"tools_{analyst_type}", tool_nodes[analyst_type])
+        workflow.add_node("Analyst Team", parallel_analyst_node)
 
-        # Add other nodes
         workflow.add_node("Bull Researcher", bull_researcher_node)
         workflow.add_node("Bear Researcher", bear_researcher_node)
         workflow.add_node("Research Manager", research_manager_node)
@@ -107,33 +109,9 @@ class GraphSetup:
         workflow.add_node("Conservative Analyst", conservative_analyst)
         workflow.add_node("Portfolio Manager", portfolio_manager_node)
 
-        # Define edges
-        # Start with the first analyst
-        first_analyst = selected_analysts[0]
-        workflow.add_edge(START, f"{first_analyst.capitalize()} Analyst")
+        workflow.add_edge(START, "Analyst Team")
+        workflow.add_edge("Analyst Team", "Bull Researcher")
 
-        # Connect analysts in sequence
-        for i, analyst_type in enumerate(selected_analysts):
-            current_analyst = f"{analyst_type.capitalize()} Analyst"
-            current_tools = f"tools_{analyst_type}"
-            current_clear = f"Msg Clear {analyst_type.capitalize()}"
-
-            # Add conditional edges for current analyst
-            workflow.add_conditional_edges(
-                current_analyst,
-                getattr(self.conditional_logic, f"should_continue_{analyst_type}"),
-                [current_tools, current_clear],
-            )
-            workflow.add_edge(current_tools, current_analyst)
-
-            # Connect to next analyst or to Bull Researcher if this is the last analyst
-            if i < len(selected_analysts) - 1:
-                next_analyst = f"{selected_analysts[i+1].capitalize()} Analyst"
-                workflow.add_edge(current_clear, next_analyst)
-            else:
-                workflow.add_edge(current_clear, "Bull Researcher")
-
-        # Add remaining edges
         workflow.add_conditional_edges(
             "Bull Researcher",
             self.conditional_logic.should_continue_debate,


### PR DESCRIPTION
## Summary
- Replaced the sequential chain of 4 analyst nodes with a single parallel "Analyst Team" node that runs all selected analysts concurrently via `ThreadPoolExecutor`, each with isolated message state and internal tool loops
- Graph reduces from ~20 nodes to 10, with the 4 analysts + 4 tool nodes + 4 msg clear nodes collapsed into one parallel node
- Updated CLI analyst status tracking to reflect parallel execution (all analysts show `in_progress` simultaneously)
- Added `portfolio_advisor.py`: an interactive entry point that asks the user for portfolio value in USD, number of shares held, and average price, then runs the full multi-agent analysis and gives personalized buy/sell/hold recommendations with specific price targets and risk management suggestions

## Test plan
- [x] All 108 existing tests pass
- [x] Graph compiles correctly with mock LLMs
- [x] Graph node count verified (10 nodes)
- [x] `portfolio_advisor.py` syntax verified