### PR TITLE
fix: raise clear error when provider API key env var is missing

### DIFF
--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -158,6 +158,7 @@ class OpenAIClient(BaseLLMClient):
                     raise ValueError(
                         f"API key for provider '{self.provider}' is not set."
                         f" Please set the {api_key_env} environment variable."
+                        f"(e.g. add {api_key_env}=your_key to your .env file)."
                     )
             else:
                 llm_kwargs["api_key"] = "ollama"

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -154,6 +154,11 @@ class OpenAIClient(BaseLLMClient):
                 api_key = os.environ.get(api_key_env)
                 if api_key:
                     llm_kwargs["api_key"] = api_key
+                else:
+                    raise ValueError(
+                        f"API key for provider '{self.provider}' is not set."
+                        f" Please set the {api_key_env} environment variable."
+                    )
             else:
                 llm_kwargs["api_key"] = "ollama"
         elif self.base_url:


### PR DESCRIPTION
Fixes #655

so I was looking at this issue and basically what happens is when you 
set openrouter as your provider but forget to add the OPENROUTER_API_KEY 
in your .env file, the error you get is complaining about OPENAI_API_KEY 
which makes zero sense if you're not even using openai.

traced it down to openai_client.py - when the provider's api key env var 
isn't set, nothing gets passed to ChatOpenAI so it just falls back to 
looking for OPENAI_API_KEY and throws that confusing error.

fix is pretty simple, just added an explicit check that raises a ValueError 
with an actually useful message telling you which env var you need to set 
for your provider instead of the generic openai one.

before the fix you'd see something like:
    OpenAIError: The api_key client option must be set... OPENAI_API_KEY

now you get:
    ValueError: API key for provider 'openrouter' is not set. 
    Please set the OPENROUTER_API_KEY environment variable.

should fix the confusion for anyone using openrouter, xai, deepseek etc 
without an openai key