### PR TITLE
feat: make alpha benchmark configurable for non-US tickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+- Configurable alpha benchmark for non-US tickers. `DEFAULT_CONFIG` now exposes
+  `benchmark_ticker` (explicit override) and `benchmark_map` (suffix-based
+  auto-detection: `.T` → `^N225`, `.HK` → `^HSI`, `.NS` → `^NSEI`, etc.).
+  US tickers continue to use SPY by default. The reflection log now labels
+  alpha against the actual benchmark used (e.g. `Alpha vs ^N225`) instead of
+  the hardcoded `Alpha vs SPY`. (#628)
+
 ## [0.2.4] — 2026-04-25
 
 ### Added

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -535,6 +535,57 @@ class TestDeferredReflection:
         assert raw is not None and alpha is not None and days is not None
         assert days == 2
 
+    # TradingAgentsGraph._resolve_benchmark
+
+    def test_resolve_benchmark_explicit_override(self):
+        """config["benchmark_ticker"] wins over the suffix map."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {"benchmark_ticker": "QQQ", "benchmark_map": {"": "SPY"}}
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "7203.T") == "QQQ"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "NVDA") == "QQQ"
+
+    def test_resolve_benchmark_suffix_map(self):
+        """Known suffixes resolve to their regional benchmark."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {"benchmark_ticker": None, "benchmark_map": {
+            ".T": "^N225", ".HK": "^HSI", ".NS": "^NSEI", ".L": "^FTSE",
+            ".TO": "^GSPTSE", ".AX": "^AXJO", ".BO": "^BSESN", "": "SPY",
+        }}
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "7203.T") == "^N225"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "0700.HK") == "^HSI"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "RELIANCE.NS") == "^NSEI"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "AZN.L") == "^FTSE"
+
+    def test_resolve_benchmark_no_suffix_us_ticker(self):
+        """US tickers without a dot suffix resolve to SPY."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {"benchmark_ticker": None, "benchmark_map": {"": "SPY"}}
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "NVDA") == "SPY"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "AAPL") == "SPY"
+
+    def test_resolve_benchmark_unknown_suffix_falls_back(self):
+        """Unrecognised suffix falls back to the "" key (SPY)."""
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.config = {"benchmark_ticker": None, "benchmark_map": {"": "SPY"}}
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "FAKE.XX") == "SPY"
+
+    # Reflector.reflect_on_final_decision — benchmark_name label
+
+    def test_reflect_includes_benchmark_name(self):
+        """benchmark_name appears in the human message sent to the LLM."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = "Directionally correct."
+        reflector = Reflector(mock_llm)
+        reflector.reflect_on_final_decision(
+            final_decision=DECISION_BUY,
+            raw_return=0.05,
+            alpha_return=0.02,
+            benchmark_name="^N225",
+        )
+        messages = mock_llm.invoke.call_args[0][0]
+        human_content = next(content for role, content in messages if role == "human")
+        assert "Alpha vs ^N225:" in human_content
+
     # TradingAgentsGraph._resolve_pending_entries
 
     def test_resolve_skips_other_tickers(self, tmp_path):

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -564,10 +564,11 @@ class TestDeferredReflection:
         assert TradingAgentsGraph._resolve_benchmark(mock_graph, "AAPL") == "SPY"
 
     def test_resolve_benchmark_unknown_suffix_falls_back(self):
-        """Unrecognised suffix falls back to the "" key (SPY)."""
+        """Unrecognised suffix (including US tickers with dots like BRK.B) falls back to SPY."""
         mock_graph = MagicMock(spec=TradingAgentsGraph)
         mock_graph.config = {"benchmark_ticker": None, "benchmark_map": {"": "SPY"}}
         assert TradingAgentsGraph._resolve_benchmark(mock_graph, "FAKE.XX") == "SPY"
+        assert TradingAgentsGraph._resolve_benchmark(mock_graph, "BRK.B") == "SPY"
 
     # Reflector.reflect_on_final_decision — benchmark_name label
 

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -43,6 +43,20 @@ DEFAULT_CONFIG = {
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
         "news_data": "yfinance",             # Options: alpha_vantage, yfinance
     },
+    # Benchmark for alpha calculation in the reflection layer.
+    # None = auto-detect from ticker suffix via benchmark_map.
+    # Set an explicit ticker (e.g. "QQQ") to override for all tickers.
+    "benchmark_ticker": None,
+    "benchmark_map": {
+        ".NS":  "^NSEI",    # NSE India — Nifty 50
+        ".BO":  "^BSESN",   # BSE India — Sensex
+        ".T":   "^N225",    # Tokyo — Nikkei 225
+        ".HK":  "^HSI",     # Hong Kong — Hang Seng
+        ".L":   "^FTSE",    # London — FTSE 100
+        ".TO":  "^GSPTSE",  # Toronto — TSX Composite
+        ".AX":  "^AXJO",    # Australia — ASX 200
+        "":     "SPY",      # default for US-listed (no suffix)
+    },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {
         # Example: "get_stock_data": "alpha_vantage",  # Override category default

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -33,6 +33,7 @@ class Reflector:
         final_decision: str,
         raw_return: float,
         alpha_return: float,
+        benchmark_name: str = "SPY",
     ) -> str:
         """Single reflection call on the final trade decision with outcome context.
 
@@ -45,7 +46,7 @@ class Reflector:
                 "human",
                 (
                     f"Raw return: {raw_return:+.1%}\n"
-                    f"Alpha vs SPY: {alpha_return:+.1%}\n\n"
+                    f"Alpha vs {benchmark_name}: {alpha_return:+.1%}\n\n"
                     f"Final Decision:\n{final_decision}"
                 ),
             ),

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -188,8 +188,22 @@ class TradingAgentsGraph:
             ),
         }
 
+    def _resolve_benchmark(self, ticker: str) -> str:
+        """Return the benchmark ticker for alpha calculation.
+
+        Explicit config["benchmark_ticker"] wins; otherwise the suffix of
+        ``ticker`` is looked up in config["benchmark_map"]; falls back to
+        "SPY" if the suffix is not in the map.
+        """
+        explicit = self.config.get("benchmark_ticker")
+        if explicit:
+            return explicit
+        benchmark_map = self.config.get("benchmark_map", {"": "SPY"})
+        suffix = "." + ticker.rsplit(".", 1)[-1] if "." in ticker else ""
+        return benchmark_map.get(suffix, benchmark_map.get("", "SPY"))
+
     def _fetch_returns(
-        self, ticker: str, trade_date: str, holding_days: int = 5
+        self, ticker: str, trade_date: str, holding_days: int = 5, benchmark: str = "SPY"
     ) -> Tuple[Optional[float], Optional[float], Optional[int]]:
         """Fetch raw and alpha return for ticker over holding_days from trade_date.
 
@@ -203,21 +217,21 @@ class TradingAgentsGraph:
             end_str = end.strftime("%Y-%m-%d")
 
             stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
-            spy = yf.Ticker("SPY").history(start=trade_date, end=end_str)
+            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
 
-            if len(stock) < 2 or len(spy) < 2:
+            if len(stock) < 2 or len(bench) < 2:
                 return None, None, None
 
-            actual_days = min(holding_days, len(stock) - 1, len(spy) - 1)
+            actual_days = min(holding_days, len(stock) - 1, len(bench) - 1)
             raw = float(
                 (stock["Close"].iloc[actual_days] - stock["Close"].iloc[0])
                 / stock["Close"].iloc[0]
             )
-            spy_ret = float(
-                (spy["Close"].iloc[actual_days] - spy["Close"].iloc[0])
-                / spy["Close"].iloc[0]
+            bench_ret = float(
+                (bench["Close"].iloc[actual_days] - bench["Close"].iloc[0])
+                / bench["Close"].iloc[0]
             )
-            alpha = raw - spy_ret
+            alpha = raw - bench_ret
             return raw, alpha, actual_days
         except Exception as e:
             logger.warning(
@@ -240,15 +254,17 @@ class TradingAgentsGraph:
         if not pending:
             return
 
+        benchmark = self._resolve_benchmark(ticker)
         updates = []
         for entry in pending:
-            raw, alpha, days = self._fetch_returns(ticker, entry["date"])
+            raw, alpha, days = self._fetch_returns(ticker, entry["date"], benchmark=benchmark)
             if raw is None:
                 continue  # price not available yet — try again next run
             reflection = self.reflector.reflect_on_final_decision(
                 final_decision=entry.get("decision", ""),
                 raw_return=raw,
                 alpha_return=alpha,
+                benchmark_name=benchmark,
             )
             updates.append({
                 "ticker": ticker,


### PR DESCRIPTION
## Summary

Closes #628.

`SPY` was hardcoded as the benchmark in two places:
- `TradingAgentsGraph._fetch_returns()` — `yf.Ticker("SPY")`
- `Reflector.reflect_on_final_decision()` — `"Alpha vs SPY: ..."` label

For international tickers (`.NS`, `.T`, `.HK`, `.L`, `.TO`, `.AX`) this produces meaningless alpha — the return of an INR stock minus a USD index reflects FX drift more than stock-specific performance.

## Changes

**`tradingagents/default_config.py`** — two new keys:
```python
"benchmark_ticker": None,          # explicit override (e.g. "QQQ"); None = auto-detect
"benchmark_map": {
    ".NS":  "^NSEI",   # NSE India — Nifty 50
    ".BO":  "^BSESN",  # BSE India — Sensex
    ".T":   "^N225",   # Tokyo — Nikkei 225
    ".HK":  "^HSI",    # Hong Kong — Hang Seng
    ".L":   "^FTSE",   # London — FTSE 100
    ".TO":  "^GSPTSE", # Toronto — TSX Composite
    ".AX":  "^AXJO",   # Australia — ASX 200
    "":     "SPY",     # default for US-listed (no suffix)
},
```

**`tradingagents/graph/trading_graph.py`**
- New `_resolve_benchmark(ticker)` method: explicit config wins → suffix map → `"SPY"` fallback
- `_fetch_returns()` gains a `benchmark: str = "SPY"` parameter
- `_resolve_pending_entries()` resolves the benchmark once and passes it to both `_fetch_returns` and `reflect_on_final_decision`

**`tradingagents/graph/reflection.py`**
- `reflect_on_final_decision()` gains `benchmark_name: str = "SPY"`; reflection log now reads `Alpha vs ^N225: ...` for Japanese tickers instead of `Alpha vs SPY`

**`tests/test_memory_log.py`** — 5 new unit tests:
- `test_resolve_benchmark_explicit_override`
- `test_resolve_benchmark_suffix_map`
- `test_resolve_benchmark_no_suffix_us_ticker`
- `test_resolve_benchmark_unknown_suffix_falls_back`
- `test_reflect_includes_benchmark_name`

## Backwards compatibility

All defaults match previous behaviour — US tickers continue to use SPY and existing configs require no changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)