### PR TITLE
Add openai-compatible provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@
 
 </div>
 
+## OpenAI-Compatible Providers
+
+TradingAgents also supports OpenAI-compatible providers through the existing OpenAI client interface.
+
+Use the `openai_compatible` provider for services that expose an OpenAI-compatible API, such as:
+
+- OpenRouter
+- Ollama
+- Together
+- Volcano Engine
+- other OpenAI-format endpoints
+
+Set:
+
+```env
+OPENAI_API_KEY=your_provider_api_key
+OPENAI_BASE_URL=your_provider_base_url
+
 ## TradingAgents Framework
 
 TradingAgents is a multi-agent trading framework that mirrors the dynamics of real-world trading firms. By deploying specialized LLM-powered agents: from fundamental analysts, sentiment experts, and technical analysts, to trader, risk management team, the platform collaboratively evaluates market conditions and informs trading decisions. Moreover, these agents engage in dynamic discussions to pinpoint the optimal strategy.

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -16,6 +16,10 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("GPT-5.4 - Latest frontier, 1M context", "gpt-5.4"),
             ("GPT-4.1 - Smartest non-reasoning model", "gpt-4.1"),
         ],
+        "openai_compatible": {
+            "quick": [("Custom OpenAI-Compatible Model", "custom")],
+            "deep": [("Custom OpenAI-Compatible Model", "custom")],
+        },
         "deep": [
             ("GPT-5.4 - Latest frontier, 1M context", "gpt-5.4"),
             ("GPT-5.2 - Strong reasoning, cost-effective", "gpt-5.2"),


### PR DESCRIPTION
## Summary
Added a generic `openai_compatible` provider option to expose support for OpenAI-compatible APIs in the CLI model catalog.

## Changes made
- Added `openai_compatible` provider to model catalog
- Added generic custom model option for quick/deep modes
- Clarified OpenAI-compatible provider usage in README
- Documented `OPENAI_BASE_URL` and `OPENAI_API_KEY` setup

This enables cleaner support for providers such as OpenRouter, Ollama, Together, and Volcano Engine.

Closes #601