### PR TITLE
fix: raise NotImplementedError for all DeepSeek models in structured output

### DIFF
--- a/tests/test_deepseek_reasoning.py
+++ b/tests/test_deepseek_reasoning.py
@@ -5,9 +5,9 @@ Two pieces verified:
 1. ``reasoning_content`` is captured on receive into the AIMessage's
    ``additional_kwargs`` and re-attached on send so DeepSeek's API
    sees the same value across turns.
-2. ``with_structured_output`` raises NotImplementedError for
-   ``deepseek-reasoner`` so the agent factories' free-text fallback
-   handles the request instead of failing at runtime.
+2. ``with_structured_output`` raises NotImplementedError for all
+   DeepSeek models so the agent factories' free-text fallback handles
+   the request instead of failing at runtime with HTTP 400.
 """
 
 import os
@@ -135,22 +135,27 @@ class TestDeepSeekReasonerStructuredOutput:
         with pytest.raises(NotImplementedError):
             client.with_structured_output(_Sample)
 
-    def test_with_structured_output_works_for_v4(self):
-        """V4 models (non-reasoner) accept tool_choice; structured output works."""
-        client = DeepSeekChatOpenAI(
-            model="deepseek-v4-flash",
-            api_key="placeholder",
-            base_url="https://api.deepseek.com",
-        )
-        from pydantic import BaseModel
+    def test_with_structured_output_raises_for_v4(self):
+        """All DeepSeek models reject tool_choice, not just deepseek-reasoner.
 
-        class _Sample(BaseModel):
-            answer: str
+        V4 Flash, V4 Pro, and deepseek-chat all return HTTP 400 when
+        tool_choice is set. Raising NotImplementedError at bind time lets
+        bind_structured() fall back to free-text cleanly without wasting
+        an API call.
+        """
+        for model in ("deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat"):
+            client = DeepSeekChatOpenAI(
+                model=model,
+                api_key="placeholder",
+                base_url="https://api.deepseek.com",
+            )
+            from pydantic import BaseModel
 
-        # Should return a Runnable, not raise. (The actual API call would
-        # require a real key; we only assert binding succeeds.)
-        wrapped = client.with_structured_output(_Sample)
-        assert wrapped is not None
+            class _Sample(BaseModel):
+                answer: str
+
+            with pytest.raises(NotImplementedError, match="does not support tool_choice"):
+                client.with_structured_output(_Sample)
 
 
 # ---------------------------------------------------------------------------

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -60,9 +60,10 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
        fails with HTTP 400. ``_create_chat_result`` captures the field on
        receive and ``_get_request_payload`` re-attaches it on send.
 
-    2. **deepseek-reasoner has no tool_choice.** Structured output via
-       function-calling is unavailable, so we raise NotImplementedError
-       and let the agent factories fall back to free-text generation
+    2. **DeepSeek models do not support tool_choice.** Structured output
+       via function-calling is unavailable for all DeepSeek models (not
+       just deepseek-reasoner), so we raise NotImplementedError and let
+       the agent factories fall back to free-text generation
        (see ``tradingagents/agents/utils/structured.py``).
     """
 
@@ -95,13 +96,11 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
         return chat_result
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
-        if self.model_name == "deepseek-reasoner":
-            raise NotImplementedError(
-                "deepseek-reasoner does not support tool_choice; structured "
-                "output is unavailable. Agent factories fall back to "
-                "free-text generation automatically."
-            )
-        return super().with_structured_output(schema, method=method, **kwargs)
+        raise NotImplementedError(
+            f"{self.model_name} does not support tool_choice; structured "
+            "output is unavailable. Agent factories fall back to "
+            "free-text generation automatically."
+        )
 
 # Kwargs forwarded from user config to ChatOpenAI
 _PASSTHROUGH_KWARGS = (


### PR DESCRIPTION
Closes #678.

All DeepSeek models reject the `tool_choice` parameter with HTTP 400, not just `deepseek-reasoner`. Previously other variants like `deepseek-chat` would bind successfully but fail at invocation, wasting an API call and logging an error before falling back to free-text. Changed `with_structured_output()` to raise `NotImplementedError` for all DeepSeek models so `bind_structured()` catches it cleanly upfront. Updated tests to cover all three variants.