### PR TITLE
Fix Docker permission error for .tradingagents directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser \
+ && mkdir -p /home/appuser/.tradingagents/cache /home/appuser/.tradingagents/results /home/appuser/app/reports \
+ && chown -R appuser:appuser /home/appuser/.tradingagents && chown -R appuser:appuser /home/appuser/app/reports
 USER appuser
 WORKDIR /home/appuser/app
 


### PR DESCRIPTION
## Summary

Fixes issue #627 - PermissionError when running TradingAgents in Docker.

## Problem

When running the application in Docker, users encountered a `PermissionError: [Errno 13] Permission denied: '/home/appuser/.tradingagents/cache'` error. This occurred because:

1. The Dockerfile switches to `appuser` with the `USER appuser` directive
2. The application tries to create directories at runtime using `os.makedirs()`
3. The `appuser` doesn't have permission to create directories in paths that don't exist

## Solution

Pre-create the required directories during the Docker build process and set proper ownership before switching to `appuser`:

- `/home/appuser/.tradingagents/cache`
- `/home/appuser/.tradingagents/results`  
- `/home/appuser/app/reports`

This ensures the directories exist with correct ownership when the application runs, preventing the permission error.

## Changes

- Modified Dockerfile to create necessary directories in the `RUN useradd` command
- Added `chown` to set proper ownership for `appuser`
- Directories are created before the `USER appuser` directive takes effect

## Testing

This fix resolves the error reported in issue #627 where users selecting "Enable Thinking" mode encountered the permission denied error during graph initialization.