### PR TITLE
Use current date for forward propagation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
+from datetime import datetime
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
-
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -8,24 +8,28 @@ load_dotenv()
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-5.4-mini"  # Use a different model
-config["quick_think_llm"] = "gpt-5.4-mini"  # Use a different model
-config["max_debate_rounds"] = 1  # Increase debate rounds
+config["deep_think_llm"] = "gpt-5.4-mini"
+config["quick_think_llm"] = "gpt-5.4-mini"
+config["max_debate_rounds"] = 1
 
-# Configure data vendors (default uses yfinance, no extra API keys needed)
+# Configure data vendors
 config["data_vendors"] = {
-    "core_stock_apis": "yfinance",           # Options: alpha_vantage, yfinance
-    "technical_indicators": "yfinance",      # Options: alpha_vantage, yfinance
-    "fundamental_data": "yfinance",          # Options: alpha_vantage, yfinance
-    "news_data": "yfinance",                 # Options: alpha_vantage, yfinance
+    "core_stock_apis": "yfinance",
+    "technical_indicators": "yfinance",
+    "fundamental_data": "yfinance",
+    "news_data": "yfinance",
 }
 
 # Initialize with custom config
 ta = TradingAgentsGraph(debug=True, config=config)
 
-# forward propagate
-_, decision = ta.propagate("NVDA", "2024-05-10")
+# Use current date dynamically
+today = datetime.today().strftime("%Y-%m-%d")
+
+# Forward propagate
+_, decision = ta.propagate("NVDA", today)
+
 print(decision)
 
 # Memorize mistakes and reflect
-# ta.reflect_and_remember(1000) # parameter is the position returns
+# ta.reflect_and_remember(1000)


### PR DESCRIPTION
Updated the date handling in the forward propagation to use th## Description

This pull request replaces the hardcoded date in `ta.propagate()` with the current system date generated dynamically using Python's `datetime` module.

### Changes Made

* Added `from datetime import datetime`
* Generated today's date using:

  ```python
  today = datetime.today().strftime("%Y-%m-%d")
  ```
* Replaced fixed date:

  ```python
  "2024-05-10"
  ```

  with:

  ```python
  today
  ```

### Benefits

* Keeps the script up to date automatically
* Removes the need to manually edit the date before running
* Improves practicality for real-time usage
e current date dynamically instead of a hardcoded date.