### PR TITLE
feat: add portfolio_advisor companion package

### DIFF
--- a/portfolio_advisor/aggregator.py
+++ b/portfolio_advisor/aggregator.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import List, Tuple
+
+from .config import Aggressiveness, Config
+
+# Map TradingAgents 5-tier rating to a numeric score for ranking within buckets.
+_SIGNAL_SCORE: dict[str, int] = {
+    "Buy": 5,
+    "Overweight": 4,
+    "Hold": 3,
+    "Underweight": 2,
+    "Sell": 1,
+}
+
+
+@dataclass
+class Action:
+    ticker: str
+    action: str    # "BUY", "SELL", or "HOLD"
+    signal: str    # raw TradingAgents 5-tier rating
+    score: int     # higher = more conviction in the direction
+    rationale: str # first substantive line from the PM decision
+    owned: bool
+
+
+def _is_buy(signal: str, aggressiveness: Aggressiveness) -> bool:
+    if aggressiveness == Aggressiveness.AGGRESSIVE:
+        return signal in ("Buy", "Overweight")
+    return signal == "Buy"
+
+
+def _is_sell(signal: str, aggressiveness: Aggressiveness) -> bool:
+    if aggressiveness == Aggressiveness.AGGRESSIVE:
+        return signal in ("Sell", "Underweight")
+    return signal == "Sell"
+
+
+def _extract_rationale(final_state: dict) -> str:
+    text = final_state.get("final_trade_decision", "")
+    for line in text.splitlines():
+        stripped = line.strip("*# \t")
+        if len(stripped) > 30:
+            return stripped[:200]
+    return text[:200]
+
+
+def aggregate(
+    results: List[Tuple[str, dict, str]],
+    owned_tickers: set,
+    cfg: Config,
+    run_date: date,
+) -> List[Action]:
+    actions: List[Action] = []
+
+    for ticker, final_state, signal in results:
+        owned = ticker in owned_tickers
+        score = _SIGNAL_SCORE.get(signal, 3)
+        rationale = _extract_rationale(final_state)
+
+        if _is_sell(signal, cfg.aggressiveness):
+            action = "SELL"
+        elif _is_buy(signal, cfg.aggressiveness):
+            action = "BUY"
+        else:
+            action = "HOLD"
+
+        actions.append(Action(
+            ticker=ticker,
+            action=action,
+            signal=signal,
+            score=score,
+            rationale=rationale,
+            owned=owned,
+        ))
+
+    # SELL first (highest urgency, lowest score = most bearish first),
+    # then BUY (highest score = most bullish first), then HOLD.
+    _order = {"SELL": 0, "BUY": 1, "HOLD": 2}
+
+    def _sort_key(a: Action) -> tuple:
+        if a.action == "SELL":
+            return (_order[a.action], a.score)       # ascending score: worst first
+        return (_order[a.action], -a.score)           # descending score: best first
+
+    actions.sort(key=_sort_key)
+    return actions

--- a/portfolio_advisor/aggregator.py
+++ b/portfolio_advisor/aggregator.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
+from .broker import Position
 from .config import Aggressiveness, Config
 
 # Map TradingAgents 5-tier rating to a numeric score for ranking within buckets.
@@ -19,11 +20,13 @@ _SIGNAL_SCORE: dict[str, int] = {
 @dataclass
 class Action:
     ticker: str
-    action: str    # "BUY", "SELL", or "HOLD"
-    signal: str    # raw TradingAgents 5-tier rating
-    score: int     # higher = more conviction in the direction
-    rationale: str # first substantive line from the PM decision
+    action: str       # "BUY", "SELL", or "HOLD"
+    signal: str       # raw TradingAgents 5-tier rating
+    score: int        # higher = more conviction in the direction
+    rationale: str    # first substantive line from the PM decision
     owned: bool
+    price: float      # current share price (0 if unknown)
+    affordable: bool  # True if price <= available cash, or already owned
 
 
 def _is_buy(signal: str, aggressiveness: Aggressiveness) -> bool:
@@ -47,18 +50,87 @@ def _extract_rationale(final_state: dict) -> str:
     return text[:200]
 
 
+def detect_condition(cash: float, positions: list, cash_threshold: float) -> int:
+    """Return strategy condition 1–4.
+
+    1 — cash available, no positions held
+    2 — cash available, at least one position held
+    3 — no cash, no positions held
+    4 — no cash, at least one position held
+    """
+    has_cash = cash >= cash_threshold
+    has_positions = bool(positions)
+    if has_cash and not has_positions:
+        return 1
+    if has_cash and has_positions:
+        return 2
+    if not has_cash and not has_positions:
+        return 3
+    return 4
+
+
+def audit_positions(positions: List[Position]) -> List[dict]:
+    """Serialize positions and annotate with strategy-doc risk flags.
+
+    Flags:
+        concentration_risk   — single position > 10% of portfolio value
+        drawdown_15pct       — position down > 15% from cost basis
+        sector_concentration — sector > 25% of portfolio value
+    """
+    if not positions:
+        return []
+
+    total_value = sum(p.market_value for p in positions)
+    sector_values: dict[str, float] = {}
+    for p in positions:
+        sector_values[p.sector] = sector_values.get(p.sector, 0.0) + p.market_value
+
+    result = []
+    for p in positions:
+        flags = []
+        if total_value > 0 and p.market_value / total_value > 0.10:
+            flags.append("concentration_risk")
+        if p.cost_basis > 0 and p.current_price < p.cost_basis * 0.85:
+            flags.append("drawdown_15pct")
+        if (
+            p.sector not in ("Unknown", None, "")
+            and total_value > 0
+            and sector_values.get(p.sector, 0.0) / total_value > 0.25
+        ):
+            flags.append("sector_concentration")
+        result.append({
+            "ticker": p.ticker,
+            "shares": p.shares,
+            "cost_basis": p.cost_basis,
+            "current_price": p.current_price,
+            "sector": p.sector,
+            "market_value": p.market_value,
+            "flags": flags,
+        })
+    return result
+
+
 def aggregate(
     results: List[Tuple[str, dict, str]],
     owned_tickers: set,
     cfg: Config,
     run_date: date,
+    cash: float = 0.0,
+    price_map: Optional[Dict[str, float]] = None,
 ) -> List[Action]:
+    pm = price_map or {}
     actions: List[Action] = []
 
     for ticker, final_state, signal in results:
         owned = ticker in owned_tickers
         score = _SIGNAL_SCORE.get(signal, 3)
         rationale = _extract_rationale(final_state)
+        price = pm.get(ticker, 0.0)
+
+        # Affordable: already owned, OR we have meaningful cash and the stock is within reach
+        affordable = owned or (
+            cash >= cfg.cash_threshold and (price == 0.0 or price <= cash)
+        )
 
         if _is_sell(signal, cfg.aggressiveness):
             action = "SELL"
@@ -74,16 +146,17 @@ def aggregate(
             score=score,
             rationale=rationale,
             owned=owned,
+            price=price,
+            affordable=affordable,
         ))
 
-    # SELL first (highest urgency, lowest score = most bearish first),
-    # then BUY (highest score = most bullish first), then HOLD.
+    # SELL first (most bearish first), then BUY (most bullish first), then HOLD.
     _order = {"SELL": 0, "BUY": 1, "HOLD": 2}
 
     def _sort_key(a: Action) -> tuple:
         if a.action == "SELL":
-            return (_order[a.action], a.score)       # ascending score: worst first
-        return (_order[a.action], -a.score)           # descending score: best first
+            return (_order[a.action], a.score)
+        return (_order[a.action], -a.score)
 
     actions.sort(key=_sort_key)
     return actions

--- a/portfolio_advisor/broker.py
+++ b/portfolio_advisor/broker.py
@@ -26,9 +26,41 @@ class Portfolio:
     source: str  # "live" or "fallback"
 
 
+# ── Settings ──────────────────────────────────────────────────────────────────
+
+def load_settings(data_dir: str) -> dict:
+    """Load user settings from {data_dir}/settings.json."""
+    path = os.path.join(data_dir, "settings.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_settings(data_dir: str, patch: dict) -> None:
+    """Merge patch into {data_dir}/settings.json."""
+    os.makedirs(data_dir, exist_ok=True)
+    existing = load_settings(data_dir)
+    existing.update(patch)
+    path = os.path.join(data_dir, "settings.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2)
+
+
+def _get_credentials(data_dir: str) -> tuple[str, str]:
+    """Return (username, password): settings.json first, env var fallback."""
+    s = load_settings(data_dir)
+    username = s.get("robinhood_username") or os.environ.get("ROBINHOOD_USERNAME", "")
+    password = s.get("robinhood_password") or os.environ.get("ROBINHOOD_PASSWORD", "")
+    return username, password
+
+
+# ── Portfolio loading ─────────────────────────────────────────────────────────
+
 def load_portfolio(data_dir: str) -> Portfolio:
     try:
-        portfolio = _load_from_robinhood()
+        portfolio = _load_from_robinhood(data_dir)
         logger.info("Portfolio loaded from Robinhood (%d positions)", len(portfolio.positions))
         return portfolio
     except Exception as exc:
@@ -36,11 +68,13 @@ def load_portfolio(data_dir: str) -> Portfolio:
         return _load_from_json(data_dir)
 
 
-def _load_from_robinhood() -> Portfolio:
+def _load_from_robinhood(data_dir: str) -> Portfolio:
     import robin_stocks.robinhood as rh
 
-    username = os.environ["ROBINHOOD_USERNAME"]
-    password = os.environ["ROBINHOOD_PASSWORD"]
+    username, password = _get_credentials(data_dir)
+    if not username or not password:
+        raise ValueError("Robinhood credentials not configured. Use Settings to add them.")
+
     # store_session persists the device token so subsequent logins skip MFA.
     rh.login(username, password, store_session=True)
 
@@ -98,7 +132,57 @@ def _load_from_json(data_dir: str) -> Portfolio:
     return Portfolio(positions=positions, cash=float(data.get("cash", 0)), source="fallback")
 
 
-def reauth_robinhood(mfa_code: str | None = None) -> tuple[str, str | None]:
+# ── Connection check (lightweight — login + profile, no position detail) ──────
+
+def check_connection(data_dir: str) -> dict:
+    """Test Robinhood connectivity without a full portfolio build.
+
+    Returns a dict with: ok, source, cash, positions (count), error (on failure).
+    Falls back to local JSON if Robinhood is unavailable.
+    """
+    import robin_stocks.robinhood as rh
+
+    username, password = _get_credentials(data_dir)
+    if not username or not password:
+        return {
+            "ok": False,
+            "source": "none",
+            "error": "No credentials configured. Open Settings to add them.",
+        }
+
+    rh_exc: Exception | None = None
+    try:
+        rh.login(username, password, store_session=True)
+        profile = rh.load_account_profile() or {}
+        cash: float = 0.0
+        for field in ("portfolio_cash", "buying_power", "cash", "excess_margin"):
+            if profile.get(field) is not None:
+                cash = float(profile[field])
+                break
+        positions_raw = rh.get_open_stock_positions() or []
+        position_count = sum(1 for p in positions_raw if float(p.get("quantity", 0)) > 0)
+        rh.logout()
+        return {"ok": True, "source": "live", "cash": cash, "positions": position_count}
+    except Exception as exc:
+        rh_exc = exc
+        logger.warning("Robinhood connection check failed: %s", exc)
+
+    # Fallback: local JSON
+    try:
+        portfolio = _load_from_json(data_dir)
+        return {
+            "ok": True,
+            "source": "fallback",
+            "cash": portfolio.cash,
+            "positions": len(portfolio.positions),
+        }
+    except Exception:
+        return {"ok": False, "source": "none", "error": str(rh_exc)}
+
+
+# ── Re-authentication ─────────────────────────────────────────────────────────
+
+def reauth_robinhood(data_dir: str, mfa_code: str | None = None) -> tuple[str, str | None]:
     """Attempt a fresh Robinhood login without blocking the server.
 
     Returns (status, message):
@@ -109,10 +193,9 @@ def reauth_robinhood(mfa_code: str | None = None) -> tuple[str, str | None]:
     import builtins
     import robin_stocks.robinhood as rh
 
-    username = os.environ.get("ROBINHOOD_USERNAME", "")
-    password = os.environ.get("ROBINHOOD_PASSWORD", "")
+    username, password = _get_credentials(data_dir)
     if not username or not password:
-        return ("error", "ROBINHOOD_USERNAME or ROBINHOOD_PASSWORD not set in environment")
+        return ("error", "No credentials configured. Open Settings to add them.")
 
     if mfa_code:
         try:
@@ -142,6 +225,8 @@ def reauth_robinhood(mfa_code: str | None = None) -> tuple[str, str | None]:
     finally:
         builtins.input = _orig_input
 
+
+# ── Portfolio JSON editor ─────────────────────────────────────────────────────
 
 def save_portfolio_json(data_dir: str, positions: list, cash: float) -> None:
     path = os.path.join(data_dir, "portfolio.json")

--- a/portfolio_advisor/broker.py
+++ b/portfolio_advisor/broker.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Position:
+    ticker: str
+    shares: float
+    cost_basis: float
+    current_price: float
+    sector: str
+    market_value: float
+
+
+@dataclass
+class Portfolio:
+    positions: List[Position]
+    cash: float
+    source: str  # "live" or "fallback"
+
+
+def load_portfolio(data_dir: str) -> Portfolio:
+    try:
+        portfolio = _load_from_robinhood()
+        logger.info("Portfolio loaded from Robinhood (%d positions)", len(portfolio.positions))
+        return portfolio
+    except Exception as exc:
+        logger.warning("robin_stocks failed (%s); falling back to portfolio.json", exc)
+        return _load_from_json(data_dir)
+
+
+def _load_from_robinhood() -> Portfolio:
+    import robin_stocks.robinhood as rh
+
+    username = os.environ["ROBINHOOD_USERNAME"]
+    password = os.environ["ROBINHOOD_PASSWORD"]
+    # store_session persists the device token so subsequent logins skip MFA.
+    rh.login(username, password, store_session=True)
+
+    positions_raw = rh.get_open_stock_positions() or []
+    cash = _get_cash(rh)
+
+    positions: List[Position] = []
+    for pos in positions_raw:
+        qty = float(pos.get("quantity", 0))
+        if qty == 0:
+            continue
+
+        instrument = rh.get_instrument_by_url(pos.get("instrument", "")) or {}
+        ticker = instrument.get("symbol", "")
+        if not ticker:
+            continue
+
+        cost_basis = float(pos.get("average_buy_price", 0))
+        quote = rh.get_latest_price(ticker) or [str(cost_basis)]
+        current_price = float(quote[0])
+
+        fundamentals = rh.get_fundamentals(ticker) or [{}]
+        sector = (fundamentals[0] or {}).get("sector", "Unknown")
+
+        positions.append(Position(
+            ticker=ticker,
+            shares=qty,
+            cost_basis=cost_basis,
+            current_price=current_price,
+            sector=sector,
+            market_value=qty * current_price,
+        ))
+
+    rh.logout()
+    return Portfolio(positions=positions, cash=cash, source="live")
+
+
+def _get_cash(rh) -> float:
+    try:
+        profile = rh.load_account_profile() or {}
+        for field in ("portfolio_cash", "buying_power", "cash", "excess_margin"):
+            val = profile.get(field)
+            if val is not None:
+                return float(val)
+    except Exception:
+        pass
+    return 0.0
+
+
+def _load_from_json(data_dir: str) -> Portfolio:
+    path = os.path.join(data_dir, "portfolio.json")
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    positions = [Position(**p) for p in data.get("positions", [])]
+    return Portfolio(positions=positions, cash=float(data.get("cash", 0)), source="fallback")
+
+
+def save_portfolio_json(data_dir: str, positions: list, cash: float) -> None:
+    path = os.path.join(data_dir, "portfolio.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"cash": cash, "positions": positions}, fh, indent=2)

--- a/portfolio_advisor/broker.py
+++ b/portfolio_advisor/broker.py
@@ -98,6 +98,51 @@ def _load_from_json(data_dir: str) -> Portfolio:
     return Portfolio(positions=positions, cash=float(data.get("cash", 0)), source="fallback")
 
 
+def reauth_robinhood(mfa_code: str | None = None) -> tuple[str, str | None]:
+    """Attempt a fresh Robinhood login without blocking the server.
+
+    Returns (status, message):
+        ("ok", None)            — login succeeded; device token stored
+        ("mfa_required", None) — MFA prompt intercepted; call again with mfa_code
+        ("error", message)     — login failed for another reason
+    """
+    import builtins
+    import robin_stocks.robinhood as rh
+
+    username = os.environ.get("ROBINHOOD_USERNAME", "")
+    password = os.environ.get("ROBINHOOD_PASSWORD", "")
+    if not username or not password:
+        return ("error", "ROBINHOOD_USERNAME or ROBINHOOD_PASSWORD not set in environment")
+
+    if mfa_code:
+        try:
+            rh.login(username, password, store_session=True, mfa_code=str(mfa_code))
+            return ("ok", None)
+        except Exception as exc:
+            return ("error", str(exc))
+
+    # First attempt: patch builtins.input so the MFA prompt raises instead of blocking.
+    _mfa_seen: list[bool] = []
+    _orig_input = builtins.input
+
+    def _catch_mfa(prompt=""):
+        _mfa_seen.append(True)
+        raise RuntimeError("__MFA_INTERCEPTED__")
+
+    builtins.input = _catch_mfa
+    try:
+        rh.login(username, password, store_session=True)
+        return ("ok", None)
+    except RuntimeError:
+        if _mfa_seen:
+            return ("mfa_required", None)
+        return ("error", "Unexpected runtime error during login")
+    except Exception as exc:
+        return ("error", str(exc))
+    finally:
+        builtins.input = _orig_input
+
+
 def save_portfolio_json(data_dir: str, positions: list, cash: float) -> None:
     path = os.path.join(data_dir, "portfolio.json")
     with open(path, "w", encoding="utf-8") as fh:

--- a/portfolio_advisor/compat_test.py
+++ b/portfolio_advisor/compat_test.py
@@ -1,0 +1,88 @@
+"""Smoke test for TradingAgents compatibility.
+
+Run this before every `git pull` on the TradingAgents repository.
+Exit code 0 = compatible. Exit code 1 = breaking change detected.
+
+Usage:
+    python -m portfolio_advisor.compat_test
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _check(label: str, fn) -> bool:
+    print(f"  {label}...", end=" ", flush=True)
+    try:
+        fn()
+        print("OK")
+        return True
+    except Exception as exc:
+        print(f"FAILED\n    {exc}")
+        return False
+
+
+def main() -> int:
+    print("TradingAgents compatibility check\n")
+    passed = True
+
+    def _imports():
+        from tradingagents.graph.trading_graph import TradingAgentsGraph  # noqa: F401
+        from tradingagents.default_config import DEFAULT_CONFIG            # noqa: F401
+        from tradingagents.agents.utils.rating import parse_rating         # noqa: F401
+
+    passed &= _check("Core imports", _imports)
+
+    def _config_keys():
+        from tradingagents.default_config import DEFAULT_CONFIG
+        required = {
+            "results_dir", "data_cache_dir", "llm_provider",
+            "deep_think_llm", "quick_think_llm",
+            "max_debate_rounds", "max_risk_discuss_rounds",
+        }
+        missing = required - set(DEFAULT_CONFIG.keys())
+        if missing:
+            raise KeyError(f"Missing DEFAULT_CONFIG keys: {missing}")
+
+    passed &= _check("DEFAULT_CONFIG keys", _config_keys)
+
+    def _propagate_signature():
+        import inspect
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+        params = list(inspect.signature(TradingAgentsGraph.propagate).parameters)
+        for expected in ("company_name", "trade_date"):
+            if expected not in params:
+                raise ValueError(f"propagate() missing param '{expected}'; got {params}")
+
+    passed &= _check("propagate() signature", _propagate_signature)
+
+    def _state_keys():
+        import inspect
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+        src = inspect.getsource(TradingAgentsGraph._log_state)
+        for key in ("final_trade_decision", "risk_debate_state", "investment_plan"):
+            if key not in src:
+                raise KeyError(f"State key '{key}' missing from _log_state")
+
+    passed &= _check("State keys in _log_state", _state_keys)
+
+    def _rating_parser():
+        from tradingagents.agents.utils.rating import parse_rating
+        result = parse_rating("**Rating**: Buy")
+        if result != "Buy":
+            raise ValueError(f"parse_rating returned {result!r}, expected 'Buy'")
+
+    passed &= _check("Rating parser", _rating_parser)
+
+    print()
+    if passed:
+        print("All checks passed. Safe to upgrade TradingAgents.")
+        return 0
+    else:
+        print("One or more checks failed. Do NOT upgrade until resolved.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/portfolio_advisor/config.py
+++ b/portfolio_advisor/config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Aggressiveness(str, Enum):
+    CONSERVATIVE = "conservative"
+    AGGRESSIVE = "aggressive"
+
+
+@dataclass
+class Config:
+    aggressiveness: Aggressiveness = Aggressiveness.CONSERVATIVE
+
+    # Screener thresholds
+    min_avg_volume: int = 500_000
+    price_range_pct: float = 0.20
+    momentum_days: int = 5
+    max_candidates: int = 50
+
+    # Scheduled job times (all ET, 24h format)
+    intraday_check_times: list = field(
+        default_factory=lambda: ["09:32", "11:30", "13:30", "15:30"]
+    )
+    eod_scan_time: str = "16:15"
+    premarket_scan_time: str = "09:00"
+
+    # TradingAgents config overrides
+    llm_provider: str = os.getenv("TRADINGAGENTS_LLM_PROVIDER", "openai")
+    deep_think_llm: str = os.getenv("TRADINGAGENTS_DEEP_MODEL", "gpt-4o")
+    quick_think_llm: str = os.getenv("TRADINGAGENTS_QUICK_MODEL", "gpt-4o-mini")
+    max_debate_rounds: int = 1
+    max_risk_discuss_rounds: int = 1
+    results_dir: str = os.getenv(
+        "TRADINGAGENTS_RESULTS_DIR",
+        os.path.join(os.path.expanduser("~"), ".tradingagents", "logs"),
+    )
+    data_cache_dir: str = os.getenv(
+        "TRADINGAGENTS_CACHE_DIR",
+        os.path.join(os.path.expanduser("~"), ".tradingagents", "cache"),
+    )
+
+    # Web UI
+    web_host: str = "0.0.0.0"
+    web_port: int = 5001
+
+    # Internal paths (resolved relative to this file)
+    data_dir: str = os.path.join(os.path.dirname(__file__), "data")
+    state_file: str = os.path.join(os.path.dirname(__file__), "data", "state.json")
+
+
+config = Config()

--- a/portfolio_advisor/config.py
+++ b/portfolio_advisor/config.py
@@ -14,11 +14,19 @@ class Aggressiveness(str, Enum):
 class Config:
     aggressiveness: Aggressiveness = Aggressiveness.CONSERVATIVE
 
+    # Cash threshold: minimum balance to be considered "has cash" (strategy Condition detection)
+    cash_threshold: float = 100.0
+
     # Screener thresholds
     min_avg_volume: int = 500_000
     price_range_pct: float = 0.20
     momentum_days: int = 5
     max_candidates: int = 50
+
+    # Aggressive mode technical filters (strategy doc: Condition 1 Aggressive, Step 2)
+    min_market_cap_b: float = 2.0   # minimum market cap in billions
+    min_rsi: float = 55.0           # RSI lower bound (trending bullish)
+    max_rsi: float = 75.0           # RSI upper bound (not yet overbought)
 
     # Scheduled job times (all ET, 24h format)
     intraday_check_times: list = field(

--- a/portfolio_advisor/data/portfolio.json
+++ b/portfolio_advisor/data/portfolio.json
@@ -1,0 +1,13 @@
+{
+  "cash": 0.00,
+  "positions": [
+    {
+      "ticker": "AAPL",
+      "shares": 10,
+      "cost_basis": 150.00,
+      "current_price": 175.00,
+      "sector": "Technology",
+      "market_value": 1750.00
+    }
+  ]
+}

--- a/portfolio_advisor/main.py
+++ b/portfolio_advisor/main.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime
+
+import pytz
+
+from .aggregator import aggregate
+from .broker import load_portfolio
+from .config import config
+from .runner import run_tickers
+from .scheduler import build_scheduler
+from .screener import screen_candidates
+from .web import create_app
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+ET = pytz.timezone("America/New_York")
+
+os.makedirs(config.data_dir, exist_ok=True)
+
+
+def _patch_state(patch: dict) -> None:
+    state: dict = {}
+    if os.path.exists(config.state_file):
+        try:
+            with open(config.state_file, encoding="utf-8") as fh:
+                state = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            pass
+    state.update(patch)
+    with open(config.state_file, "w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2, default=str)
+
+
+def _serialize_actions(actions) -> list:
+    return [
+        {
+            "ticker": a.ticker,
+            "action": a.action,
+            "signal": a.signal,
+            "score": a.score,
+            "rationale": a.rationale,
+            "owned": a.owned,
+        }
+        for a in actions
+    ]
+
+
+def _serialize_positions(portfolio) -> list:
+    return [
+        {
+            "ticker": p.ticker,
+            "shares": p.shares,
+            "cost_basis": p.cost_basis,
+            "current_price": p.current_price,
+            "sector": p.sector,
+            "market_value": p.market_value,
+        }
+        for p in portfolio.positions
+    ]
+
+
+def run_intraday() -> None:
+    """Check owned positions for sell signals (runs 4x per trading day)."""
+    logger.info("--- Intraday check ---")
+    trade_date = date.today()
+    portfolio = load_portfolio(config.data_dir)
+    owned_tickers = [p.ticker for p in portfolio.positions]
+
+    if not owned_tickers:
+        logger.info("No owned positions to check")
+        return
+
+    results = run_tickers(owned_tickers, trade_date, config)
+    owned_set = {p.ticker for p in portfolio.positions}
+    actions = aggregate(results, owned_set, config, trade_date)
+
+    _patch_state({
+        "last_intraday_run": datetime.now(ET).isoformat(),
+        "portfolio_source": portfolio.source,
+        "portfolio_positions": _serialize_positions(portfolio),
+        "cash": portfolio.cash,
+        "actions": _serialize_actions(actions),
+        "aggressiveness": config.aggressiveness.value,
+        "running": False,
+    })
+    logger.info("Intraday check complete: %d positions reviewed", len(owned_tickers))
+
+
+def run_eod() -> None:
+    """Screen NASDAQ candidates and run full analysis (EOD + Monday pre-market)."""
+    logger.info("--- EOD/pre-market scan ---")
+    trade_date = date.today()
+    portfolio = load_portfolio(config.data_dir)
+
+    candidates = screen_candidates(portfolio, config)
+    logger.info("%d candidates after screening", len(candidates))
+
+    # Always include owned positions so the UI has a complete picture
+    owned_set = {p.ticker for p in portfolio.positions}
+    all_tickers = list(owned_set | set(candidates))
+
+    results = run_tickers(all_tickers, trade_date, config)
+    actions = aggregate(results, owned_set, config, trade_date)
+
+    _patch_state({
+        "last_eod_run": datetime.now(ET).isoformat(),
+        "portfolio_source": portfolio.source,
+        "portfolio_positions": _serialize_positions(portfolio),
+        "cash": portfolio.cash,
+        "actions": _serialize_actions(actions),
+        "aggressiveness": config.aggressiveness.value,
+        "running": False,
+    })
+    logger.info("EOD scan complete: %d tickers analyzed", len(all_tickers))
+
+
+def main() -> None:
+    logger.info("Starting Portfolio Advisor")
+
+    scheduler = build_scheduler(config, run_intraday, run_eod)
+    scheduler.start()
+    logger.info(
+        "Scheduler started: %d jobs registered",
+        len(scheduler.get_jobs()),
+    )
+
+    app = create_app(config, run_eod)
+    logger.info("Web UI at http://%s:%d", config.web_host, config.web_port)
+    app.run(host=config.web_host, port=config.web_port, debug=False, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/portfolio_advisor/main.py
+++ b/portfolio_advisor/main.py
@@ -5,14 +5,16 @@ import logging
 import os
 from datetime import date, datetime
 
+import pandas as pd
 import pytz
+import yfinance as yf
 
-from .aggregator import aggregate
+from .aggregator import aggregate, audit_positions, detect_condition
 from .broker import load_portfolio
-from .config import config
+from .config import Aggressiveness, config
 from .runner import run_tickers
 from .scheduler import build_scheduler
-from .screener import screen_candidates
+from .screener import get_market_regime, screen_candidates
 from .web import create_app
 
 logging.basicConfig(
@@ -47,23 +49,35 @@ def _serialize_actions(actions) -> list:
             "score": a.score,
             "rationale": a.rationale,
             "owned": a.owned,
+            "price": a.price,
+            "affordable": a.affordable,
         }
         for a in actions
     ]
 
 
-def _serialize_positions(portfolio) -> list:
-    return [
-        {
-            "ticker": p.ticker,
-            "shares": p.shares,
-            "cost_basis": p.cost_basis,
-            "current_price": p.current_price,
-            "sector": p.sector,
-            "market_value": p.market_value,
-        }
-        for p in portfolio.positions
-    ]
+def _fetch_prices(tickers: list, portfolio) -> dict:
+    """Batch-fetch current prices. Uses owned position prices where available."""
+    price_map: dict[str, float] = {p.ticker: p.current_price for p in portfolio.positions}
+    new_tickers = [t for t in tickers if t not in price_map]
+    if not new_tickers:
+        return price_map
+    try:
+        data = yf.download(new_tickers, period="2d", auto_adjust=True, progress=False, threads=True)
+        if not data.empty:
+            close = (
+                data["Close"]
+                if isinstance(data.columns, pd.MultiIndex)
+                else data[["Close"]].rename(columns={"Close": new_tickers[0]})
+            )
+            for t in new_tickers:
+                if t in close.columns:
+                    s = close[t].dropna()
+                    if not s.empty:
+                        price_map[t] = float(s.iloc[-1])
+    except Exception as exc:
+        logger.warning("Price fetch failed: %s", exc)
+    return price_map
 
 
 def run_intraday() -> None:
@@ -77,17 +91,25 @@ def run_intraday() -> None:
         logger.info("No owned positions to check")
         return
 
+    regime = get_market_regime()
     results = run_tickers(owned_tickers, trade_date, config)
     owned_set = {p.ticker for p in portfolio.positions}
-    actions = aggregate(results, owned_set, config, trade_date)
+    price_map = _fetch_prices(owned_tickers, portfolio)
+    actions = aggregate(
+        results, owned_set, config, trade_date,
+        cash=portfolio.cash, price_map=price_map,
+    )
+    condition = detect_condition(portfolio.cash, portfolio.positions, config.cash_threshold)
 
     _patch_state({
         "last_intraday_run": datetime.now(ET).isoformat(),
         "portfolio_source": portfolio.source,
-        "portfolio_positions": _serialize_positions(portfolio),
+        "portfolio_positions": audit_positions(portfolio.positions),
         "cash": portfolio.cash,
         "actions": _serialize_actions(actions),
         "aggressiveness": config.aggressiveness.value,
+        "condition": condition,
+        "market_regime": regime,
         "running": False,
     })
     logger.info("Intraday check complete: %d positions reviewed", len(owned_tickers))
@@ -99,23 +121,46 @@ def run_eod() -> None:
     trade_date = date.today()
     portfolio = load_portfolio(config.data_dir)
 
-    candidates = screen_candidates(portfolio, config)
+    regime = get_market_regime()
+    logger.info("Market regime: %s", regime.get("regime"))
+
+    # Aggressive strategy: no new long positions when market is in a downtrend
+    # (strategy doc: Condition 1 Aggressive, Step 1 — SPY below 50-day SMA = downtrend)
+    skip_new_buys = (
+        config.aggressiveness == Aggressiveness.AGGRESSIVE
+        and regime.get("regime") in ("bear", "confirmed_bear")
+    )
+    if skip_new_buys:
+        logger.info(
+            "Aggressive mode: market regime is %s — skipping new buy candidates",
+            regime.get("regime"),
+        )
+        candidates = []
+    else:
+        candidates = screen_candidates(portfolio, config, cash=portfolio.cash)
     logger.info("%d candidates after screening", len(candidates))
 
-    # Always include owned positions so the UI has a complete picture
+    # Always include owned positions so sell signals are evaluated
     owned_set = {p.ticker for p in portfolio.positions}
     all_tickers = list(owned_set | set(candidates))
 
     results = run_tickers(all_tickers, trade_date, config)
-    actions = aggregate(results, owned_set, config, trade_date)
+    price_map = _fetch_prices(all_tickers, portfolio)
+    actions = aggregate(
+        results, owned_set, config, trade_date,
+        cash=portfolio.cash, price_map=price_map,
+    )
+    condition = detect_condition(portfolio.cash, portfolio.positions, config.cash_threshold)
 
     _patch_state({
         "last_eod_run": datetime.now(ET).isoformat(),
         "portfolio_source": portfolio.source,
-        "portfolio_positions": _serialize_positions(portfolio),
+        "portfolio_positions": audit_positions(portfolio.positions),
         "cash": portfolio.cash,
         "actions": _serialize_actions(actions),
         "aggressiveness": config.aggressiveness.value,
+        "condition": condition,
+        "market_regime": regime,
         "running": False,
     })
     logger.info("EOD scan complete: %d tickers analyzed", len(all_tickers))

--- a/portfolio_advisor/main.py
+++ b/portfolio_advisor/main.py
@@ -27,6 +27,8 @@ ET = pytz.timezone("America/New_York")
 os.makedirs(config.data_dir, exist_ok=True)
 
 
+# ── State helpers ────────────────────────────────────────────────────────────
+
 def _patch_state(patch: dict) -> None:
     state: dict = {}
     if os.path.exists(config.state_file):
@@ -39,6 +41,13 @@ def _patch_state(patch: dict) -> None:
     with open(config.state_file, "w", encoding="utf-8") as fh:
         json.dump(state, fh, indent=2, default=str)
 
+
+def _set_stage(stage: str, progress: int, detail: str = "") -> None:
+    """Patch just the progress fields — cheap, called frequently during runs."""
+    _patch_state({"stage": stage, "progress": progress, "stage_detail": detail})
+
+
+# ── Serializers ──────────────────────────────────────────────────────────────
 
 def _serialize_actions(actions) -> list:
     return [
@@ -80,19 +89,33 @@ def _fetch_prices(tickers: list, portfolio) -> dict:
     return price_map
 
 
+# ── Run functions ────────────────────────────────────────────────────────────
+
 def run_intraday() -> None:
     """Check owned positions for sell signals (runs 4x per trading day)."""
     logger.info("--- Intraday check ---")
+    _set_stage("Loading portfolio", 2)
+
     trade_date = date.today()
     portfolio = load_portfolio(config.data_dir)
     owned_tickers = [p.ticker for p in portfolio.positions]
 
     if not owned_tickers:
         logger.info("No owned positions to check")
+        _patch_state({"running": False, "stage": "No positions to check", "progress": 100, "stage_detail": ""})
         return
 
+    _set_stage("Checking market regime", 8)
     regime = get_market_regime()
-    results = run_tickers(owned_tickers, trade_date, config)
+
+    _set_stage("Running analysis", 15, f"0/{len(owned_tickers)} positions")
+
+    def _analysis_progress(fraction, detail):
+        _set_stage("Running analysis", int(15 + fraction * 75), detail)
+
+    results = run_tickers(owned_tickers, trade_date, config, on_progress=_analysis_progress)
+
+    _set_stage("Aggregating results", 92)
     owned_set = {p.ticker for p in portfolio.positions}
     price_map = _fetch_prices(owned_tickers, portfolio)
     actions = aggregate(
@@ -111,6 +134,9 @@ def run_intraday() -> None:
         "condition": condition,
         "market_regime": regime,
         "running": False,
+        "stage": "Complete",
+        "progress": 100,
+        "stage_detail": f"{len(owned_tickers)} positions reviewed",
     })
     logger.info("Intraday check complete: %d positions reviewed", len(owned_tickers))
 
@@ -118,33 +144,52 @@ def run_intraday() -> None:
 def run_eod() -> None:
     """Screen NASDAQ candidates and run full analysis (EOD + Monday pre-market)."""
     logger.info("--- EOD/pre-market scan ---")
+    _set_stage("Loading portfolio", 2)
+
     trade_date = date.today()
     portfolio = load_portfolio(config.data_dir)
 
+    _set_stage("Checking market regime", 5)
     regime = get_market_regime()
     logger.info("Market regime: %s", regime.get("regime"))
 
     # Aggressive strategy: no new long positions when market is in a downtrend
-    # (strategy doc: Condition 1 Aggressive, Step 1 — SPY below 50-day SMA = downtrend)
     skip_new_buys = (
         config.aggressiveness == Aggressiveness.AGGRESSIVE
         and regime.get("regime") in ("bear", "confirmed_bear")
     )
+
     if skip_new_buys:
         logger.info(
             "Aggressive mode: market regime is %s — skipping new buy candidates",
             regime.get("regime"),
         )
         candidates = []
+        _set_stage("Screening skipped", 50, f"Regime: {regime.get('regime')} — no new longs")
     else:
-        candidates = screen_candidates(portfolio, config, cash=portfolio.cash)
+        _set_stage("Screening NASDAQ candidates", 10, "Fetching ticker list…")
+
+        def _screen_progress(fraction, detail):
+            _set_stage("Screening NASDAQ candidates", int(10 + fraction * 40), detail)
+
+        candidates = screen_candidates(
+            portfolio, config, cash=portfolio.cash, on_progress=_screen_progress,
+        )
+
     logger.info("%d candidates after screening", len(candidates))
 
     # Always include owned positions so sell signals are evaluated
     owned_set = {p.ticker for p in portfolio.positions}
     all_tickers = list(owned_set | set(candidates))
 
-    results = run_tickers(all_tickers, trade_date, config)
+    _set_stage("Running analysis", 52, f"0/{len(all_tickers)} tickers")
+
+    def _analysis_progress(fraction, detail):
+        _set_stage("Running analysis", int(52 + fraction * 43), detail)
+
+    results = run_tickers(all_tickers, trade_date, config, on_progress=_analysis_progress)
+
+    _set_stage("Aggregating results", 97)
     price_map = _fetch_prices(all_tickers, portfolio)
     actions = aggregate(
         results, owned_set, config, trade_date,
@@ -162,9 +207,14 @@ def run_eod() -> None:
         "condition": condition,
         "market_regime": regime,
         "running": False,
+        "stage": "Complete",
+        "progress": 100,
+        "stage_detail": f"{len(all_tickers)} tickers analyzed",
     })
     logger.info("EOD scan complete: %d tickers analyzed", len(all_tickers))
 
+
+# ── Entry point ──────────────────────────────────────────────────────────────
 
 def main() -> None:
     logger.info("Starting Portfolio Advisor")

--- a/portfolio_advisor/runner.py
+++ b/portfolio_advisor/runner.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import List, Tuple
+
+from .config import Config
+
+logger = logging.getLogger(__name__)
+
+# Validate at import time so a broken TradingAgents upgrade fails loudly at
+# startup rather than silently during a scheduled run.
+try:
+    from tradingagents.graph.trading_graph import TradingAgentsGraph
+    from tradingagents.default_config import DEFAULT_CONFIG
+    _IMPORT_OK = True
+except Exception as exc:
+    logger.error("TradingAgents import failed — check installation: %s", exc)
+    _IMPORT_OK = False
+
+
+def _build_ta_config(cfg: Config) -> dict:
+    ta_cfg = DEFAULT_CONFIG.copy()
+    ta_cfg.update({
+        "llm_provider": cfg.llm_provider,
+        "deep_think_llm": cfg.deep_think_llm,
+        "quick_think_llm": cfg.quick_think_llm,
+        "max_debate_rounds": cfg.max_debate_rounds,
+        "max_risk_discuss_rounds": cfg.max_risk_discuss_rounds,
+        "results_dir": cfg.results_dir,
+        "data_cache_dir": cfg.data_cache_dir,
+    })
+    return ta_cfg
+
+
+def run_tickers(
+    tickers: List[str],
+    trade_date: date,
+    cfg: Config,
+) -> List[Tuple[str, dict, str]]:
+    """Run TradingAgents on each ticker.
+
+    Returns a list of (ticker, final_state, signal) tuples.
+    Tickers that fail are logged and skipped.
+    """
+    if not _IMPORT_OK:
+        raise RuntimeError(
+            "TradingAgents is not importable. Run compat_test.py to diagnose."
+        )
+
+    ta_cfg = _build_ta_config(cfg)
+    graph = TradingAgentsGraph(
+        selected_analysts=["market", "social", "news", "fundamentals"],
+        debug=False,
+        config=ta_cfg,
+    )
+
+    date_str = trade_date.strftime("%Y-%m-%d")
+    results: List[Tuple[str, dict, str]] = []
+
+    for ticker in tickers:
+        try:
+            final_state, signal = graph.propagate(ticker, date_str)
+            results.append((ticker, final_state, signal))
+            logger.info("%s → %s", ticker, signal)
+        except Exception as exc:
+            logger.error("TradingAgents failed for %s: %s", ticker, exc)
+
+    return results

--- a/portfolio_advisor/runner.py
+++ b/portfolio_advisor/runner.py
@@ -37,11 +37,15 @@ def run_tickers(
     tickers: List[str],
     trade_date: date,
     cfg: Config,
+    on_progress=None,
 ) -> List[Tuple[str, dict, str]]:
     """Run TradingAgents on each ticker.
 
     Returns a list of (ticker, final_state, signal) tuples.
     Tickers that fail are logged and skipped.
+
+    on_progress(fraction: float, detail: str) is called before each ticker
+    with fraction in [0, 1) and a human-readable detail string.
     """
     if not _IMPORT_OK:
         raise RuntimeError(
@@ -57,8 +61,11 @@ def run_tickers(
 
     date_str = trade_date.strftime("%Y-%m-%d")
     results: List[Tuple[str, dict, str]] = []
+    total = len(tickers)
 
-    for ticker in tickers:
+    for idx, ticker in enumerate(tickers):
+        if on_progress and total:
+            on_progress(idx / total, f"{ticker} ({idx + 1}/{total})")
         try:
             final_state, signal = graph.propagate(ticker, date_str)
             results.append((ticker, final_state, signal))

--- a/portfolio_advisor/scheduler.py
+++ b/portfolio_advisor/scheduler.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Callable
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from .config import Config
+
+logger = logging.getLogger(__name__)
+ET = pytz.timezone("America/New_York")
+
+
+def _is_trading_day(dt: datetime) -> bool:
+    try:
+        import pandas_market_calendars as mcal
+        nyse = mcal.get_calendar("NYSE")
+        schedule = nyse.schedule(
+            start_date=dt.strftime("%Y-%m-%d"),
+            end_date=dt.strftime("%Y-%m-%d"),
+        )
+        return not schedule.empty
+    except Exception:
+        return dt.weekday() < 5
+
+
+def _is_first_trading_day_of_week(dt: datetime) -> bool:
+    """True when dt is a trading day and no earlier day in its ISO week is also a trading day."""
+    if not _is_trading_day(dt):
+        return False
+    for offset in range(1, dt.weekday() + 1):
+        if _is_trading_day(dt - timedelta(days=offset)):
+            return False
+    return True
+
+
+def build_scheduler(
+    cfg: Config,
+    run_intraday_fn: Callable,
+    run_eod_fn: Callable,
+) -> BackgroundScheduler:
+    scheduler = BackgroundScheduler(timezone=ET)
+
+    def _guarded_intraday() -> None:
+        if _is_trading_day(datetime.now(ET)):
+            run_intraday_fn()
+
+    def _guarded_eod() -> None:
+        if _is_trading_day(datetime.now(ET)):
+            run_eod_fn()
+
+    def _guarded_premarket() -> None:
+        if _is_first_trading_day_of_week(datetime.now(ET)):
+            run_eod_fn()
+
+    for time_str in cfg.intraday_check_times:
+        hour, minute = time_str.split(":")
+        scheduler.add_job(
+            _guarded_intraday,
+            CronTrigger(
+                day_of_week="mon-fri",
+                hour=int(hour),
+                minute=int(minute),
+                timezone=ET,
+            ),
+            id=f"intraday_{time_str.replace(':', '')}",
+            max_instances=1,
+            coalesce=True,
+        )
+
+    eod_hour, eod_minute = cfg.eod_scan_time.split(":")
+    scheduler.add_job(
+        _guarded_eod,
+        CronTrigger(
+            day_of_week="mon-fri",
+            hour=int(eod_hour),
+            minute=int(eod_minute),
+            timezone=ET,
+        ),
+        id="eod_scan",
+        max_instances=1,
+        coalesce=True,
+    )
+
+    pm_hour, pm_minute = cfg.premarket_scan_time.split(":")
+    scheduler.add_job(
+        _guarded_premarket,
+        CronTrigger(
+            day_of_week="mon-fri",
+            hour=int(pm_hour),
+            minute=int(pm_minute),
+            timezone=ET,
+        ),
+        id="premarket_scan",
+        max_instances=1,
+        coalesce=True,
+    )
+
+    return scheduler

--- a/portfolio_advisor/screener.py
+++ b/portfolio_advisor/screener.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import io
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List
+
+import pandas as pd
+import requests
+import yfinance as yf
+
+from .broker import Portfolio
+from .config import Aggressiveness, Config
+
+logger = logging.getLogger(__name__)
+
+NASDAQ_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
+
+
+def fetch_nasdaq_tickers() -> List[str]:
+    resp = requests.get(NASDAQ_LISTED_URL, timeout=30)
+    resp.raise_for_status()
+    df = pd.read_csv(io.StringIO(resp.text), sep="|")
+    # Drop the trailing file-creation-timestamp row and non-standard symbols
+    df = df[df["Symbol"].str.match(r"^[A-Z]{1,5}$", na=False)]
+    df = df[df["Test Issue"] == "N"]
+    df = df[df["ETF"] == "N"]
+    df = df[df["Financial Status"] == "N"]
+    return df["Symbol"].tolist()
+
+
+def screen_candidates(portfolio: Portfolio, cfg: Config) -> List[str]:
+    owned = {p.ticker for p in portfolio.positions}
+    owned_sectors = {p.sector for p in portfolio.positions if p.sector != "Unknown"}
+    prices = [p.current_price for p in portfolio.positions]
+
+    if not prices:
+        logger.warning("Portfolio has no positions; skipping screener")
+        return []
+
+    price_min = min(prices) * (1 - cfg.price_range_pct)
+    price_max = max(prices) * (1 + cfg.price_range_pct)
+
+    logger.info("Fetching NASDAQ ticker list")
+    all_tickers = [t for t in fetch_nasdaq_tickers() if t not in owned]
+    logger.info("%d NASDAQ tickers after removing owned", len(all_tickers))
+
+    passed: List[dict] = []
+    batch_size = 200
+    period = f"{cfg.momentum_days + 25}d"
+
+    for i in range(0, len(all_tickers), batch_size):
+        batch = all_tickers[i : i + batch_size]
+        try:
+            data = yf.download(
+                batch,
+                period=period,
+                auto_adjust=True,
+                progress=False,
+                threads=True,
+            )
+            if data.empty:
+                continue
+
+            # yfinance returns multi-level columns for multiple tickers
+            if isinstance(data.columns, pd.MultiIndex):
+                close = data["Close"]
+                volume = data["Volume"]
+            else:
+                close = data[["Close"]].rename(columns={"Close": batch[0]})
+                volume = data[["Volume"]].rename(columns={"Volume": batch[0]})
+
+            for ticker in batch:
+                if ticker not in close.columns:
+                    continue
+                price_series = close[ticker].dropna()
+                vol_series = volume[ticker].dropna()
+                if len(price_series) < cfg.momentum_days + 2:
+                    continue
+
+                current = float(price_series.iloc[-1])
+                avg_vol = float(vol_series.tail(20).mean())
+                momentum = float(
+                    price_series.iloc[-1] - price_series.iloc[-(cfg.momentum_days + 1)]
+                )
+
+                if not (price_min <= current <= price_max):
+                    continue
+                if avg_vol < cfg.min_avg_volume:
+                    continue
+                if momentum <= 0:
+                    continue
+
+                passed.append({"ticker": ticker, "momentum": momentum, "price": current})
+
+        except Exception as exc:
+            logger.warning("Batch %d–%d failed: %s", i, i + batch_size, exc)
+
+    logger.info("%d tickers passed price/volume/momentum filter", len(passed))
+
+    if cfg.aggressiveness == Aggressiveness.CONSERVATIVE and owned_sectors:
+        passed = _filter_by_sector(passed, owned_sectors)
+        logger.info("%d tickers after sector filter", len(passed))
+
+    passed.sort(key=lambda x: x["momentum"], reverse=True)
+    return [item["ticker"] for item in passed[: cfg.max_candidates]]
+
+
+def _filter_by_sector(candidates: List[dict], owned_sectors: set) -> List[dict]:
+    ticker_sector: dict[str, str] = {}
+
+    def _fetch(ticker: str) -> tuple[str, str]:
+        try:
+            return ticker, yf.Ticker(ticker).info.get("sector", "Unknown")
+        except Exception:
+            return ticker, "Unknown"
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        for ticker, sector in pool.map(_fetch, [c["ticker"] for c in candidates]):
+            ticker_sector[ticker] = sector
+
+    return [c for c in candidates if ticker_sector.get(c["ticker"], "Unknown") in owned_sectors]

--- a/portfolio_advisor/screener.py
+++ b/portfolio_advisor/screener.py
@@ -103,7 +103,12 @@ def fetch_nasdaq_tickers() -> List[str]:
     return df["Symbol"].tolist()
 
 
-def screen_candidates(portfolio: Portfolio, cfg: Config, cash: float = 0.0) -> List[str]:
+def screen_candidates(
+    portfolio: Portfolio,
+    cfg: Config,
+    cash: float = 0.0,
+    on_progress=None,
+) -> List[str]:
     owned = {p.ticker for p in portfolio.positions}
     prices = [p.current_price for p in portfolio.positions]
 
@@ -129,9 +134,13 @@ def screen_candidates(portfolio: Portfolio, cfg: Config, cash: float = 0.0) -> L
 
     passed: List[dict] = []
     batch_size = 200
+    total_batches = max(1, (len(all_tickers) + batch_size - 1) // batch_size)
 
     for i in range(0, len(all_tickers), batch_size):
         batch = all_tickers[i : i + batch_size]
+        batch_num = i // batch_size + 1
+        if on_progress:
+            on_progress(batch_num / total_batches, f"Batch {batch_num}/{total_batches}")
         try:
             data = yf.download(
                 batch,

--- a/portfolio_advisor/screener.py
+++ b/portfolio_advisor/screener.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from typing import List
 
 import pandas as pd
@@ -16,12 +16,86 @@ logger = logging.getLogger(__name__)
 
 NASDAQ_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
 
+# Conservative Condition 1 (no existing positions): restrict to defensive sectors
+# per strategy doc: utilities, consumer staples, healthcare, REITs
+CONSERVATIVE_SECTORS = {"Utilities", "Consumer Defensive", "Healthcare", "Real Estate"}
+
+
+def get_market_regime() -> dict:
+    """Fetch S&P 500 and return current market regime.
+
+    Regimes per strategy doc Universal Risk Management table:
+        bull           — above both 50-day and 200-day SMA
+        corrective     — above 200-day, below 50-day
+        bear           — below 200-day SMA
+        confirmed_bear — below 200-day AND death cross (50-day < 200-day)
+        unknown        — insufficient data
+    """
+    try:
+        spy = yf.download("SPY", period="1y", auto_adjust=True, progress=False, threads=False)
+        if spy.empty or len(spy) < 50:
+            return {"regime": "unknown"}
+
+        close = spy["Close"].squeeze()
+        current = float(close.iloc[-1])
+        sma50 = float(close.rolling(50).mean().iloc[-1])
+        sma200 = float(close.rolling(200).mean().iloc[-1]) if len(close) >= 200 else None
+
+        above_sma50 = current > sma50
+        above_sma200 = sma200 is not None and current > sma200
+        death_cross = sma200 is not None and sma50 < sma200
+
+        if above_sma50 and above_sma200:
+            regime = "bull"
+        elif above_sma200 and not above_sma50:
+            regime = "corrective"
+        elif sma200 is not None and not above_sma200:
+            regime = "confirmed_bear" if death_cross else "bear"
+        else:
+            regime = "unknown"
+
+        return {
+            "regime": regime,
+            "spy_price": round(current, 2),
+            "sma50": round(sma50, 2),
+            "sma200": round(sma200, 2) if sma200 is not None else None,
+            "above_sma50": above_sma50,
+            "above_sma200": above_sma200,
+            "death_cross": death_cross,
+        }
+    except Exception as exc:
+        logger.warning("Market regime check failed: %s", exc)
+        return {"regime": "unknown"}
+
+
+def _rsi(series: pd.Series, period: int = 14) -> float:
+    """Compute RSI using exponential smoothing."""
+    if len(series) < period + 1:
+        return float("nan")
+    delta = series.diff().dropna()
+    gain = delta.clip(lower=0).ewm(com=period - 1, min_periods=period).mean()
+    loss = (-delta).clip(lower=0).ewm(com=period - 1, min_periods=period).mean()
+    rs = gain / loss.replace(0, float("nan"))
+    return float((100 - 100 / (1 + rs)).iloc[-1])
+
+
+def _macd_ok(series: pd.Series) -> bool:
+    """True if MACD line > signal line AND both > 0 (strategy doc: Condition 1 Aggressive, Step 2)."""
+    if len(series) < 35:
+        return False
+    ema12 = series.ewm(span=12, adjust=False).mean()
+    ema26 = series.ewm(span=26, adjust=False).mean()
+    macd_line = ema12 - ema26
+    signal_line = macd_line.ewm(span=9, adjust=False).mean()
+    m = float(macd_line.iloc[-1])
+    s = float(signal_line.iloc[-1])
+    return m > s and m > 0 and s > 0
+
 
 def fetch_nasdaq_tickers() -> List[str]:
     resp = requests.get(NASDAQ_LISTED_URL, timeout=30)
     resp.raise_for_status()
     df = pd.read_csv(io.StringIO(resp.text), sep="|")
-    # Drop the trailing file-creation-timestamp row and non-standard symbols
     df = df[df["Symbol"].str.match(r"^[A-Z]{1,5}$", na=False)]
     df = df[df["Test Issue"] == "N"]
     df = df[df["ETF"] == "N"]
@@ -29,25 +103,32 @@ def fetch_nasdaq_tickers() -> List[str]:
     return df["Symbol"].tolist()
 
 
-def screen_candidates(portfolio: Portfolio, cfg: Config) -> List[str]:
+def screen_candidates(portfolio: Portfolio, cfg: Config, cash: float = 0.0) -> List[str]:
     owned = {p.ticker for p in portfolio.positions}
-    owned_sectors = {p.sector for p in portfolio.positions if p.sector != "Unknown"}
     prices = [p.current_price for p in portfolio.positions]
 
-    if not prices:
-        logger.warning("Portfolio has no positions; skipping screener")
+    # Build price bounds — use owned positions if available, else fall back to cash
+    if prices:
+        price_min = min(prices) * (1 - cfg.price_range_pct)
+        price_max = max(prices) * (1 + cfg.price_range_pct)
+    elif cash >= cfg.cash_threshold:
+        # Condition 1 (cash, no positions): any stock affordable with available cash
+        price_min = 1.0
+        price_max = cash
+    else:
+        logger.info("No positions and no meaningful cash — skipping screener")
         return []
-
-    price_min = min(prices) * (1 - cfg.price_range_pct)
-    price_max = max(prices) * (1 + cfg.price_range_pct)
 
     logger.info("Fetching NASDAQ ticker list")
     all_tickers = [t for t in fetch_nasdaq_tickers() if t not in owned]
     logger.info("%d NASDAQ tickers after removing owned", len(all_tickers))
 
+    # Aggressive mode needs more history for RSI(14) and MACD(12,26,9)
+    lookback = 70 if cfg.aggressiveness == Aggressiveness.AGGRESSIVE else cfg.momentum_days + 25
+    period = f"{lookback}d"
+
     passed: List[dict] = []
     batch_size = 200
-    period = f"{cfg.momentum_days + 25}d"
 
     for i in range(0, len(all_tickers), batch_size):
         batch = all_tickers[i : i + batch_size]
@@ -62,7 +143,6 @@ def screen_candidates(portfolio: Portfolio, cfg: Config) -> List[str]:
             if data.empty:
                 continue
 
-            # yfinance returns multi-level columns for multiple tickers
             if isinstance(data.columns, pd.MultiIndex):
                 close = data["Close"]
                 volume = data["Volume"]
@@ -73,17 +153,17 @@ def screen_candidates(portfolio: Portfolio, cfg: Config) -> List[str]:
             for ticker in batch:
                 if ticker not in close.columns:
                     continue
-                price_series = close[ticker].dropna()
-                vol_series = volume[ticker].dropna()
-                if len(price_series) < cfg.momentum_days + 2:
+                ps = close[ticker].dropna()
+                vs = volume[ticker].dropna()
+                if len(ps) < cfg.momentum_days + 2:
                     continue
 
-                current = float(price_series.iloc[-1])
-                avg_vol = float(vol_series.tail(20).mean())
-                momentum = float(
-                    price_series.iloc[-1] - price_series.iloc[-(cfg.momentum_days + 1)]
-                )
+                current = float(ps.iloc[-1])
+                avg_vol = float(vs.tail(20).mean())
+                recent_vol = float(vs.iloc[-1])
+                momentum = float(ps.iloc[-1] - ps.iloc[-(cfg.momentum_days + 1)])
 
+                # Universal base filters
                 if not (price_min <= current <= price_max):
                     continue
                 if avg_vol < cfg.min_avg_volume:
@@ -91,32 +171,79 @@ def screen_candidates(portfolio: Portfolio, cfg: Config) -> List[str]:
                 if momentum <= 0:
                     continue
 
+                # Aggressive technical filters (strategy doc: Condition 1 Aggressive, Step 2)
+                if cfg.aggressiveness == Aggressiveness.AGGRESSIVE:
+                    # Volume confirmation: breakout day >= 150% of 20-day average
+                    if recent_vol < avg_vol * 1.5:
+                        continue
+                    # RSI between 55 and 75 (trending bullish, not yet overbought)
+                    rsi_val = _rsi(ps)
+                    if not (cfg.min_rsi <= rsi_val <= cfg.max_rsi):
+                        continue
+                    # MACD: line above signal line, both above zero
+                    if not _macd_ok(ps):
+                        continue
+
                 passed.append({"ticker": ticker, "momentum": momentum, "price": current})
 
         except Exception as exc:
             logger.warning("Batch %d–%d failed: %s", i, i + batch_size, exc)
 
-    logger.info("%d tickers passed price/volume/momentum filter", len(passed))
+    logger.info("%d tickers passed base filter", len(passed))
 
-    if cfg.aggressiveness == Aggressiveness.CONSERVATIVE and owned_sectors:
-        passed = _filter_by_sector(passed, owned_sectors)
-        logger.info("%d tickers after sector filter", len(passed))
+    # Sector filters
+    if cfg.aggressiveness == Aggressiveness.CONSERVATIVE:
+        if prices:
+            # Condition 2 conservative: match sectors already held in portfolio
+            owned_sectors = {
+                p.sector for p in portfolio.positions
+                if p.sector not in ("Unknown", None, "")
+            }
+            if owned_sectors:
+                passed = _filter_by_sector(passed, owned_sectors)
+                logger.info("%d after owned-sector filter", len(passed))
+        else:
+            # Condition 1 conservative: defensive sectors only
+            passed = _filter_by_sector(passed, CONSERVATIVE_SECTORS)
+            logger.info("%d after conservative-sector filter", len(passed))
+
+    # Aggressive: minimum market cap $2B (strategy doc: Condition 1 Aggressive, Step 2, criterion 5)
+    if cfg.aggressiveness == Aggressiveness.AGGRESSIVE and cfg.min_market_cap_b > 0:
+        passed = _filter_by_market_cap(passed, cfg.min_market_cap_b)
+        logger.info("%d after market cap filter", len(passed))
 
     passed.sort(key=lambda x: x["momentum"], reverse=True)
     return [item["ticker"] for item in passed[: cfg.max_candidates]]
 
 
-def _filter_by_sector(candidates: List[dict], owned_sectors: set) -> List[dict]:
-    ticker_sector: dict[str, str] = {}
-
+def _filter_by_sector(candidates: List[dict], target_sectors: set) -> List[dict]:
     def _fetch(ticker: str) -> tuple[str, str]:
         try:
             return ticker, yf.Ticker(ticker).info.get("sector", "Unknown")
         except Exception:
             return ticker, "Unknown"
 
+    ticker_sector: dict[str, str] = {}
     with ThreadPoolExecutor(max_workers=10) as pool:
         for ticker, sector in pool.map(_fetch, [c["ticker"] for c in candidates]):
             ticker_sector[ticker] = sector
 
-    return [c for c in candidates if ticker_sector.get(c["ticker"], "Unknown") in owned_sectors]
+    return [c for c in candidates if ticker_sector.get(c["ticker"]) in target_sectors]
+
+
+def _filter_by_market_cap(candidates: List[dict], min_cap_b: float) -> List[dict]:
+    min_cap = min_cap_b * 1_000_000_000
+
+    def _fetch(ticker: str) -> tuple[str, float]:
+        try:
+            cap = yf.Ticker(ticker).fast_info.market_cap or 0
+            return ticker, float(cap)
+        except Exception:
+            return ticker, 0.0
+
+    ticker_cap: dict[str, float] = {}
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        for ticker, cap in pool.map(_fetch, [c["ticker"] for c in candidates]):
+            ticker_cap[ticker] = cap
+
+    return [c for c in candidates if ticker_cap.get(c["ticker"], 0) >= min_cap]

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -5,197 +5,518 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio Advisor</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <style>
-    body { background: #0f1117; color: #e0e0e0; }
-    .card { background: #1a1d27; border: 1px solid #2a2d3a; }
-    .card-header { background: #1f2235; border-bottom: 1px solid #2a2d3a; font-weight: 600; }
-    .table { color: #e0e0e0; }
-    .table th { color: #8b95a1; font-size: .8rem; text-transform: uppercase; border-color: #2a2d3a; }
-    .table td { border-color: #2a2d3a; vertical-align: middle; }
-    .source-live { color: #4ade80; }
-    .source-fallback { color: #facc15; }
-    .source-unknown  { color: #9ca3af; }
-    .unaffordable { opacity: 0.5; }
-    .rationale { font-size: .8rem; color: #6b7280; max-width: 420px; }
-    #spinner { display: none; }
-    #portfolio-form { display: none; }
-    pre { color: #a5b4fc; background: #0f1117; padding: 1rem; border-radius: .375rem; font-size: .8rem; }
+    :root {
+      --bg:        #0d1117;
+      --surface:   #161b22;
+      --surface2:  #1c2128;
+      --border:    #30363d;
+      --text:      #e6edf3;
+      --muted:     #8b949e;
+      --green:     #3fb950;
+      --green-bg:  #0a2818;
+      --green-dim: rgba(63,185,80,.08);
+      --red:       #f85149;
+      --red-bg:    #2d1117;
+      --red-dim:   rgba(248,81,73,.08);
+      --yellow:    #d29922;
+      --blue:      #58a6ff;
+      --orange:    #fb8f44;
+      --purple:    #bc8cff;
+    }
 
-    /* Regime colors */
-    .regime-bull          { color: #4ade80; }
-    .regime-corrective    { color: #facc15; }
-    .regime-bear          { color: #fb923c; }
-    .regime-confirmed_bear{ color: #f87171; }
-    .regime-unknown       { color: #9ca3af; }
+    * { box-sizing: border-box; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      font-size: .9rem;
+      min-height: 100vh;
+    }
 
-    /* Condition badge */
-    .condition-1 { background: #14532d; color: #86efac; }
-    .condition-2 { background: #1e3a5f; color: #93c5fd; }
-    .condition-3 { background: #3f3f46; color: #a1a1aa; }
-    .condition-4 { background: #422006; color: #fdba74; }
+    /* ── Layout ── */
+    .app-wrapper { max-width: 1400px; margin: 0 auto; padding: 1.5rem 1.25rem; }
+
+    /* ── Header ── */
+    .app-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .app-title { font-size: 1.2rem; font-weight: 700; color: var(--text); margin: 0; }
+    .app-subtitle { font-size: .75rem; color: var(--muted); margin: 0; }
+    .header-controls { display: flex; gap: .5rem; align-items: center; }
+
+    /* ── Mode toggle ── */
+    .mode-toggle {
+      display: flex;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .mode-btn {
+      padding: .3rem .85rem;
+      font-size: .8rem;
+      font-weight: 500;
+      border: none;
+      background: transparent;
+      color: var(--muted);
+      cursor: pointer;
+      transition: all .15s;
+      white-space: nowrap;
+    }
+    .mode-btn.active-conservative {
+      background: var(--surface2);
+      color: var(--blue);
+    }
+    .mode-btn.active-aggressive {
+      background: var(--surface2);
+      color: var(--orange);
+    }
+    .mode-btn:hover:not(.active-conservative):not(.active-aggressive) {
+      color: var(--text);
+      background: rgba(255,255,255,.04);
+    }
+
+    /* ── Run button ── */
+    .run-btn {
+      display: flex;
+      align-items: center;
+      gap: .35rem;
+      padding: .35rem .9rem;
+      font-size: .8rem;
+      font-weight: 500;
+      background: var(--blue);
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background .15s;
+    }
+    .run-btn:hover:not(:disabled) { background: #79b8ff; }
+    .run-btn:disabled { opacity: .55; cursor: not-allowed; }
+
+    /* ── Status strip ── */
+    .status-strip {
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: .75rem;
+      margin-bottom: 1.5rem;
+    }
+    @media (max-width: 1100px) { .status-strip { grid-template-columns: repeat(3, 1fr); } }
+    @media (max-width: 640px)  { .status-strip { grid-template-columns: repeat(2, 1fr); } }
+
+    .stat-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: .75rem 1rem;
+      position: relative;
+      overflow: hidden;
+    }
+    .stat-card::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 2px;
+      background: var(--accent-color, var(--border));
+    }
+    .stat-label {
+      font-size: .7rem;
+      font-weight: 600;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: .3rem;
+      display: flex;
+      align-items: center;
+      gap: .3rem;
+    }
+    .stat-value { font-size: 1.05rem; font-weight: 700; color: var(--text); line-height: 1.2; }
+    .stat-sub   { font-size: .7rem; color: var(--muted); margin-top: .15rem; }
+
+    /* ── Content grid ── */
+    .content-grid {
+      display: grid;
+      grid-template-columns: 1fr 320px;
+      gap: 1rem;
+    }
+    @media (max-width: 900px) { .content-grid { grid-template-columns: 1fr; } }
+
+    /* ── Panels ── */
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      margin-bottom: 1rem;
+    }
+    .panel:last-child { margin-bottom: 0; }
+    .panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: .65rem 1rem;
+      background: var(--surface2);
+      border-bottom: 1px solid var(--border);
+      font-size: .8rem;
+      font-weight: 600;
+    }
+    .panel-header .panel-title {
+      display: flex;
+      align-items: center;
+      gap: .4rem;
+    }
+    .panel-count {
+      font-size: .7rem;
+      font-weight: 500;
+      padding: .1rem .45rem;
+      border-radius: 20px;
+      background: var(--surface);
+      color: var(--muted);
+      border: 1px solid var(--border);
+    }
+
+    /* ── Tables ── */
+    .data-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .data-table th {
+      font-size: .68rem;
+      font-weight: 600;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      color: var(--muted);
+      padding: .5rem 1rem;
+      border-bottom: 1px solid var(--border);
+      background: transparent;
+      white-space: nowrap;
+    }
+    .data-table td {
+      padding: .55rem 1rem;
+      border-bottom: 1px solid rgba(48,54,61,.5);
+      vertical-align: middle;
+    }
+    .data-table tbody tr:last-child td { border-bottom: none; }
+    .data-table tbody tr:hover td { background: rgba(255,255,255,.03); }
+
+    /* Action row accents */
+    .row-sell td:first-child { border-left: 3px solid var(--red); }
+    .row-buy  td:first-child { border-left: 3px solid var(--green); }
+    .row-hold td:first-child { border-left: 3px solid var(--border); }
+
+    .row-sell { background: var(--red-dim); }
+    .row-buy  { background: var(--green-dim); }
+
+    /* ── Badges ── */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: .2rem;
+      font-size: .68rem;
+      font-weight: 600;
+      padding: .18rem .45rem;
+      border-radius: 4px;
+      white-space: nowrap;
+    }
+    .badge-buy        { background: rgba(63,185,80,.15);  color: var(--green); border: 1px solid rgba(63,185,80,.3); }
+    .badge-overweight { background: rgba(63,185,80,.1);   color: #a0d7a6;      border: 1px solid rgba(63,185,80,.2); }
+    .badge-sell       { background: rgba(248,81,73,.15);  color: var(--red);   border: 1px solid rgba(248,81,73,.3); }
+    .badge-underweight{ background: rgba(248,81,73,.1);   color: #f4a09a;      border: 1px solid rgba(248,81,73,.2); }
+    .badge-hold       { background: rgba(139,148,158,.1); color: var(--muted); border: 1px solid rgba(139,148,158,.2); }
+    .badge-owned      { background: rgba(88,166,255,.1);  color: var(--blue);  border: 1px solid rgba(88,166,255,.2); }
+    .badge-new        { background: transparent;           color: var(--muted); border: 1px solid var(--border); }
+    .badge-warn       { background: rgba(210,153,34,.15); color: var(--yellow);border: 1px solid rgba(210,153,34,.3); }
+    .badge-dim        { background: var(--surface2);      color: var(--muted); border: 1px solid var(--border); font-style: italic; }
+    .badge-flag-conc  { background: rgba(210,153,34,.12); color: var(--yellow);border: 1px solid rgba(210,153,34,.25); }
+    .badge-flag-down  { background: rgba(248,81,73,.12);  color: #f4a09a;      border: 1px solid rgba(248,81,73,.25); }
+    .badge-flag-sec   { background: rgba(188,140,255,.1); color: var(--purple);border: 1px solid rgba(188,140,255,.25); }
+
+    /* ── Ticker + price ── */
+    .ticker { font-weight: 700; font-size: .9rem; letter-spacing: .02em; }
+    .price-cell { font-variant-numeric: tabular-nums; font-size: .85rem; color: var(--text); }
+    .rationale-cell { font-size: .75rem; color: var(--muted); max-width: 380px; }
+
+    /* ── PnL ── */
+    .pnl-pos { color: var(--green); }
+    .pnl-neg { color: var(--red); }
+    .pnl-sub { font-size: .72rem; opacity: .8; }
+
+    /* ── Unaffordable ── */
+    .row-unaffordable { opacity: .45; }
+
+    /* ── Empty state ── */
+    .empty-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1rem;
+      color: var(--muted);
+      font-size: .8rem;
+      gap: .4rem;
+    }
+    .empty-state i { font-size: 1.4rem; opacity: .4; }
+
+    /* ── Source indicator ── */
+    .src-live     { color: var(--green); }
+    .src-fallback { color: var(--yellow); }
+    .src-unknown  { color: var(--muted); }
+
+    /* ── Regime colors ── */
+    .regime-bull          { color: var(--green); }
+    .regime-corrective    { color: var(--yellow); }
+    .regime-bear          { color: var(--orange); }
+    .regime-confirmed_bear{ color: var(--red); }
+    .regime-unknown       { color: var(--muted); }
+
+    /* Accent colors per stat card */
+    .accent-cash    { --accent-color: var(--blue); }
+    .accent-source  { --accent-color: var(--purple); }
+    .accent-cond    { --accent-color: var(--muted); }
+    .accent-regime  { --accent-color: var(--muted); } /* overridden by JS */
+    .accent-intra   { --accent-color: #3dc9b0; }
+    .accent-eod     { --accent-color: #3dc9b0; }
+
+    /* ── Condition badge ── */
+    .cond-1 { color: var(--green); }
+    .cond-2 { color: var(--blue); }
+    .cond-3 { color: var(--muted); }
+    .cond-4 { color: var(--orange); }
+
+    /* ── Spinner ── */
+    .spin {
+      display: none;
+      width: .75rem;
+      height: .75rem;
+      border: 2px solid rgba(255,255,255,.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin .6s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Portfolio editor ── */
+    .editor-body { padding: .85rem; display: none; border-top: 1px solid var(--border); }
+    .form-label-sm { font-size: .72rem; font-weight: 600; text-transform: uppercase;
+                     letter-spacing: .04em; color: var(--muted); margin-bottom: .3rem; }
+    .form-ctrl {
+      width: 100%; background: var(--bg); color: var(--text);
+      border: 1px solid var(--border); border-radius: 6px;
+      padding: .4rem .6rem; font-size: .82rem;
+      transition: border-color .15s;
+    }
+    .form-ctrl:focus { outline: none; border-color: var(--blue); }
+    textarea.form-ctrl { resize: vertical; font-family: 'Courier New', monospace; }
+
+    .btn-save {
+      width: 100%; margin-top: .5rem;
+      padding: .45rem; border: none; border-radius: 6px;
+      background: var(--blue); color: #fff; font-weight: 600;
+      font-size: .82rem; cursor: pointer; transition: background .15s;
+    }
+    .btn-save:hover { background: #79b8ff; }
+
+    .btn-edit {
+      font-size: .72rem; padding: .2rem .55rem;
+      background: transparent; color: var(--muted);
+      border: 1px solid var(--border); border-radius: 4px;
+      cursor: pointer; transition: all .15s;
+    }
+    .btn-edit:hover { color: var(--text); border-color: var(--muted); }
+
+    .save-msg { font-size: .75rem; margin-top: .4rem; color: var(--green); display: none; }
   </style>
 </head>
 <body>
-<div class="container-fluid py-4 px-4">
+<div class="app-wrapper">
 
   <!-- Header -->
-  <div class="d-flex align-items-center justify-content-between mb-4">
+  <header class="app-header">
     <div>
-      <h4 class="mb-0 fw-bold">Portfolio Advisor</h4>
-      <small class="text-muted">Powered by TradingAgents</small>
+      <p class="app-title"><i class="bi bi-graph-up-arrow" style="color:var(--blue)"></i> Portfolio Advisor</p>
+      <p class="app-subtitle">Powered by TradingAgents &mdash; multi-agent LLM analysis</p>
     </div>
-    <div class="d-flex gap-2 align-items-center">
-      <div class="btn-group" role="group" id="aggToggle">
-        <button type="button" class="btn btn-sm btn-outline-secondary agg-btn"
-                data-value="conservative">Conservative</button>
-        <button type="button" class="btn btn-sm btn-outline-warning agg-btn"
-                data-value="aggressive">Aggressive</button>
+    <div class="header-controls">
+      <div class="mode-toggle" id="modeToggle">
+        <button class="mode-btn" data-value="conservative">
+          <i class="bi bi-shield-check"></i> Conservative
+        </button>
+        <button class="mode-btn" data-value="aggressive">
+          <i class="bi bi-lightning-charge"></i> Aggressive
+        </button>
       </div>
-      <button class="btn btn-sm btn-primary" id="runBtn" onclick="triggerRun()">
-        Run Now
-        <span id="spinner" class="spinner-border spinner-border-sm ms-1"></span>
+      <button class="run-btn" id="runBtn" onclick="triggerRun()">
+        <i class="bi bi-play-fill"></i>
+        <span>Run Now</span>
+        <div class="spin" id="spinner"></div>
       </button>
     </div>
+  </header>
+
+  <!-- Status strip -->
+  <div class="status-strip">
+
+    <div class="stat-card accent-cash">
+      <div class="stat-label"><i class="bi bi-wallet2"></i> Cash Available</div>
+      <div class="stat-value" id="cashVal">—</div>
+    </div>
+
+    <div class="stat-card accent-source">
+      <div class="stat-label"><i class="bi bi-plug"></i> Data Source</div>
+      <div class="stat-value" id="sourceVal">—</div>
+    </div>
+
+    <div class="stat-card accent-cond" id="condCard">
+      <div class="stat-label"><i class="bi bi-diagram-3"></i> Condition</div>
+      <div class="stat-value" id="conditionVal">—</div>
+      <div class="stat-sub" id="conditionSub"></div>
+    </div>
+
+    <div class="stat-card accent-regime" id="regimeCard">
+      <div class="stat-label"><i class="bi bi-activity"></i> Market Regime</div>
+      <div class="stat-value" id="regimeVal">—</div>
+      <div class="stat-sub" id="regimeSub"></div>
+    </div>
+
+    <div class="stat-card accent-intra">
+      <div class="stat-label"><i class="bi bi-clock-history"></i> Last Intraday</div>
+      <div class="stat-value" style="font-size:.85rem" id="intradayVal">—</div>
+    </div>
+
+    <div class="stat-card accent-eod">
+      <div class="stat-label"><i class="bi bi-calendar-check"></i> Last EOD Scan</div>
+      <div class="stat-value" style="font-size:.85rem" id="eodVal">—</div>
+    </div>
+
   </div>
 
-  <!-- Status row -->
-  <div class="row g-3 mb-4" id="statusCards">
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Cash Available</div>
-          <div class="fs-4 fw-bold" id="cashVal">—</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Data Source</div>
-          <div class="fs-5 fw-bold" id="sourceVal">—</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Condition</div>
-          <div id="conditionVal" class="fw-bold">—</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Market Regime</div>
-          <div id="regimeVal" class="fw-bold">—</div>
-          <div id="regimeSub" class="text-muted" style="font-size:.75rem"></div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Last Intraday</div>
-          <div class="fw-bold" id="intradayVal">—</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-2">
-      <div class="card h-100">
-        <div class="card-body">
-          <div class="text-muted small">Last EOD Scan</div>
-          <div class="fw-bold" id="eodVal">—</div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <!-- Content grid -->
+  <div class="content-grid">
 
-  <div class="row g-3">
-    <!-- Action list -->
-    <div class="col-lg-8">
+    <!-- Left column: action tables -->
+    <div>
 
       <!-- SELL -->
-      <div class="card mb-3">
-        <div class="card-header text-danger">Sell Alerts</div>
-        <div class="card-body p-0">
-          <table class="table table-hover mb-0" id="sellTable">
+      <div class="panel" id="sellPanel">
+        <div class="panel-header" style="color:var(--red)">
+          <div class="panel-title">
+            <i class="bi bi-arrow-down-circle-fill"></i>
+            Sell Alerts
+            <span class="panel-count" id="sellCount">0</span>
+          </div>
+        </div>
+        <div id="sellBody">
+          <table class="data-table" id="sellTable">
             <thead><tr>
               <th>Ticker</th><th>Signal</th><th>Price</th><th>Rationale</th>
             </tr></thead>
             <tbody></tbody>
           </table>
-          <div class="text-center text-muted py-3 empty-msg" id="sellEmpty">No sell alerts</div>
+          <div class="empty-state" id="sellEmpty">
+            <i class="bi bi-check-circle"></i>
+            No sell alerts
+          </div>
         </div>
       </div>
 
       <!-- BUY -->
-      <div class="card mb-3">
-        <div class="card-header text-success">Buy Candidates</div>
-        <div class="card-body p-0">
-          <table class="table table-hover mb-0" id="buyTable">
+      <div class="panel" id="buyPanel">
+        <div class="panel-header" style="color:var(--green)">
+          <div class="panel-title">
+            <i class="bi bi-arrow-up-circle-fill"></i>
+            Buy Candidates
+            <span class="panel-count" id="buyCount">0</span>
+          </div>
+        </div>
+        <div id="buyBody">
+          <table class="data-table" id="buyTable">
             <thead><tr>
-              <th>Ticker</th><th>Signal</th><th>Price</th><th>Owned</th><th>Rationale</th>
+              <th>Ticker</th><th>Signal</th><th>Price</th><th>Status</th><th>Rationale</th>
             </tr></thead>
             <tbody></tbody>
           </table>
-          <div class="text-center text-muted py-3 empty-msg" id="buyEmpty">No buy candidates</div>
+          <div class="empty-state" id="buyEmpty">
+            <i class="bi bi-search"></i>
+            No buy candidates
+          </div>
         </div>
       </div>
 
       <!-- HOLD -->
-      <div class="card mb-3">
-        <div class="card-header text-secondary">Hold</div>
-        <div class="card-body p-0">
-          <table class="table table-hover mb-0" id="holdTable">
-            <thead><tr>
-              <th>Ticker</th><th>Signal</th><th>Price</th><th>Rationale</th>
-            </tr></thead>
-            <tbody></tbody>
-          </table>
-          <div class="text-center text-muted py-3 empty-msg" id="holdEmpty">No hold positions</div>
+      <div class="panel">
+        <div class="panel-header" style="color:var(--muted)">
+          <div class="panel-title">
+            <i class="bi bi-pause-circle"></i>
+            Hold
+            <span class="panel-count" id="holdCount">0</span>
+          </div>
+        </div>
+        <table class="data-table" id="holdTable">
+          <thead><tr>
+            <th>Ticker</th><th>Signal</th><th>Price</th><th>Rationale</th>
+          </tr></thead>
+          <tbody></tbody>
+        </table>
+        <div class="empty-state" id="holdEmpty">
+          <i class="bi bi-hourglass-split"></i>
+          No hold positions
         </div>
       </div>
 
     </div>
 
-    <!-- Right column: positions + fallback editor -->
-    <div class="col-lg-4">
+    <!-- Right column -->
+    <div>
 
       <!-- Positions -->
-      <div class="card mb-3">
-        <div class="card-header">Current Positions</div>
-        <div class="card-body p-0">
-          <table class="table table-sm mb-0" id="posTable">
-            <thead><tr>
-              <th>Ticker</th><th>Shares</th><th>Price</th><th>P&amp;L</th>
-            </tr></thead>
-            <tbody></tbody>
-          </table>
-          <div class="text-center text-muted py-3 empty-msg" id="posEmpty">No positions loaded</div>
+      <div class="panel">
+        <div class="panel-header">
+          <div class="panel-title">
+            <i class="bi bi-briefcase"></i>
+            Positions
+            <span class="panel-count" id="posCount">0</span>
+          </div>
+        </div>
+        <table class="data-table" id="posTable">
+          <thead><tr>
+            <th>Ticker</th><th>Shares</th><th>Price</th><th>P&amp;L</th>
+          </tr></thead>
+          <tbody></tbody>
+        </table>
+        <div class="empty-state" id="posEmpty">
+          <i class="bi bi-briefcase"></i>
+          No positions loaded
         </div>
       </div>
 
       <!-- Fallback portfolio editor -->
-      <div class="card">
-        <div class="card-header d-flex justify-content-between align-items-center">
-          <span>Fallback Portfolio</span>
-          <button class="btn btn-sm btn-outline-secondary" onclick="toggleEditor()">Edit</button>
+      <div class="panel">
+        <div class="panel-header">
+          <div class="panel-title">
+            <i class="bi bi-pencil-square"></i>
+            Fallback Portfolio
+          </div>
+          <button class="btn-edit" onclick="toggleEditor()">Edit</button>
         </div>
-        <div id="portfolio-form" class="card-body">
-          <div class="mb-2">
-            <label class="form-label small">Cash</label>
-            <input type="number" class="form-control form-control-sm bg-dark text-light border-secondary"
-                   id="cashInput" step="0.01" placeholder="0.00">
+        <div class="editor-body" id="editorBody">
+          <div style="margin-bottom:.6rem">
+            <div class="form-label-sm">Cash ($)</div>
+            <input type="number" class="form-ctrl" id="cashInput" step="0.01" placeholder="0.00">
           </div>
-          <div class="mb-2">
-            <label class="form-label small">Positions (JSON array)</label>
-            <textarea class="form-control form-control-sm bg-dark text-light border-secondary"
-                      id="positionsInput" rows="8"
-                      placeholder='[{"ticker":"AAPL","shares":10,"cost_basis":150,"current_price":175,"sector":"Technology","market_value":1750}]'></textarea>
+          <div>
+            <div class="form-label-sm">Positions — JSON array</div>
+            <textarea class="form-ctrl" id="positionsInput" rows="8"
+              placeholder='[{"ticker":"AAPL","shares":10,"cost_basis":150,"current_price":175,"sector":"Technology","market_value":1750}]'></textarea>
           </div>
-          <button class="btn btn-sm btn-primary w-100" onclick="savePortfolio()">Save Portfolio</button>
-          <div id="saveMsg" class="text-success small mt-1" style="display:none">Saved.</div>
+          <button class="btn-save" onclick="savePortfolio()">Save Portfolio</button>
+          <div class="save-msg" id="saveMsg">Saved successfully.</div>
         </div>
       </div>
 
@@ -207,190 +528,229 @@
 const initialState = {{ state | tojson }};
 let currentState = initialState;
 
+// ── Formatters ──────────────────────────────────────────────────────────────
+
 function fmt(ts) {
   if (!ts) return '—';
-  const d = new Date(ts);
-  return d.toLocaleString('en-US', {timeZone: 'America/New_York', hour12: false,
-    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'}) + ' ET';
+  return new Date(ts).toLocaleString('en-US', {
+    timeZone: 'America/New_York', hour12: false,
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit'
+  }) + ' ET';
 }
 
 function fmtMoney(n) {
-  if (!n && n !== 0) return '—';
+  if (n == null || n === '') return '—';
   return '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
 }
 
+// ── Badge builders ──────────────────────────────────────────────────────────
+
 function signalBadge(signal) {
-  const cls = {Buy:'success', Overweight:'success', Hold:'secondary', Underweight:'warning', Sell:'danger'};
-  return `<span class="badge bg-${cls[signal]||'secondary'}">${signal}</span>`;
+  const map = {
+    Buy:         ['badge-buy',         '<i class="bi bi-arrow-up-short"></i> Buy'],
+    Overweight:  ['badge-overweight',  '<i class="bi bi-arrow-up-short"></i> Overweight'],
+    Hold:        ['badge-hold',        'Hold'],
+    Underweight: ['badge-underweight', '<i class="bi bi-arrow-down-short"></i> Underweight'],
+    Sell:        ['badge-sell',        '<i class="bi bi-arrow-down-short"></i> Sell'],
+  };
+  const [cls, label] = map[signal] || ['badge-hold', signal];
+  return `<span class="badge ${cls}">${label}</span>`;
 }
 
-const CONDITION_LABELS = {
-  1: 'Cash, No Positions',
-  2: 'Cash + Positions',
-  3: 'No Cash, No Positions',
-  4: 'No Cash, Has Positions',
+// ── Condition & regime metadata ─────────────────────────────────────────────
+
+const COND = {
+  1: { label: 'Condition 1', sub: 'Cash available — no positions', cls: 'cond-1', accent: 'var(--green)' },
+  2: { label: 'Condition 2', sub: 'Cash available + positions held', cls: 'cond-2', accent: 'var(--blue)' },
+  3: { label: 'Condition 3', sub: 'No cash — no positions', cls: 'cond-3', accent: 'var(--muted)' },
+  4: { label: 'Condition 4', sub: 'No cash — positions held', cls: 'cond-4', accent: 'var(--orange)' },
 };
 
-const REGIME_LABELS = {
-  bull:           'Bull Market',
-  corrective:     'Corrective',
-  bear:           'Bear Market',
-  confirmed_bear: 'Confirmed Bear',
-  unknown:        'Unknown',
+const REGIME = {
+  bull:           { label: 'Bull Market',     sub: 'SPY above 50 & 200-day SMA', cls: 'regime-bull',           accent: 'var(--green)' },
+  corrective:     { label: 'Corrective',      sub: 'SPY above 200-day, below 50-day', cls: 'regime-corrective',accent: 'var(--yellow)' },
+  bear:           { label: 'Bear Market',     sub: 'SPY below 200-day SMA', cls: 'regime-bear',                accent: 'var(--orange)' },
+  confirmed_bear: { label: 'Confirmed Bear',  sub: 'Death cross — sell pressure', cls: 'regime-confirmed_bear',accent: 'var(--red)' },
+  unknown:        { label: 'Unknown',         sub: 'Insufficient data', cls: 'regime-unknown',                 accent: 'var(--muted)' },
 };
 
-const REGIME_SUB = {
-  bull:           'SPY above 50-day & 200-day SMA',
-  corrective:     'SPY above 200-day, below 50-day',
-  bear:           'SPY below 200-day SMA',
-  confirmed_bear: 'Death cross — 50-day below 200-day',
-  unknown:        '',
-};
+// ── Main render ─────────────────────────────────────────────────────────────
 
 function renderState(s) {
   currentState = s;
 
-  // Status cards
+  // Cash
   document.getElementById('cashVal').textContent = fmtMoney(s.cash || 0);
+
+  // Source
   const src = s.portfolio_source || 'unknown';
   const srcEl = document.getElementById('sourceVal');
   srcEl.textContent = src.charAt(0).toUpperCase() + src.slice(1);
-  srcEl.className = 'fs-5 fw-bold source-' + src;
-  document.getElementById('intradayVal').textContent = fmt(s.last_intraday_run);
-  document.getElementById('eodVal').textContent = fmt(s.last_eod_run);
+  srcEl.className = 'stat-value src-' + src;
 
   // Condition
-  const cond = s.condition;
-  const condEl = document.getElementById('conditionVal');
-  if (cond) {
-    condEl.innerHTML = `<span class="badge condition-${cond} fs-6">Condition ${cond}</span>
-      <div class="text-muted mt-1" style="font-size:.75rem">${CONDITION_LABELS[cond]||''}</div>`;
+  const c = COND[s.condition];
+  const condCard = document.getElementById('condCard');
+  if (c) {
+    condCard.style.setProperty('--accent-color', c.accent);
+    document.getElementById('conditionVal').innerHTML =
+      `<span class="${c.cls}">${c.label}</span>`;
+    document.getElementById('conditionSub').textContent = c.sub;
   } else {
-    condEl.textContent = '—';
+    document.getElementById('conditionVal').textContent = '—';
+    document.getElementById('conditionSub').textContent = '';
   }
 
   // Market regime
-  const regime = (s.market_regime || {});
-  const r = regime.regime || 'unknown';
+  const rm = (s.market_regime || {});
+  const r = REGIME[rm.regime] || REGIME.unknown;
+  const regimeCard = document.getElementById('regimeCard');
+  regimeCard.style.setProperty('--accent-color', r.accent);
   const regimeEl = document.getElementById('regimeVal');
-  regimeEl.textContent = REGIME_LABELS[r] || r;
-  regimeEl.className = 'fw-bold regime-' + r;
-  const subEl = document.getElementById('regimeSub');
-  subEl.textContent = (regime.spy_price && r !== 'unknown')
-    ? `SPY ${fmtMoney(regime.spy_price)} | SMA50 ${fmtMoney(regime.sma50)}`
-    : (REGIME_SUB[r] || '');
+  regimeEl.textContent = r.label;
+  regimeEl.className = 'stat-value ' + r.cls;
+  document.getElementById('regimeSub').textContent =
+    rm.spy_price ? `SPY ${fmtMoney(rm.spy_price)} · SMA50 ${fmtMoney(rm.sma50)}` : r.sub;
 
-  // Aggressiveness toggle
-  document.querySelectorAll('.agg-btn').forEach(btn => {
-    const active = btn.dataset.value === (s.aggressiveness || 'conservative');
-    btn.classList.toggle('active', active);
-    btn.classList.toggle('btn-secondary', active && btn.dataset.value === 'conservative');
-    btn.classList.toggle('btn-warning', active && btn.dataset.value === 'aggressive');
-    btn.classList.toggle('btn-outline-secondary', !active && btn.dataset.value === 'conservative');
-    btn.classList.toggle('btn-outline-warning', !active && btn.dataset.value === 'aggressive');
+  // Timestamps
+  document.getElementById('intradayVal').textContent = fmt(s.last_intraday_run);
+  document.getElementById('eodVal').textContent      = fmt(s.last_eod_run);
+
+  // Mode toggle
+  const mode = s.aggressiveness || 'conservative';
+  document.querySelectorAll('.mode-btn').forEach(btn => {
+    btn.classList.remove('active-conservative', 'active-aggressive');
+    if (btn.dataset.value === mode) btn.classList.add(`active-${mode}`);
   });
 
-  // Run button spinner
-  const running = s.running || false;
+  // Run button
+  const running = !!s.running;
   document.getElementById('runBtn').disabled = running;
-  document.getElementById('spinner').style.display = running ? 'inline-block' : 'none';
+  document.getElementById('spinner').style.display = running ? 'block' : 'none';
 
-  // Positions table
-  const positions = s.portfolio_positions || [];
-  const posBody = document.querySelector('#posTable tbody');
-  posBody.innerHTML = '';
-  positions.forEach(p => {
-    const pnl = (p.current_price - p.cost_basis) * p.shares;
-    const pnlPct = p.cost_basis > 0
-      ? ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1)
-      : '0.0';
-    const pnlCls = pnl >= 0 ? 'text-success' : 'text-danger';
-    const flags = (p.flags || []);
-    const flagBadges = flags.map(f => {
-      if (f === 'concentration_risk')
-        return '<span class="badge bg-warning text-dark ms-1" title="Position >10% of portfolio">Conc.</span>';
-      if (f === 'drawdown_15pct')
-        return '<span class="badge bg-danger ms-1" title="Down >15% from cost basis">-15%</span>';
-      if (f === 'sector_concentration')
-        return '<span class="badge bg-secondary ms-1" title="Sector >25% of portfolio">Sector</span>';
-      return '';
-    }).join('');
-    const row = posBody.insertRow();
-    row.innerHTML = `<td><strong>${p.ticker}</strong>${flagBadges}</td>
-      <td>${p.shares}</td>
-      <td>${fmtMoney(p.current_price)}</td>
-      <td class="${pnlCls}">${pnl >= 0 ? '+' : ''}${fmtMoney(pnl)}<br>
-        <small>${pnl >= 0 ? '+' : ''}${pnlPct}%</small></td>`;
-  });
-  document.getElementById('posEmpty').style.display = positions.length ? 'none' : 'block';
+  // Actions
+  const all = s.actions || [];
+  renderActions('sellTable', 'sellEmpty', 'sellCount',
+    all.filter(a => a.action === 'SELL'), ['ticker','signal','price','rationale']);
+  renderActions('buyTable',  'buyEmpty',  'buyCount',
+    all.filter(a => a.action === 'BUY'),  ['ticker','signal','price','owned','rationale']);
+  renderActions('holdTable', 'holdEmpty', 'holdCount',
+    all.filter(a => a.action === 'HOLD'), ['ticker','signal','price','rationale']);
 
-  // Action tables
-  const actions = s.actions || [];
-  const sells = actions.filter(a => a.action === 'SELL');
-  const buys  = actions.filter(a => a.action === 'BUY');
-  const holds = actions.filter(a => a.action === 'HOLD');
-
-  renderActionTable('sellTable', 'sellEmpty', sells, ['ticker','signal','price','rationale']);
-  renderActionTable('buyTable',  'buyEmpty',  buys,  ['ticker','signal','price','owned','rationale']);
-  renderActionTable('holdTable', 'holdEmpty', holds, ['ticker','signal','price','rationale']);
+  // Positions
+  renderPositions(s.portfolio_positions || []);
 }
 
-function renderActionTable(tableId, emptyId, rows, cols) {
+// ── Action tables ───────────────────────────────────────────────────────────
+
+function renderActions(tableId, emptyId, countId, rows, cols) {
+  document.getElementById(countId).textContent = rows.length;
   const tbody = document.querySelector(`#${tableId} tbody`);
   tbody.innerHTML = '';
+  document.getElementById(emptyId).style.display = rows.length ? 'none' : 'flex';
+  document.getElementById(tableId).style.display = rows.length ? 'table' : 'none';
+
   rows.forEach(a => {
     const tr = tbody.insertRow();
-    if (a.action === 'BUY' && a.affordable === false) {
-      tr.classList.add('unaffordable');
-      tr.title = 'Insufficient cash to purchase at current price';
-    }
+    const actionCls = { BUY: 'row-buy', SELL: 'row-sell', HOLD: 'row-hold' }[a.action] || '';
+    tr.className = actionCls;
+    if (a.action === 'BUY' && a.affordable === false) tr.classList.add('row-unaffordable');
+
     cols.forEach(col => {
       const td = tr.insertCell();
       if (col === 'ticker') {
-        td.innerHTML = `<strong>${a.ticker}</strong>`;
-        if (a.action === 'BUY' && a.affordable === false) {
-          td.innerHTML += ' <span class="badge bg-secondary" title="Price exceeds available cash">N/A</span>';
-        }
+        let html = `<span class="ticker">${a.ticker}</span>`;
+        if (a.action === 'BUY' && a.affordable === false)
+          html += ` <span class="badge badge-dim" title="Price exceeds available cash">Unaffordable</span>`;
+        td.innerHTML = html;
+
       } else if (col === 'signal') {
         td.innerHTML = signalBadge(a.signal);
+
       } else if (col === 'price') {
+        td.className = 'price-cell';
         td.textContent = a.price ? fmtMoney(a.price) : '—';
-        td.style.fontVariantNumeric = 'tabular-nums';
+
       } else if (col === 'owned') {
         td.innerHTML = a.owned
-          ? '<span class="badge bg-secondary">Owned</span>'
-          : '<span class="badge bg-dark border border-secondary">New</span>';
+          ? '<span class="badge badge-owned"><i class="bi bi-check2"></i> Owned</span>'
+          : '<span class="badge badge-new">New</span>';
+
       } else if (col === 'rationale') {
-        td.className = 'rationale';
+        td.className = 'rationale-cell';
         td.textContent = a.rationale || '—';
       }
     });
   });
-  document.getElementById(emptyId).style.display = rows.length ? 'none' : 'block';
 }
 
+// ── Positions table ─────────────────────────────────────────────────────────
+
+function renderPositions(positions) {
+  document.getElementById('posCount').textContent = positions.length;
+  const tbody = document.querySelector('#posTable tbody');
+  tbody.innerHTML = '';
+  document.getElementById('posEmpty').style.display  = positions.length ? 'none' : 'flex';
+  document.getElementById('posTable').style.display  = positions.length ? 'table' : 'none';
+
+  positions.forEach(p => {
+    const pnl    = (p.current_price - p.cost_basis) * p.shares;
+    const pnlPct = p.cost_basis > 0
+      ? ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1)
+      : '0.0';
+    const pnlCls = pnl >= 0 ? 'pnl-pos' : 'pnl-neg';
+    const sign   = pnl >= 0 ? '+' : '';
+
+    const flags = (p.flags || []).map(f => {
+      if (f === 'concentration_risk')
+        return `<span class="badge badge-flag-conc ms-1" title="Position >10% of portfolio"><i class="bi bi-exclamation-triangle"></i> Conc.</span>`;
+      if (f === 'drawdown_15pct')
+        return `<span class="badge badge-flag-down ms-1" title="Down >15% from cost basis"><i class="bi bi-arrow-down-circle"></i> −15%</span>`;
+      if (f === 'sector_concentration')
+        return `<span class="badge badge-flag-sec ms-1" title="Sector >25% of portfolio"><i class="bi bi-pie-chart"></i> Sector</span>`;
+      return '';
+    }).join('');
+
+    const tr = tbody.insertRow();
+    tr.innerHTML = `
+      <td><span class="ticker">${p.ticker}</span>${flags}</td>
+      <td>${p.shares}</td>
+      <td class="price-cell">${fmtMoney(p.current_price)}</td>
+      <td class="${pnlCls}">
+        ${sign}${fmtMoney(pnl)}
+        <div class="pnl-sub">${sign}${pnlPct}%</div>
+      </td>`;
+  });
+}
+
+// ── Portfolio editor ────────────────────────────────────────────────────────
+
 function toggleEditor() {
-  const form = document.getElementById('portfolio-form');
-  if (form.style.display === 'none') {
-    const pos = (currentState.portfolio_positions || []);
-    document.getElementById('cashInput').value = currentState.cash || 0;
-    document.getElementById('positionsInput').value = JSON.stringify(pos, null, 2);
+  const body = document.getElementById('editorBody');
+  const open = body.style.display === 'block';
+  if (!open) {
+    document.getElementById('cashInput').value =
+      currentState.cash || 0;
+    document.getElementById('positionsInput').value =
+      JSON.stringify(currentState.portfolio_positions || [], null, 2);
   }
-  form.style.display = form.style.display === 'none' ? 'block' : 'none';
+  body.style.display = open ? 'none' : 'block';
 }
 
 async function savePortfolio() {
   try {
     const positions = JSON.parse(document.getElementById('positionsInput').value || '[]');
-    const cash = parseFloat(document.getElementById('cashInput').value) || 0;
-    const res = await fetch('/api/portfolio', {
+    const cash      = parseFloat(document.getElementById('cashInput').value) || 0;
+    const res  = await fetch('/api/portfolio', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({cash, positions}),
     });
     const data = await res.json();
-    const msg = document.getElementById('saveMsg');
-    msg.textContent = data.ok ? 'Saved.' : 'Error: ' + data.reason;
+    const msg  = document.getElementById('saveMsg');
+    msg.textContent  = data.ok ? 'Saved successfully.' : 'Error: ' + data.reason;
+    msg.style.color  = data.ok ? 'var(--green)' : 'var(--red)';
     msg.style.display = 'block';
     setTimeout(() => msg.style.display = 'none', 3000);
   } catch (e) {
@@ -398,14 +758,18 @@ async function savePortfolio() {
   }
 }
 
-async function setAggressiveness(value) {
-  await fetch('/api/aggressiveness', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({aggressiveness: value}),
+// ── Controls ────────────────────────────────────────────────────────────────
+
+document.querySelectorAll('.mode-btn').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    await fetch('/api/aggressiveness', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({aggressiveness: btn.dataset.value}),
+    });
+    refresh();
   });
-  refresh();
-}
+});
 
 async function triggerRun() {
   const res = await fetch('/api/run', {method: 'POST'});
@@ -415,24 +779,19 @@ async function triggerRun() {
     return;
   }
   document.getElementById('runBtn').disabled = true;
-  document.getElementById('spinner').style.display = 'inline-block';
+  document.getElementById('spinner').style.display = 'block';
 }
 
 async function refresh() {
   try {
-    const res = await fetch('/api/state');
-    const state = await res.json();
+    const state = await fetch('/api/state').then(r => r.json());
     renderState(state);
   } catch (e) {
-    console.warn('State refresh failed:', e);
+    console.warn('Refresh failed:', e);
   }
 }
 
-document.querySelectorAll('.agg-btn').forEach(btn => {
-  btn.addEventListener('click', () => setAggressiveness(btn.dataset.value));
-});
-
-// Initial render and auto-refresh every 60 seconds
+// Initial render + 60-second auto-refresh
 renderState(initialState);
 setInterval(refresh, 60_000);
 </script>

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio Advisor</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <style>
+    body { background: #0f1117; color: #e0e0e0; }
+    .card { background: #1a1d27; border: 1px solid #2a2d3a; }
+    .card-header { background: #1f2235; border-bottom: 1px solid #2a2d3a; font-weight: 600; }
+    .table { color: #e0e0e0; }
+    .table th { color: #8b95a1; font-size: .8rem; text-transform: uppercase; border-color: #2a2d3a; }
+    .table td { border-color: #2a2d3a; vertical-align: middle; }
+    .badge-sell  { background: #7f1d1d; color: #fca5a5; }
+    .badge-buy   { background: #14532d; color: #86efac; }
+    .badge-hold  { background: #1e293b; color: #94a3b8; }
+    .pill-sell   { background: #991b1b; }
+    .pill-buy    { background: #166534; }
+    .pill-hold   { background: #334155; }
+    .rationale   { font-size: .8rem; color: #6b7280; max-width: 420px; }
+    .source-live { color: #4ade80; }
+    .source-fallback { color: #facc15; }
+    .source-unknown  { color: #9ca3af; }
+    #spinner { display: none; }
+    #portfolio-form { display: none; }
+    pre { color: #a5b4fc; background: #0f1117; padding: 1rem; border-radius: .375rem; font-size: .8rem; }
+  </style>
+</head>
+<body>
+<div class="container-fluid py-4 px-4">
+
+  <!-- Header -->
+  <div class="d-flex align-items-center justify-content-between mb-4">
+    <div>
+      <h4 class="mb-0 fw-bold">Portfolio Advisor</h4>
+      <small class="text-muted">Powered by TradingAgents</small>
+    </div>
+    <div class="d-flex gap-2 align-items-center">
+      <div class="btn-group" role="group" id="aggToggle">
+        <button type="button" class="btn btn-sm btn-outline-secondary agg-btn"
+                data-value="conservative">Conservative</button>
+        <button type="button" class="btn btn-sm btn-outline-warning agg-btn"
+                data-value="aggressive">Aggressive</button>
+      </div>
+      <button class="btn btn-sm btn-primary" id="runBtn" onclick="triggerRun()">
+        Run Now
+        <span id="spinner" class="spinner-border spinner-border-sm ms-1"></span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Status row -->
+  <div class="row g-3 mb-4" id="statusCards">
+    <div class="col-md-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Cash Available</div>
+          <div class="fs-4 fw-bold" id="cashVal">—</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Data Source</div>
+          <div class="fs-5 fw-bold" id="sourceVal">—</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Last Intraday Check</div>
+          <div class="fw-bold" id="intradayVal">—</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Last EOD Scan</div>
+          <div class="fw-bold" id="eodVal">—</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    <!-- Action list -->
+    <div class="col-lg-8">
+
+      <!-- SELL -->
+      <div class="card mb-3">
+        <div class="card-header text-danger">Sell Alerts</div>
+        <div class="card-body p-0">
+          <table class="table table-hover mb-0" id="sellTable">
+            <thead><tr>
+              <th>Ticker</th><th>Signal</th><th>Rationale</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="text-center text-muted py-3 empty-msg" id="sellEmpty">No sell alerts</div>
+        </div>
+      </div>
+
+      <!-- BUY -->
+      <div class="card mb-3">
+        <div class="card-header text-success">Buy Candidates</div>
+        <div class="card-body p-0">
+          <table class="table table-hover mb-0" id="buyTable">
+            <thead><tr>
+              <th>Ticker</th><th>Signal</th><th>Owned</th><th>Rationale</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="text-center text-muted py-3 empty-msg" id="buyEmpty">No buy candidates</div>
+        </div>
+      </div>
+
+      <!-- HOLD -->
+      <div class="card mb-3">
+        <div class="card-header text-secondary">Hold</div>
+        <div class="card-body p-0">
+          <table class="table table-hover mb-0" id="holdTable">
+            <thead><tr>
+              <th>Ticker</th><th>Signal</th><th>Rationale</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="text-center text-muted py-3 empty-msg" id="holdEmpty">No hold positions</div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Right column: positions + fallback editor -->
+    <div class="col-lg-4">
+
+      <!-- Positions -->
+      <div class="card mb-3">
+        <div class="card-header">Current Positions</div>
+        <div class="card-body p-0">
+          <table class="table table-sm mb-0" id="posTable">
+            <thead><tr>
+              <th>Ticker</th><th>Shares</th><th>Price</th><th>P&amp;L</th>
+            </tr></thead>
+            <tbody></tbody>
+          </table>
+          <div class="text-center text-muted py-3 empty-msg" id="posEmpty">No positions loaded</div>
+        </div>
+      </div>
+
+      <!-- Fallback portfolio editor -->
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Fallback Portfolio</span>
+          <button class="btn btn-sm btn-outline-secondary" onclick="toggleEditor()">Edit</button>
+        </div>
+        <div id="portfolio-form" class="card-body">
+          <div class="mb-2">
+            <label class="form-label small">Cash</label>
+            <input type="number" class="form-control form-control-sm bg-dark text-light border-secondary"
+                   id="cashInput" step="0.01" placeholder="0.00">
+          </div>
+          <div class="mb-2">
+            <label class="form-label small">Positions (JSON array)</label>
+            <textarea class="form-control form-control-sm bg-dark text-light border-secondary"
+                      id="positionsInput" rows="8"
+                      placeholder='[{"ticker":"AAPL","shares":10,"cost_basis":150,"current_price":175,"sector":"Technology","market_value":1750}]'></textarea>
+          </div>
+          <button class="btn btn-sm btn-primary w-100" onclick="savePortfolio()">Save Portfolio</button>
+          <div id="saveMsg" class="text-success small mt-1" style="display:none">Saved.</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+const initialState = {{ state | tojson }};
+let currentState = initialState;
+
+function fmt(ts) {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return d.toLocaleString('en-US', {timeZone: 'America/New_York', hour12: false,
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'}) + ' ET';
+}
+
+function fmtMoney(n) {
+  return '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
+
+function signalBadge(signal) {
+  const cls = {Buy:'success', Overweight:'success', Hold:'secondary', Underweight:'warning', Sell:'danger'};
+  return `<span class="badge bg-${cls[signal]||'secondary'}">${signal}</span>`;
+}
+
+function renderState(s) {
+  currentState = s;
+
+  // Status cards
+  document.getElementById('cashVal').textContent = fmtMoney(s.cash || 0);
+  const src = s.portfolio_source || 'unknown';
+  const srcEl = document.getElementById('sourceVal');
+  srcEl.textContent = src.charAt(0).toUpperCase() + src.slice(1);
+  srcEl.className = 'fs-5 fw-bold source-' + src;
+  document.getElementById('intradayVal').textContent = fmt(s.last_intraday_run);
+  document.getElementById('eodVal').textContent = fmt(s.last_eod_run);
+
+  // Aggressiveness toggle
+  document.querySelectorAll('.agg-btn').forEach(btn => {
+    const active = btn.dataset.value === (s.aggressiveness || 'conservative');
+    btn.classList.toggle('active', active);
+    btn.classList.toggle('btn-secondary', active && btn.dataset.value === 'conservative');
+    btn.classList.toggle('btn-warning', active && btn.dataset.value === 'aggressive');
+    btn.classList.toggle('btn-outline-secondary', !active && btn.dataset.value === 'conservative');
+    btn.classList.toggle('btn-outline-warning', !active && btn.dataset.value === 'aggressive');
+  });
+
+  // Run button spinner
+  const running = s.running || false;
+  document.getElementById('runBtn').disabled = running;
+  document.getElementById('spinner').style.display = running ? 'inline-block' : 'none';
+
+  // Positions table
+  const positions = s.portfolio_positions || [];
+  const posBody = document.querySelector('#posTable tbody');
+  posBody.innerHTML = '';
+  positions.forEach(p => {
+    const pnl = (p.current_price - p.cost_basis) * p.shares;
+    const pnlPct = ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1);
+    const pnlCls = pnl >= 0 ? 'text-success' : 'text-danger';
+    const row = posBody.insertRow();
+    row.innerHTML = `<td><strong>${p.ticker}</strong></td>
+      <td>${p.shares}</td>
+      <td>${fmtMoney(p.current_price)}</td>
+      <td class="${pnlCls}">${pnl >= 0 ? '+' : ''}${fmtMoney(pnl)}<br>
+        <small>${pnl >= 0 ? '+' : ''}${pnlPct}%</small></td>`;
+  });
+  document.getElementById('posEmpty').style.display = positions.length ? 'none' : 'block';
+
+  // Action tables
+  const actions = s.actions || [];
+  const sells = actions.filter(a => a.action === 'SELL');
+  const buys  = actions.filter(a => a.action === 'BUY');
+  const holds = actions.filter(a => a.action === 'HOLD');
+
+  renderActionTable('sellTable', 'sellEmpty', sells, ['ticker','signal','rationale']);
+  renderActionTable('buyTable',  'buyEmpty',  buys,  ['ticker','signal','owned','rationale']);
+  renderActionTable('holdTable', 'holdEmpty', holds, ['ticker','signal','rationale']);
+}
+
+function renderActionTable(tableId, emptyId, rows, cols) {
+  const tbody = document.querySelector(`#${tableId} tbody`);
+  tbody.innerHTML = '';
+  rows.forEach(a => {
+    const tr = tbody.insertRow();
+    cols.forEach(col => {
+      const td = tr.insertCell();
+      if (col === 'ticker') td.innerHTML = `<strong>${a.ticker}</strong>`;
+      else if (col === 'signal') td.innerHTML = signalBadge(a.signal);
+      else if (col === 'owned') td.innerHTML = a.owned
+        ? '<span class="badge bg-secondary">Owned</span>'
+        : '<span class="badge bg-dark border border-secondary">New</span>';
+      else if (col === 'rationale') {
+        td.className = 'rationale';
+        td.textContent = a.rationale || '—';
+      }
+    });
+  });
+  document.getElementById(emptyId).style.display = rows.length ? 'none' : 'block';
+}
+
+function toggleEditor() {
+  const form = document.getElementById('portfolio-form');
+  if (form.style.display === 'none') {
+    const pos = (currentState.portfolio_positions || []);
+    document.getElementById('cashInput').value = currentState.cash || 0;
+    document.getElementById('positionsInput').value = JSON.stringify(pos, null, 2);
+  }
+  form.style.display = form.style.display === 'none' ? 'block' : 'none';
+}
+
+async function savePortfolio() {
+  try {
+    const positions = JSON.parse(document.getElementById('positionsInput').value || '[]');
+    const cash = parseFloat(document.getElementById('cashInput').value) || 0;
+    const res = await fetch('/api/portfolio', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({cash, positions}),
+    });
+    const data = await res.json();
+    const msg = document.getElementById('saveMsg');
+    msg.textContent = data.ok ? 'Saved.' : 'Error: ' + data.reason;
+    msg.style.display = 'block';
+    setTimeout(() => msg.style.display = 'none', 3000);
+  } catch (e) {
+    alert('Invalid JSON: ' + e.message);
+  }
+}
+
+async function setAggressiveness(value) {
+  await fetch('/api/aggressiveness', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({aggressiveness: value}),
+  });
+  refresh();
+}
+
+async function triggerRun() {
+  const res = await fetch('/api/run', {method: 'POST'});
+  if (!res.ok) {
+    const d = await res.json();
+    alert(d.reason || 'Run failed');
+    return;
+  }
+  document.getElementById('runBtn').disabled = true;
+  document.getElementById('spinner').style.display = 'inline-block';
+}
+
+async function refresh() {
+  try {
+    const res = await fetch('/api/state');
+    const state = await res.json();
+    renderState(state);
+  } catch (e) {
+    console.warn('State refresh failed:', e);
+  }
+}
+
+document.querySelectorAll('.agg-btn').forEach(btn => {
+  btn.addEventListener('click', () => setAggressiveness(btn.dataset.value));
+});
+
+// Initial render and auto-refresh every 60 seconds
+renderState(initialState);
+setInterval(refresh, 60_000);
+</script>
+</body>
+</html>

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -302,6 +302,61 @@
     }
     @keyframes spin { to { transform: rotate(360deg); } }
 
+    /* ── Progress bar ── */
+    .progress-bar-wrap {
+      display: none;
+      margin-top: 1rem;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: .75rem 1rem;
+    }
+    .progress-bar-wrap.visible { display: block; }
+    .progress-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: .4rem;
+    }
+    .progress-stage { font-size: .82rem; font-weight: 600; color: var(--text); }
+    .progress-pct   { font-size: .82rem; font-weight: 700; color: var(--blue); font-variant-numeric: tabular-nums; }
+    .progress-track {
+      height: 6px;
+      background: var(--surface2);
+      border-radius: 3px;
+      overflow: hidden;
+    }
+    .progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--blue), #3fb950);
+      border-radius: 3px;
+      transition: width .4s ease;
+      width: 0%;
+    }
+    .progress-detail { font-size: .72rem; color: var(--muted); margin-top: .35rem; min-height: 1em; }
+
+    /* ── Broker status ── */
+    .broker-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: .3rem;
+      font-size: .72rem;
+      font-weight: 600;
+      padding: .2rem .55rem;
+      border-radius: 20px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--muted);
+      cursor: pointer;
+      transition: all .15s;
+      white-space: nowrap;
+    }
+    .broker-pill:hover { border-color: var(--muted); color: var(--text); }
+    .broker-pill.live     { color: var(--green); border-color: rgba(63,185,80,.4); }
+    .broker-pill.fallback { color: var(--yellow); border-color: rgba(210,153,34,.4); }
+    .broker-pill.error    { color: var(--red);   border-color: rgba(248,81,73,.4); }
+    .broker-pill.checking { color: var(--muted); }
+
     /* ── Portfolio editor ── */
     .editor-body { padding: .85rem; display: none; border-top: 1px solid var(--border); }
     .form-label-sm { font-size: .72rem; font-weight: 600; text-transform: uppercase;
@@ -344,6 +399,10 @@
       <p class="app-subtitle">Powered by TradingAgents &mdash; multi-agent LLM analysis</p>
     </div>
     <div class="header-controls">
+      <button class="broker-pill" id="brokerPill" onclick="checkBroker()" title="Check brokerage connection">
+        <i class="bi bi-plug" id="brokerIcon"></i>
+        <span id="brokerLabel">Check connection</span>
+      </button>
       <div class="mode-toggle" id="modeToggle">
         <button class="mode-btn" data-value="conservative">
           <i class="bi bi-shield-check"></i> Conservative
@@ -359,6 +418,18 @@
       </button>
     </div>
   </header>
+
+  <!-- Progress bar (shown during active runs) -->
+  <div class="progress-bar-wrap" id="progressWrap">
+    <div class="progress-top">
+      <span class="progress-stage" id="progressStage">Starting…</span>
+      <span class="progress-pct" id="progressPct">0%</span>
+    </div>
+    <div class="progress-track">
+      <div class="progress-fill" id="progressFill"></div>
+    </div>
+    <div class="progress-detail" id="progressDetail"></div>
+  </div>
 
   <!-- Status strip -->
   <div class="status-strip">
@@ -526,9 +597,12 @@
 
 <script>
 const initialState = {{ state | tojson }};
-let currentState = initialState;
+let currentState   = initialState;
+let _wasRunning    = !!initialState.running;
+let _slowTimer     = null;
+let _fastTimer     = null;
 
-// ── Formatters ──────────────────────────────────────────────────────────────
+// ── Formatters ────────────────────────────────────────────────────────────────
 
 function fmt(ts) {
   if (!ts) return '—';
@@ -544,7 +618,7 @@ function fmtMoney(n) {
   return '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
 }
 
-// ── Badge builders ──────────────────────────────────────────────────────────
+// ── Badge builders ────────────────────────────────────────────────────────────
 
 function signalBadge(signal) {
   const map = {
@@ -558,7 +632,7 @@ function signalBadge(signal) {
   return `<span class="badge ${cls}">${label}</span>`;
 }
 
-// ── Condition & regime metadata ─────────────────────────────────────────────
+// ── Condition & regime metadata ───────────────────────────────────────────────
 
 const COND = {
   1: { label: 'Condition 1', sub: 'Cash available — no positions', cls: 'cond-1', accent: 'var(--green)' },
@@ -568,14 +642,64 @@ const COND = {
 };
 
 const REGIME = {
-  bull:           { label: 'Bull Market',     sub: 'SPY above 50 & 200-day SMA', cls: 'regime-bull',           accent: 'var(--green)' },
-  corrective:     { label: 'Corrective',      sub: 'SPY above 200-day, below 50-day', cls: 'regime-corrective',accent: 'var(--yellow)' },
-  bear:           { label: 'Bear Market',     sub: 'SPY below 200-day SMA', cls: 'regime-bear',                accent: 'var(--orange)' },
-  confirmed_bear: { label: 'Confirmed Bear',  sub: 'Death cross — sell pressure', cls: 'regime-confirmed_bear',accent: 'var(--red)' },
-  unknown:        { label: 'Unknown',         sub: 'Insufficient data', cls: 'regime-unknown',                 accent: 'var(--muted)' },
+  bull:           { label: 'Bull Market',    sub: 'SPY above 50 & 200-day SMA',        cls: 'regime-bull',           accent: 'var(--green)'  },
+  corrective:     { label: 'Corrective',     sub: 'SPY above 200-day, below 50-day',   cls: 'regime-corrective',     accent: 'var(--yellow)' },
+  bear:           { label: 'Bear Market',    sub: 'SPY below 200-day SMA',             cls: 'regime-bear',           accent: 'var(--orange)' },
+  confirmed_bear: { label: 'Confirmed Bear', sub: 'Death cross — broad sell pressure', cls: 'regime-confirmed_bear', accent: 'var(--red)'    },
+  unknown:        { label: 'Unknown',        sub: 'Insufficient data',                  cls: 'regime-unknown',        accent: 'var(--muted)'  },
 };
 
-// ── Main render ─────────────────────────────────────────────────────────────
+// ── Progress bar ──────────────────────────────────────────────────────────────
+
+function showProgress(visible) {
+  document.getElementById('progressWrap').classList.toggle('visible', visible);
+}
+
+function updateProgress(stage, progress, detail) {
+  const pct = Math.min(100, Math.max(0, progress || 0));
+  document.getElementById('progressStage').textContent  = stage || 'Running…';
+  document.getElementById('progressPct').textContent    = pct + '%';
+  document.getElementById('progressFill').style.width   = pct + '%';
+  document.getElementById('progressDetail').textContent = detail || '';
+}
+
+// ── Broker check ──────────────────────────────────────────────────────────────
+
+async function checkBroker() {
+  const pill  = document.getElementById('brokerPill');
+  const icon  = document.getElementById('brokerIcon');
+  const label = document.getElementById('brokerLabel');
+
+  pill.className       = 'broker-pill checking';
+  icon.className       = 'bi bi-arrow-repeat';
+  icon.style.animation = 'spin .6s linear infinite';
+  label.textContent    = 'Checking…';
+
+  try {
+    const data = await fetch('/api/broker/check', {method: 'POST'}).then(r => r.json());
+
+    icon.style.animation = '';
+    if (data.ok) {
+      const src = data.source || 'unknown';
+      pill.className = `broker-pill ${src}`;
+      icon.className = src === 'live' ? 'bi bi-plug-fill' : 'bi bi-exclamation-triangle';
+      label.textContent = src === 'live'
+        ? `Live · ${data.positions} pos · $${Number(data.cash).toFixed(2)}`
+        : `Fallback · ${data.positions} pos`;
+    } else {
+      pill.className = 'broker-pill error';
+      icon.className = 'bi bi-x-circle';
+      label.textContent = 'Connection failed';
+    }
+  } catch {
+    icon.style.animation = '';
+    pill.className = 'broker-pill error';
+    icon.className = 'bi bi-x-circle';
+    label.textContent = 'Network error';
+  }
+}
+
+// ── Main render ───────────────────────────────────────────────────────────────
 
 function renderState(s) {
   currentState = s;
@@ -584,18 +708,17 @@ function renderState(s) {
   document.getElementById('cashVal').textContent = fmtMoney(s.cash || 0);
 
   // Source
-  const src = s.portfolio_source || 'unknown';
+  const src   = s.portfolio_source || 'unknown';
   const srcEl = document.getElementById('sourceVal');
   srcEl.textContent = src.charAt(0).toUpperCase() + src.slice(1);
-  srcEl.className = 'stat-value src-' + src;
+  srcEl.className   = 'stat-value src-' + src;
 
   // Condition
-  const c = COND[s.condition];
+  const c        = COND[s.condition];
   const condCard = document.getElementById('condCard');
   if (c) {
     condCard.style.setProperty('--accent-color', c.accent);
-    document.getElementById('conditionVal').innerHTML =
-      `<span class="${c.cls}">${c.label}</span>`;
+    document.getElementById('conditionVal').innerHTML    = `<span class="${c.cls}">${c.label}</span>`;
     document.getElementById('conditionSub').textContent = c.sub;
   } else {
     document.getElementById('conditionVal').textContent = '—';
@@ -603,15 +726,16 @@ function renderState(s) {
   }
 
   // Market regime
-  const rm = (s.market_regime || {});
-  const r = REGIME[rm.regime] || REGIME.unknown;
+  const rm         = s.market_regime || {};
+  const r          = REGIME[rm.regime] || REGIME.unknown;
   const regimeCard = document.getElementById('regimeCard');
   regimeCard.style.setProperty('--accent-color', r.accent);
-  const regimeEl = document.getElementById('regimeVal');
-  regimeEl.textContent = r.label;
-  regimeEl.className = 'stat-value ' + r.cls;
-  document.getElementById('regimeSub').textContent =
-    rm.spy_price ? `SPY ${fmtMoney(rm.spy_price)} · SMA50 ${fmtMoney(rm.sma50)}` : r.sub;
+  const regimeEl        = document.getElementById('regimeVal');
+  regimeEl.textContent  = r.label;
+  regimeEl.className    = 'stat-value ' + r.cls;
+  document.getElementById('regimeSub').textContent = rm.spy_price
+    ? `SPY ${fmtMoney(rm.spy_price)} · SMA50 ${fmtMoney(rm.sma50)}`
+    : r.sub;
 
   // Timestamps
   document.getElementById('intradayVal').textContent = fmt(s.last_intraday_run);
@@ -624,10 +748,36 @@ function renderState(s) {
     if (btn.dataset.value === mode) btn.classList.add(`active-${mode}`);
   });
 
-  // Run button
+  // Run button & spinner
   const running = !!s.running;
-  document.getElementById('runBtn').disabled = running;
-  document.getElementById('spinner').style.display = running ? 'block' : 'none';
+  document.getElementById('runBtn').disabled            = running;
+  document.getElementById('spinner').style.display      = running ? 'block' : 'none';
+
+  // Progress bar
+  if (running) {
+    showProgress(true);
+    updateProgress(s.stage, s.progress, s.stage_detail);
+  } else if (_wasRunning) {
+    // Run just finished — flash complete state then hide
+    showProgress(true);
+    updateProgress(s.stage || 'Complete', 100, s.stage_detail || '');
+    setTimeout(() => showProgress(false), 4000);
+  } else {
+    showProgress(false);
+  }
+
+  // Polling speed: 3s during run, 60s otherwise
+  if (running && !_fastTimer) {
+    clearInterval(_slowTimer);
+    _slowTimer = null;
+    _fastTimer = setInterval(refresh, 3000);
+  } else if (!running && _fastTimer) {
+    clearInterval(_fastTimer);
+    _fastTimer = null;
+    _slowTimer = setInterval(refresh, 60_000);
+  }
+
+  _wasRunning = running;
 
   // Actions
   const all = s.actions || [];
@@ -642,19 +792,18 @@ function renderState(s) {
   renderPositions(s.portfolio_positions || []);
 }
 
-// ── Action tables ───────────────────────────────────────────────────────────
+// ── Action tables ─────────────────────────────────────────────────────────────
 
 function renderActions(tableId, emptyId, countId, rows, cols) {
-  document.getElementById(countId).textContent = rows.length;
+  document.getElementById(countId).textContent          = rows.length;
   const tbody = document.querySelector(`#${tableId} tbody`);
   tbody.innerHTML = '';
-  document.getElementById(emptyId).style.display = rows.length ? 'none' : 'flex';
-  document.getElementById(tableId).style.display = rows.length ? 'table' : 'none';
+  document.getElementById(emptyId).style.display        = rows.length ? 'none'  : 'flex';
+  document.getElementById(tableId).style.display        = rows.length ? 'table' : 'none';
 
   rows.forEach(a => {
     const tr = tbody.insertRow();
-    const actionCls = { BUY: 'row-buy', SELL: 'row-sell', HOLD: 'row-hold' }[a.action] || '';
-    tr.className = actionCls;
+    tr.className = ({ BUY: 'row-buy', SELL: 'row-sell', HOLD: 'row-hold' }[a.action] || '');
     if (a.action === 'BUY' && a.affordable === false) tr.classList.add('row-unaffordable');
 
     cols.forEach(col => {
@@ -664,67 +813,60 @@ function renderActions(tableId, emptyId, countId, rows, cols) {
         if (a.action === 'BUY' && a.affordable === false)
           html += ` <span class="badge badge-dim" title="Price exceeds available cash">Unaffordable</span>`;
         td.innerHTML = html;
-
       } else if (col === 'signal') {
         td.innerHTML = signalBadge(a.signal);
-
       } else if (col === 'price') {
-        td.className = 'price-cell';
+        td.className   = 'price-cell';
         td.textContent = a.price ? fmtMoney(a.price) : '—';
-
       } else if (col === 'owned') {
         td.innerHTML = a.owned
           ? '<span class="badge badge-owned"><i class="bi bi-check2"></i> Owned</span>'
           : '<span class="badge badge-new">New</span>';
-
       } else if (col === 'rationale') {
-        td.className = 'rationale-cell';
+        td.className   = 'rationale-cell';
         td.textContent = a.rationale || '—';
       }
     });
   });
 }
 
-// ── Positions table ─────────────────────────────────────────────────────────
+// ── Positions table ───────────────────────────────────────────────────────────
 
 function renderPositions(positions) {
-  document.getElementById('posCount').textContent = positions.length;
+  document.getElementById('posCount').textContent       = positions.length;
   const tbody = document.querySelector('#posTable tbody');
   tbody.innerHTML = '';
-  document.getElementById('posEmpty').style.display  = positions.length ? 'none' : 'flex';
-  document.getElementById('posTable').style.display  = positions.length ? 'table' : 'none';
+  document.getElementById('posEmpty').style.display     = positions.length ? 'none'  : 'flex';
+  document.getElementById('posTable').style.display     = positions.length ? 'table' : 'none';
 
   positions.forEach(p => {
     const pnl    = (p.current_price - p.cost_basis) * p.shares;
     const pnlPct = p.cost_basis > 0
       ? ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1)
       : '0.0';
-    const pnlCls = pnl >= 0 ? 'pnl-pos' : 'pnl-neg';
     const sign   = pnl >= 0 ? '+' : '';
-
-    const flags = (p.flags || []).map(f => {
+    const flags  = (p.flags || []).map(f => {
       if (f === 'concentration_risk')
-        return `<span class="badge badge-flag-conc ms-1" title="Position >10% of portfolio"><i class="bi bi-exclamation-triangle"></i> Conc.</span>`;
+        return `<span class="badge badge-flag-conc" title=">10% of portfolio"><i class="bi bi-exclamation-triangle"></i> Conc.</span>`;
       if (f === 'drawdown_15pct')
-        return `<span class="badge badge-flag-down ms-1" title="Down >15% from cost basis"><i class="bi bi-arrow-down-circle"></i> −15%</span>`;
+        return `<span class="badge badge-flag-down" title="Down >15% from cost"><i class="bi bi-arrow-down-circle"></i> −15%</span>`;
       if (f === 'sector_concentration')
-        return `<span class="badge badge-flag-sec ms-1" title="Sector >25% of portfolio"><i class="bi bi-pie-chart"></i> Sector</span>`;
+        return `<span class="badge badge-flag-sec" title="Sector >25% of portfolio"><i class="bi bi-pie-chart"></i> Sector</span>`;
       return '';
-    }).join('');
+    }).join(' ');
 
     const tr = tbody.insertRow();
     tr.innerHTML = `
-      <td><span class="ticker">${p.ticker}</span>${flags}</td>
+      <td><span class="ticker">${p.ticker}</span>${flags ? ' ' + flags : ''}</td>
       <td>${p.shares}</td>
       <td class="price-cell">${fmtMoney(p.current_price)}</td>
-      <td class="${pnlCls}">
-        ${sign}${fmtMoney(pnl)}
-        <div class="pnl-sub">${sign}${pnlPct}%</div>
+      <td class="${pnl >= 0 ? 'pnl-pos' : 'pnl-neg'}">
+        ${sign}${fmtMoney(pnl)}<div class="pnl-sub">${sign}${pnlPct}%</div>
       </td>`;
   });
 }
 
-// ── Portfolio editor ────────────────────────────────────────────────────────
+// ── Portfolio editor ──────────────────────────────────────────────────────────
 
 function toggleEditor() {
   const body = document.getElementById('editorBody');
@@ -742,15 +884,14 @@ async function savePortfolio() {
   try {
     const positions = JSON.parse(document.getElementById('positionsInput').value || '[]');
     const cash      = parseFloat(document.getElementById('cashInput').value) || 0;
-    const res  = await fetch('/api/portfolio', {
+    const data = await fetch('/api/portfolio', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({cash, positions}),
-    });
-    const data = await res.json();
-    const msg  = document.getElementById('saveMsg');
-    msg.textContent  = data.ok ? 'Saved successfully.' : 'Error: ' + data.reason;
-    msg.style.color  = data.ok ? 'var(--green)' : 'var(--red)';
+    }).then(r => r.json());
+    const msg       = document.getElementById('saveMsg');
+    msg.textContent = data.ok ? 'Saved successfully.' : 'Error: ' + data.reason;
+    msg.style.color = data.ok ? 'var(--green)' : 'var(--red)';
     msg.style.display = 'block';
     setTimeout(() => msg.style.display = 'none', 3000);
   } catch (e) {
@@ -758,13 +899,12 @@ async function savePortfolio() {
   }
 }
 
-// ── Controls ────────────────────────────────────────────────────────────────
+// ── Controls ──────────────────────────────────────────────────────────────────
 
 document.querySelectorAll('.mode-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
     await fetch('/api/aggressiveness', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      method: 'POST', headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({aggressiveness: btn.dataset.value}),
     });
     refresh();
@@ -773,27 +913,27 @@ document.querySelectorAll('.mode-btn').forEach(btn => {
 
 async function triggerRun() {
   const res = await fetch('/api/run', {method: 'POST'});
-  if (!res.ok) {
-    const d = await res.json();
-    alert(d.reason || 'Run failed');
-    return;
-  }
-  document.getElementById('runBtn').disabled = true;
+  if (!res.ok) { alert((await res.json()).reason || 'Run failed'); return; }
+  document.getElementById('runBtn').disabled       = true;
   document.getElementById('spinner').style.display = 'block';
+  showProgress(true);
+  updateProgress('Starting…', 0, '');
 }
 
 async function refresh() {
-  try {
-    const state = await fetch('/api/state').then(r => r.json());
-    renderState(state);
-  } catch (e) {
-    console.warn('Refresh failed:', e);
-  }
+  try { renderState(await fetch('/api/state').then(r => r.json())); }
+  catch (e) { console.warn('Refresh failed:', e); }
 }
 
-// Initial render + 60-second auto-refresh
+// ── Boot ──────────────────────────────────────────────────────────────────────
+
 renderState(initialState);
-setInterval(refresh, 60_000);
+// Start appropriate polling interval based on initial state
+if (_wasRunning) {
+  _fastTimer = setInterval(refresh, 3000);
+} else {
+  _slowTimer = setInterval(refresh, 60_000);
+}
 </script>
 </body>
 </html>

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -387,6 +387,80 @@
     .btn-edit:hover { color: var(--text); border-color: var(--muted); }
 
     .save-msg { font-size: .75rem; margin-top: .4rem; color: var(--green); display: none; }
+
+    /* ── Reconnect button (header, shown when broker is in error/fallback) ── */
+    .reconnect-btn {
+      display: none;
+      align-items: center;
+      gap: .3rem;
+      font-size: .72rem;
+      font-weight: 600;
+      padding: .2rem .6rem;
+      border-radius: 20px;
+      border: 1px solid rgba(248,81,73,.4);
+      background: rgba(248,81,73,.08);
+      color: var(--red);
+      cursor: pointer;
+      transition: all .15s;
+      white-space: nowrap;
+    }
+    .reconnect-btn:hover { background: rgba(248,81,73,.16); }
+    .reconnect-btn.fallback {
+      border-color: rgba(210,153,34,.4);
+      background: rgba(210,153,34,.08);
+      color: var(--yellow);
+    }
+    .reconnect-btn.fallback:hover { background: rgba(210,153,34,.16); }
+
+    /* ── Modal ── */
+    .modal-overlay {
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,.65);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1000;
+    }
+    .modal-box {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      width: 420px; max-width: 95vw;
+      overflow: hidden;
+    }
+    .modal-header {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: .85rem 1.1rem;
+      background: var(--surface2);
+      border-bottom: 1px solid var(--border);
+      font-weight: 600; font-size: .88rem;
+    }
+    .modal-close {
+      background: transparent; border: none; color: var(--muted);
+      font-size: 1.2rem; cursor: pointer; line-height: 1; padding: 0 .25rem;
+    }
+    .modal-close:hover { color: var(--text); }
+    .modal-body { padding: 1.1rem; }
+    .modal-footer {
+      display: flex; justify-content: flex-end; gap: .5rem;
+      padding: .75rem 1.1rem;
+      border-top: 1px solid var(--border);
+    }
+    .btn-cancel {
+      padding: .4rem .85rem; border-radius: 6px; font-size: .82rem;
+      background: transparent; color: var(--muted);
+      border: 1px solid var(--border); cursor: pointer;
+    }
+    .btn-cancel:hover { color: var(--text); border-color: var(--muted); }
+    .btn-action {
+      display: inline-flex; align-items: center; gap: .35rem;
+      padding: .4rem .85rem; border-radius: 6px; font-size: .82rem;
+      background: var(--blue); color: #fff; border: none; cursor: pointer;
+      transition: background .15s;
+    }
+    .btn-action:hover:not(:disabled) { background: #79b8ff; }
+    .btn-action:disabled { opacity: .55; cursor: not-allowed; }
+    .reauth-msg  { font-size: .82rem; color: var(--muted); margin: 0 0 .9rem; min-height: 1.4em; }
+    .msg-error   { color: var(--red); }
+    .msg-success { color: var(--green); }
   </style>
 </head>
 <body>
@@ -402,6 +476,9 @@
       <button class="broker-pill" id="brokerPill" onclick="checkBroker()" title="Check brokerage connection">
         <i class="bi bi-plug" id="brokerIcon"></i>
         <span id="brokerLabel">Check connection</span>
+      </button>
+      <button class="reconnect-btn" id="reconnectBtn" onclick="openReauth()" title="Re-authenticate with Robinhood">
+        <i class="bi bi-arrow-clockwise"></i> Reconnect
       </button>
       <div class="mode-toggle" id="modeToggle">
         <button class="mode-btn" data-value="conservative">
@@ -595,6 +672,32 @@
   </div>
 </div>
 
+<!-- Reconnect modal -->
+<div class="modal-overlay" id="reauthOverlay" style="display:none" onclick="reauthOverlayClick(event)">
+  <div class="modal-box">
+    <div class="modal-header">
+      <span><i class="bi bi-plug" style="color:var(--blue)"></i>&nbsp; Reconnect to Robinhood</span>
+      <button class="modal-close" onclick="closeReauth()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="reauth-msg" id="reauthMsg">Click <strong>Reconnect</strong> to attempt login with stored credentials.</p>
+      <div id="mfaSection" style="display:none">
+        <div class="form-label-sm">Verification code (SMS / authenticator app)</div>
+        <input type="text" class="form-ctrl" id="mfaInput" maxlength="8"
+               placeholder="6-digit code" inputmode="numeric" autocomplete="one-time-code"
+               onkeydown="if(event.key==='Enter') submitReauth()">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn-cancel" id="reauthCancelBtn" onclick="closeReauth()">Cancel</button>
+      <button class="btn-action" id="reauthSubmitBtn" onclick="submitReauth()">
+        <div class="spin" id="reauthSpin" style="border-color:rgba(255,255,255,.3);border-top-color:#fff"></div>
+        <span id="reauthBtnLabel">Reconnect</span>
+      </button>
+    </div>
+  </div>
+</div>
+
 <script>
 const initialState = {{ state | tojson }};
 let currentState   = initialState;
@@ -665,20 +768,33 @@ function updateProgress(stage, progress, detail) {
 
 // ── Broker check ──────────────────────────────────────────────────────────────
 
+function _setBrokerError(msg) {
+  const pill = document.getElementById('brokerPill');
+  const rBtn = document.getElementById('reconnectBtn');
+  pill.className = 'broker-pill error';
+  document.getElementById('brokerIcon').className  = 'bi bi-x-circle';
+  document.getElementById('brokerIcon').style.animation = '';
+  document.getElementById('brokerLabel').textContent = msg;
+  rBtn.className = 'reconnect-btn';
+  rBtn.style.display = 'inline-flex';
+}
+
 async function checkBroker() {
   const pill  = document.getElementById('brokerPill');
   const icon  = document.getElementById('brokerIcon');
   const label = document.getElementById('brokerLabel');
+  const rBtn  = document.getElementById('reconnectBtn');
 
   pill.className       = 'broker-pill checking';
   icon.className       = 'bi bi-arrow-repeat';
   icon.style.animation = 'spin .6s linear infinite';
   label.textContent    = 'Checking…';
+  rBtn.style.display   = 'none';
 
   try {
     const data = await fetch('/api/broker/check', {method: 'POST'}).then(r => r.json());
-
     icon.style.animation = '';
+
     if (data.ok) {
       const src = data.source || 'unknown';
       pill.className = `broker-pill ${src}`;
@@ -686,16 +802,91 @@ async function checkBroker() {
       label.textContent = src === 'live'
         ? `Live · ${data.positions} pos · $${Number(data.cash).toFixed(2)}`
         : `Fallback · ${data.positions} pos`;
+      // Show reconnect button for fallback so user can try to get a live connection
+      if (src === 'fallback') {
+        rBtn.className = 'reconnect-btn fallback';
+        rBtn.style.display = 'inline-flex';
+      }
     } else {
-      pill.className = 'broker-pill error';
-      icon.className = 'bi bi-x-circle';
-      label.textContent = 'Connection failed';
+      _setBrokerError('Connection failed');
     }
   } catch {
-    icon.style.animation = '';
-    pill.className = 'broker-pill error';
-    icon.className = 'bi bi-x-circle';
-    label.textContent = 'Network error';
+    _setBrokerError('Network error');
+  }
+}
+
+// ── Reconnect (reauth) flow ───────────────────────────────────────────────────
+
+function openReauth() {
+  const msg = document.getElementById('reauthMsg');
+  msg.textContent = 'Click Reconnect to attempt login with stored credentials.';
+  msg.className = 'reauth-msg';
+  document.getElementById('mfaSection').style.display  = 'none';
+  document.getElementById('mfaInput').value            = '';
+  document.getElementById('reauthBtnLabel').textContent = 'Reconnect';
+  document.getElementById('reauthSubmitBtn').disabled  = false;
+  document.getElementById('reauthSpin').style.display  = 'none';
+  document.getElementById('reauthCancelBtn').textContent = 'Cancel';
+  document.getElementById('reauthOverlay').style.display = 'flex';
+}
+
+function closeReauth() {
+  document.getElementById('reauthOverlay').style.display = 'none';
+}
+
+function reauthOverlayClick(e) {
+  if (e.target === document.getElementById('reauthOverlay')) closeReauth();
+}
+
+async function submitReauth() {
+  const mfaSection = document.getElementById('mfaSection');
+  const mfaCode    = mfaSection.style.display !== 'none'
+    ? document.getElementById('mfaInput').value.trim() : null;
+
+  const submitBtn = document.getElementById('reauthSubmitBtn');
+  const spin      = document.getElementById('reauthSpin');
+  const msg       = document.getElementById('reauthMsg');
+
+  submitBtn.disabled    = true;
+  spin.style.display    = 'block';
+  msg.className         = 'reauth-msg';
+  msg.textContent       = mfaCode ? 'Verifying code…' : 'Connecting to Robinhood…';
+
+  try {
+    const body = mfaCode ? {mfa_code: mfaCode} : {};
+    const data = await fetch('/api/broker/reauth', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(body),
+    }).then(r => r.json());
+
+    spin.style.display = 'none';
+
+    if (data.ok) {
+      msg.className = 'reauth-msg msg-success';
+      msg.textContent = 'Connected! Refreshing status…';
+      mfaSection.style.display = 'none';
+      document.getElementById('reauthBtnLabel').textContent = 'Done';
+      document.getElementById('reauthCancelBtn').textContent = 'Close';
+      setTimeout(() => { closeReauth(); checkBroker(); }, 1500);
+
+    } else if (data.requires_mfa) {
+      msg.textContent = 'A verification code was sent to your registered device. Enter it below.';
+      mfaSection.style.display = 'block';
+      document.getElementById('mfaInput').focus();
+      document.getElementById('reauthBtnLabel').textContent = 'Verify';
+      submitBtn.disabled = false;
+
+    } else {
+      msg.className = 'reauth-msg msg-error';
+      msg.textContent = 'Error: ' + (data.error || 'Unknown error');
+      submitBtn.disabled = false;
+    }
+  } catch (e) {
+    spin.style.display = 'none';
+    msg.className = 'reauth-msg msg-error';
+    msg.textContent = 'Network error — is the server reachable?';
+    submitBtn.disabled = false;
   }
 }
 

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -388,6 +388,23 @@
 
     .save-msg { font-size: .75rem; margin-top: .4rem; color: var(--green); display: none; }
 
+    /* ── Settings gear button ── */
+    .gear-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem; height: 2rem;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--muted);
+      cursor: pointer;
+      font-size: .95rem;
+      transition: all .15s;
+      flex-shrink: 0;
+    }
+    .gear-btn:hover { color: var(--text); border-color: var(--muted); background: var(--surface2); }
+
     /* ── Reconnect button (header, shown when broker is in error/fallback) ── */
     .reconnect-btn {
       display: none;
@@ -473,6 +490,9 @@
       <p class="app-subtitle">Powered by TradingAgents &mdash; multi-agent LLM analysis</p>
     </div>
     <div class="header-controls">
+      <button class="gear-btn" onclick="openSettings()" title="Settings">
+        <i class="bi bi-gear"></i>
+      </button>
       <button class="broker-pill" id="brokerPill" onclick="checkBroker()" title="Check brokerage connection">
         <i class="bi bi-plug" id="brokerIcon"></i>
         <span id="brokerLabel">Check connection</span>
@@ -672,6 +692,48 @@
   </div>
 </div>
 
+<!-- Settings modal -->
+<div class="modal-overlay" id="settingsOverlay" style="display:none" onclick="settingsOverlayClick(event)">
+  <div class="modal-box">
+    <div class="modal-header">
+      <span><i class="bi bi-gear" style="color:var(--blue)"></i>&nbsp; Settings</span>
+      <button class="modal-close" onclick="closeSettings()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div style="font-size:.72rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin-bottom:.75rem">
+        Robinhood Credentials
+      </div>
+      <div style="margin-bottom:.65rem">
+        <div class="form-label-sm">Username (email)</div>
+        <input type="email" class="form-ctrl" id="settingsUsername" placeholder="you@example.com" autocomplete="username">
+      </div>
+      <div style="margin-bottom:.65rem">
+        <div class="form-label-sm">Password</div>
+        <div style="position:relative">
+          <input type="password" class="form-ctrl" id="settingsPassword"
+                 placeholder="Leave blank to keep current"
+                 autocomplete="current-password"
+                 style="padding-right:2.5rem">
+          <button type="button" onclick="toggleSettingsPw()" tabindex="-1"
+                  style="position:absolute;right:.55rem;top:50%;transform:translateY(-50%);
+                         background:none;border:none;color:var(--muted);cursor:pointer;padding:0;font-size:.9rem">
+            <i class="bi bi-eye" id="settingsPwEye"></i>
+          </button>
+        </div>
+        <div id="settingsPwNote" style="font-size:.7rem;color:var(--muted);margin-top:.25rem"></div>
+      </div>
+      <p class="reauth-msg" id="settingsMsg" style="margin-top:.5rem;min-height:1.2em"></p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn-cancel" onclick="closeSettings()">Cancel</button>
+      <button class="btn-action" id="settingsSaveBtn" onclick="saveSettings()">
+        <div class="spin" id="settingsSpin" style="border-color:rgba(255,255,255,.3);border-top-color:#fff"></div>
+        <span id="settingsBtnLabel">Save &amp; Test Connection</span>
+      </button>
+    </div>
+  </div>
+</div>
+
 <!-- Reconnect modal -->
 <div class="modal-overlay" id="reauthOverlay" style="display:none" onclick="reauthOverlayClick(event)">
   <div class="modal-box">
@@ -768,15 +830,33 @@ function updateProgress(stage, progress, detail) {
 
 // ── Broker check ──────────────────────────────────────────────────────────────
 
-function _setBrokerError(msg) {
-  const pill = document.getElementById('brokerPill');
-  const rBtn = document.getElementById('reconnectBtn');
-  pill.className = 'broker-pill error';
-  document.getElementById('brokerIcon').className  = 'bi bi-x-circle';
-  document.getElementById('brokerIcon').style.animation = '';
-  document.getElementById('brokerLabel').textContent = msg;
-  rBtn.className = 'reconnect-btn';
-  rBtn.style.display = 'inline-flex';
+function _applyBrokerResult(data) {
+  const pill  = document.getElementById('brokerPill');
+  const icon  = document.getElementById('brokerIcon');
+  const label = document.getElementById('brokerLabel');
+  const rBtn  = document.getElementById('reconnectBtn');
+
+  icon.style.animation = '';
+  rBtn.style.display   = 'none';
+
+  if (data.ok) {
+    const src = data.source || 'unknown';
+    pill.className = `broker-pill ${src}`;
+    icon.className = src === 'live' ? 'bi bi-plug-fill' : 'bi bi-exclamation-triangle';
+    label.textContent = src === 'live'
+      ? `Live · ${data.positions} pos · $${Number(data.cash).toFixed(2)}`
+      : `Fallback · ${data.positions} pos`;
+    if (src === 'fallback') {
+      rBtn.className = 'reconnect-btn fallback';
+      rBtn.style.display = 'inline-flex';
+    }
+  } else {
+    pill.className = 'broker-pill error';
+    icon.className = 'bi bi-x-circle';
+    label.textContent = 'Connection failed';
+    rBtn.className = 'reconnect-btn';
+    rBtn.style.display = 'inline-flex';
+  }
 }
 
 async function checkBroker() {
@@ -793,25 +873,126 @@ async function checkBroker() {
 
   try {
     const data = await fetch('/api/broker/check', {method: 'POST'}).then(r => r.json());
-    icon.style.animation = '';
-
-    if (data.ok) {
-      const src = data.source || 'unknown';
-      pill.className = `broker-pill ${src}`;
-      icon.className = src === 'live' ? 'bi bi-plug-fill' : 'bi bi-exclamation-triangle';
-      label.textContent = src === 'live'
-        ? `Live · ${data.positions} pos · $${Number(data.cash).toFixed(2)}`
-        : `Fallback · ${data.positions} pos`;
-      // Show reconnect button for fallback so user can try to get a live connection
-      if (src === 'fallback') {
-        rBtn.className = 'reconnect-btn fallback';
-        rBtn.style.display = 'inline-flex';
-      }
-    } else {
-      _setBrokerError('Connection failed');
-    }
+    _applyBrokerResult(data);
   } catch {
-    _setBrokerError('Network error');
+    _applyBrokerResult({ok: false});
+  }
+}
+
+// ── Settings modal ────────────────────────────────────────────────────────────
+
+async function openSettings() {
+  // Reset state
+  const msg = document.getElementById('settingsMsg');
+  msg.textContent = '';
+  msg.className = 'reauth-msg';
+  document.getElementById('settingsPassword').value = '';
+  document.getElementById('settingsBtnLabel').textContent = 'Save & Test Connection';
+  document.getElementById('settingsSaveBtn').disabled = false;
+  document.getElementById('settingsSpin').style.display = 'none';
+
+  // Pre-populate from server
+  try {
+    const s = await fetch('/api/settings').then(r => r.json());
+    document.getElementById('settingsUsername').value = s.robinhood_username || '';
+    document.getElementById('settingsPwNote').textContent =
+      s.robinhood_password_set ? 'Password is set. Leave blank to keep it.' : 'No password saved yet.';
+  } catch {
+    document.getElementById('settingsPwNote').textContent = 'Could not load current settings.';
+  }
+
+  document.getElementById('settingsOverlay').style.display = 'flex';
+}
+
+function closeSettings() {
+  document.getElementById('settingsOverlay').style.display = 'none';
+}
+
+function settingsOverlayClick(e) {
+  if (e.target === document.getElementById('settingsOverlay')) closeSettings();
+}
+
+function toggleSettingsPw() {
+  const inp  = document.getElementById('settingsPassword');
+  const icon = document.getElementById('settingsPwEye');
+  if (inp.type === 'password') {
+    inp.type = 'text';
+    icon.className = 'bi bi-eye-slash';
+  } else {
+    inp.type = 'password';
+    icon.className = 'bi bi-eye';
+  }
+}
+
+async function saveSettings() {
+  const username = document.getElementById('settingsUsername').value.trim();
+  const password = document.getElementById('settingsPassword').value;
+
+  if (!username) {
+    const m = document.getElementById('settingsMsg');
+    m.className = 'reauth-msg msg-error';
+    m.textContent = 'Username is required.';
+    return;
+  }
+
+  const btn  = document.getElementById('settingsSaveBtn');
+  const spin = document.getElementById('settingsSpin');
+  const msg  = document.getElementById('settingsMsg');
+  btn.disabled = true;
+  spin.style.display = 'block';
+  msg.className = 'reauth-msg';
+  msg.textContent = 'Saving…';
+
+  try {
+    const body = { robinhood_username: username };
+    if (password) body.robinhood_password = password;
+
+    const saved = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then(r => r.json());
+
+    if (!saved.ok) {
+      msg.className = 'reauth-msg msg-error';
+      msg.textContent = 'Save failed: ' + (saved.reason || 'unknown error');
+      btn.disabled = false;
+      spin.style.display = 'none';
+      return;
+    }
+
+    // Saved — now test connection
+    msg.textContent = 'Saved. Testing connection…';
+    const result = await fetch('/api/broker/check', { method: 'POST' }).then(r => r.json());
+    spin.style.display = 'none';
+
+    if (result.ok && result.source === 'live') {
+      msg.className = 'reauth-msg msg-success';
+      msg.textContent = `Connected — Live · ${result.positions} position(s) · $${Number(result.cash).toFixed(2)}`;
+      document.getElementById('settingsBtnLabel').textContent = 'Done';
+      // Update the pill immediately
+      _applyBrokerResult(result);
+      setTimeout(closeSettings, 2500);
+    } else if (result.ok && result.source === 'fallback') {
+      msg.className = 'reauth-msg';
+      msg.textContent = `Settings saved. Robinhood unreachable — using local fallback (${result.positions} positions).`;
+      _applyBrokerResult(result);
+      document.getElementById('settingsBtnLabel').textContent = 'Close';
+      btn.disabled = false;
+      btn.onclick = closeSettings;
+    } else {
+      msg.className = 'reauth-msg msg-error';
+      msg.textContent = 'Settings saved, but connection failed: ' + (result.error || 'unknown');
+      _applyBrokerResult(result);
+      btn.disabled = false;
+      document.getElementById('settingsBtnLabel').textContent = 'Close';
+      btn.onclick = closeSettings;
+    }
+  } catch (e) {
+    spin.style.display = 'none';
+    msg.className = 'reauth-msg msg-error';
+    msg.textContent = 'Network error: ' + e.message;
+    btn.disabled = false;
   }
 }
 
@@ -868,7 +1049,12 @@ async function submitReauth() {
       mfaSection.style.display = 'none';
       document.getElementById('reauthBtnLabel').textContent = 'Done';
       document.getElementById('reauthCancelBtn').textContent = 'Close';
-      setTimeout(() => { closeReauth(); checkBroker(); }, 1500);
+      // Run check and apply result to pill, then close
+      fetch('/api/broker/check', {method: 'POST'})
+        .then(r => r.json())
+        .then(r => { _applyBrokerResult(r); })
+        .catch(() => {});
+      setTimeout(closeReauth, 1500);
 
     } else if (data.requires_mfa) {
       msg.textContent = 'A verification code was sent to your registered device. Enter it below.';

--- a/portfolio_advisor/templates/index.html
+++ b/portfolio_advisor/templates/index.html
@@ -12,19 +12,27 @@
     .table { color: #e0e0e0; }
     .table th { color: #8b95a1; font-size: .8rem; text-transform: uppercase; border-color: #2a2d3a; }
     .table td { border-color: #2a2d3a; vertical-align: middle; }
-    .badge-sell  { background: #7f1d1d; color: #fca5a5; }
-    .badge-buy   { background: #14532d; color: #86efac; }
-    .badge-hold  { background: #1e293b; color: #94a3b8; }
-    .pill-sell   { background: #991b1b; }
-    .pill-buy    { background: #166534; }
-    .pill-hold   { background: #334155; }
-    .rationale   { font-size: .8rem; color: #6b7280; max-width: 420px; }
     .source-live { color: #4ade80; }
     .source-fallback { color: #facc15; }
     .source-unknown  { color: #9ca3af; }
+    .unaffordable { opacity: 0.5; }
+    .rationale { font-size: .8rem; color: #6b7280; max-width: 420px; }
     #spinner { display: none; }
     #portfolio-form { display: none; }
     pre { color: #a5b4fc; background: #0f1117; padding: 1rem; border-radius: .375rem; font-size: .8rem; }
+
+    /* Regime colors */
+    .regime-bull          { color: #4ade80; }
+    .regime-corrective    { color: #facc15; }
+    .regime-bear          { color: #fb923c; }
+    .regime-confirmed_bear{ color: #f87171; }
+    .regime-unknown       { color: #9ca3af; }
+
+    /* Condition badge */
+    .condition-1 { background: #14532d; color: #86efac; }
+    .condition-2 { background: #1e3a5f; color: #93c5fd; }
+    .condition-3 { background: #3f3f46; color: #a1a1aa; }
+    .condition-4 { background: #422006; color: #fdba74; }
   </style>
 </head>
 <body>
@@ -52,7 +60,7 @@
 
   <!-- Status row -->
   <div class="row g-3 mb-4" id="statusCards">
-    <div class="col-md-3">
+    <div class="col-md-2">
       <div class="card h-100">
         <div class="card-body">
           <div class="text-muted small">Cash Available</div>
@@ -60,7 +68,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-2">
       <div class="card h-100">
         <div class="card-body">
           <div class="text-muted small">Data Source</div>
@@ -68,15 +76,32 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-2">
       <div class="card h-100">
         <div class="card-body">
-          <div class="text-muted small">Last Intraday Check</div>
+          <div class="text-muted small">Condition</div>
+          <div id="conditionVal" class="fw-bold">—</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-2">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Market Regime</div>
+          <div id="regimeVal" class="fw-bold">—</div>
+          <div id="regimeSub" class="text-muted" style="font-size:.75rem"></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-2">
+      <div class="card h-100">
+        <div class="card-body">
+          <div class="text-muted small">Last Intraday</div>
           <div class="fw-bold" id="intradayVal">—</div>
         </div>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-2">
       <div class="card h-100">
         <div class="card-body">
           <div class="text-muted small">Last EOD Scan</div>
@@ -96,7 +121,7 @@
         <div class="card-body p-0">
           <table class="table table-hover mb-0" id="sellTable">
             <thead><tr>
-              <th>Ticker</th><th>Signal</th><th>Rationale</th>
+              <th>Ticker</th><th>Signal</th><th>Price</th><th>Rationale</th>
             </tr></thead>
             <tbody></tbody>
           </table>
@@ -110,7 +135,7 @@
         <div class="card-body p-0">
           <table class="table table-hover mb-0" id="buyTable">
             <thead><tr>
-              <th>Ticker</th><th>Signal</th><th>Owned</th><th>Rationale</th>
+              <th>Ticker</th><th>Signal</th><th>Price</th><th>Owned</th><th>Rationale</th>
             </tr></thead>
             <tbody></tbody>
           </table>
@@ -124,7 +149,7 @@
         <div class="card-body p-0">
           <table class="table table-hover mb-0" id="holdTable">
             <thead><tr>
-              <th>Ticker</th><th>Signal</th><th>Rationale</th>
+              <th>Ticker</th><th>Signal</th><th>Price</th><th>Rationale</th>
             </tr></thead>
             <tbody></tbody>
           </table>
@@ -190,6 +215,7 @@ function fmt(ts) {
 }
 
 function fmtMoney(n) {
+  if (!n && n !== 0) return '—';
   return '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
 }
 
@@ -197,6 +223,29 @@ function signalBadge(signal) {
   const cls = {Buy:'success', Overweight:'success', Hold:'secondary', Underweight:'warning', Sell:'danger'};
   return `<span class="badge bg-${cls[signal]||'secondary'}">${signal}</span>`;
 }
+
+const CONDITION_LABELS = {
+  1: 'Cash, No Positions',
+  2: 'Cash + Positions',
+  3: 'No Cash, No Positions',
+  4: 'No Cash, Has Positions',
+};
+
+const REGIME_LABELS = {
+  bull:           'Bull Market',
+  corrective:     'Corrective',
+  bear:           'Bear Market',
+  confirmed_bear: 'Confirmed Bear',
+  unknown:        'Unknown',
+};
+
+const REGIME_SUB = {
+  bull:           'SPY above 50-day & 200-day SMA',
+  corrective:     'SPY above 200-day, below 50-day',
+  bear:           'SPY below 200-day SMA',
+  confirmed_bear: 'Death cross — 50-day below 200-day',
+  unknown:        '',
+};
 
 function renderState(s) {
   currentState = s;
@@ -209,6 +258,27 @@ function renderState(s) {
   srcEl.className = 'fs-5 fw-bold source-' + src;
   document.getElementById('intradayVal').textContent = fmt(s.last_intraday_run);
   document.getElementById('eodVal').textContent = fmt(s.last_eod_run);
+
+  // Condition
+  const cond = s.condition;
+  const condEl = document.getElementById('conditionVal');
+  if (cond) {
+    condEl.innerHTML = `<span class="badge condition-${cond} fs-6">Condition ${cond}</span>
+      <div class="text-muted mt-1" style="font-size:.75rem">${CONDITION_LABELS[cond]||''}</div>`;
+  } else {
+    condEl.textContent = '—';
+  }
+
+  // Market regime
+  const regime = (s.market_regime || {});
+  const r = regime.regime || 'unknown';
+  const regimeEl = document.getElementById('regimeVal');
+  regimeEl.textContent = REGIME_LABELS[r] || r;
+  regimeEl.className = 'fw-bold regime-' + r;
+  const subEl = document.getElementById('regimeSub');
+  subEl.textContent = (regime.spy_price && r !== 'unknown')
+    ? `SPY ${fmtMoney(regime.spy_price)} | SMA50 ${fmtMoney(regime.sma50)}`
+    : (REGIME_SUB[r] || '');
 
   // Aggressiveness toggle
   document.querySelectorAll('.agg-btn').forEach(btn => {
@@ -231,10 +301,22 @@ function renderState(s) {
   posBody.innerHTML = '';
   positions.forEach(p => {
     const pnl = (p.current_price - p.cost_basis) * p.shares;
-    const pnlPct = ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1);
+    const pnlPct = p.cost_basis > 0
+      ? ((p.current_price - p.cost_basis) / p.cost_basis * 100).toFixed(1)
+      : '0.0';
     const pnlCls = pnl >= 0 ? 'text-success' : 'text-danger';
+    const flags = (p.flags || []);
+    const flagBadges = flags.map(f => {
+      if (f === 'concentration_risk')
+        return '<span class="badge bg-warning text-dark ms-1" title="Position >10% of portfolio">Conc.</span>';
+      if (f === 'drawdown_15pct')
+        return '<span class="badge bg-danger ms-1" title="Down >15% from cost basis">-15%</span>';
+      if (f === 'sector_concentration')
+        return '<span class="badge bg-secondary ms-1" title="Sector >25% of portfolio">Sector</span>';
+      return '';
+    }).join('');
     const row = posBody.insertRow();
-    row.innerHTML = `<td><strong>${p.ticker}</strong></td>
+    row.innerHTML = `<td><strong>${p.ticker}</strong>${flagBadges}</td>
       <td>${p.shares}</td>
       <td>${fmtMoney(p.current_price)}</td>
       <td class="${pnlCls}">${pnl >= 0 ? '+' : ''}${fmtMoney(pnl)}<br>
@@ -248,9 +330,9 @@ function renderState(s) {
   const buys  = actions.filter(a => a.action === 'BUY');
   const holds = actions.filter(a => a.action === 'HOLD');
 
-  renderActionTable('sellTable', 'sellEmpty', sells, ['ticker','signal','rationale']);
-  renderActionTable('buyTable',  'buyEmpty',  buys,  ['ticker','signal','owned','rationale']);
-  renderActionTable('holdTable', 'holdEmpty', holds, ['ticker','signal','rationale']);
+  renderActionTable('sellTable', 'sellEmpty', sells, ['ticker','signal','price','rationale']);
+  renderActionTable('buyTable',  'buyEmpty',  buys,  ['ticker','signal','price','owned','rationale']);
+  renderActionTable('holdTable', 'holdEmpty', holds, ['ticker','signal','price','rationale']);
 }
 
 function renderActionTable(tableId, emptyId, rows, cols) {
@@ -258,14 +340,27 @@ function renderActionTable(tableId, emptyId, rows, cols) {
   tbody.innerHTML = '';
   rows.forEach(a => {
     const tr = tbody.insertRow();
+    if (a.action === 'BUY' && a.affordable === false) {
+      tr.classList.add('unaffordable');
+      tr.title = 'Insufficient cash to purchase at current price';
+    }
     cols.forEach(col => {
       const td = tr.insertCell();
-      if (col === 'ticker') td.innerHTML = `<strong>${a.ticker}</strong>`;
-      else if (col === 'signal') td.innerHTML = signalBadge(a.signal);
-      else if (col === 'owned') td.innerHTML = a.owned
-        ? '<span class="badge bg-secondary">Owned</span>'
-        : '<span class="badge bg-dark border border-secondary">New</span>';
-      else if (col === 'rationale') {
+      if (col === 'ticker') {
+        td.innerHTML = `<strong>${a.ticker}</strong>`;
+        if (a.action === 'BUY' && a.affordable === false) {
+          td.innerHTML += ' <span class="badge bg-secondary" title="Price exceeds available cash">N/A</span>';
+        }
+      } else if (col === 'signal') {
+        td.innerHTML = signalBadge(a.signal);
+      } else if (col === 'price') {
+        td.textContent = a.price ? fmtMoney(a.price) : '—';
+        td.style.fontVariantNumeric = 'tabular-nums';
+      } else if (col === 'owned') {
+        td.innerHTML = a.owned
+          ? '<span class="badge bg-secondary">Owned</span>'
+          : '<span class="badge bg-dark border border-secondary">New</span>';
+      } else if (col === 'rationale') {
         td.className = 'rationale';
         td.textContent = a.rationale || '—';
       }

--- a/portfolio_advisor/web.py
+++ b/portfolio_advisor/web.py
@@ -8,7 +8,13 @@ from typing import Callable
 
 from flask import Flask, jsonify, render_template, request
 
-from .broker import reauth_robinhood, save_portfolio_json
+from .broker import (
+    check_connection,
+    load_settings,
+    reauth_robinhood,
+    save_portfolio_json,
+    save_settings,
+)
 from .config import Aggressiveness, Config
 
 logger = logging.getLogger(__name__)
@@ -49,6 +55,8 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
     def api_state():
         return jsonify(_read_state())
 
+    # ── Aggressiveness ────────────────────────────────────────────────────────
+
     @app.route("/api/aggressiveness", methods=["POST"])
     def set_aggressiveness():
         value = (request.json or {}).get("aggressiveness", "conservative")
@@ -58,6 +66,8 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
             return jsonify({"ok": False, "reason": f"Unknown value: {value}"}), 400
         _patch_state({"aggressiveness": value})
         return jsonify({"ok": True})
+
+    # ── Run ───────────────────────────────────────────────────────────────────
 
     @app.route("/api/run", methods=["POST"])
     def trigger_run():
@@ -78,6 +88,8 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
         threading.Thread(target=_run, daemon=True).start()
         return jsonify({"ok": True})
 
+    # ── Portfolio (fallback JSON editor) ──────────────────────────────────────
+
     @app.route("/api/portfolio", methods=["POST"])
     def save_portfolio():
         data = request.json or {}
@@ -91,6 +103,49 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
             return jsonify({"ok": False, "reason": str(exc)}), 400
         return jsonify({"ok": True})
 
+    # ── Settings ──────────────────────────────────────────────────────────────
+
+    @app.route("/api/settings", methods=["GET"])
+    def get_settings():
+        """Return current settings (password masked)."""
+        s = load_settings(cfg.data_dir)
+        return jsonify({
+            "robinhood_username": s.get("robinhood_username", ""),
+            "robinhood_password_set": bool(s.get("robinhood_password")),
+        })
+
+    @app.route("/api/settings", methods=["POST"])
+    def post_settings():
+        """Save settings to data_dir/settings.json. Empty password = keep current."""
+        data = request.json or {}
+        patch: dict = {}
+        if "robinhood_username" in data:
+            patch["robinhood_username"] = str(data["robinhood_username"]).strip()
+        if data.get("robinhood_password"):
+            patch["robinhood_password"] = data["robinhood_password"]
+        if not patch:
+            return jsonify({"ok": False, "reason": "No settings provided"}), 400
+        try:
+            save_settings(cfg.data_dir, patch)
+            return jsonify({"ok": True})
+        except Exception as exc:
+            logger.error("save_settings failed: %s", exc)
+            return jsonify({"ok": False, "reason": str(exc)}), 500
+
+    # ── Broker connection check ───────────────────────────────────────────────
+
+    @app.route("/api/broker/check", methods=["POST"])
+    def check_broker():
+        """Lightweight connection check: login + profile only, no full portfolio build."""
+        try:
+            result = check_connection(cfg.data_dir)
+            return jsonify(result)
+        except Exception as exc:
+            logger.error("check_connection raised unexpectedly: %s", exc)
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+    # ── Broker re-authentication ──────────────────────────────────────────────
+
     @app.route("/api/broker/reauth", methods=["POST"])
     def reauth_broker_route():
         """Re-authenticate with Robinhood.
@@ -102,7 +157,7 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
         data = request.json or {}
         mfa_code = data.get("mfa_code") or None
         try:
-            status, message = reauth_robinhood(mfa_code)
+            status, message = reauth_robinhood(cfg.data_dir, mfa_code)
         except Exception as exc:
             logger.error("reauth_robinhood raised unexpectedly: %s", exc)
             return jsonify({"ok": False, "error": str(exc)}), 500
@@ -112,20 +167,5 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
         if status == "mfa_required":
             return jsonify({"ok": False, "requires_mfa": True})
         return jsonify({"ok": False, "error": message}), 400
-
-    @app.route("/api/broker/check", methods=["POST"])
-    def check_broker():
-        """Live brokerage connection check. Returns current source, cash, and position count."""
-        try:
-            portfolio = load_portfolio(cfg.data_dir)
-            return jsonify({
-                "ok": True,
-                "source": portfolio.source,
-                "cash": portfolio.cash,
-                "positions": len(portfolio.positions),
-            })
-        except Exception as exc:
-            logger.error("Broker check failed: %s", exc)
-            return jsonify({"ok": False, "error": str(exc)}), 500
 
     return app

--- a/portfolio_advisor/web.py
+++ b/portfolio_advisor/web.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from typing import Callable
+
+from flask import Flask, jsonify, render_template, request
+
+from .broker import save_portfolio_json
+from .config import Aggressiveness, Config
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
+    app = Flask(__name__, template_folder="templates")
+    _running = threading.Event()
+
+    def _read_state() -> dict:
+        try:
+            with open(cfg.state_file, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {
+                "last_intraday_run": None,
+                "last_eod_run": None,
+                "portfolio_source": "unknown",
+                "portfolio_positions": [],
+                "cash": 0,
+                "actions": [],
+                "aggressiveness": cfg.aggressiveness.value,
+                "running": False,
+            }
+
+    def _patch_state(patch: dict) -> None:
+        state = _read_state()
+        state.update(patch)
+        os.makedirs(os.path.dirname(cfg.state_file), exist_ok=True)
+        with open(cfg.state_file, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2, default=str)
+
+    @app.route("/")
+    def index():
+        return render_template("index.html", state=_read_state())
+
+    @app.route("/api/state")
+    def api_state():
+        return jsonify(_read_state())
+
+    @app.route("/api/aggressiveness", methods=["POST"])
+    def set_aggressiveness():
+        value = (request.json or {}).get("aggressiveness", "conservative")
+        try:
+            cfg.aggressiveness = Aggressiveness(value)
+        except ValueError:
+            return jsonify({"ok": False, "reason": f"Unknown value: {value}"}), 400
+        _patch_state({"aggressiveness": value})
+        return jsonify({"ok": True})
+
+    @app.route("/api/run", methods=["POST"])
+    def trigger_run():
+        if _running.is_set():
+            return jsonify({"ok": False, "reason": "run already in progress"}), 409
+
+        def _run() -> None:
+            _running.set()
+            _patch_state({"running": True})
+            try:
+                run_now_fn()
+            except Exception as exc:
+                logger.error("On-demand run failed: %s", exc)
+            finally:
+                _running.clear()
+                _patch_state({"running": False})
+
+        threading.Thread(target=_run, daemon=True).start()
+        return jsonify({"ok": True})
+
+    @app.route("/api/portfolio", methods=["POST"])
+    def save_portfolio():
+        data = request.json or {}
+        try:
+            save_portfolio_json(
+                cfg.data_dir,
+                data.get("positions", []),
+                float(data.get("cash", 0)),
+            )
+        except Exception as exc:
+            return jsonify({"ok": False, "reason": str(exc)}), 400
+        return jsonify({"ok": True})
+
+    return app

--- a/portfolio_advisor/web.py
+++ b/portfolio_advisor/web.py
@@ -91,4 +91,19 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
             return jsonify({"ok": False, "reason": str(exc)}), 400
         return jsonify({"ok": True})
 
+    @app.route("/api/broker/check", methods=["POST"])
+    def check_broker():
+        """Live brokerage connection check. Returns current source, cash, and position count."""
+        try:
+            portfolio = load_portfolio(cfg.data_dir)
+            return jsonify({
+                "ok": True,
+                "source": portfolio.source,
+                "cash": portfolio.cash,
+                "positions": len(portfolio.positions),
+            })
+        except Exception as exc:
+            logger.error("Broker check failed: %s", exc)
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
     return app

--- a/portfolio_advisor/web.py
+++ b/portfolio_advisor/web.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 from flask import Flask, jsonify, render_template, request
 
-from .broker import save_portfolio_json
+from .broker import reauth_robinhood, save_portfolio_json
 from .config import Aggressiveness, Config
 
 logger = logging.getLogger(__name__)
@@ -90,6 +90,28 @@ def create_app(cfg: Config, run_now_fn: Callable) -> Flask:
         except Exception as exc:
             return jsonify({"ok": False, "reason": str(exc)}), 400
         return jsonify({"ok": True})
+
+    @app.route("/api/broker/reauth", methods=["POST"])
+    def reauth_broker_route():
+        """Re-authenticate with Robinhood.
+
+        First call: POST {} — attempts login with stored credentials.
+            Returns {"ok": false, "requires_mfa": true} if MFA is needed.
+        Second call: POST {"mfa_code": "123456"} — completes MFA login.
+        """
+        data = request.json or {}
+        mfa_code = data.get("mfa_code") or None
+        try:
+            status, message = reauth_robinhood(mfa_code)
+        except Exception as exc:
+            logger.error("reauth_robinhood raised unexpectedly: %s", exc)
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+        if status == "ok":
+            return jsonify({"ok": True})
+        if status == "mfa_required":
+            return jsonify({"ok": False, "requires_mfa": True})
+        return jsonify({"ok": False, "error": message}), 400
 
     @app.route("/api/broker/check", methods=["POST"])
     def check_broker():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,19 @@ dependencies = [
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",
     "yfinance>=0.2.63",
+    # portfolio-advisor dependencies
+    "apscheduler>=3.10.0",
+    "flask>=3.0.0",
+    "pandas-market-calendars>=4.4.0",
+    "robin-stocks>=3.0.0",
 ]
 
 [project.scripts]
 tradingagents = "cli.main:app"
+portfolio-advisor = "portfolio_advisor.main:main"
 
 [tool.setuptools.packages.find]
-include = ["tradingagents*", "cli*"]
+include = ["tradingagents*", "cli*", "portfolio_advisor*"]
 
 [tool.setuptools.package-data]
 cli = ["static/*"]


### PR DESCRIPTION
## Summary

- Adds `portfolio_advisor/` as a self-contained companion package that consumes TradingAgents without modifying its internals
- Live portfolio loaded via `robin_stocks` (Robinhood API) with automatic fallback to a user-edited `portfolio.json`
- NASDAQ universe screened by price range, volume, momentum, and sector (sector filter bypassed in aggressive mode) before passing candidates to TradingAgents
- Aggressiveness setting controls signal thresholds: conservative = Buy/Sell only; aggressive = Overweight→BUY, Underweight→SELL
- Scheduled jobs: intraday checks 4×/trading day (09:32, 11:30, 13:30, 15:30 ET), EOD scan at 16:15 ET, pre-market scan at 09:00 ET on first trading day of each week
- Flask web UI at port 5001: ranked action list (SELL alerts, BUY candidates, HOLD), aggressiveness toggle, Run Now button, fallback portfolio editor
- `compat_test.py` smoke test to validate TradingAgents compatibility before any upstream upgrade

## Test plan

- [ ] Run `python -m portfolio_advisor.compat_test` and confirm all checks pass
- [ ] Set `ROBINHOOD_USERNAME` / `ROBINHOOD_PASSWORD` env vars and verify live portfolio loads
- [ ] Remove env vars and confirm fallback to `portfolio.json` with a warning in logs
- [ ] Start with `portfolio-advisor` and confirm web UI renders at `http://localhost:5001`
- [ ] Toggle aggressiveness and confirm state persists after page refresh
- [ ] Click Run Now and confirm spinner appears while run is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)