### PR TITLE
fix(security): allow '=' character in ticker symbol for path generation

### DIFF
--- a/tests/test_safe_ticker_component.py
+++ b/tests/test_safe_ticker_component.py
@@ -11,7 +11,7 @@ from tradingagents.dataflows.utils import safe_ticker_component
 @pytest.mark.unit
 class TestSafeTickerComponent(unittest.TestCase):
     def test_accepts_common_ticker_formats(self):
-        for ticker in ("AAPL", "BRK-B", "BRK.A", "0700.HK", "7203.T", "BHP.AX", "^GSPC"):
+        for ticker in ("AAPL", "BRK-B", "BRK.A", "0700.HK", "7203.T", "BHP.AX", "^GSPC", "XAUUSD=X", "GC=F"):
             self.assertEqual(safe_ticker_component(ticker), ticker)
 
     def test_rejects_path_separators(self):

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -7,10 +7,10 @@ from typing import Annotated
 
 SavePathType = Annotated[str, "File path to save data. If None, data is not saved."]
 
-# Tickers can contain letters, digits, dot, dash, underscore, and caret
-# (for index symbols like ^GSPC). Anything else is rejected so the value
-# never escapes a containing directory when interpolated into a path.
-_TICKER_PATH_RE = re.compile(r"^[A-Za-z0-9._\-\^]+$")
+# Tickers can contain letters, digits, dot, dash, underscore, equals sign,
+# and caret (for index symbols like ^GSPC). Anything else is rejected so
+# the value never escapes a containing directory when interpolated into a path.
+_TICKER_PATH_RE = re.compile(r"^[A-Za-z0-9._\-^=]+$")
 
 
 def safe_ticker_component(value: str, *, max_len: int = 32) -> str:


### PR DESCRIPTION
## Description
This PR addresses an issue where valid financial tickers containing the `=` character were being incorrectly rejected by the `safe_ticker_component` validator, which caused errors during filesystem operations (such as path generation for caching or reports).

Many Yahoo Finance tickers for Forex and Commodities rely on the `=` character (e.g., `XAUUSD=X` for Gold/USD, `EURUSD=X`, or `GC=F` for Gold Futures). This PR adds the `=` character to the `_TICKER_PATH_RE` regex to safely allow these common tickers to be processed while still maintaining protection against path traversal.

## Changes
- Updated `_TICKER_PATH_RE` in `tradingagents/dataflows/utils.py` to include the `=` character.
- Added test cases for `XAUUSD=X` and `GC=F` in `tests/test_safe_ticker_component.py` to ensure they pass validation safely.
