### PR TITLE
feat: add Custom OpenAI-Compatible provider for local LLM servers

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -930,6 +930,10 @@ def run_analysis(checkpoint: bool = False):
     # First get all user selections
     selections = get_user_selections()
 
+    # Persist LLM selections for next run
+    from cli.preferences import save_preferences
+    save_preferences(selections)
+
     # Create config with selected research depth
     config = DEFAULT_CONFIG.copy()
     config["max_debate_rounds"] = selections["research_depth"]
@@ -1155,6 +1159,16 @@ def run_analysis(checkpoint: bool = False):
         # Get final state and decision
         final_state = trace[-1]
         decision = graph.process_signal(final_state["final_trade_decision"])
+
+        # Persist decision log and state (the CLI streams directly and
+        # bypasses TradingAgentsGraph._run_graph which normally does this)
+        graph.ticker = selections["ticker"]
+        graph._log_state(selections["analysis_date"], final_state)
+        graph.memory_log.store_decision(
+            ticker=selections["ticker"],
+            trade_date=selections["analysis_date"],
+            final_trade_decision=final_state["final_trade_decision"],
+        )
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/cli/main.py
+++ b/cli/main.py
@@ -596,6 +596,17 @@ def get_user_selections():
         )
         anthropic_effort = ask_anthropic_effort()
 
+    # Step 9: LLM timeout for local inference providers
+    llm_timeout = None
+    if provider_lower in ("custom_openai", "ollama"):
+        console.print(
+            create_question_box(
+                "Step 9: Request Timeout",
+                "Set timeout in seconds for LLM API calls (increase for slow local models)"
+            )
+        )
+        llm_timeout = ask_llm_timeout()
+
     return {
         "ticker": selected_ticker,
         "analysis_date": analysis_date,
@@ -609,6 +620,7 @@ def get_user_selections():
         "openai_reasoning_effort": reasoning_effort,
         "anthropic_effort": anthropic_effort,
         "output_language": output_language,
+        "llm_timeout": llm_timeout,
     }
 
 
@@ -947,6 +959,7 @@ def run_analysis(checkpoint: bool = False):
     config["openai_reasoning_effort"] = selections.get("openai_reasoning_effort")
     config["anthropic_effort"] = selections.get("anthropic_effort")
     config["output_language"] = selections.get("output_language", "English")
+    config["llm_timeout"] = selections.get("llm_timeout")
     config["checkpoint_enabled"] = checkpoint
 
     # Create stats callback handler for tracking LLM/tool calls

--- a/cli/preferences.py
+++ b/cli/preferences.py
@@ -1,0 +1,36 @@
+"""Persist CLI selections between runs.
+
+Saves LLM provider, base URL, and model choices to
+~/.tradingagents/cli_preferences.json so the user doesn't
+have to re-enter them every time.
+"""
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+_PREFS_PATH = os.path.join(
+    os.path.expanduser("~"), ".tradingagents", "cli_preferences.json"
+)
+
+_SAVED_KEYS = (
+    "llm_provider",
+    "backend_url",
+    "shallow_thinker",
+    "deep_thinker",
+)
+
+
+def load_preferences() -> Dict[str, Any]:
+    try:
+        with open(_PREFS_PATH, encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_preferences(selections: Dict[str, Any]) -> None:
+    data = {k: selections[k] for k in _SAVED_KEYS if k in selections}
+    os.makedirs(os.path.dirname(_PREFS_PATH), exist_ok=True)
+    with open(_PREFS_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -402,3 +402,36 @@ def ask_output_language() -> str:
         ).ask().strip()
 
     return choice
+
+
+def ask_llm_timeout() -> int | None:
+    """Ask for LLM request timeout (seconds). Returns None for provider default."""
+    TIMEOUT_OPTIONS = [
+        ("Default (provider decides)", None),
+        ("5 minutes (300s) - fast local models", 300),
+        ("15 minutes (900s) - moderate local models", 900),
+        ("30 minutes (1800s) - slow or large local models", 1800),
+        ("Custom", "custom"),
+    ]
+
+    choice = questionary.select(
+        "Select Request Timeout:",
+        choices=[
+            questionary.Choice(display, value=value) for display, value in TIMEOUT_OPTIONS
+        ],
+        style=questionary.Style([
+            ("selected", "fg:cyan noinherit"),
+            ("highlighted", "fg:cyan noinherit"),
+            ("pointer", "fg:cyan noinherit"),
+        ]),
+    ).ask()
+
+    if choice == "custom":
+        val = questionary.text(
+            "Enter timeout in seconds:",
+            validate=lambda x: x.strip().isdigit() and int(x.strip()) > 0
+            or "Enter a positive integer.",
+        ).ask()
+        return int(val.strip()) if val else None
+
+    return choice

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -4,9 +4,12 @@ from typing import List, Optional, Tuple, Dict
 from rich.console import Console
 
 from cli.models import AnalystType
+from cli.preferences import load_preferences
 from tradingagents.llm_clients.model_catalog import get_model_options
 
 console = Console()
+
+_prefs = load_preferences()
 
 TICKER_INPUT_EXAMPLES = "Examples: SPY, CNC.TO, 7203.T, 0700.HK"
 
@@ -187,6 +190,19 @@ def _select_model(provider: str, mode: str) -> str:
     if provider.lower() == "openrouter":
         return select_openrouter_model()
 
+    if provider.lower() == "custom_openai":
+        saved_key = "shallow_thinker" if mode == "quick" else "deep_thinker"
+        saved_model = _prefs.get(saved_key, "")
+        model_name = questionary.text(
+            f"Enter model name for {mode}-thinking (as shown in your server):",
+            default=saved_model,
+            validate=lambda x: len(x.strip()) > 0 or "Please enter a model name.",
+        ).ask()
+        if model_name is None:
+            console.print(f"\n[red]No {mode} thinking model name provided. Exiting...[/red]")
+            exit(1)
+        return model_name.strip()
+
     if provider.lower() == "azure":
         return questionary.text(
             f"Enter Azure deployment name ({mode}-thinking):",
@@ -242,14 +258,25 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", "http://localhost:11434/v1"),
+        ("Custom OpenAI-Compatible (LM Studio, vLLM, llama.cpp, etc.)", "custom_openai", None),
     ]
+
+    saved_provider = _prefs.get("llm_provider")
+    provider_choices = [
+        questionary.Choice(display, value=(provider_key, url))
+        for display, provider_key, url in PROVIDERS
+    ]
+    default_choice = None
+    if saved_provider:
+        for display, provider_key, url in PROVIDERS:
+            if provider_key == saved_provider:
+                default_choice = (provider_key, url)
+                break
 
     choice = questionary.select(
         "Select your LLM Provider:",
-        choices=[
-            questionary.Choice(display, value=(provider_key, url))
-            for display, provider_key, url in PROVIDERS
-        ],
+        choices=provider_choices,
+        default=default_choice,
         instruction="\n- Use arrow keys to navigate\n- Press Enter to select",
         style=questionary.Style(
             [
@@ -259,12 +286,29 @@ def select_llm_provider() -> tuple[str, str | None]:
             ]
         ),
     ).ask()
-    
+
     if choice is None:
         console.print("\n[red]No LLM provider selected. Exiting...[/red]")
         exit(1)
 
     provider, url = choice
+
+    if provider == "custom_openai":
+        saved_url = _prefs.get("backend_url") or "http://localhost:1234/v1"
+        url = questionary.text(
+            "Enter base URL for your OpenAI-compatible endpoint:",
+            default=saved_url,
+            validate=lambda x: len(x.strip()) > 0 or "Please enter a base URL.",
+            style=questionary.Style([
+                ("text", "fg:green"),
+                ("highlighted", "noinherit"),
+            ]),
+        ).ask()
+        if not url:
+            console.print("\n[red]No base URL provided. Exiting...[/red]")
+            exit(1)
+        url = url.strip()
+
     return provider, url
 
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -34,10 +34,22 @@ def get_language_instruction() -> str:
     return f" Write your entire response in {lang}."
 
 
+def _resolve_company_name(ticker: str) -> str | None:
+    """Best-effort company name lookup via yfinance."""
+    try:
+        import yfinance as yf
+        info = yf.Ticker(ticker.upper()).info
+        return info.get("longName") or info.get("shortName")
+    except Exception:
+        return None
+
+
 def build_instrument_context(ticker: str) -> str:
     """Describe the exact instrument so agents preserve exchange-qualified tickers."""
+    name = _resolve_company_name(ticker)
+    name_clause = f" ({name})" if name else ""
     return (
-        f"The instrument to analyze is `{ticker}`. "
+        f"The instrument to analyze is `{ticker}`{name_clause}. "
         "Use this exact ticker in every tool call, report, and recommendation, "
         "preserving any exchange suffix (e.g. `.TO`, `.L`, `.HK`, `.T`)."
     )

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -25,6 +25,9 @@ DEFAULT_CONFIG = {
     "google_thinking_level": None,      # "high", "minimal", etc.
     "openai_reasoning_effort": None,    # "medium", "high", "low"
     "anthropic_effort": None,           # "high", "medium", "low"
+    # Request timeout in seconds for LLM API calls. None uses the provider
+    # default. Increase for slow local inference (LM Studio, Ollama, vLLM).
+    "llm_timeout": None,
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -150,6 +150,12 @@ class TradingAgentsGraph:
             if effort:
                 kwargs["effort"] = effort
 
+        timeout = self.config.get("llm_timeout")
+        if timeout is None and provider in ("custom_openai", "ollama"):
+            timeout = 900
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
         return kwargs
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -5,6 +5,7 @@ from .base_client import BaseLLMClient
 # Providers that use the OpenAI-compatible chat completions API
 _OPENAI_COMPATIBLE = (
     "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
+    "custom_openai",
 )
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -117,6 +117,7 @@ _PROVIDER_CONFIG = {
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
     "ollama": ("http://localhost:11434/v1", None),
+    "custom_openai": ("http://localhost:1234/v1", "CUSTOM_OPENAI_API_KEY"),
 }
 
 
@@ -154,6 +155,8 @@ class OpenAIClient(BaseLLMClient):
                 api_key = os.environ.get(api_key_env)
                 if api_key:
                     llm_kwargs["api_key"] = api_key
+                elif self.provider == "custom_openai":
+                    llm_kwargs["api_key"] = "not-needed"
             else:
                 llm_kwargs["api_key"] = "ollama"
         elif self.base_url:

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -17,7 +17,7 @@ def validate_model(provider: str, model: str) -> bool:
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in ("ollama", "openrouter", "custom_openai"):
         return True
 
     if provider_lower not in VALID_MODELS:


### PR DESCRIPTION
## Summary

- Adds a **Custom OpenAI-Compatible** provider option to the CLI provider selection menu, enabling use of **LM Studio**, **vLLM**, **llama.cpp server**, **LocalAI**, and any other endpoint that implements the OpenAI Chat Completions API
- Prompts the user for a base URL (defaults to `http://localhost:1234/v1`) and free-text model names for quick/deep thinking — no hardcoded model list
- **Persists LLM selections** (provider, base URL, model names) to `~/.tradingagents/cli_preferences.json` so subsequent runs pre-fill the last-used configuration — just press Enter to repeat
- **Fixes missing decision log in CLI mode** — the CLI streams the graph directly and bypassed `_log_state()` and `memory_log.store_decision()`, so `full_states_log_*.json` and `trading_memory.md` were never written. Now persists both after each run.
- **Resolves company name from yfinance in agent prompts** — `build_instrument_context()` now looks up `longName` so agents see "BA (The Boeing Company)" instead of just "BA", preventing smaller models from misidentifying the ticker
- **Configurable LLM timeout for local inference** — adds `llm_timeout` config option with a 15-minute default for `custom_openai` and `ollama` providers. Local models can exceed the standard 600s timeout on large debate contexts. The CLI presents a timeout selector (5/15/30 min or custom) for local providers.
- Reuses the existing `OpenAIClient` path via the `_OPENAI_COMPATIBLE` factory tuple — zero new dependencies
- Optional `CUSTOM_OPENAI_API_KEY` env var for endpoints that require auth; otherwise a dummy key is sent (standard for local servers like LM Studio and Ollama)

### Files changed

| File | Change |
|---|---|
| `cli/utils.py` | New provider choice + URL prompt + free-text model selection + preference defaults + timeout selector |
| `cli/preferences.py` | New — load/save LLM selections to `~/.tradingagents/cli_preferences.json` |
| `cli/main.py` | Save preferences after selections; call `_log_state()` and `store_decision()` after stream; wire `llm_timeout` to config |
| `tradingagents/default_config.py` | Added `llm_timeout` config option (default: None) |
| `tradingagents/graph/trading_graph.py` | Pass `timeout` kwarg to LLM clients; 15-min default for custom_openai/ollama |
| `tradingagents/llm_clients/factory.py` | Added `custom_openai` to `_OPENAI_COMPATIBLE` |
| `tradingagents/llm_clients/openai_client.py` | Added `custom_openai` to `_PROVIDER_CONFIG` with dummy API key fallback |
| `tradingagents/llm_clients/validators.py` | Accept any model name for `custom_openai` |
| `tradingagents/agents/utils/agent_utils.py` | `build_instrument_context()` resolves company name via yfinance |

### User flow

1. **Step 6** — Select "Custom OpenAI-Compatible (LM Studio, vLLM, llama.cpp, etc.)"
2. Enter base URL (e.g. `http://192.168.1.50:1234/v1`)
3. **Step 7** — Type model names exactly as they appear in your server
4. **Step 8** — Skipped (no provider-specific thinking config)
5. **Step 9** — Select request timeout (default 15 min for local inference)
6. **Next run** — all of the above pre-filled from last run, just press Enter

## Test plan

- [x] `docker compose build` succeeds
- [x] Select "Custom OpenAI-Compatible" in CLI, enter LM Studio/LiteLLM URL and model name
- [x] Verify requests hit the custom endpoint (confirmed via LiteLLM proxy logs)
- [x] Verify preferences persist — second run pre-fills provider, URL, and model names
- [x] Verify `full_states_log_*.json` and `trading_memory.md` are written after CLI run
- [ ] Verify company name resolution (BA shows "The Boeing Company" in agent context)
- [ ] Verify existing providers (OpenAI, Ollama, etc.) still work unchanged
- [ ] Verify `CUSTOM_OPENAI_API_KEY` env var is picked up when set
- [ ] Verify 15-min timeout prevents 408 on slow local inference