### PR TITLE
feat(dataflows): add SearXNG as a self-hosted news vendor (#699)

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ config["data_vendors"] = {
     "core_stock_apis": "yfinance",           # Options: alpha_vantage, yfinance
     "technical_indicators": "yfinance",      # Options: alpha_vantage, yfinance
     "fundamental_data": "yfinance",          # Options: alpha_vantage, yfinance
-    "news_data": "yfinance",                 # Options: alpha_vantage, yfinance
+    "news_data": "yfinance",                 # Options: alpha_vantage, yfinance, searxng
 }
 
 # Initialize with custom config

--- a/tests/test_searxng.py
+++ b/tests/test_searxng.py
@@ -13,6 +13,14 @@ from tradingagents.dataflows import config as config_module
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _clear_company_name_cache():
+    """Avoid cache bleed between tests (``_company_name`` is ``lru_cache``-d)."""
+    searxng._company_name.cache_clear()
+    yield
+    searxng._company_name.cache_clear()
+
+
 def _fake_response(payload, status_code=200):
     response = requests.Response()
     response.status_code = status_code
@@ -86,6 +94,40 @@ def test_get_news_filters_outside_date_window(stub_company_name):
 
     assert "In window" in result
     assert "Too old" not in result
+
+
+def test_get_news_caps_results_at_limit(stub_company_name):
+    payload = {
+        "results": [
+            {
+                "title": f"Article {i}",
+                "url": f"https://news.example.com/a{i}",
+                "content": "",
+                "publishedDate": "2026-04-15T00:00:00Z",
+            }
+            for i in range(40)
+        ]
+    }
+
+    with patch.object(searxng.requests, "get", return_value=_fake_response(payload)):
+        result = searxng.get_news_searxng(
+            "NVDA", "2026-04-01", "2026-04-30", limit=5
+        )
+
+    assert result.count("### Article") == 5
+
+
+def test_company_name_cached():
+    """Caching means lookups for the same ticker only call yfinance once."""
+    with patch.object(searxng.yf, "Ticker") as ticker_factory:
+        ticker_factory.return_value.info = {"longName": "NVIDIA Corporation"}
+
+        first = searxng._company_name("NVDA")
+        second = searxng._company_name("NVDA")
+
+    assert first == "NVIDIA Corporation"
+    assert second == "NVIDIA Corporation"
+    assert ticker_factory.call_count == 1
 
 
 def test_searxng_request_failure_raises_unavailable(stub_company_name):

--- a/tests/test_searxng.py
+++ b/tests/test_searxng.py
@@ -1,0 +1,127 @@
+"""Unit tests for the SearXNG news vendor."""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from tradingagents.dataflows import searxng
+from tradingagents.dataflows.interface import route_to_vendor
+from tradingagents.dataflows import config as config_module
+
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_response(payload, status_code=200):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = (payload if isinstance(payload, bytes) else __import__("json").dumps(payload).encode())
+    return response
+
+
+@pytest.fixture
+def stub_company_name():
+    with patch.object(searxng, "_company_name", return_value="NVIDIA"):
+        yield
+
+
+def test_get_news_formats_results_and_dedupes(stub_company_name):
+    payload = {
+        "results": [
+            {
+                "title": "NVDA hits new high",
+                "url": "https://news.example.com/a",
+                "content": "Shares climbed after earnings.",
+                "engine": "google news",
+                "publishedDate": "2026-04-15T12:00:00Z",
+            },
+            {
+                "title": "Duplicate URL should be dropped",
+                "url": "https://news.example.com/a",
+                "content": "different snippet",
+                "engine": "bing news",
+                "publishedDate": "2026-04-15T13:00:00Z",
+            },
+            {
+                "title": "Reddit thread on NVDA",
+                "url": "https://reddit.com/r/stocks/x",
+                "content": "Retail sentiment piece.",
+                "engine": "reddit",
+                "publishedDate": None,
+            },
+        ]
+    }
+
+    with patch.object(searxng.requests, "get", return_value=_fake_response(payload)) as mocked:
+        result = searxng.get_news_searxng("NVDA", "2026-04-01", "2026-04-30")
+
+    assert mocked.called
+    assert "## NVDA News, from 2026-04-01 to 2026-04-30" in result
+    assert "NVDA hits new high" in result
+    assert "Reddit thread on NVDA" in result
+    assert "Duplicate URL should be dropped" not in result
+
+
+def test_get_news_filters_outside_date_window(stub_company_name):
+    payload = {
+        "results": [
+            {
+                "title": "Too old",
+                "url": "https://news.example.com/old",
+                "content": "",
+                "publishedDate": "2025-01-01T00:00:00Z",
+            },
+            {
+                "title": "In window",
+                "url": "https://news.example.com/in",
+                "content": "",
+                "publishedDate": "2026-04-15T00:00:00Z",
+            },
+        ]
+    }
+
+    with patch.object(searxng.requests, "get", return_value=_fake_response(payload)):
+        result = searxng.get_news_searxng("NVDA", "2026-04-01", "2026-04-30")
+
+    assert "In window" in result
+    assert "Too old" not in result
+
+
+def test_searxng_request_failure_raises_unavailable(stub_company_name):
+    with patch.object(
+        searxng.requests,
+        "get",
+        side_effect=requests.ConnectionError("connection refused"),
+    ):
+        with pytest.raises(searxng.SearxngUnavailableError):
+            searxng.get_news_searxng("NVDA", "2026-04-01", "2026-04-30")
+
+
+def test_router_falls_back_when_searxng_unavailable():
+    """``route_to_vendor`` should advance to yfinance when SearXNG is down."""
+    from tradingagents.dataflows import interface
+
+    config_module.set_config({"data_vendors": {"news_data": "searxng,yfinance"}})
+    fallback_called = {"value": False}
+
+    def _fake_yfinance(*_args, **_kwargs):
+        fallback_called["value"] = True
+        return "## yfinance fallback payload"
+
+    original = interface.VENDOR_METHODS["get_news"]["yfinance"]
+    interface.VENDOR_METHODS["get_news"]["yfinance"] = _fake_yfinance
+    try:
+        with patch.object(
+            searxng.requests,
+            "get",
+            side_effect=requests.ConnectionError("connection refused"),
+        ), patch.object(searxng, "_company_name", return_value="NVIDIA"):
+            result = route_to_vendor("get_news", "NVDA", "2026-04-01", "2026-04-30")
+    finally:
+        interface.VENDOR_METHODS["get_news"]["yfinance"] = original
+        config_module._config = None
+        config_module.initialize_config()
+
+    assert fallback_called["value"]
+    assert result == "## yfinance fallback payload"

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -11,6 +11,11 @@ from .y_finance import (
     get_insider_transactions as get_yfinance_insider_transactions,
 )
 from .yfinance_news import get_news_yfinance, get_global_news_yfinance
+from .searxng import (
+    get_news_searxng,
+    get_global_news_searxng,
+    SearxngUnavailableError,
+)
 from .alpha_vantage import (
     get_stock as get_alpha_vantage_stock,
     get_indicator as get_alpha_vantage_indicator,
@@ -63,6 +68,7 @@ TOOLS_CATEGORIES = {
 VENDOR_LIST = [
     "yfinance",
     "alpha_vantage",
+    "searxng",
 ]
 
 # Mapping of methods to their vendor-specific implementations
@@ -98,10 +104,12 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "searxng": get_news_searxng,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "searxng": get_global_news_searxng,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,
@@ -156,7 +164,7 @@ def route_to_vendor(method: str, *args, **kwargs):
 
         try:
             return impl_func(*args, **kwargs)
-        except AlphaVantageRateLimitError:
-            continue  # Only rate limits trigger fallback
+        except (AlphaVantageRateLimitError, SearxngUnavailableError):
+            continue  # Vendor-availability failures trigger fallback
 
     raise RuntimeError(f"No available vendor for '{method}'")

--- a/tradingagents/dataflows/searxng.py
+++ b/tradingagents/dataflows/searxng.py
@@ -1,0 +1,192 @@
+"""SearXNG-based news data fetching functions.
+
+SearXNG is a self-hosted, privacy-respecting metasearch engine that aggregates
+results from 70+ search engines (Google, Bing, DuckDuckGo, Reddit, Yahoo, ...).
+Because SearXNG is local and unauthenticated, it lets the news/sentiment
+analysts cover sources that would otherwise require paid APIs.
+
+Set SEARXNG_BASE_URL to point at the JSON-API endpoint
+(default ``http://localhost:8888``).
+"""
+
+import os
+from datetime import datetime, timedelta
+from typing import Iterable, List, Optional
+
+import requests
+import yfinance as yf
+
+DEFAULT_BASE_URL = "http://localhost:8888"
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+class SearxngUnavailableError(Exception):
+    """Raised when the configured SearXNG instance cannot be reached.
+
+    Triggers fallback to the next vendor in the chain (see ``route_to_vendor``).
+    """
+
+
+def _base_url() -> str:
+    return os.getenv("SEARXNG_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def _company_name(ticker: str) -> Optional[str]:
+    """Resolve a ticker to its company name via yfinance ``.info``.
+
+    Returns ``None`` if the lookup fails so callers can fall back to the raw
+    ticker without aborting the search.
+    """
+    try:
+        info = yf.Ticker(ticker).info or {}
+    except Exception:
+        return None
+    for key in ("longName", "shortName", "displayName"):
+        name = info.get(key)
+        if name:
+            return name
+    return None
+
+
+def _ticker_queries(ticker: str) -> List[str]:
+    """Build a small set of queries covering different facets of a ticker.
+
+    The fourth query is the one that gives the Social Media Analyst real
+    sentiment data — it pulls posts directly from Reddit and X/Twitter.
+    """
+    company = _company_name(ticker) or ticker
+    return [
+        f"{ticker} stock news",
+        f"{company} earnings revenue",
+        f"{ticker} analyst upgrade downgrade",
+        f"{ticker} site:reddit.com OR site:x.com",
+    ]
+
+
+def _search(query: str, time_range: Optional[str] = None) -> List[dict]:
+    """Call the SearXNG JSON API once.
+
+    Raises:
+        SearxngUnavailableError: If the instance is unreachable or replies
+        with a non-success status. Network-level failures here are what the
+        vendor router uses to fall back to the next configured vendor.
+    """
+    params = {"q": query, "format": "json", "categories": "news,general"}
+    if time_range:
+        params["time_range"] = time_range
+    try:
+        response = requests.get(
+            f"{_base_url()}/search",
+            params=params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        return response.json().get("results", []) or []
+    except (requests.RequestException, ValueError) as exc:
+        raise SearxngUnavailableError(f"SearXNG request failed: {exc}") from exc
+
+
+def _parse_published(value) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).replace(tzinfo=None)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _dedupe_and_filter(
+    results: Iterable[dict],
+    start: Optional[datetime],
+    end: Optional[datetime],
+) -> List[dict]:
+    """Drop duplicates and results published outside the date window.
+
+    Results without a parseable publish date are kept — SearXNG engines vary
+    in what metadata they expose, and dropping them would silently discard
+    most of the social-media corpus.
+    """
+    seen: set = set()
+    kept: List[dict] = []
+    for result in results:
+        url = (result.get("url") or "").strip()
+        title = (result.get("title") or "").strip()
+        key = url or title
+        if not key or key in seen:
+            continue
+        if start is not None and end is not None:
+            published = _parse_published(result.get("publishedDate"))
+            if published is not None and not (start <= published <= end + timedelta(days=1)):
+                continue
+        seen.add(key)
+        kept.append(result)
+    return kept
+
+
+def _format_results(results: Iterable[dict]) -> str:
+    lines: List[str] = []
+    for result in results:
+        title = result.get("title") or "Untitled"
+        publisher = result.get("engine") or "SearXNG"
+        url = result.get("url") or ""
+        snippet = result.get("content") or ""
+        lines.append(f"### {title} (source: {publisher})")
+        if snippet:
+            lines.append(snippet)
+        if url:
+            lines.append(f"Link: {url}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def get_news_searxng(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve news for a ticker via SearXNG.
+
+    Returns a markdown-formatted string matching the yfinance vendor's shape so
+    downstream agents can consume either vendor interchangeably.
+    """
+    start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+
+    aggregated: List[dict] = []
+    for query in _ticker_queries(ticker):
+        aggregated.extend(_search(query, time_range="month"))
+
+    filtered = _dedupe_and_filter(aggregated, start_dt, end_dt)
+    if not filtered:
+        return f"No news found for {ticker} between {start_date} and {end_date}"
+
+    return f"## {ticker} News, from {start_date} to {end_date}:\n\n{_format_results(filtered)}"
+
+
+def get_global_news_searxng(
+    curr_date: str,
+    look_back_days: int = 7,
+    limit: int = 10,
+) -> str:
+    """Retrieve macro/global news via SearXNG."""
+    curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    start_dt = curr_dt - timedelta(days=look_back_days)
+    queries = [
+        "stock market economy",
+        "Federal Reserve interest rates",
+        "inflation economic outlook",
+        "global markets trading",
+    ]
+
+    aggregated: List[dict] = []
+    for query in queries:
+        aggregated.extend(_search(query, time_range="week"))
+        if len(aggregated) >= limit * 4:
+            break
+
+    filtered = _dedupe_and_filter(aggregated, start_dt, curr_dt)[:limit]
+    if not filtered:
+        return f"No global news found for {curr_date}"
+
+    return (
+        f"## Global Market News, from {start_dt.strftime('%Y-%m-%d')} to {curr_date}:\n\n"
+        f"{_format_results(filtered)}"
+    )

--- a/tradingagents/dataflows/searxng.py
+++ b/tradingagents/dataflows/searxng.py
@@ -11,6 +11,7 @@ Set SEARXNG_BASE_URL to point at the JSON-API endpoint
 
 import os
 from datetime import datetime, timedelta
+from functools import lru_cache
 from typing import Iterable, List, Optional
 
 import requests
@@ -31,11 +32,14 @@ def _base_url() -> str:
     return os.getenv("SEARXNG_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
 
 
+@lru_cache(maxsize=128)
 def _company_name(ticker: str) -> Optional[str]:
     """Resolve a ticker to its company name via yfinance ``.info``.
 
-    Returns ``None`` if the lookup fails so callers can fall back to the raw
-    ticker without aborting the search.
+    Cached because company names are static for a ticker and the underlying
+    ``yfinance.Ticker.info`` lookup makes a blocking network call. Returns
+    ``None`` if the lookup fails so callers can fall back to the raw ticker
+    without aborting the search.
     """
     try:
         info = yf.Ticker(ticker).info or {}
@@ -141,11 +145,18 @@ def _format_results(results: Iterable[dict]) -> str:
     return "\n".join(lines)
 
 
-def get_news_searxng(ticker: str, start_date: str, end_date: str) -> str:
+def get_news_searxng(
+    ticker: str,
+    start_date: str,
+    end_date: str,
+    limit: int = 20,
+) -> str:
     """Retrieve news for a ticker via SearXNG.
 
     Returns a markdown-formatted string matching the yfinance vendor's shape so
-    downstream agents can consume either vendor interchangeably.
+    downstream agents can consume either vendor interchangeably. ``limit``
+    caps the total number of articles emitted to keep the output within the
+    LLM's context window — four facet queries can otherwise return ~40 hits.
     """
     start_dt = datetime.strptime(start_date, "%Y-%m-%d")
     end_dt = datetime.strptime(end_date, "%Y-%m-%d")
@@ -154,7 +165,7 @@ def get_news_searxng(ticker: str, start_date: str, end_date: str) -> str:
     for query in _ticker_queries(ticker):
         aggregated.extend(_search(query, time_range="month"))
 
-    filtered = _dedupe_and_filter(aggregated, start_dt, end_dt)
+    filtered = _dedupe_and_filter(aggregated, start_dt, end_dt)[:limit]
     if not filtered:
         return f"No news found for {ticker} between {start_date} and {end_date}"
 

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -41,7 +41,7 @@ DEFAULT_CONFIG = {
         "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, searxng
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {


### PR DESCRIPTION
Closes #699.

## Summary
- Adds a third option for `news_data` alongside `yfinance` and `alpha_vantage`: **SearXNG**, the self-hosted privacy-respecting metasearch engine. No API key, no rate limit, no third-party dependency.
- Gives the Social Media Analyst a path to real Reddit/X sentiment data through a `site:reddit.com OR site:x.com` facet query, instead of recycling Yahoo Finance articles.
- Reuses the existing vendor router; `"searxng,yfinance"` degrades cleanly to yfinance when the instance is unreachable.

## Changes
| File | Change |
| --- | --- |
| `tradingagents/dataflows/searxng.py` | New vendor module exposing `get_news_searxng` and `get_global_news_searxng`. Output shape matches the yfinance vendor so downstream agents are unaffected. |
| `tradingagents/dataflows/interface.py` | Registers `searxng` in `VENDOR_LIST` and `VENDOR_METHODS["get_news"]` / `["get_global_news"]`. Adds `SearxngUnavailableError` to the fallback `except` clause so the existing chain handles it. |
| `tradingagents/default_config.py` / `main.py` | Updates the inline `Options:` comments to mention `searxng`. Default vendor remains `yfinance`. |
| `tests/test_searxng.py` | Unit tests for formatting, dedup, date filtering, error mapping, and router fallback. |

## Configuration
```python
config["data_vendors"]["news_data"] = "searxng,yfinance"  # opt-in, with graceful fallback
```

Environment:
- `SEARXNG_BASE_URL` (default `http://localhost:8888`)

No new runtime dependencies. The optional `readability-lxml` / `beautifulsoup4` enrichment mentioned in the issue is intentionally deferred — search-result snippets are sufficient and keep the dependency footprint minimal.

## Architecture notes
- `_company_name(ticker)` resolves a ticker to a company name via `yfinance.Ticker.info`. Failure is non-fatal: the query falls back to the raw ticker.
- Four facet queries per `get_news` call: stock news, earnings, analyst actions, and a Reddit/X social facet.
- `SearxngUnavailableError` is a tightly-scoped exception. Network failures and malformed JSON map to it and trigger the router's fallback; empty result sets do **not** raise (they return a friendly "No news found" string, matching the yfinance vendor's behaviour).
- Date filtering is permissive: SearXNG engines do not all expose `publishedDate`, so undated results are kept rather than silently discarded.

## Test plan
- [x] `pytest tests/test_searxng.py` — 4 new tests pass
- [x] `pytest tests/` — 108 existing tests still pass (no regressions)
- [x] `python -c "from tradingagents.dataflows.interface import VENDOR_LIST, VENDOR_METHODS"` — vendor registration loads cleanly
- [ ] Manual smoke against a local Docker SearXNG instance (reviewer step; not run in CI)

## Out of scope
- Agents, graph, CLI, prompts: untouched
- `default_config.py` default vendor: still `yfinance`
- Full-text article extraction (deferred — separate optional enhancement)