### PR TITLE
fix(docker): pre-create .tradingagents dir with correct ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 RUN useradd --create-home appuser \
     && mkdir -p /home/appuser/.tradingagents \
-    && chown -R appuser:appuser /home/appuser/.tradingagents
+    && chown -R appuser:appuser /home/appuser
 USER appuser
 WORKDIR /home/appuser/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser \
+    && mkdir -p /home/appuser/.tradingagents \
+    && chown -R appuser:appuser /home/appuser/.tradingagents
 USER appuser
 WORKDIR /home/appuser/app
 


### PR DESCRIPTION
## Summary

- `useradd --create-home` creates `/home/appuser` but not the app-specific subdirectory `/home/appuser/.tradingagents`
- The first write to that path (cache, memory log, checkpoints) fails with `PermissionError: [Errno 13] Permission denied` because the directory is created at runtime by root but accessed by `appuser`
- Fix: create the directory and `chown` it to `appuser` in the same `RUN` layer, before `USER appuser`

Closes #627, closes #672

## Test plan

- [ ] Build the image (`docker compose build`) and run `docker compose run --rm tradingagents` — first-run analysis completes without a `PermissionError`
- [ ] Verify `/home/appuser/.tradingagents` exists and is owned by `appuser` inside the container: `docker run --rm tradingagents stat /home/appuser/.tradingagents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)