### PR TITLE
fix: load CLI dotenv files from current working directory

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4,11 +4,11 @@ import typer
 from pathlib import Path
 from functools import wraps
 from rich.console import Console
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 # Load environment variables
-load_dotenv()
-load_dotenv(".env.enterprise", override=False)
+load_dotenv(find_dotenv(usecwd=True))
+load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
 from rich.panel import Panel
 from rich.spinner import Spinner
 from rich.live import Live

--- a/tests/test_cli_env_loading.py
+++ b/tests/test_cli_env_loading.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+import types
+
+
+def test_cli_dotenv_searches_from_current_working_directory(monkeypatch):
+    calls = []
+
+    def fake_find_dotenv(filename=".env", usecwd=False):
+        calls.append(("find", filename, usecwd))
+        return f"/cwd/{filename}"
+
+    def fake_load_dotenv(dotenv_path=None, override=False):
+        calls.append(("load", dotenv_path, override))
+        return True
+
+    import dotenv
+
+    monkeypatch.setattr(dotenv, "find_dotenv", fake_find_dotenv)
+    monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+    graph_package = types.ModuleType("tradingagents.graph")
+    graph_module = types.ModuleType("tradingagents.graph.trading_graph")
+    graph_module.TradingAgentsGraph = object
+    config_module = types.ModuleType("tradingagents.default_config")
+    config_module.DEFAULT_CONFIG = {}
+    monkeypatch.setitem(sys.modules, "tradingagents.graph", graph_package)
+    monkeypatch.setitem(sys.modules, "tradingagents.graph.trading_graph", graph_module)
+    monkeypatch.setitem(sys.modules, "tradingagents.default_config", config_module)
+    sys.modules.pop("cli.main", None)
+
+    importlib.import_module("cli.main")
+
+    assert calls[:4] == [
+        ("find", ".env", True),
+        ("load", "/cwd/.env", False),
+        ("find", ".env.enterprise", True),
+        ("load", "/cwd/.env.enterprise", False),
+    ]


### PR DESCRIPTION
## Summary
- load `.env` and `.env.enterprise` by searching from the user's current working directory
- add a regression test that imports the installed-console-script entry module with dotenv calls stubbed

## Why
`tradingagents` is exposed as a console script, so `load_dotenv()` without an explicit path can search from the installed `cli/main.py` location instead of the directory where the user launched the command. That misses project-level `.env` files even when the user is in the repo or working directory that contains them.

Fixes #726.

## Verification
- RED: `python -m pytest tests/test_cli_env_loading.py -q` failed because dotenv was loaded without `find_dotenv(usecwd=True)`
- GREEN: `python -m pytest tests/test_cli_env_loading.py -q` -> `1 passed`
- `python -m py_compile cli/main.py tests/test_cli_env_loading.py`
- `python -m black --check tests/test_cli_env_loading.py`

## Note
A broader nearby run with `tests/test_google_api_key.py` is blocked in this local environment before reaching this patch by an existing dependency mismatch: `ImportError: cannot import name 'RunTree' from 'langsmith'` through `langchain_core`.