### PR TITLE
Fix load_dotenv() not finding .env via console script

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4,11 +4,11 @@ import typer
 from pathlib import Path
 from functools import wraps
 from rich.console import Console
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 # Load environment variables
-load_dotenv()
-load_dotenv(".env.enterprise", override=False)
+load_dotenv(find_dotenv(usecwd=True))
+load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
 from rich.panel import Panel
 from rich.spinner import Spinner
 from rich.live import Live


### PR DESCRIPTION
## Summary
- Uses `find_dotenv(usecwd=True)` so `.env` is resolved from the user's working directory instead of walking up from the installed package path under `site-packages/`
- Fixes both `.env` and `.env.enterprise` loading in `cli/main.py`

Fixes #726

## Test plan
- [x] `pip install .` then `tradingagents` from repo root with `.env` present — keys are loaded correctly
- [x] `python -m cli.main` continues to work as before