### PR TITLE
fix: merge trace chunks into final_state so reports save correctly

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1156,7 +1156,7 @@ def run_analysis(checkpoint: bool = False):
         final_state = {}
         for chunk in trace:
             final_state.update(chunk)
-        decision = graph.process_signal(final_state["final_trade_decision"])
+        decision = graph.process_signal(final_state.get("final_trade_decision", ""))
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1153,7 +1153,9 @@ def run_analysis(checkpoint: bool = False):
             trace.append(chunk)
 
         # Get final state and decision
-        final_state = trace[-1]
+        final_state = {}
+        for chunk in trace:
+            final_state.update(chunk)
         decision = graph.process_signal(final_state["final_trade_decision"])
 
         # Update all agent statuses to completed


### PR DESCRIPTION
Fixes #719

## Problem
when you select yes to save the report after analysis completes, nothing 
happens. no success message, no error message, no file created, the reports 
folder doesnt even get created. basically silent failure.

## What was causing it
took me a bit to trace this but the issue is that final_state was being set 
to trace[-1] which is just the last chunk from langraphs stream, not the 
actual complete state. each chunk only has the delta from that one node so 
all the report fields (market_report, trader_investment_plan etc) come back 
as None.

so save_report_to_disk() was getting called with an almost empty state, 
wrote a basically empty complete_report.md, returned the path successfully 
and thats why there was no error thrown either. it technically "worked" just 
with no content lol

## Fix
instead of just taking the last chunk, merge all chunks together first:

    final_state = {}
    for chunk in trace:
        final_state.update(chunk)

now final_state has the full accumulated state with all the report fields 
actually populated, so the save works correctly and all the subfolders and 
files get created properly.

pretty simple fix once you find it, just took a while to figure out why 
there was no error being thrown