### PR TITLE
fix: use find_dotenv(usecwd=True) so .env is loaded from user's CWD when installed via pip

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -4,11 +4,13 @@ import typer
 from pathlib import Path
 from functools import wraps
 from rich.console import Console
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 # Load environment variables
-load_dotenv()
-load_dotenv(".env.enterprise", override=False)
+# Use usecwd=True so the search starts from the user's working directory,
+# not from the installed package's site-packages directory.
+load_dotenv(find_dotenv(usecwd=True))
+load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
 from rich.panel import Panel
 from rich.spinner import Spinner
 from rich.live import Live


### PR DESCRIPTION
## Problem

Closes #726

When TradingAgents is installed via `pip install .` and launched as the `tradingagents` console script, `load_dotenv()` silently fails to load the user's `.env` file. This causes confusing errors like:

> `OpenAIError: Missing credentials. Please pass an api_key... or set OPENAI_API_KEY...`

**Root cause:** `load_dotenv()` with no arguments calls `find_dotenv(usecwd=False)`, which starts walking up from the *installed package's* `site-packages/cli/` directory — never reaching the user's project `.env`.

## Fix

Pass `find_dotenv(usecwd=True)` so the search starts from the user's current working directory instead:

```python
from dotenv import load_dotenv, find_dotenv

load_dotenv(find_dotenv(usecwd=True))
load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
```

Two-line change in `cli/main.py`. Behavior when running from the source tree is unchanged (CWD is the repo root, `.env` is found immediately).

## Testing

- Installed via `pip install .` in a fresh conda env
- `tradingagents` console script now correctly picks up `OPENROUTER_API_KEY` from `.env` in the repo root
- Running from source tree with `python -m cli.main` also works as before
