### PR TITLE
feat(llm): subscription-routed agentic-CLI providers (Claude Code, Gemini CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,15 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# TradingAgents runtime artifacts (kept inside workspace, ignored by git)
+/reports/
+/.cache/
+/.memory/
+*.run.log
+
+# Local agent / IDE / OS artifacts
+.DS_Store
+**/.DS_Store
+/.claude/
+/CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
 
 # TradingAgents: Multi-Agents LLM Financial Trading Framework
 
+> **Fork notice.** This is a personal fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) (Apache License 2.0). All credit for the original framework — design, implementation, agent architecture, and trading methodology — belongs to the [Tauric Research](https://github.com/TauricResearch) team.
+>
+> **What's added in this fork:**
+> - A `claude_code` LLM provider that routes every agent call through your Claude Code Pro/Max subscription via the headless `claude -p` CLI — no API keys required.
+> - Workspace-local outputs: every analysis run produces exactly one canonical structured folder under `reports/<TICKER>_<DATE>_<TIMESTAMP>/` (CLI and programmatic runs share the same writer).
+>
+> See [`tradingagents/llm_clients/claude_code_client.py`](tradingagents/llm_clients/claude_code_client.py) and [`tradingagents/reporting.py`](tradingagents/reporting.py) for the additions. Apache 2.0 attribution and the original `LICENSE` are preserved.
+
 ## News
 - [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 - [2026-03] **TradingAgents v0.2.3** released with multi-language support, GPT-5.4 family models, unified model catalog, backtesting date fidelity, and proxy support.

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,7 +2,6 @@ from typing import Optional
 import datetime
 import typer
 from pathlib import Path
-from functools import wraps
 from rich.console import Console
 from dotenv import load_dotenv
 
@@ -569,6 +568,7 @@ def get_user_selections():
     thinking_level = None
     reasoning_effort = None
     anthropic_effort = None
+    claude_code_effort = None
 
     provider_lower = selected_llm_provider.lower()
     if provider_lower == "google":
@@ -595,6 +595,14 @@ def get_user_selections():
             )
         )
         anthropic_effort = ask_anthropic_effort()
+    elif provider_lower == "claude_code":
+        console.print(
+            create_question_box(
+                "Step 8: Effort Level",
+                "Configure Claude Code effort level"
+            )
+        )
+        claude_code_effort = ask_claude_code_effort()
 
     return {
         "ticker": selected_ticker,
@@ -608,6 +616,7 @@ def get_user_selections():
         "google_thinking_level": thinking_level,
         "openai_reasoning_effort": reasoning_effort,
         "anthropic_effort": anthropic_effort,
+        "claude_code_effort": claude_code_effort,
         "output_language": output_language,
     }
 
@@ -636,94 +645,7 @@ def get_analysis_date():
             )
 
 
-def save_report_to_disk(final_state, ticker: str, save_path: Path):
-    """Save complete analysis report to disk with organized subfolders."""
-    save_path.mkdir(parents=True, exist_ok=True)
-    sections = []
-
-    # 1. Analysts
-    analysts_dir = save_path / "1_analysts"
-    analyst_parts = []
-    if final_state.get("market_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "market.md").write_text(final_state["market_report"], encoding="utf-8")
-        analyst_parts.append(("Market Analyst", final_state["market_report"]))
-    if final_state.get("sentiment_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "sentiment.md").write_text(final_state["sentiment_report"], encoding="utf-8")
-        analyst_parts.append(("Social Analyst", final_state["sentiment_report"]))
-    if final_state.get("news_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "news.md").write_text(final_state["news_report"], encoding="utf-8")
-        analyst_parts.append(("News Analyst", final_state["news_report"]))
-    if final_state.get("fundamentals_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
-        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
-    if analyst_parts:
-        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
-        sections.append(f"## I. Analyst Team Reports\n\n{content}")
-
-    # 2. Research
-    if final_state.get("investment_debate_state"):
-        research_dir = save_path / "2_research"
-        debate = final_state["investment_debate_state"]
-        research_parts = []
-        if debate.get("bull_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bull.md").write_text(debate["bull_history"], encoding="utf-8")
-            research_parts.append(("Bull Researcher", debate["bull_history"]))
-        if debate.get("bear_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bear.md").write_text(debate["bear_history"], encoding="utf-8")
-            research_parts.append(("Bear Researcher", debate["bear_history"]))
-        if debate.get("judge_decision"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "manager.md").write_text(debate["judge_decision"], encoding="utf-8")
-            research_parts.append(("Research Manager", debate["judge_decision"]))
-        if research_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
-            sections.append(f"## II. Research Team Decision\n\n{content}")
-
-    # 3. Trading
-    if final_state.get("trader_investment_plan"):
-        trading_dir = save_path / "3_trading"
-        trading_dir.mkdir(exist_ok=True)
-        (trading_dir / "trader.md").write_text(final_state["trader_investment_plan"], encoding="utf-8")
-        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}")
-
-    # 4. Risk Management
-    if final_state.get("risk_debate_state"):
-        risk_dir = save_path / "4_risk"
-        risk = final_state["risk_debate_state"]
-        risk_parts = []
-        if risk.get("aggressive_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "aggressive.md").write_text(risk["aggressive_history"], encoding="utf-8")
-            risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
-        if risk.get("conservative_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "conservative.md").write_text(risk["conservative_history"], encoding="utf-8")
-            risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
-        if risk.get("neutral_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "neutral.md").write_text(risk["neutral_history"], encoding="utf-8")
-            risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
-        if risk_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
-            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
-
-        # 5. Portfolio Manager
-        if risk.get("judge_decision"):
-            portfolio_dir = save_path / "5_portfolio"
-            portfolio_dir.mkdir(exist_ok=True)
-            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
-            sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
-
-    # Write consolidated report
-    header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-    (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
-    return save_path / "complete_report.md"
+from tradingagents.reporting import save_report_to_disk
 
 
 def display_complete_report(final_state):
@@ -942,6 +864,7 @@ def run_analysis(checkpoint: bool = False):
     config["google_thinking_level"] = selections.get("google_thinking_level")
     config["openai_reasoning_effort"] = selections.get("openai_reasoning_effort")
     config["anthropic_effort"] = selections.get("anthropic_effort")
+    config["claude_code_effort"] = selections.get("claude_code_effort")
     config["output_language"] = selections.get("output_language", "English")
     config["checkpoint_enabled"] = checkpoint
 
@@ -966,53 +889,10 @@ def run_analysis(checkpoint: bool = False):
     # Track start time for elapsed display
     start_time = time.time()
 
-    # Create result directory
-    results_dir = Path(config["results_dir"]) / selections["ticker"] / selections["analysis_date"]
-    results_dir.mkdir(parents=True, exist_ok=True)
-    report_dir = results_dir / "reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
-    log_file = results_dir / "message_tool.log"
-    log_file.touch(exist_ok=True)
-
-    def save_message_decorator(obj, func_name):
-        func = getattr(obj, func_name)
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            func(*args, **kwargs)
-            timestamp, message_type, content = obj.messages[-1]
-            content = content.replace("\n", " ")  # Replace newlines with spaces
-            with open(log_file, "a", encoding="utf-8") as f:
-                f.write(f"{timestamp} [{message_type}] {content}\n")
-        return wrapper
-    
-    def save_tool_call_decorator(obj, func_name):
-        func = getattr(obj, func_name)
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            func(*args, **kwargs)
-            timestamp, tool_name, args = obj.tool_calls[-1]
-            args_str = ", ".join(f"{k}={v}" for k, v in args.items())
-            with open(log_file, "a", encoding="utf-8") as f:
-                f.write(f"{timestamp} [Tool Call] {tool_name}({args_str})\n")
-        return wrapper
-
-    def save_report_section_decorator(obj, func_name):
-        func = getattr(obj, func_name)
-        @wraps(func)
-        def wrapper(section_name, content):
-            func(section_name, content)
-            if section_name in obj.report_sections and obj.report_sections[section_name] is not None:
-                content = obj.report_sections[section_name]
-                if content:
-                    file_name = f"{section_name}.md"
-                    text = "\n".join(str(item) for item in content) if isinstance(content, list) else content
-                    with open(report_dir / file_name, "w", encoding="utf-8") as f:
-                        f.write(text)
-        return wrapper
-
-    message_buffer.add_message = save_message_decorator(message_buffer, "add_message")
-    message_buffer.add_tool_call = save_tool_call_decorator(message_buffer, "add_tool_call")
-    message_buffer.update_report_section = save_report_section_decorator(message_buffer, "update_report_section")
+    # Note: previously the CLI also streamed per-section markdown and a
+    # message_tool.log into <results_dir>/<TICKER>/<DATE>/. That layout was
+    # duplicative — every run now produces exactly one canonical folder
+    # under TradingAgentsGraph._run_graph (see tradingagents/reporting.py).
 
     # Now start the display layout
     layout = create_layout()
@@ -1173,23 +1053,13 @@ def run_analysis(checkpoint: bool = False):
 
     # Post-analysis prompts (outside Live context for clean interaction)
     console.print("\n[bold cyan]Analysis Complete![/bold cyan]\n")
-
-    # Prompt to save report
-    save_choice = typer.prompt("Save report?", default="Y").strip().upper()
-    if save_choice in ("Y", "YES", ""):
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        default_path = Path.cwd() / "reports" / f"{selections['ticker']}_{timestamp}"
-        save_path_str = typer.prompt(
-            "Save path (press Enter for default)",
-            default=str(default_path)
-        ).strip()
-        save_path = Path(save_path_str)
-        try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
-            console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
-            console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
-        except Exception as e:
-            console.print(f"[red]Error saving report: {e}[/red]")
+    # Report folder is already written by TradingAgentsGraph._run_graph in the
+    # canonical structured layout under config["results_dir"].
+    from tradingagents.default_config import DEFAULT_CONFIG as _DC
+    console.print(
+        f"[green]✓ Report saved under:[/green] {Path(_DC['results_dir']).resolve()}/"
+        f"{selections['ticker']}_<DATE>_<TIMESTAMP>/"
+    )
 
     # Prompt to display full report
     display_choice = typer.prompt("\nDisplay full report on screen?", default="Y").strip().upper()

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -232,6 +232,7 @@ def select_llm_provider() -> tuple[str, str | None]:
     """Select the LLM provider and its API endpoint."""
     # (display_name, provider_key, base_url)
     PROVIDERS = [
+        ("Claude Code (subscription, no API key)", "claude_code", None),
         ("OpenAI", "openai", "https://api.openai.com/v1"),
         ("Google", "google", None),
         ("Anthropic", "anthropic", "https://api.anthropic.com/"),
@@ -278,6 +279,30 @@ def ask_openai_reasoning_effort() -> str:
     return questionary.select(
         "Select Reasoning Effort:",
         choices=choices,
+        style=questionary.Style([
+            ("selected", "fg:cyan noinherit"),
+            ("highlighted", "fg:cyan noinherit"),
+            ("pointer", "fg:cyan noinherit"),
+        ]),
+    ).ask()
+
+
+def ask_claude_code_effort() -> str | None:
+    """Ask for Claude Code effort level.
+
+    Mirrors the levels accepted by `claude --effort` in the headless CLI.
+    Returning None lets the CLI use its default.
+    """
+    return questionary.select(
+        "Select Effort Level:",
+        choices=[
+            questionary.Choice("Default (let `claude` decide)", None),
+            questionary.Choice("High", "high"),
+            questionary.Choice("Medium", "medium"),
+            questionary.Choice("Low (faster)", "low"),
+            questionary.Choice("XHigh", "xhigh"),
+            questionary.Choice("Max", "max"),
+        ],
         style=questionary.Style([
             ("selected", "fg:cyan noinherit"),
             ("highlighted", "fg:cyan noinherit"),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -233,6 +233,7 @@ def select_llm_provider() -> tuple[str, str | None]:
     # (display_name, provider_key, base_url)
     PROVIDERS = [
         ("Claude Code (subscription, no API key)", "claude_code", None),
+        ("Gemini CLI (subscription, no API key)", "gemini_cli", None),
         ("OpenAI", "openai", "https://api.openai.com/v1"),
         ("Google", "google", None),
         ("Anthropic", "anthropic", "https://api.anthropic.com/"),

--- a/tests/test_llm_client_review_fixes.py
+++ b/tests/test_llm_client_review_fixes.py
@@ -1,0 +1,103 @@
+"""Regression tests for fixes applied per gemini-code-assist review on PR #746.
+
+Covers:
+- claude_code rejects non-dict payloads with a clear error.
+- gemini_cli injects ``json_schema`` into the inlined system prompt when
+  ``with_structured_output`` is used.
+- ``_try_parse_json`` recovers a top-level JSON array from prose-wrapped text.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Dict, Optional
+
+import pytest
+
+from tradingagents.llm_clients.claude_code_client import ChatClaudeCode
+from tradingagents.llm_clients.gemini_cli_client import ChatGeminiCli, _try_parse_json
+
+
+@pytest.mark.unit
+class TestClaudeCodeNonDictPayload(unittest.TestCase):
+    def test_top_level_list_payload_raises(self):
+        chat = ChatClaudeCode(model="sonnet")
+        with self.assertRaises(RuntimeError) as ctx:
+            chat._parse_response('[{"result": "hi"}]', json_schema=None)
+        self.assertIn("not an object", str(ctx.exception))
+        self.assertIn("list", str(ctx.exception))
+
+    def test_top_level_string_payload_raises(self):
+        chat = ChatClaudeCode(model="sonnet")
+        with self.assertRaises(RuntimeError) as ctx:
+            chat._parse_response('"just a string"', json_schema=None)
+        self.assertIn("not an object", str(ctx.exception))
+
+    def test_dict_payload_still_parses(self):
+        chat = ChatClaudeCode(model="sonnet")
+        text, structured = chat._parse_response(
+            '{"result": "hello", "is_error": false}', json_schema=None
+        )
+        self.assertEqual(text, "hello")
+        self.assertIsNone(structured)
+
+
+@pytest.mark.unit
+class TestGeminiCliJsonSchemaInjection(unittest.TestCase):
+    def test_schema_appended_when_bound(self):
+        chat = ChatGeminiCli(model="gemini-2.5-flash")
+        chat.json_schema = {
+            "type": "object",
+            "properties": {"verdict": {"type": "string"}},
+        }
+        out = chat._subprocess_input("Be concise.", "Decide on AAPL.")
+        self.assertIn("Be concise.", out)
+        self.assertIn("Return your response as a JSON object matching this schema", out)
+        self.assertIn('"verdict"', out)
+        self.assertIn("<<USER>>", out)
+        self.assertIn("Decide on AAPL.", out)
+
+    def test_schema_with_empty_system_prompt(self):
+        chat = ChatGeminiCli(model="gemini-2.5-flash")
+        chat.json_schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        out = chat._subprocess_input("", "What is 1+1?")
+        self.assertIn("Return your response as a JSON object", out)
+        self.assertIn("<<USER>>", out)
+
+    def test_no_schema_no_injection(self):
+        chat = ChatGeminiCli(model="gemini-2.5-flash")
+        out = chat._subprocess_input("System.", "User.")
+        self.assertNotIn("matching this schema", out)
+        self.assertIn("System.", out)
+        self.assertIn("User.", out)
+
+
+@pytest.mark.unit
+class TestTryParseJsonArraySupport(unittest.TestCase):
+    def test_prose_wrapped_top_level_array(self):
+        text = 'Here is the data you asked for: [{"x": 1}, {"y": 2}] hope it helps.'
+        out = _try_parse_json(text)
+        self.assertEqual(out, [{"x": 1}, {"y": 2}])
+
+    def test_prose_wrapped_top_level_object_still_works(self):
+        text = 'Sure! {"verdict": "buy", "score": 9} done.'
+        out = _try_parse_json(text)
+        self.assertEqual(out, {"verdict": "buy", "score": 9})
+
+    def test_earlier_open_char_wins(self):
+        # Object opens before array → object branch should be used
+        text = 'mixed {"a": 1} then [1, 2, 3] more'
+        out = _try_parse_json(text)
+        self.assertEqual(out, {"a": 1})
+
+    def test_nested_array_in_object_via_fence(self):
+        text = '```json\n{"items": [1, 2, 3]}\n```'
+        out = _try_parse_json(text)
+        self.assertEqual(out, {"items": [1, 2, 3]})
+
+    def test_no_json_returns_none(self):
+        self.assertIsNone(_try_parse_json("just prose, no braces here"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subprocess_chat_base.py
+++ b/tests/test_subprocess_chat_base.py
@@ -1,0 +1,231 @@
+"""Unit tests for the SubprocessChatModel base class.
+
+Uses a fake subclass + a mocked subprocess.run so the tests don't depend on
+any real CLI being installed. Validates the contract every concrete provider
+(claude_code, gemini_cli, ...) inherits.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+from tradingagents.llm_clients.subprocess_chat_base import SubprocessChatModel
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+class _FakeChat(SubprocessChatModel):
+    """Minimal concrete subclass that returns canned responses."""
+
+    canned_text: str = ""
+    canned_structured: Optional[Any] = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake_cli"
+
+    def _binary_name(self) -> str:
+        return "fake-cli"
+
+    def _binary_env_var(self) -> str:
+        return "FAKE_CLI_BIN"
+
+    def _build_command(
+        self,
+        binary: str,
+        system_prompt: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> List[str]:
+        return [binary, "-p", "--system-prompt", system_prompt]
+
+    def _parse_response(
+        self,
+        stdout: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Tuple[str, Optional[Any]]:
+        return self.canned_text, self.canned_structured
+
+
+@pytest.mark.unit
+class TestSubprocessChatModelMessageRendering(unittest.TestCase):
+    def test_system_messages_concatenate_into_system_prompt(self):
+        chat = _FakeChat(model="x")
+        sys, user = chat._render_messages(
+            [
+                SystemMessage(content="Be concise."),
+                SystemMessage(content="Use plain English."),
+                HumanMessage(content="Hello."),
+            ]
+        )
+        self.assertIn("Be concise.", sys)
+        self.assertIn("Use plain English.", sys)
+        self.assertIn("### user\nHello.", user)
+
+    def test_assistant_tool_calls_serialized_back_into_history(self):
+        chat = _FakeChat(model="x")
+        ai = AIMessage(
+            content="",
+            tool_calls=[{"name": "get_stock_data", "args": {"sym": "AAPL"}, "id": "x"}],
+        )
+        sys, user = chat._render_messages(
+            [HumanMessage(content="fetch"), ai, ToolMessage(content="data!", tool_call_id="x", name="get_stock_data")]
+        )
+        # Round-trip: the assistant block contains the JSON envelope
+        self.assertIn('"tool_calls"', user)
+        self.assertIn("get_stock_data", user)
+        # ToolMessage gets a tool[name] block
+        self.assertIn("### tool[get_stock_data]", user)
+
+    def test_bound_tools_inject_protocol_into_system_prompt(self):
+        @tool
+        def echo(text: str) -> str:
+            """Echo a string back."""
+            return text
+
+        chat = _FakeChat(model="x").bind_tools([echo])
+        sys, _ = chat._render_messages([HumanMessage(content="hi")])
+        self.assertIn("TOOL PROTOCOL", sys)
+        self.assertIn("echo", sys)
+
+
+@pytest.mark.unit
+class TestSubprocessChatModelToolEnvelope(unittest.TestCase):
+    def test_pure_json_envelope(self):
+        env = SubprocessChatModel._extract_tool_envelope(
+            '{"tool_calls": [{"name": "f", "args": {"a": 1}}]}'
+        )
+        self.assertIsNotNone(env)
+        self.assertEqual(env["tool_calls"][0]["name"], "f")
+
+    def test_envelope_wrapped_in_prose(self):
+        text = (
+            "Sure, let me fetch that for you.\n"
+            '{"tool_calls": [{"name": "fetch", "args": {"id": 42}}]}\n'
+            "Hope this helps!"
+        )
+        env = SubprocessChatModel._extract_tool_envelope(text)
+        self.assertIsNotNone(env)
+        self.assertEqual(env["tool_calls"][0]["args"]["id"], 42)
+
+    def test_no_envelope_returns_none(self):
+        self.assertIsNone(
+            SubprocessChatModel._extract_tool_envelope("Just regular prose.")
+        )
+
+    def test_parse_tool_calls_assigns_ids(self):
+        calls = SubprocessChatModel._parse_tool_calls(
+            {"tool_calls": [{"name": "f", "args": {"a": 1}}]}
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["name"], "f")
+        self.assertTrue(calls[0]["id"].startswith("call_"))
+        self.assertEqual(calls[0]["type"], "tool_call")
+
+
+@pytest.mark.unit
+class TestSubprocessChatModelGenerate(unittest.TestCase):
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value="/usr/local/bin/fake-cli",
+    )
+    @patch("tradingagents.llm_clients.subprocess_chat_base.subprocess.run")
+    def test_generate_returns_text_when_no_tool_envelope(self, mock_run, _which):
+        mock_run.return_value = _FakeProc(stdout='{"ignored": true}')
+        chat = _FakeChat(model="x", canned_text="Hello world")
+        result = chat.invoke([HumanMessage(content="hi")])
+        self.assertIsInstance(result, AIMessage)
+        self.assertEqual(result.content, "Hello world")
+        self.assertFalse(result.tool_calls)
+
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value="/usr/local/bin/fake-cli",
+    )
+    @patch("tradingagents.llm_clients.subprocess_chat_base.subprocess.run")
+    def test_generate_extracts_tool_calls_when_bound(self, mock_run, _which):
+        mock_run.return_value = _FakeProc(stdout='{"ignored": true}')
+
+        @tool
+        def fetch(sym: str) -> str:
+            """Fetch by symbol."""
+            return ""
+
+        chat = _FakeChat(
+            model="x",
+            canned_text='{"tool_calls": [{"name": "fetch", "args": {"sym": "AAPL"}}]}',
+        ).bind_tools([fetch])
+        result = chat.invoke([HumanMessage(content="get AAPL")])
+        self.assertEqual(result.content, "")
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0]["name"], "fetch")
+        self.assertEqual(result.tool_calls[0]["args"]["sym"], "AAPL")
+
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value="/usr/local/bin/fake-cli",
+    )
+    @patch("tradingagents.llm_clients.subprocess_chat_base.subprocess.run")
+    def test_generate_prefers_structured_output_over_text(self, mock_run, _which):
+        mock_run.return_value = _FakeProc(stdout="{}")
+
+        class Out(BaseModel):
+            verdict: str = Field(...)
+            score: int = Field(...)
+
+        chat = _FakeChat(
+            model="x",
+            canned_text="ignored prose",
+            canned_structured={"verdict": "buy", "score": 9},
+        )
+        result = chat.with_structured_output(Out).invoke([HumanMessage(content="?")])
+        self.assertIsInstance(result, Out)
+        self.assertEqual(result.verdict, "buy")
+        self.assertEqual(result.score, 9)
+
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value="/usr/local/bin/fake-cli",
+    )
+    @patch("tradingagents.llm_clients.subprocess_chat_base.subprocess.run")
+    def test_subprocess_failure_raises_with_stderr(self, mock_run, _which):
+        mock_run.return_value = _FakeProc(returncode=1, stderr="boom: not authenticated")
+        chat = _FakeChat(model="x")
+        with self.assertRaises(RuntimeError) as ctx:
+            chat.invoke([HumanMessage(content="hi")])
+        self.assertIn("not authenticated", str(ctx.exception))
+
+
+@pytest.mark.unit
+class TestSubprocessChatModelBinaryResolution(unittest.TestCase):
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value=None,
+    )
+    def test_missing_binary_raises_clear_error(self, _which):
+        chat = _FakeChat(model="x")
+        with self.assertRaises(RuntimeError) as ctx:
+            chat._resolve_binary()
+        self.assertIn("fake-cli", str(ctx.exception))
+        self.assertIn("FAKE_CLI_BIN", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subprocess_chat_base.py
+++ b/tests/test_subprocess_chat_base.py
@@ -227,5 +227,21 @@ class TestSubprocessChatModelBinaryResolution(unittest.TestCase):
         self.assertIn("FAKE_CLI_BIN", str(ctx.exception))
 
 
+@pytest.mark.unit
+class TestSubprocessChatModelEncoding(unittest.TestCase):
+    @patch(
+        "tradingagents.llm_clients.subprocess_chat_base.shutil.which",
+        return_value="/usr/local/bin/fake-cli",
+    )
+    @patch("tradingagents.llm_clients.subprocess_chat_base.subprocess.run")
+    def test_subprocess_pinned_to_utf8(self, mock_run, _which):
+        mock_run.return_value = _FakeProc(stdout='{"ignored": true}')
+        chat = _FakeChat(model="x", canned_text="ok")
+        chat.invoke([HumanMessage(content="hi 你好 🎉")])
+        kwargs = mock_run.call_args.kwargs
+        self.assertEqual(kwargs.get("encoding"), "utf-8")
+        self.assertTrue(kwargs.get("text"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -1,12 +1,12 @@
 import os
 
-_TRADINGAGENTS_HOME = os.path.join(os.path.expanduser("~"), ".tradingagents")
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
-    "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", os.path.join(_TRADINGAGENTS_HOME, "logs")),
-    "data_cache_dir": os.getenv("TRADINGAGENTS_CACHE_DIR", os.path.join(_TRADINGAGENTS_HOME, "cache")),
-    "memory_log_path": os.getenv("TRADINGAGENTS_MEMORY_LOG_PATH", os.path.join(_TRADINGAGENTS_HOME, "memory", "trading_memory.md")),
+    "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", os.path.join(_PROJECT_ROOT, "reports")),
+    "data_cache_dir": os.getenv("TRADINGAGENTS_CACHE_DIR", os.path.join(_PROJECT_ROOT, ".cache")),
+    "memory_log_path": os.getenv("TRADINGAGENTS_MEMORY_LOG_PATH", os.path.join(_PROJECT_ROOT, ".memory", "trading_memory.md")),
     # Optional cap on the number of resolved memory log entries. When set,
     # the oldest resolved entries are pruned once this limit is exceeded.
     # Pending entries are never pruned. None disables rotation entirely.
@@ -25,6 +25,10 @@ DEFAULT_CONFIG = {
     "google_thinking_level": None,      # "high", "minimal", etc.
     "openai_reasoning_effort": None,    # "medium", "high", "low"
     "anthropic_effort": None,           # "high", "medium", "low"
+    # Claude Code (subscription) provider knobs. All optional.
+    "claude_code_effort": None,                # "low" | "medium" | "high" | "xhigh" | "max"
+    "claude_code_max_budget_usd": None,        # per-call USD cap forwarded to `claude --max-budget-usd`
+    "claude_code_force_subscription": False,   # strip ANTHROPIC_API_KEY from subprocess env
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -29,6 +29,9 @@ DEFAULT_CONFIG = {
     "claude_code_effort": None,                # "low" | "medium" | "high" | "xhigh" | "max"
     "claude_code_max_budget_usd": None,        # per-call USD cap forwarded to `claude --max-budget-usd`
     "claude_code_force_subscription": False,   # strip ANTHROPIC_API_KEY from subprocess env
+    # Gemini CLI (subscription) provider knobs. All optional.
+    "gemini_cli_yolo": False,                  # auto-approve all actions (rarely useful here)
+    "gemini_cli_force_subscription": False,    # strip GEMINI_API_KEY/GOOGLE_API_KEY from subprocess env
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -160,6 +160,12 @@ class TradingAgentsGraph:
             if self.config.get("claude_code_force_subscription"):
                 kwargs["force_subscription"] = True
 
+        elif provider == "gemini_cli":
+            if self.config.get("gemini_cli_yolo"):
+                kwargs["yolo"] = True
+            if self.config.get("gemini_cli_force_subscription"):
+                kwargs["force_subscription"] = True
+
         return kwargs
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -18,13 +18,13 @@ from tradingagents.llm_clients import create_llm_client
 from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import TradingMemoryLog
-from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.agents.utils.agent_states import (
     AgentState,
     InvestDebateState,
     RiskDebateState,
 )
 from tradingagents.dataflows.config import set_config
+from tradingagents.reporting import save_report_to_disk, default_save_path
 
 # Import the new abstract tool methods from agent_utils
 from tradingagents.agents.utils.agent_utils import (
@@ -149,6 +149,16 @@ class TradingAgentsGraph:
             effort = self.config.get("anthropic_effort")
             if effort:
                 kwargs["effort"] = effort
+
+        elif provider == "claude_code":
+            effort = self.config.get("claude_code_effort")
+            if effort:
+                kwargs["effort"] = effort
+            max_budget = self.config.get("claude_code_max_budget_usd")
+            if max_budget is not None:
+                kwargs["max_budget_usd"] = max_budget
+            if self.config.get("claude_code_force_subscription"):
+                kwargs["force_subscription"] = True
 
         return kwargs
 
@@ -329,8 +339,25 @@ class TradingAgentsGraph:
         # Store current state for reflection.
         self.curr_state = final_state
 
-        # Log state to disk.
-        self._log_state(trade_date, final_state)
+        # Compute one folder per run; both the JSON state dump and the
+        # structured markdown layout land inside it.
+        save_path = default_save_path(
+            self.config["results_dir"],
+            final_state["company_of_interest"],
+            final_state["trade_date"],
+        )
+        save_path.mkdir(parents=True, exist_ok=True)
+
+        # JSON state dump (machine-readable; also populates self.log_states_dict
+        # for any in-process reflection consumers).
+        self._log_state(trade_date, final_state, save_path)
+
+        # Structured markdown report — same layout the CLI used to produce.
+        try:
+            save_report_to_disk(final_state, final_state["company_of_interest"], save_path)
+            logger.info("Report written to %s", save_path)
+        except Exception as e:
+            logger.warning("Failed to write structured report: %s", e)
 
         # Store decision for deferred reflection on the next same-ticker run.
         self.memory_log.store_decision(
@@ -347,8 +374,8 @@ class TradingAgentsGraph:
 
         return final_state, self.process_signal(final_state["final_trade_decision"])
 
-    def _log_state(self, trade_date, final_state):
-        """Log the final state to a JSON file."""
+    def _log_state(self, trade_date, final_state, save_path: Path):
+        """Log the final state to a JSON file inside the run's report folder."""
         self.log_states_dict[str(trade_date)] = {
             "company_of_interest": final_state["company_of_interest"],
             "trade_date": final_state["trade_date"],
@@ -379,13 +406,7 @@ class TradingAgentsGraph:
             "final_trade_decision": final_state["final_trade_decision"],
         }
 
-        # Save to file. Reject ticker values that would escape the
-        # results directory when joined as a path component.
-        safe_ticker = safe_ticker_component(self.ticker)
-        directory = Path(self.config["results_dir"]) / safe_ticker / "TradingAgentsStrategy_logs"
-        directory.mkdir(parents=True, exist_ok=True)
-
-        log_path = directory / f"full_states_log_{trade_date}.json"
+        log_path = save_path / "full_states_log.json"
         with open(log_path, "w", encoding="utf-8") as f:
             json.dump(self.log_states_dict[str(trade_date)], f, indent=4)
 

--- a/tradingagents/llm_clients/claude_code_client.py
+++ b/tradingagents/llm_clients/claude_code_client.py
@@ -100,6 +100,12 @@ class ChatClaudeCode(SubprocessChatModel):
                 f"`claude -p` returned non-JSON output: {stdout[:500]}"
             ) from exc
 
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"`claude -p` JSON is not an object "
+                f"(got {type(payload).__name__}): {stdout[:500]}"
+            )
+
         if payload.get("is_error"):
             err = payload.get("result") or payload.get("error") or ""
             raise RuntimeError(f"`claude -p` returned error: {str(err)[:500]}")

--- a/tradingagents/llm_clients/claude_code_client.py
+++ b/tradingagents/llm_clients/claude_code_client.py
@@ -1,0 +1,427 @@
+"""Claude Code subscription provider — routes LLM calls through the local
+`claude -p` headless CLI instead of an HTTP API.
+
+Users with a Claude Pro/Max subscription get the full multi-agent pipeline
+without paying per-token API charges. Each call spawns a `claude` subprocess,
+feeds the serialized chat history on stdin, and parses the JSON result.
+
+Isolation strategy: we cannot use `--bare` because that mode disables
+OAuth/keychain auth (subscription routing). Instead we layer:
+- `--system-prompt` (replaces the default system prompt → no CLAUDE.md
+  auto-discovery, no auto-memory, no dynamic sections)
+- `--setting-sources ""` (skip user/project/local settings → no hooks,
+  output styles, custom permissions)
+- `--disable-slash-commands` (no skills)
+- `--tools ""` (no built-in tools — project tools run in langgraph's ToolNode)
+- `--no-session-persistence` (no session files written per call)
+- run from a temp cwd so no project-local CLAUDE.md is discovered
+
+Tool calling and structured output piggy-back on CLI flags:
+- `bind_tools(tools)` injects a JSON-envelope tool-call protocol into the
+  system prompt; we parse the assistant's reply for `{"tool_calls": [...]}`.
+- `with_structured_output(schema)` adds `--json-schema <schema>` so the CLI
+  enforces JSON-shape conformance.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel
+
+from .base_client import BaseLLMClient
+from .validators import validate_model
+
+
+_TOOL_PROTOCOL_INSTRUCTION = (
+    "TOOL PROTOCOL — READ CAREFULLY.\n"
+    "Ignore any tools (MCP, built-in, or otherwise) that you may believe are "
+    "available in this environment. The ONLY tools you can call are the ones "
+    "listed below, and you call them by emitting a JSON envelope, NOT by "
+    "invoking any tool API.\n\n"
+    "When you decide to call a tool, your ENTIRE reply must be a single JSON "
+    "object — no prose before or after, no markdown, no code fences — matching "
+    "this exact shape:\n"
+    '{"tool_calls": [{"name": "<tool_name>", "args": {<json_args>}}]}\n'
+    "You may include multiple objects in the tool_calls array to fan out. To "
+    "respond with normal text instead, write text that does not start with '{'.\n\n"
+    "Available tools (JSON-Schema):\n"
+)
+
+
+def _content_to_str(content: Any) -> str:
+    """Reduce langchain message content (str | list[block]) to a plain string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(item.get("text", ""))
+                elif "text" in item:
+                    parts.append(item["text"])
+        return "\n".join(p for p in parts if p)
+    if content is None:
+        return ""
+    return str(content)
+
+
+class ChatClaudeCode(BaseChatModel):
+    """LangChain BaseChatModel that delegates each call to `claude -p`."""
+
+    model: str = "sonnet"
+    timeout: int = 300
+    effort: Optional[str] = None
+    max_budget_usd: Optional[float] = None
+    append_system_prompt: Optional[str] = None
+    force_subscription: bool = False
+    binary_path: Optional[str] = None
+
+    bound_tools: Optional[List[Dict[str, Any]]] = None
+    json_schema: Optional[Dict[str, Any]] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def _llm_type(self) -> str:
+        return "claude_code"
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        system_prompt, user_prompt = self._render_messages(messages)
+        payload = self._run_subprocess(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            json_schema=self.json_schema,
+        )
+
+        # When --json-schema was passed, the CLI parses the assistant's reply
+        # against the schema and surfaces the parsed object on a separate
+        # `structured_output` field. The `result` field still holds the
+        # assistant's prose, which may wrap the JSON in markdown.
+        if self.json_schema is not None and isinstance(
+            payload.get("structured_output"), (dict, list)
+        ):
+            content = json.dumps(payload["structured_output"])
+            ai_msg = AIMessage(content=content)
+            return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+        result_text = payload.get("result", "") or ""
+
+        if self.bound_tools:
+            envelope = self._extract_tool_envelope(result_text)
+            if envelope is not None:
+                tool_calls = self._parse_tool_calls(envelope)
+                if tool_calls:
+                    ai_msg = AIMessage(content="", tool_calls=tool_calls)
+                    return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+        ai_msg = AIMessage(content=result_text)
+        return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+    def bind_tools(
+        self,
+        tools: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]],
+        **kwargs: Any,
+    ) -> "ChatClaudeCode":
+        """Return a copy of this model with tool definitions attached.
+
+        Tool calls come back via a JSON envelope in the system prompt rather
+        than a native tool-use API, since the parent app runs tools in
+        langgraph's ToolNode (not inside the `claude` subprocess).
+        """
+        formatted: List[Dict[str, Any]] = []
+        for t in tools:
+            spec = convert_to_openai_tool(t)
+            fn = spec.get("function", spec)
+            formatted.append(
+                {
+                    "name": fn.get("name"),
+                    "description": fn.get("description", ""),
+                    "input_schema": fn.get("parameters", {}),
+                }
+            )
+        return self.model_copy(update={"bound_tools": formatted})
+
+    def with_structured_output(
+        self,
+        schema: Type[BaseModel],
+        **kwargs: Any,
+    ):
+        """Return a Runnable that produces an instance of `schema`.
+
+        Uses `claude -p --json-schema`, which constrains the assistant's reply
+        to valid JSON matching the schema. The result is parsed into a Pydantic
+        instance. Raises NotImplementedError for non-Pydantic schemas so
+        invoke_structured_or_freetext falls back to free-text generation.
+        """
+        if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
+            raise NotImplementedError(
+                "ChatClaudeCode.with_structured_output requires a Pydantic "
+                "BaseModel schema."
+            )
+
+        json_schema = schema.model_json_schema()
+        bound = self.model_copy(update={"json_schema": json_schema})
+
+        def _parse(input_: Any) -> BaseModel:
+            ai = bound.invoke(input_)
+            content = _content_to_str(getattr(ai, "content", ""))
+            return schema.model_validate_json(content)
+
+        return RunnableLambda(_parse)
+
+    def _render_messages(
+        self, messages: List[BaseMessage]
+    ) -> tuple[str, str]:
+        sys_parts: List[str] = []
+        if self.append_system_prompt:
+            sys_parts.append(self.append_system_prompt)
+
+        body_parts: List[str] = []
+        for msg in messages:
+            text = _content_to_str(getattr(msg, "content", ""))
+            if isinstance(msg, SystemMessage):
+                if text:
+                    sys_parts.append(text)
+            elif isinstance(msg, HumanMessage):
+                body_parts.append(f"### user\n{text}")
+            elif isinstance(msg, AIMessage):
+                rendered = text
+                tool_calls = getattr(msg, "tool_calls", None) or []
+                if tool_calls:
+                    envelope = {
+                        "tool_calls": [
+                            {"name": tc.get("name"), "args": tc.get("args", {})}
+                            for tc in tool_calls
+                        ]
+                    }
+                    rendered = (rendered + "\n" if rendered else "") + json.dumps(envelope)
+                body_parts.append(f"### assistant\n{rendered}")
+            elif isinstance(msg, ToolMessage):
+                tool_name = getattr(msg, "name", None) or "tool"
+                body_parts.append(f"### tool[{tool_name}]\n{text}")
+            else:
+                role = getattr(msg, "type", "unknown")
+                body_parts.append(f"### {role}\n{text}")
+
+        if self.bound_tools:
+            tools_doc = json.dumps(self.bound_tools, indent=2)
+            sys_parts.append(_TOOL_PROTOCOL_INSTRUCTION + tools_doc)
+
+        system_prompt = "\n\n".join(p for p in sys_parts if p).strip()
+        user_prompt = "\n\n".join(body_parts).strip() or "(no user message)"
+        return system_prompt, user_prompt
+
+    def _run_subprocess(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        binary = self.binary_path or os.environ.get("CLAUDE_CODE_BIN") or shutil.which("claude")
+        if not binary:
+            raise RuntimeError(
+                "`claude` CLI not found. Install Claude Code "
+                "(https://claude.com/code) or set CLAUDE_CODE_BIN."
+            )
+
+        # Always pass --system-prompt to suppress the default (which would
+        # auto-discover CLAUDE.md from cwd and inject memory paths). When the
+        # caller has no system content, fall back to a minimal placeholder.
+        effective_system = system_prompt or "You are a helpful AI assistant."
+
+        cmd: List[str] = [
+            binary, "-p",
+            "--system-prompt", effective_system,
+            "--tools", "",
+            "--output-format", "json",
+            "--no-session-persistence",
+            "--setting-sources", "",
+            "--disable-slash-commands",
+            "--strict-mcp-config",
+            "--model", self.model,
+        ]
+        if self.effort:
+            cmd += ["--effort", self.effort]
+        if self.max_budget_usd is not None:
+            cmd += ["--max-budget-usd", str(self.max_budget_usd)]
+        if json_schema is not None:
+            cmd += ["--json-schema", json.dumps(json_schema)]
+
+        env = os.environ.copy()
+        if self.force_subscription:
+            env.pop("ANTHROPIC_API_KEY", None)
+
+        # Run from a stable temp directory so no project-local CLAUDE.md is
+        # auto-discovered as the cwd context. The default system prompt would
+        # also pull this in; --system-prompt above already overrides it, but
+        # belt-and-suspenders.
+        proc = subprocess.run(
+            cmd,
+            input=user_prompt,
+            capture_output=True,
+            text=True,
+            timeout=self.timeout,
+            check=False,
+            env=env,
+            cwd=tempfile.gettempdir(),
+        )
+
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip()
+            raise RuntimeError(
+                f"`claude -p` failed (rc={proc.returncode}): {err[:1000]}"
+            )
+
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"`claude -p` returned non-JSON output: {proc.stdout[:500]}"
+            ) from exc
+
+        if payload.get("is_error"):
+            err = payload.get("result") or payload.get("error") or ""
+            raise RuntimeError(f"`claude -p` returned error: {str(err)[:500]}")
+
+        if "result" not in payload and "structured_output" not in payload:
+            raise RuntimeError(
+                f"`claude -p` JSON missing 'result'/'structured_output' field: "
+                f"{json.dumps(payload)[:500]}"
+            )
+
+        return payload
+
+    @staticmethod
+    def _extract_tool_envelope(text: str) -> Optional[Dict[str, Any]]:
+        """Find a `{"tool_calls": [...]}` JSON object inside arbitrary text.
+
+        Models often prefix the envelope with a sentence ("Sure, let me...")
+        or wrap it in a code fence, even when instructed to emit pure JSON.
+        Locate the JSON object by brace-matching around the `"tool_calls"`
+        substring and try to parse it.
+        """
+        stripped = text.strip()
+        if stripped.startswith("{"):
+            try:
+                obj = json.loads(stripped)
+                if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
+                    return obj
+            except json.JSONDecodeError:
+                pass
+
+        needle = '"tool_calls"'
+        idx = text.find(needle)
+        if idx == -1:
+            return None
+        start = text.rfind("{", 0, idx)
+        if start == -1:
+            return None
+
+        depth = 0
+        in_str = False
+        escape = False
+        for i in range(start, len(text)):
+            ch = text[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"' and not escape:
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(text[start : i + 1])
+                    except json.JSONDecodeError:
+                        return None
+                    if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
+                        return obj
+                    return None
+        return None
+
+    @staticmethod
+    def _parse_tool_calls(envelope: Dict[str, Any]) -> List[Dict[str, Any]]:
+        raw_calls = envelope.get("tool_calls", [])
+        out: List[Dict[str, Any]] = []
+        for raw in raw_calls:
+            if not isinstance(raw, dict):
+                continue
+            name = raw.get("name")
+            if not name:
+                continue
+            args = raw.get("args", {})
+            if not isinstance(args, dict):
+                args = {}
+            out.append(
+                {
+                    "name": name,
+                    "args": args,
+                    "id": raw.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                    "type": "tool_call",
+                }
+            )
+        return out
+
+
+_PASSTHROUGH_KWARGS = (
+    "timeout",
+    "effort",
+    "max_budget_usd",
+    "append_system_prompt",
+    "force_subscription",
+    "binary_path",
+)
+
+
+class ClaudeCodeClient(BaseLLMClient):
+    """Client routing through the user's Claude Code subscription via `claude -p`."""
+
+    def __init__(self, model: str, base_url: Optional[str] = None, **kwargs: Any):
+        super().__init__(model, base_url, **kwargs)
+
+    def get_llm(self) -> Any:
+        self.warn_if_unknown_model()
+        llm_kwargs: Dict[str, Any] = {"model": self.model}
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs and self.kwargs[key] is not None:
+                llm_kwargs[key] = self.kwargs[key]
+        return ChatClaudeCode(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        return validate_model("claude_code", self.model)

--- a/tradingagents/llm_clients/claude_code_client.py
+++ b/tradingagents/llm_clients/claude_code_client.py
@@ -1,257 +1,64 @@
 """Claude Code subscription provider — routes LLM calls through the local
-`claude -p` headless CLI instead of an HTTP API.
+``claude -p`` headless CLI instead of an HTTP API.
 
 Users with a Claude Pro/Max subscription get the full multi-agent pipeline
-without paying per-token API charges. Each call spawns a `claude` subprocess,
+without paying per-token API charges. Each call spawns a ``claude`` subprocess,
 feeds the serialized chat history on stdin, and parses the JSON result.
 
-Isolation strategy: we cannot use `--bare` because that mode disables
+Isolation strategy: we cannot use ``--bare`` because that mode disables
 OAuth/keychain auth (subscription routing). Instead we layer:
-- `--system-prompt` (replaces the default system prompt → no CLAUDE.md
+
+- ``--system-prompt`` (replaces the default system prompt → no CLAUDE.md
   auto-discovery, no auto-memory, no dynamic sections)
-- `--setting-sources ""` (skip user/project/local settings → no hooks,
+- ``--setting-sources ""`` (skip user/project/local settings → no hooks,
   output styles, custom permissions)
-- `--disable-slash-commands` (no skills)
-- `--tools ""` (no built-in tools — project tools run in langgraph's ToolNode)
-- `--no-session-persistence` (no session files written per call)
+- ``--disable-slash-commands`` (no skills)
+- ``--tools ""`` (no built-in tools — project tools run in langgraph's ToolNode)
+- ``--no-session-persistence`` (no session files written per call)
 - run from a temp cwd so no project-local CLAUDE.md is discovered
 
 Tool calling and structured output piggy-back on CLI flags:
-- `bind_tools(tools)` injects a JSON-envelope tool-call protocol into the
-  system prompt; we parse the assistant's reply for `{"tool_calls": [...]}`.
-- `with_structured_output(schema)` adds `--json-schema <schema>` so the CLI
+
+- ``bind_tools(tools)`` injects a JSON-envelope tool-call protocol into the
+  system prompt; we parse the assistant's reply for ``{"tool_calls": [...]}``.
+- ``with_structured_output(schema)`` adds ``--json-schema <schema>`` so the CLI
   enforces JSON-shape conformance.
 """
 
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import subprocess
-import tempfile
-import uuid
-from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
-
-from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import (
-    AIMessage,
-    BaseMessage,
-    HumanMessage,
-    SystemMessage,
-    ToolMessage,
-)
-from langchain_core.outputs import ChatGeneration, ChatResult
-from langchain_core.runnables import RunnableLambda
-from langchain_core.tools import BaseTool
-from langchain_core.utils.function_calling import convert_to_openai_tool
-from pydantic import BaseModel
+from typing import Any, Dict, List, Optional, Tuple
 
 from .base_client import BaseLLMClient
+from .subprocess_chat_base import SubprocessChatModel
 from .validators import validate_model
 
 
-_TOOL_PROTOCOL_INSTRUCTION = (
-    "TOOL PROTOCOL — READ CAREFULLY.\n"
-    "Ignore any tools (MCP, built-in, or otherwise) that you may believe are "
-    "available in this environment. The ONLY tools you can call are the ones "
-    "listed below, and you call them by emitting a JSON envelope, NOT by "
-    "invoking any tool API.\n\n"
-    "When you decide to call a tool, your ENTIRE reply must be a single JSON "
-    "object — no prose before or after, no markdown, no code fences — matching "
-    "this exact shape:\n"
-    '{"tool_calls": [{"name": "<tool_name>", "args": {<json_args>}}]}\n'
-    "You may include multiple objects in the tool_calls array to fan out. To "
-    "respond with normal text instead, write text that does not start with '{'.\n\n"
-    "Available tools (JSON-Schema):\n"
-)
-
-
-def _content_to_str(content: Any) -> str:
-    """Reduce langchain message content (str | list[block]) to a plain string."""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                if item.get("type") == "text":
-                    parts.append(item.get("text", ""))
-                elif "text" in item:
-                    parts.append(item["text"])
-        return "\n".join(p for p in parts if p)
-    if content is None:
-        return ""
-    return str(content)
-
-
-class ChatClaudeCode(BaseChatModel):
-    """LangChain BaseChatModel that delegates each call to `claude -p`."""
+class ChatClaudeCode(SubprocessChatModel):
+    """LangChain BaseChatModel that delegates each call to ``claude -p``."""
 
     model: str = "sonnet"
-    timeout: int = 300
     effort: Optional[str] = None
     max_budget_usd: Optional[float] = None
-    append_system_prompt: Optional[str] = None
     force_subscription: bool = False
-    binary_path: Optional[str] = None
-
-    bound_tools: Optional[List[Dict[str, Any]]] = None
-    json_schema: Optional[Dict[str, Any]] = None
-
-    model_config = {"arbitrary_types_allowed": True}
 
     @property
     def _llm_type(self) -> str:
         return "claude_code"
 
-    def _generate(
+    def _binary_name(self) -> str:
+        return "claude"
+
+    def _binary_env_var(self) -> str:
+        return "CLAUDE_CODE_BIN"
+
+    def _build_command(
         self,
-        messages: List[BaseMessage],
-        stop: Optional[List[str]] = None,
-        run_manager: Optional[Any] = None,
-        **kwargs: Any,
-    ) -> ChatResult:
-        system_prompt, user_prompt = self._render_messages(messages)
-        payload = self._run_subprocess(
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            json_schema=self.json_schema,
-        )
-
-        # When --json-schema was passed, the CLI parses the assistant's reply
-        # against the schema and surfaces the parsed object on a separate
-        # `structured_output` field. The `result` field still holds the
-        # assistant's prose, which may wrap the JSON in markdown.
-        if self.json_schema is not None and isinstance(
-            payload.get("structured_output"), (dict, list)
-        ):
-            content = json.dumps(payload["structured_output"])
-            ai_msg = AIMessage(content=content)
-            return ChatResult(generations=[ChatGeneration(message=ai_msg)])
-
-        result_text = payload.get("result", "") or ""
-
-        if self.bound_tools:
-            envelope = self._extract_tool_envelope(result_text)
-            if envelope is not None:
-                tool_calls = self._parse_tool_calls(envelope)
-                if tool_calls:
-                    ai_msg = AIMessage(content="", tool_calls=tool_calls)
-                    return ChatResult(generations=[ChatGeneration(message=ai_msg)])
-
-        ai_msg = AIMessage(content=result_text)
-        return ChatResult(generations=[ChatGeneration(message=ai_msg)])
-
-    def bind_tools(
-        self,
-        tools: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]],
-        **kwargs: Any,
-    ) -> "ChatClaudeCode":
-        """Return a copy of this model with tool definitions attached.
-
-        Tool calls come back via a JSON envelope in the system prompt rather
-        than a native tool-use API, since the parent app runs tools in
-        langgraph's ToolNode (not inside the `claude` subprocess).
-        """
-        formatted: List[Dict[str, Any]] = []
-        for t in tools:
-            spec = convert_to_openai_tool(t)
-            fn = spec.get("function", spec)
-            formatted.append(
-                {
-                    "name": fn.get("name"),
-                    "description": fn.get("description", ""),
-                    "input_schema": fn.get("parameters", {}),
-                }
-            )
-        return self.model_copy(update={"bound_tools": formatted})
-
-    def with_structured_output(
-        self,
-        schema: Type[BaseModel],
-        **kwargs: Any,
-    ):
-        """Return a Runnable that produces an instance of `schema`.
-
-        Uses `claude -p --json-schema`, which constrains the assistant's reply
-        to valid JSON matching the schema. The result is parsed into a Pydantic
-        instance. Raises NotImplementedError for non-Pydantic schemas so
-        invoke_structured_or_freetext falls back to free-text generation.
-        """
-        if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
-            raise NotImplementedError(
-                "ChatClaudeCode.with_structured_output requires a Pydantic "
-                "BaseModel schema."
-            )
-
-        json_schema = schema.model_json_schema()
-        bound = self.model_copy(update={"json_schema": json_schema})
-
-        def _parse(input_: Any) -> BaseModel:
-            ai = bound.invoke(input_)
-            content = _content_to_str(getattr(ai, "content", ""))
-            return schema.model_validate_json(content)
-
-        return RunnableLambda(_parse)
-
-    def _render_messages(
-        self, messages: List[BaseMessage]
-    ) -> tuple[str, str]:
-        sys_parts: List[str] = []
-        if self.append_system_prompt:
-            sys_parts.append(self.append_system_prompt)
-
-        body_parts: List[str] = []
-        for msg in messages:
-            text = _content_to_str(getattr(msg, "content", ""))
-            if isinstance(msg, SystemMessage):
-                if text:
-                    sys_parts.append(text)
-            elif isinstance(msg, HumanMessage):
-                body_parts.append(f"### user\n{text}")
-            elif isinstance(msg, AIMessage):
-                rendered = text
-                tool_calls = getattr(msg, "tool_calls", None) or []
-                if tool_calls:
-                    envelope = {
-                        "tool_calls": [
-                            {"name": tc.get("name"), "args": tc.get("args", {})}
-                            for tc in tool_calls
-                        ]
-                    }
-                    rendered = (rendered + "\n" if rendered else "") + json.dumps(envelope)
-                body_parts.append(f"### assistant\n{rendered}")
-            elif isinstance(msg, ToolMessage):
-                tool_name = getattr(msg, "name", None) or "tool"
-                body_parts.append(f"### tool[{tool_name}]\n{text}")
-            else:
-                role = getattr(msg, "type", "unknown")
-                body_parts.append(f"### {role}\n{text}")
-
-        if self.bound_tools:
-            tools_doc = json.dumps(self.bound_tools, indent=2)
-            sys_parts.append(_TOOL_PROTOCOL_INSTRUCTION + tools_doc)
-
-        system_prompt = "\n\n".join(p for p in sys_parts if p).strip()
-        user_prompt = "\n\n".join(body_parts).strip() or "(no user message)"
-        return system_prompt, user_prompt
-
-    def _run_subprocess(
-        self,
+        binary: str,
         system_prompt: str,
-        user_prompt: str,
         json_schema: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
-        binary = self.binary_path or os.environ.get("CLAUDE_CODE_BIN") or shutil.which("claude")
-        if not binary:
-            raise RuntimeError(
-                "`claude` CLI not found. Install Claude Code "
-                "(https://claude.com/code) or set CLAUDE_CODE_BIN."
-            )
-
+    ) -> List[str]:
         # Always pass --system-prompt to suppress the default (which would
         # auto-discover CLAUDE.md from cwd and inject memory paths). When the
         # caller has no system content, fall back to a minimal placeholder.
@@ -274,37 +81,23 @@ class ChatClaudeCode(BaseChatModel):
             cmd += ["--max-budget-usd", str(self.max_budget_usd)]
         if json_schema is not None:
             cmd += ["--json-schema", json.dumps(json_schema)]
+        return cmd
 
-        env = os.environ.copy()
+    def _subprocess_env(self, parent_env: Dict[str, str]) -> Dict[str, str]:
         if self.force_subscription:
-            env.pop("ANTHROPIC_API_KEY", None)
+            parent_env.pop("ANTHROPIC_API_KEY", None)
+        return parent_env
 
-        # Run from a stable temp directory so no project-local CLAUDE.md is
-        # auto-discovered as the cwd context. The default system prompt would
-        # also pull this in; --system-prompt above already overrides it, but
-        # belt-and-suspenders.
-        proc = subprocess.run(
-            cmd,
-            input=user_prompt,
-            capture_output=True,
-            text=True,
-            timeout=self.timeout,
-            check=False,
-            env=env,
-            cwd=tempfile.gettempdir(),
-        )
-
-        if proc.returncode != 0:
-            err = (proc.stderr or proc.stdout or "").strip()
-            raise RuntimeError(
-                f"`claude -p` failed (rc={proc.returncode}): {err[:1000]}"
-            )
-
+    def _parse_response(
+        self,
+        stdout: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Tuple[str, Optional[Any]]:
         try:
-            payload = json.loads(proc.stdout)
+            payload = json.loads(stdout)
         except json.JSONDecodeError as exc:
             raise RuntimeError(
-                f"`claude -p` returned non-JSON output: {proc.stdout[:500]}"
+                f"`claude -p` returned non-JSON output: {stdout[:500]}"
             ) from exc
 
         if payload.get("is_error"):
@@ -317,86 +110,9 @@ class ChatClaudeCode(BaseChatModel):
                 f"{json.dumps(payload)[:500]}"
             )
 
-        return payload
-
-    @staticmethod
-    def _extract_tool_envelope(text: str) -> Optional[Dict[str, Any]]:
-        """Find a `{"tool_calls": [...]}` JSON object inside arbitrary text.
-
-        Models often prefix the envelope with a sentence ("Sure, let me...")
-        or wrap it in a code fence, even when instructed to emit pure JSON.
-        Locate the JSON object by brace-matching around the `"tool_calls"`
-        substring and try to parse it.
-        """
-        stripped = text.strip()
-        if stripped.startswith("{"):
-            try:
-                obj = json.loads(stripped)
-                if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
-                    return obj
-            except json.JSONDecodeError:
-                pass
-
-        needle = '"tool_calls"'
-        idx = text.find(needle)
-        if idx == -1:
-            return None
-        start = text.rfind("{", 0, idx)
-        if start == -1:
-            return None
-
-        depth = 0
-        in_str = False
-        escape = False
-        for i in range(start, len(text)):
-            ch = text[i]
-            if escape:
-                escape = False
-                continue
-            if ch == "\\":
-                escape = True
-                continue
-            if ch == '"' and not escape:
-                in_str = not in_str
-                continue
-            if in_str:
-                continue
-            if ch == "{":
-                depth += 1
-            elif ch == "}":
-                depth -= 1
-                if depth == 0:
-                    try:
-                        obj = json.loads(text[start : i + 1])
-                    except json.JSONDecodeError:
-                        return None
-                    if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
-                        return obj
-                    return None
-        return None
-
-    @staticmethod
-    def _parse_tool_calls(envelope: Dict[str, Any]) -> List[Dict[str, Any]]:
-        raw_calls = envelope.get("tool_calls", [])
-        out: List[Dict[str, Any]] = []
-        for raw in raw_calls:
-            if not isinstance(raw, dict):
-                continue
-            name = raw.get("name")
-            if not name:
-                continue
-            args = raw.get("args", {})
-            if not isinstance(args, dict):
-                args = {}
-            out.append(
-                {
-                    "name": name,
-                    "args": args,
-                    "id": raw.get("id") or f"call_{uuid.uuid4().hex[:12]}",
-                    "type": "tool_call",
-                }
-            )
-        return out
+        text = payload.get("result", "") or ""
+        structured = payload.get("structured_output")
+        return text, structured
 
 
 _PASSTHROUGH_KWARGS = (
@@ -410,7 +126,7 @@ _PASSTHROUGH_KWARGS = (
 
 
 class ClaudeCodeClient(BaseLLMClient):
-    """Client routing through the user's Claude Code subscription via `claude -p`."""
+    """Client routing through the user's Claude Code subscription via ``claude -p``."""
 
     def __init__(self, model: str, base_url: Optional[str] = None, **kwargs: Any):
         super().__init__(model, base_url, **kwargs)

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -50,4 +50,8 @@ def create_llm_client(
         from .azure_client import AzureOpenAIClient
         return AzureOpenAIClient(model, base_url, **kwargs)
 
+    if provider_lower == "claude_code":
+        from .claude_code_client import ClaudeCodeClient
+        return ClaudeCodeClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -54,4 +54,8 @@ def create_llm_client(
         from .claude_code_client import ClaudeCodeClient
         return ClaudeCodeClient(model, base_url, **kwargs)
 
+    if provider_lower == "gemini_cli":
+        from .gemini_cli_client import GeminiCliClient
+        return GeminiCliClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/llm_clients/gemini_cli_client.py
+++ b/tradingagents/llm_clients/gemini_cli_client.py
@@ -65,12 +65,27 @@ class ChatGeminiCli(SubprocessChatModel):
         return cmd
 
     def _subprocess_input(self, system_prompt: str, user_prompt: str) -> str:
-        """Inline the system prompt into stdin since Gemini has no --system-prompt flag."""
-        if not system_prompt:
+        """Inline the system prompt into stdin since Gemini has no --system-prompt flag.
+
+        When a JSON schema is bound (via ``with_structured_output``), append it
+        to the system prompt — Gemini CLI has no ``--json-schema`` flag, so the
+        schema must travel inline if we want the model to honor it.
+        """
+        effective_system = system_prompt
+        if self.json_schema is not None:
+            schema_instr = (
+                "Return your response as a JSON object matching this schema:\n"
+                f"{json.dumps(self.json_schema, indent=2)}"
+            )
+            effective_system = (
+                f"{effective_system}\n\n{schema_instr}" if effective_system else schema_instr
+            )
+
+        if not effective_system:
             return user_prompt
         return (
             "<<SYSTEM>>\n"
-            f"{system_prompt}\n"
+            f"{effective_system}\n"
             "<<END SYSTEM>>\n\n"
             "<<USER>>\n"
             f"{user_prompt}\n"
@@ -126,7 +141,7 @@ _FENCED_JSON = re.compile(r"```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```", re.DOTALL)
 def _try_parse_json(text: str) -> Optional[Any]:
     """Best-effort JSON extraction for CLIs without a --json-schema flag.
 
-    Tries: raw parse → fenced block → first balanced object.
+    Tries: raw parse → fenced block → first balanced object or array.
     """
     s = text.strip()
     if not s:
@@ -143,10 +158,15 @@ def _try_parse_json(text: str) -> Optional[Any]:
         except json.JSONDecodeError:
             pass
 
-    # Find first balanced { ... }
-    start = s.find("{")
-    if start == -1:
+    # Find the earliest top-level balanced { ... } or [ ... ]
+    obj_start = s.find("{")
+    arr_start = s.find("[")
+    candidates = [(i, c) for i, c in ((obj_start, "{"), (arr_start, "[")) if i != -1]
+    if not candidates:
         return None
+    start, open_ch = min(candidates)
+    close_ch = "}" if open_ch == "{" else "]"
+
     depth = 0
     in_str = False
     escape = False
@@ -163,9 +183,9 @@ def _try_parse_json(text: str) -> Optional[Any]:
             continue
         if in_str:
             continue
-        if ch == "{":
+        if ch == open_ch:
             depth += 1
-        elif ch == "}":
+        elif ch == close_ch:
             depth -= 1
             if depth == 0:
                 try:

--- a/tradingagents/llm_clients/gemini_cli_client.py
+++ b/tradingagents/llm_clients/gemini_cli_client.py
@@ -1,0 +1,202 @@
+"""Google Gemini CLI subscription provider — routes LLM calls through the
+local ``gemini -p`` headless CLI instead of the Generative Language API.
+
+Users authenticated via ``gemini auth`` (GOOGLE_GENAI_USE_GCA / OAuth) get
+the full multi-agent pipeline without an API key. Like Claude Code, each
+call spawns one subprocess; auth is whatever the CLI already holds.
+
+Differences from Claude Code that drive this subclass:
+
+- Gemini CLI has no ``--system-prompt`` flag, so we inline the system prompt
+  into the prompt argument with a clear ``<system>`` / ``<user>`` partition.
+- Tools/MCP are governed by ``--approval-mode plan`` (read-only) plus an
+  empty ``--allowed-mcp-server-names`` to keep the subprocess from running
+  any tools itself; project tools run in langgraph's ToolNode via the
+  JSON-envelope protocol inherited from :class:`SubprocessChatModel`.
+- Response format with ``-o json`` is ``{"response": "...", ...}`` rather
+  than Claude's ``{"result": ..., "structured_output": ...}``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base_client import BaseLLMClient
+from .subprocess_chat_base import SubprocessChatModel
+from .validators import validate_model
+
+
+class ChatGeminiCli(SubprocessChatModel):
+    """LangChain BaseChatModel that delegates each call to ``gemini -p``."""
+
+    model: str = "gemini-2.5-flash"
+    yolo: bool = False  # let the model auto-approve actions; usually leave False
+    force_subscription: bool = False
+
+    @property
+    def _llm_type(self) -> str:
+        return "gemini_cli"
+
+    def _binary_name(self) -> str:
+        return "gemini"
+
+    def _binary_env_var(self) -> str:
+        return "GEMINI_CLI_BIN"
+
+    def _build_command(
+        self,
+        binary: str,
+        system_prompt: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> List[str]:
+        cmd: List[str] = [
+            binary,
+            "--prompt", "",       # actual prompt is sent on stdin
+            "--output-format", "json",
+            "--approval-mode", "plan",  # read-only — no edits, no shell, no writes
+            "--allowed-mcp-server-names", "",  # disable user-configured MCP servers
+        ]
+        if self.model:
+            cmd += ["--model", self.model]
+        if self.yolo:
+            cmd = [c if c != "plan" else "yolo" for c in cmd]
+        return cmd
+
+    def _subprocess_input(self, system_prompt: str, user_prompt: str) -> str:
+        """Inline the system prompt into stdin since Gemini has no --system-prompt flag."""
+        if not system_prompt:
+            return user_prompt
+        return (
+            "<<SYSTEM>>\n"
+            f"{system_prompt}\n"
+            "<<END SYSTEM>>\n\n"
+            "<<USER>>\n"
+            f"{user_prompt}\n"
+            "<<END USER>>\n"
+        )
+
+    def _subprocess_env(self, parent_env: Dict[str, str]) -> Dict[str, str]:
+        if self.force_subscription:
+            # Strip API-key-style env vars so the CLI falls back to OAuth.
+            for var in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+                parent_env.pop(var, None)
+        return parent_env
+
+    def _parse_response(
+        self,
+        stdout: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Tuple[str, Optional[Any]]:
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"`gemini -p` returned non-JSON output: {stdout[:500]}"
+            ) from exc
+
+        if isinstance(payload, dict) and payload.get("error"):
+            err = payload["error"]
+            msg = err.get("message") if isinstance(err, dict) else str(err)
+            raise RuntimeError(f"`gemini -p` returned error: {str(msg)[:500]}")
+
+        # Gemini's --output-format json schema:
+        #   { "response": "...", "stats": {...}, "session_id": "..." }
+        text = ""
+        if isinstance(payload, dict):
+            text = payload.get("response") or payload.get("result") or ""
+        if not isinstance(text, str):
+            text = json.dumps(text)
+
+        structured: Optional[Any] = None
+        if json_schema is not None:
+            # Gemini CLI does not expose a --json-schema flag like Claude Code;
+            # the schema is included in the prompt by the base class via a
+            # tool-protocol-like instruction. Best effort: parse the response
+            # text as JSON and surface as structured if it parses cleanly.
+            structured = _try_parse_json(text)
+
+        return text, structured
+
+
+_FENCED_JSON = re.compile(r"```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```", re.DOTALL)
+
+
+def _try_parse_json(text: str) -> Optional[Any]:
+    """Best-effort JSON extraction for CLIs without a --json-schema flag.
+
+    Tries: raw parse → fenced block → first balanced object.
+    """
+    s = text.strip()
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        pass
+
+    m = _FENCED_JSON.search(s)
+    if m:
+        try:
+            return json.loads(m.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Find first balanced { ... }
+    start = s.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    in_str = False
+    escape = False
+    for i in range(start, len(s)):
+        ch = s[i]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(s[start : i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+_PASSTHROUGH_KWARGS = (
+    "timeout",
+    "yolo",
+    "append_system_prompt",
+    "force_subscription",
+    "binary_path",
+)
+
+
+class GeminiCliClient(BaseLLMClient):
+    """Client routing through the user's Gemini CLI subscription via ``gemini -p``."""
+
+    def __init__(self, model: str, base_url: Optional[str] = None, **kwargs: Any):
+        super().__init__(model, base_url, **kwargs)
+
+    def get_llm(self) -> Any:
+        self.warn_if_unknown_model()
+        llm_kwargs: Dict[str, Any] = {"model": self.model}
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs and self.kwargs[key] is not None:
+                llm_kwargs[key] = self.kwargs[key]
+        return ChatGeminiCli(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        return validate_model("gemini_cli", self.model)

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -53,6 +53,18 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Claude Sonnet 4.6 - Pin to specific version", "claude-sonnet-4-6"),
         ],
     },
+    # Google Gemini CLI subprocess provider — routes through `gemini -p`,
+    # auth via the user's `gemini auth` OAuth login.
+    "gemini_cli": {
+        "quick": [
+            ("Gemini 2.5 Flash - Balanced, fast", "gemini-2.5-flash"),
+            ("Gemini 2.5 Flash Lite - Fastest", "gemini-2.5-flash-lite"),
+        ],
+        "deep": [
+            ("Gemini 2.5 Pro - Most capable", "gemini-2.5-pro"),
+            ("Gemini 2.5 Flash - Balanced, fast", "gemini-2.5-flash"),
+        ],
+    },
     "google": {
         "quick": [
             ("Gemini 3 Flash - Next-gen fast", "gemini-3-flash-preview"),

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -36,6 +36,23 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Claude Sonnet 4.5 - Agents and coding", "claude-sonnet-4-5"),
         ],
     },
+    # Routes through the local `claude -p` CLI under the user's subscription —
+    # no API key. Aliases (sonnet/opus/haiku) and full IDs are both accepted by
+    # the CLI's --model flag, so both shapes are listed here for validate_model().
+    "claude_code": {
+        "quick": [
+            ("Sonnet (latest) - Best speed/intelligence balance", "sonnet"),
+            ("Haiku (latest) - Fast, near-instant", "haiku"),
+            ("Claude Sonnet 4.6 - Pin to specific version", "claude-sonnet-4-6"),
+            ("Claude Haiku 4.5 - Pin to specific version", "claude-haiku-4-5"),
+        ],
+        "deep": [
+            ("Opus (latest) - Most intelligent", "opus"),
+            ("Sonnet (latest) - Best speed/intelligence balance", "sonnet"),
+            ("Claude Opus 4.6 - Pin to specific version", "claude-opus-4-6"),
+            ("Claude Sonnet 4.6 - Pin to specific version", "claude-sonnet-4-6"),
+        ],
+    },
     "google": {
         "quick": [
             ("Gemini 3 Flash - Next-gen fast", "gemini-3-flash-preview"),

--- a/tradingagents/llm_clients/subprocess_chat_base.py
+++ b/tradingagents/llm_clients/subprocess_chat_base.py
@@ -319,6 +319,7 @@ class SubprocessChatModel(BaseChatModel):
             input=stdin_text,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=self.timeout,
             check=False,
             env=env,

--- a/tradingagents/llm_clients/subprocess_chat_base.py
+++ b/tradingagents/llm_clients/subprocess_chat_base.py
@@ -1,0 +1,415 @@
+"""Subprocess-based chat model base.
+
+Some agentic CLIs ship a headless mode that lets you run a single inference
+without authenticating an HTTP client — auth comes from the user's OAuth
+session that the CLI already holds. Examples:
+
+- Anthropic Claude Code: ``claude -p ...`` (Pro/Max subscription)
+- Google Gemini CLI:     ``gemini -p ...`` (Google AI subscription)
+
+This module provides the common machinery for plugging any such CLI into the
+project's LangGraph pipeline as a regular langchain ``BaseChatModel``:
+
+- per-call subprocess spawning with isolation flags
+- chat-history serialization
+- a JSON-envelope tool-calling protocol so langgraph's ToolNode runs the
+  project's tools (the subprocess sees no real tools)
+- structured output (Pydantic) via ``--json-schema``-style flags
+- consistent ``AIMessage`` shape so the rest of the pipeline doesn't notice
+
+Concrete providers subclass :class:`SubprocessChatModel` and implement just
+the CLI-specific bits: which binary, what flags, how to parse the response.
+See ``claude_code_client.py`` and ``gemini_cli_client.py`` for examples.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+from abc import abstractmethod
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel
+
+
+_TOOL_PROTOCOL_INSTRUCTION = (
+    "TOOL PROTOCOL — READ CAREFULLY.\n"
+    "Ignore any tools (MCP, built-in, or otherwise) that you may believe are "
+    "available in this environment. The ONLY tools you can call are the ones "
+    "listed below, and you call them by emitting a JSON envelope, NOT by "
+    "invoking any tool API.\n\n"
+    "When you decide to call a tool, your ENTIRE reply must be a single JSON "
+    "object — no prose before or after, no markdown, no code fences — matching "
+    "this exact shape:\n"
+    '{"tool_calls": [{"name": "<tool_name>", "args": {<json_args>}}]}\n'
+    "You may include multiple objects in the tool_calls array to fan out. To "
+    "respond with normal text instead, write text that does not start with '{'.\n\n"
+    "Available tools (JSON-Schema):\n"
+)
+
+
+def _content_to_str(content: Any) -> str:
+    """Reduce langchain message content (str | list[block]) to a plain string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if item.get("type") == "text":
+                    parts.append(item.get("text", ""))
+                elif "text" in item:
+                    parts.append(item["text"])
+        return "\n".join(p for p in parts if p)
+    if content is None:
+        return ""
+    return str(content)
+
+
+class SubprocessChatModel(BaseChatModel):
+    """Abstract base for chat models backed by a headless agent CLI subprocess.
+
+    Subclasses implement five hooks:
+
+    - :meth:`_binary_name`        — CLI binary basename (e.g. ``"claude"``)
+    - :meth:`_binary_env_var`     — env var that overrides the binary path
+    - :meth:`_build_command`      — argv (excluding stdin) for one call
+    - :meth:`_parse_response`     — pull text + optional structured object out of stdout
+    - :meth:`_llm_type`           — provider identifier used by langchain
+
+    Plus two optional hooks:
+
+    - :meth:`_subprocess_input`   — what goes on stdin (default: rendered user prompt)
+    - :meth:`_subprocess_env`     — env var sanitization (default: passthrough)
+    """
+
+    model: str
+    timeout: int = 300
+    binary_path: Optional[str] = None
+    append_system_prompt: Optional[str] = None
+
+    # Set by bind_tools / with_structured_output. Internal.
+    bound_tools: Optional[List[Dict[str, Any]]] = None
+    json_schema: Optional[Dict[str, Any]] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    # --- Subclass hooks -----------------------------------------------------
+
+    @abstractmethod
+    def _binary_name(self) -> str:
+        """Basename of the CLI binary, e.g. ``"claude"`` or ``"gemini"``."""
+
+    @abstractmethod
+    def _binary_env_var(self) -> str:
+        """Env var that overrides the binary path (e.g. ``"CLAUDE_CODE_BIN"``)."""
+
+    @abstractmethod
+    def _build_command(
+        self,
+        binary: str,
+        system_prompt: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> List[str]:
+        """Return the full argv (binary + flags). Stdin is supplied separately."""
+
+    @abstractmethod
+    def _parse_response(
+        self,
+        stdout: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Tuple[str, Optional[Any]]:
+        """Pull (assistant_text, structured_output) from raw CLI stdout.
+
+        ``structured_output`` should be a parsed dict/list when the CLI honored
+        the ``--json-schema``-style flag, otherwise None. The base class will
+        prefer ``structured_output`` when ``json_schema`` is set.
+        """
+
+    def _subprocess_input(self, system_prompt: str, user_prompt: str) -> str:
+        """What to send on stdin. Default: just the rendered user prompt.
+
+        Override if your CLI consumes the system prompt via stdin too.
+        """
+        return user_prompt
+
+    def _subprocess_env(self, parent_env: Dict[str, str]) -> Dict[str, str]:
+        """Mutate/return the env dict the subprocess will inherit. Default: no changes."""
+        return parent_env
+
+    # --- Common machinery ---------------------------------------------------
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        system_prompt, user_prompt = self._render_messages(messages)
+        result_text, structured = self._run_subprocess(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            json_schema=self.json_schema,
+        )
+
+        # Prefer structured_output when --json-schema was passed and the CLI
+        # surfaced it. The text field may otherwise be prose-wrapped JSON.
+        if self.json_schema is not None and isinstance(structured, (dict, list)):
+            ai_msg = AIMessage(content=json.dumps(structured))
+            return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+        if self.bound_tools:
+            envelope = self._extract_tool_envelope(result_text)
+            if envelope is not None:
+                tool_calls = self._parse_tool_calls(envelope)
+                if tool_calls:
+                    ai_msg = AIMessage(content="", tool_calls=tool_calls)
+                    return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+        ai_msg = AIMessage(content=result_text)
+        return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+    def bind_tools(
+        self,
+        tools: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]],
+        **kwargs: Any,
+    ) -> "SubprocessChatModel":
+        """Return a copy of this model with tool definitions attached.
+
+        Tool calls come back via a JSON envelope in the system prompt rather
+        than a native tool-use API, since the parent app runs tools in
+        langgraph's ToolNode (not inside the CLI subprocess).
+        """
+        formatted: List[Dict[str, Any]] = []
+        for t in tools:
+            spec = convert_to_openai_tool(t)
+            fn = spec.get("function", spec)
+            formatted.append(
+                {
+                    "name": fn.get("name"),
+                    "description": fn.get("description", ""),
+                    "input_schema": fn.get("parameters", {}),
+                }
+            )
+        return self.model_copy(update={"bound_tools": formatted})
+
+    def with_structured_output(
+        self,
+        schema: Type[BaseModel],
+        **kwargs: Any,
+    ):
+        """Return a Runnable that produces an instance of ``schema``.
+
+        Subclasses with a ``--json-schema``-style flag get schema-constrained
+        output for free. Schemas that are not Pydantic ``BaseModel`` raise
+        NotImplementedError so ``invoke_structured_or_freetext`` falls back
+        to free-text generation.
+        """
+        if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
+            raise NotImplementedError(
+                f"{type(self).__name__}.with_structured_output requires a "
+                "Pydantic BaseModel schema."
+            )
+
+        json_schema = schema.model_json_schema()
+        bound = self.model_copy(update={"json_schema": json_schema})
+
+        def _parse(input_: Any) -> BaseModel:
+            ai = bound.invoke(input_)
+            content = _content_to_str(getattr(ai, "content", ""))
+            return schema.model_validate_json(content)
+
+        return RunnableLambda(_parse)
+
+    def _render_messages(self, messages: List[BaseMessage]) -> Tuple[str, str]:
+        """Serialize a langgraph chat history into (system_prompt, user_prompt).
+
+        SystemMessages are concatenated into ``system_prompt``. Everything
+        else is role-tagged in ``user_prompt`` with ``### user`` / ``### assistant``
+        / ``### tool[name]`` markers so the model can follow the conversation.
+        """
+        sys_parts: List[str] = []
+        if self.append_system_prompt:
+            sys_parts.append(self.append_system_prompt)
+
+        body_parts: List[str] = []
+        for msg in messages:
+            text = _content_to_str(getattr(msg, "content", ""))
+            if isinstance(msg, SystemMessage):
+                if text:
+                    sys_parts.append(text)
+            elif isinstance(msg, HumanMessage):
+                body_parts.append(f"### user\n{text}")
+            elif isinstance(msg, AIMessage):
+                rendered = text
+                tool_calls = getattr(msg, "tool_calls", None) or []
+                if tool_calls:
+                    envelope = {
+                        "tool_calls": [
+                            {"name": tc.get("name"), "args": tc.get("args", {})}
+                            for tc in tool_calls
+                        ]
+                    }
+                    rendered = (rendered + "\n" if rendered else "") + json.dumps(envelope)
+                body_parts.append(f"### assistant\n{rendered}")
+            elif isinstance(msg, ToolMessage):
+                tool_name = getattr(msg, "name", None) or "tool"
+                body_parts.append(f"### tool[{tool_name}]\n{text}")
+            else:
+                role = getattr(msg, "type", "unknown")
+                body_parts.append(f"### {role}\n{text}")
+
+        if self.bound_tools:
+            tools_doc = json.dumps(self.bound_tools, indent=2)
+            sys_parts.append(_TOOL_PROTOCOL_INSTRUCTION + tools_doc)
+
+        system_prompt = "\n\n".join(p for p in sys_parts if p).strip()
+        user_prompt = "\n\n".join(body_parts).strip() or "(no user message)"
+        return system_prompt, user_prompt
+
+    def _resolve_binary(self) -> str:
+        if self.binary_path:
+            return self.binary_path
+        env_bin = os.environ.get(self._binary_env_var())
+        if env_bin:
+            return env_bin
+        found = shutil.which(self._binary_name())
+        if not found:
+            raise RuntimeError(
+                f"`{self._binary_name()}` CLI not found on PATH. "
+                f"Install it or set {self._binary_env_var()}."
+            )
+        return found
+
+    def _run_subprocess(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        json_schema: Optional[Dict[str, Any]],
+    ) -> Tuple[str, Optional[Any]]:
+        """Spawn the CLI once, return (assistant_text, structured_output_or_None)."""
+        binary = self._resolve_binary()
+        cmd = self._build_command(binary, system_prompt, json_schema)
+        stdin_text = self._subprocess_input(system_prompt, user_prompt)
+        env = self._subprocess_env(os.environ.copy())
+
+        # Run from a stable temp dir so no project-local CLI config files
+        # (e.g. a CLAUDE.md or a `.gemini/`) are auto-discovered as cwd context.
+        proc = subprocess.run(
+            cmd,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=self.timeout,
+            check=False,
+            env=env,
+            cwd=tempfile.gettempdir(),
+        )
+
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip()
+            raise RuntimeError(
+                f"`{self._binary_name()}` failed (rc={proc.returncode}): {err[:1000]}"
+            )
+
+        return self._parse_response(proc.stdout, json_schema)
+
+    # --- Tool envelope parsing ---------------------------------------------
+
+    @staticmethod
+    def _extract_tool_envelope(text: str) -> Optional[Dict[str, Any]]:
+        """Find a ``{"tool_calls": [...]}`` JSON object inside arbitrary text.
+
+        Models often prefix the envelope with a sentence ("Sure, let me...")
+        or wrap it in a code fence even when instructed to emit pure JSON.
+        Locate the JSON object by brace-matching around the ``"tool_calls"``
+        substring and try to parse it.
+        """
+        stripped = text.strip()
+        if stripped.startswith("{"):
+            try:
+                obj = json.loads(stripped)
+                if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
+                    return obj
+            except json.JSONDecodeError:
+                pass
+
+        needle = '"tool_calls"'
+        idx = text.find(needle)
+        if idx == -1:
+            return None
+        start = text.rfind("{", 0, idx)
+        if start == -1:
+            return None
+
+        depth = 0
+        in_str = False
+        escape = False
+        for i in range(start, len(text)):
+            ch = text[i]
+            if escape:
+                escape = False
+                continue
+            if ch == "\\":
+                escape = True
+                continue
+            if ch == '"' and not escape:
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        obj = json.loads(text[start : i + 1])
+                    except json.JSONDecodeError:
+                        return None
+                    if isinstance(obj, dict) and isinstance(obj.get("tool_calls"), list):
+                        return obj
+                    return None
+        return None
+
+    @staticmethod
+    def _parse_tool_calls(envelope: Dict[str, Any]) -> List[Dict[str, Any]]:
+        raw_calls = envelope.get("tool_calls", [])
+        out: List[Dict[str, Any]] = []
+        for raw in raw_calls:
+            if not isinstance(raw, dict):
+                continue
+            name = raw.get("name")
+            if not name:
+                continue
+            args = raw.get("args", {})
+            if not isinstance(args, dict):
+                args = {}
+            out.append(
+                {
+                    "name": name,
+                    "args": args,
+                    "id": raw.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                    "type": "tool_call",
+                }
+            )
+        return out

--- a/tradingagents/reporting.py
+++ b/tradingagents/reporting.py
@@ -1,0 +1,130 @@
+"""Shared report writer.
+
+Produces the canonical structured-folder layout under `<save_path>`:
+
+    1_analysts/{market,sentiment,news,fundamentals}.md
+    2_research/{bull,bear,manager}.md
+    3_trading/trader.md
+    4_risk/{aggressive,conservative,neutral}.md
+    5_portfolio/decision.md
+    complete_report.md
+
+Both `cli/main.py` and `TradingAgentsGraph._run_graph` call this so every
+analysis — whether interactive or programmatic — emits the same layout.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def save_report_to_disk(final_state: Mapping[str, Any], ticker: str, save_path: Path) -> Path:
+    """Save complete analysis report to disk with organized subfolders."""
+    save_path = Path(save_path)
+    save_path.mkdir(parents=True, exist_ok=True)
+    sections: list[str] = []
+
+    # 1. Analysts
+    analysts_dir = save_path / "1_analysts"
+    analyst_parts: list[tuple[str, str]] = []
+    if final_state.get("market_report"):
+        analysts_dir.mkdir(exist_ok=True)
+        (analysts_dir / "market.md").write_text(final_state["market_report"], encoding="utf-8")
+        analyst_parts.append(("Market Analyst", final_state["market_report"]))
+    if final_state.get("sentiment_report"):
+        analysts_dir.mkdir(exist_ok=True)
+        (analysts_dir / "sentiment.md").write_text(final_state["sentiment_report"], encoding="utf-8")
+        analyst_parts.append(("Social Analyst", final_state["sentiment_report"]))
+    if final_state.get("news_report"):
+        analysts_dir.mkdir(exist_ok=True)
+        (analysts_dir / "news.md").write_text(final_state["news_report"], encoding="utf-8")
+        analyst_parts.append(("News Analyst", final_state["news_report"]))
+    if final_state.get("fundamentals_report"):
+        analysts_dir.mkdir(exist_ok=True)
+        (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
+        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
+    if analyst_parts:
+        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
+        sections.append(f"## I. Analyst Team Reports\n\n{content}")
+
+    # 2. Research
+    if final_state.get("investment_debate_state"):
+        research_dir = save_path / "2_research"
+        debate = final_state["investment_debate_state"]
+        research_parts: list[tuple[str, str]] = []
+        if debate.get("bull_history"):
+            research_dir.mkdir(exist_ok=True)
+            (research_dir / "bull.md").write_text(debate["bull_history"], encoding="utf-8")
+            research_parts.append(("Bull Researcher", debate["bull_history"]))
+        if debate.get("bear_history"):
+            research_dir.mkdir(exist_ok=True)
+            (research_dir / "bear.md").write_text(debate["bear_history"], encoding="utf-8")
+            research_parts.append(("Bear Researcher", debate["bear_history"]))
+        if debate.get("judge_decision"):
+            research_dir.mkdir(exist_ok=True)
+            (research_dir / "manager.md").write_text(debate["judge_decision"], encoding="utf-8")
+            research_parts.append(("Research Manager", debate["judge_decision"]))
+        if research_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
+            sections.append(f"## II. Research Team Decision\n\n{content}")
+
+    # 3. Trading — accept either the live state key (`trader_investment_plan`)
+    # or the JSON-dump alias (`trader_investment_decision`) so this works when
+    # called from a re-loaded JSON, not just live state.
+    trader_text = final_state.get("trader_investment_plan") or final_state.get("trader_investment_decision")
+    if trader_text:
+        trading_dir = save_path / "3_trading"
+        trading_dir.mkdir(exist_ok=True)
+        (trading_dir / "trader.md").write_text(trader_text, encoding="utf-8")
+        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{trader_text}")
+
+    # 4. Risk Management
+    if final_state.get("risk_debate_state"):
+        risk_dir = save_path / "4_risk"
+        risk = final_state["risk_debate_state"]
+        risk_parts: list[tuple[str, str]] = []
+        if risk.get("aggressive_history"):
+            risk_dir.mkdir(exist_ok=True)
+            (risk_dir / "aggressive.md").write_text(risk["aggressive_history"], encoding="utf-8")
+            risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
+        if risk.get("conservative_history"):
+            risk_dir.mkdir(exist_ok=True)
+            (risk_dir / "conservative.md").write_text(risk["conservative_history"], encoding="utf-8")
+            risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
+        if risk.get("neutral_history"):
+            risk_dir.mkdir(exist_ok=True)
+            (risk_dir / "neutral.md").write_text(risk["neutral_history"], encoding="utf-8")
+            risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
+        if risk_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
+            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
+
+        # 5. Portfolio Manager
+        if risk.get("judge_decision"):
+            portfolio_dir = save_path / "5_portfolio"
+            portfolio_dir.mkdir(exist_ok=True)
+            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
+            sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
+
+    header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
+    return save_path / "complete_report.md"
+
+
+def default_save_path(results_dir: str | Path, ticker: str, trade_date: str | None = None) -> Path:
+    """Compute the canonical save path: `<results_dir>/<TICKER>_<DATE>_<TIMESTAMP>/`.
+
+    Ticker is sanitized via `safe_ticker_component` to prevent path escape.
+    """
+    from tradingagents.dataflows.utils import safe_ticker_component
+
+    safe_ticker = safe_ticker_component(ticker)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    if trade_date:
+        date_token = str(trade_date).replace("-", "")
+        folder = f"{safe_ticker}_{date_token}_{timestamp}"
+    else:
+        folder = f"{safe_ticker}_{timestamp}"
+    return Path(results_dir) / folder


### PR DESCRIPTION
## Summary

Adds two new LLM providers that route agent calls through a local **agentic CLI** in headless mode, using the user's existing OAuth/keychain login — no API key required. Generalized via a shared `SubprocessChatModel` base so future CLIs (Codex, etc.) drop in cleanly.

- `claude_code` — spawns `claude -p` (Claude Pro/Max subscription)
- `gemini_cli`  — spawns `gemini -p` (Google AI subscription)

Tested locally end-to-end with `claude_code` (full multi-agent NVDA pipeline run, structured-output and tool-call protocols verified). `gemini_cli` is implementation-complete but its end-to-end run depends on the user's local `gemini auth` setup.

## Why

Many users have a Claude Pro/Max or Google AI subscription but no LLM API budget. The existing provider clients all assume an HTTP API + key. This PR adds a parallel path: route each agent's call through a subprocess of the user's already-authenticated agent CLI.

Pattern is shared, so the abstraction lives in a base class. Adding a new provider (e.g. OpenAI Codex CLI when its non-interactive mode stabilizes) takes one file with five hook implementations.

## What's in this PR

### New: `tradingagents/llm_clients/subprocess_chat_base.py`
`SubprocessChatModel(BaseChatModel)` — the abstract base. Handles:
- per-call subprocess spawning with isolation (temp cwd, env sanitization, timeout)
- chat-history rendering into system prompt + role-tagged user prompt
- **JSON-envelope tool-calling protocol** — system prompt instructs the model to emit `{\"tool_calls\": [...]}` when calling a tool. We parse with brace-matching tolerance for prose-wrapped responses. Project tools run inside langgraph's `ToolNode`; the subprocess never has direct tool access (this matters because the project's tools rely on in-memory state)
- structured output via `with_structured_output(schema)` — concrete providers expose their `--json-schema`-equivalent flag, base normalizes the result back to a Pydantic instance

Five hooks subclasses implement: `_binary_name`, `_binary_env_var`, `_build_command`, `_parse_response`, `_llm_type`. Two optional: `_subprocess_input`, `_subprocess_env`.

### New: `tradingagents/llm_clients/claude_code_client.py` (`ChatClaudeCode`)
Routes through `claude -p`. Isolation flags:
- `--system-prompt` (suppress default sys prompt → no CLAUDE.md auto-discovery)
- `--setting-sources \"\"` (skip user/project/local settings → no hooks/output styles)
- `--disable-slash-commands` (no skills)
- `--strict-mcp-config` (no user-configured MCP servers leaking in)
- `--tools \"\"` (no built-in tools — project tools run via langgraph)
- `--no-session-persistence` (no per-call session files)

Optional: `--effort {low|medium|high|xhigh|max}`, `--max-budget-usd`. `--bare` is intentionally **not** used because that mode forces `ANTHROPIC_API_KEY`-only auth and disables OAuth/keychain (kills subscription routing).

### New: `tradingagents/llm_clients/gemini_cli_client.py` (`ChatGeminiCli`)
Routes through `gemini -p`. Equivalents of Claude Code's isolation:
- `--approval-mode plan` (read-only — no edits, no shell, no writes)
- `--allowed-mcp-server-names \"\"` (disable user-configured MCP servers)
- `--output-format json`

Notable difference: Gemini CLI has no `--system-prompt` flag, so the system prompt is inlined into the prompt argument with `<<SYSTEM>>` / `<<USER>>` partitions in `_subprocess_input`.

### Wiring
- `factory.py` — `claude_code` and `gemini_cli` provider branches
- `model_catalog.py` — model lists for both providers (aliases + pinned IDs)
- `default_config.py` — provider-specific knobs (`claude_code_effort`, `gemini_cli_force_subscription`, etc.)
- `graph/trading_graph.py` — kwargs forwarding in `_get_provider_kwargs`
- `cli/utils.py` — provider picker entries
- `cli/main.py` — CLI prompts the user for effort level when picking `claude_code`

### Tests
- `tests/test_subprocess_chat_base.py` (new) — 12 unit tests using a fake subclass + mocked `subprocess.run`. Covers message rendering, tool-envelope extraction (pure / prose-wrapped / absent), generate flow (text / tool-bound / structured), error handling, missing-binary diagnostics.
- Full suite goes from 108 → 120 passing.

## Test plan

- [x] Unit tests: `pytest tests/` → 120 passed
- [x] `claude_code` smoke: `from tradingagents.llm_clients import create_llm_client; create_llm_client('claude_code', 'sonnet').get_llm().invoke('Reply PONG')` → returns `'PONG'`
- [x] `claude_code` tool envelope: `bind_tools([get_stock_data]).invoke(...)` returns `AIMessage(tool_calls=[{name, args, id}])`
- [x] `claude_code` structured output: `with_structured_output(MyModel).invoke(...)` returns a Pydantic instance
- [x] `claude_code` full pipeline: NVDA / opus / high effort — completed cleanly (~30 min, all 7 stages, structured report folder produced)
- [ ] `gemini_cli` end-to-end — requires reviewer's `gemini auth` setup (the binary refused with `Please set an Auth method` on my machine, expected for an unauthenticated CLI)

## Notes

- The bundle also includes a small earlier commit that shipped the canonical structured-report folder layout (`tradingagents/reporting.py`) so every run, CLI or programmatic, produces an identical `reports/<TICKER>_<DATE>_<TIMESTAMP>/` folder. Happy to split that out into a separate PR if preferred.
- No CLAUDE.md added to the repo. No changes to `.env.example`. Apache 2.0 license preserved.