### PR TITLE
Add experimental Codex OAuth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,24 +149,12 @@ export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```
 
 For experimental ChatGPT/Codex subscription access without an OpenAI Platform
-API key, login with Codex OAuth:
-
-```bash
-python scripts/codex_oauth_login.py
-python scripts/codex_oauth_smoke.py
-```
-
-For headless terminals, use the device-code flow instead:
-
-```bash
-python scripts/codex_oauth_login.py --device
-python scripts/codex_oauth_smoke.py
-```
-
-Then choose `Codex OAuth (ChatGPT subscription)` in the CLI. The CLI fetches
-the current Codex model list for your ChatGPT account when you select quick and
-deep models, so newly available models appear without a code change. If the
-model fetch fails, choose `Custom model ID` and enter a model manually.
+API key, choose `Codex OAuth (ChatGPT subscription)` in the CLI. If no saved
+Codex OAuth token is available, the CLI starts the login flow immediately and
+lets you choose browser login or device-code login. It then fetches the current
+Codex model list for your ChatGPT account when you select quick and deep models,
+so newly available models appear without a code change. If the model fetch
+fails, choose `Custom model ID` and enter a model manually.
 
 Codex OAuth uses the ChatGPT/Codex subscription backend rather than the OpenAI
 Platform API. It does not require `OPENAI_API_KEY`, but it depends on
@@ -180,7 +168,9 @@ python scripts/codex_oauth_logout.py
 ```
 
 `codex_oauth_smoke.py` is a manual live check for your local account and should
-not be required in CI.
+not be required in CI. You can also run `python scripts/codex_oauth_login.py`
+or `python scripts/codex_oauth_login.py --device` manually if you want to log in
+before starting the CLI.
 
 For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,40 @@ export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```
 
+For experimental ChatGPT/Codex subscription access without an OpenAI Platform
+API key, login with Codex OAuth:
+
+```bash
+python scripts/codex_oauth_login.py
+python scripts/codex_oauth_smoke.py
+```
+
+For headless terminals, use the device-code flow instead:
+
+```bash
+python scripts/codex_oauth_login.py --device
+python scripts/codex_oauth_smoke.py
+```
+
+Then choose `Codex OAuth (ChatGPT subscription)` in the CLI. The CLI fetches
+the current Codex model list for your ChatGPT account when you select quick and
+deep models, so newly available models appear without a code change. If the
+model fetch fails, choose `Custom model ID` and enter a model manually.
+
+Codex OAuth uses the ChatGPT/Codex subscription backend rather than the OpenAI
+Platform API. It does not require `OPENAI_API_KEY`, but it depends on
+ChatGPT/Codex backend behavior that may change. Tokens are saved to
+`~/.tradingagents/cache/codex_oauth.json` with owner-only permissions by
+default. Override the location with `TRADINGAGENTS_CODEX_OAUTH_FILE`. To remove
+the saved token:
+
+```bash
+python scripts/codex_oauth_logout.py
+```
+
+`codex_oauth_smoke.py` is a manual live check for your local account and should
+not be required in CI.
+
 For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
 
 For local models, configure Ollama with `llm_provider: "ollama"` in your config.

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -213,6 +213,54 @@ def select_codex_model(mode: str) -> str:
     return choice
 
 
+def ensure_codex_oauth_login() -> None:
+    """Ensure Codex OAuth is configured when the provider is selected."""
+    from tradingagents.llm_clients.codex_oauth import (
+        CodexOAuthStore,
+        get_valid_tokens,
+        run_device_login_flow,
+        run_login_flow,
+    )
+
+    store = CodexOAuthStore()
+    try:
+        get_valid_tokens(store)
+        return
+    except RuntimeError as e:
+        console.print(f"\n[yellow]{e}[/yellow]")
+
+    choice = questionary.select(
+        "Codex OAuth login required:",
+        choices=[
+            questionary.Choice("Open browser login", value="browser"),
+            questionary.Choice("Use device code", value="device"),
+            questionary.Choice("Cancel", value="cancel"),
+        ],
+        instruction="\n- Use arrow keys to navigate\n- Press Enter to select",
+        style=questionary.Style([
+            ("selected", "fg:magenta noinherit"),
+            ("highlighted", "fg:magenta noinherit"),
+            ("pointer", "fg:magenta noinherit"),
+        ]),
+    ).ask()
+
+    if choice is None or choice == "cancel":
+        console.print("\n[red]Codex OAuth login cancelled. Exiting...[/red]")
+        exit(1)
+
+    try:
+        if choice == "device":
+            tokens = run_device_login_flow(store)
+        else:
+            tokens = run_login_flow(store)
+    except RuntimeError as e:
+        console.print(f"\n[red]Codex OAuth login failed: {e}[/red]")
+        exit(1)
+
+    account = tokens.account_id or "unknown account"
+    console.print(f"\n[green]Codex OAuth login saved for {account}.[/green]")
+
+
 def _prompt_custom_model_id() -> str:
     """Prompt user to type a custom model ID."""
     return questionary.text(
@@ -308,6 +356,8 @@ def select_llm_provider() -> tuple[str, str | None]:
         exit(1)
 
     provider, url = choice
+    if provider == "codex":
+        ensure_codex_oauth_login()
     return provider, url
 
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -174,6 +174,41 @@ def select_openrouter_model() -> str:
     return choice
 
 
+def _fetch_codex_models() -> List[Tuple[str, str]]:
+    """Fetch Codex OAuth models available to the logged-in ChatGPT account."""
+    from tradingagents.llm_clients.codex_oauth_client import fetch_codex_model_options
+
+    try:
+        return fetch_codex_model_options()
+    except Exception as e:
+        console.print(f"\n[yellow]Could not fetch Codex OAuth models: {e}[/yellow]")
+        return []
+
+
+def select_codex_model(mode: str) -> str:
+    """Select a Codex OAuth model from the account's live backend list."""
+    models = _fetch_codex_models()
+
+    choices = [questionary.Choice(name, value=mid) for name, mid in models]
+    choices.append(questionary.Choice("Custom model ID", value="custom"))
+
+    choice = questionary.select(
+        f"Select Codex OAuth Model ({mode}-thinking):",
+        choices=choices,
+        instruction="\n- Use arrow keys to navigate\n- Press Enter to select",
+        style=questionary.Style([
+            ("selected", "fg:magenta noinherit"),
+            ("highlighted", "fg:magenta noinherit"),
+            ("pointer", "fg:magenta noinherit"),
+        ]),
+    ).ask()
+
+    if choice is None or choice == "custom":
+        return _prompt_custom_model_id()
+
+    return choice
+
+
 def _prompt_custom_model_id() -> str:
     """Prompt user to type a custom model ID."""
     return questionary.text(
@@ -186,6 +221,9 @@ def _select_model(provider: str, mode: str) -> str:
     """Select a model for the given provider and mode (quick/deep)."""
     if provider.lower() == "openrouter":
         return select_openrouter_model()
+
+    if provider.lower() == "codex":
+        return select_codex_model(mode)
 
     if provider.lower() == "azure":
         return questionary.text(
@@ -242,6 +280,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", "http://localhost:11434/v1"),
+        ("Codex OAuth (ChatGPT subscription)", "codex", None),
     ]
 
     choice = questionary.select(

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -203,7 +203,11 @@ def select_codex_model(mode: str) -> str:
         ]),
     ).ask()
 
-    if choice is None or choice == "custom":
+    if choice is None:
+        console.print("\n[red]No Codex model selected. Exiting...[/red]")
+        exit(1)
+
+    if choice == "custom":
         return _prompt_custom_model_id()
 
     return choice

--- a/scripts/codex_oauth_login.py
+++ b/scripts/codex_oauth_login.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Login to ChatGPT/Codex OAuth for TradingAgents."""
+
+import argparse
+
+from tradingagents.llm_clients.codex_oauth import (
+    CodexOAuthStore,
+    run_device_login_flow,
+    run_login_flow,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", action="store_true", help="Use the headless device-code login flow")
+    parser.add_argument("--no-browser", action="store_true", help="Print the login URL without opening a browser")
+    parser.add_argument("--timeout", type=int, default=300, help="Seconds to wait for the OAuth callback")
+    args = parser.parse_args()
+
+    store = CodexOAuthStore()
+    if args.device:
+        tokens = run_device_login_flow(store, timeout_seconds=args.timeout)
+    else:
+        tokens = run_login_flow(
+            store,
+            open_browser=not args.no_browser,
+            timeout_seconds=args.timeout,
+        )
+    account = tokens.account_id or "unknown account"
+    print(f"Codex OAuth login saved for {account}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex_oauth_logout.py
+++ b/scripts/codex_oauth_logout.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Remove the saved ChatGPT/Codex OAuth token for TradingAgents."""
+
+import argparse
+
+from tradingagents.llm_clients.codex_oauth import CodexOAuthStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Print the token path without removing it")
+    args = parser.parse_args()
+
+    path = CodexOAuthStore().path
+    if args.dry_run:
+        print(f"Codex OAuth token file path: {path}")
+        return
+
+    if path.exists():
+        path.unlink()
+        print(f"Removed Codex OAuth token file: {path}")
+    else:
+        print(f"No Codex OAuth token file found at: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex_oauth_smoke.py
+++ b/scripts/codex_oauth_smoke.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Smoke-test the TradingAgents Codex OAuth provider after login."""
+
+from langchain_core.messages import HumanMessage
+
+from tradingagents.llm_clients.codex_oauth_client import CodexOAuthChatModel
+
+
+def main() -> None:
+    try:
+        response = CodexOAuthChatModel(
+            model_name="gpt-5.4-mini",
+            reasoning_effort="low",
+            text_verbosity="low",
+            timeout=60,
+        ).invoke([HumanMessage(content="Reply with exactly: codex-oauth-ok")])
+    except RuntimeError as exc:
+        print(f"Codex OAuth smoke failed: {exc}")
+        raise SystemExit(1) from exc
+    print(response.content.strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -1,0 +1,340 @@
+import base64
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from pydantic import BaseModel
+
+from tradingagents.llm_clients.codex_oauth import (
+    CodexOAuthTokens,
+    create_authorization_url,
+    extract_account_id,
+    extract_account_id_from_tokens,
+)
+from tradingagents.llm_clients.codex_oauth_client import (
+    CODEX_RESPONSES_PATH,
+    CodexOAuthChatModel,
+    codex_models_to_options,
+)
+
+
+class SampleStructuredOutput(BaseModel):
+    rating: str
+    rationale: str
+
+
+def _jwt(payload: dict) -> str:
+    raw = json.dumps(payload).encode()
+    encoded = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def test_extract_account_id_from_codex_claim():
+    token = _jwt({
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "acct_123",
+        }
+    })
+
+    assert extract_account_id(token) == "acct_123"
+
+
+def test_authorization_url_matches_codex_oauth_shape():
+    url, verifier, state = create_authorization_url()
+
+    assert "client_id=app_EMoamEEZ73f0CkXaXp7hrann" in url
+    assert "scope=openid+profile+email+offline_access" in url
+    assert "codex_cli_simplified_flow=true" in url
+    assert "originator=opencode" in url
+    assert verifier
+    assert state
+
+
+def test_extract_account_id_from_id_token_and_organizations():
+    access_token = _jwt({})
+    id_token = _jwt({
+        "https://api.openai.com/auth": {
+            "organizations": [{"id": "org_123"}],
+        }
+    })
+
+    assert extract_account_id_from_tokens(access_token, id_token) == "org_123"
+
+
+def test_codex_oauth_tokens_round_trip_shape():
+    tokens = CodexOAuthTokens(
+        access_token="access",
+        refresh_token="refresh",
+        expires_at=time.time() + 100,
+        account_id="acct_123",
+        id_token="id",
+    )
+
+    restored = CodexOAuthTokens.from_json(tokens.__dict__)
+
+    assert restored.access_token == "access"
+    assert restored.refresh_token == "refresh"
+    assert restored.account_id == "acct_123"
+    assert restored.id_token == "id"
+
+
+def test_codex_models_to_options_uses_live_payload_shape():
+    options = codex_models_to_options({
+        "models": [
+            {"slug": "gpt-5.5", "display_name": "GPT-5.5"},
+            {"slug": "gpt-5.4-mini", "display_name": "GPT-5.4 Mini"},
+            {"slug": "codex-auto-review", "display_name": "Codex Auto Review"},
+            {"slug": "gpt-5.5", "display_name": "Duplicate"},
+            {"slug": "", "display_name": "Missing"},
+        ]
+    })
+
+    assert options == [
+        ("GPT-5.5 - ChatGPT OAuth", "gpt-5.5"),
+        ("GPT-5.4 Mini - ChatGPT OAuth", "gpt-5.4-mini"),
+    ]
+
+
+def test_codex_oauth_payload_maps_tools_and_tool_outputs():
+    @tool
+    def get_stock_data(ticker: str) -> str:
+        """Fetch stock data."""
+        return ticker
+
+    llm = CodexOAuthChatModel(model_name="gpt-5.4-mini").bind_tools([get_stock_data])
+
+    payload = llm._build_payload([HumanMessage(content="Fetch NVDA")])
+    tool_payload = payload["tools"][0]
+
+    assert payload["store"] is False
+    assert payload["stream"] is True
+    assert payload["instructions"]
+    assert tool_payload["type"] == "function"
+    assert tool_payload["name"] == "get_stock_data"
+
+    followup = llm._build_payload([ToolMessage(content="price=1", tool_call_id="call_1")])
+
+    assert followup["input"][0]["type"] == "function_call_output"
+    assert followup["input"][0]["call_id"] == "call_1"
+
+    prior_call = llm._build_payload([
+        AIMessage(
+            content="",
+            tool_calls=[{
+                "name": "get_stock_data",
+                "args": {"ticker": "NVDA"},
+                "id": "call_1",
+                "type": "tool_call",
+            }],
+        )
+    ])
+
+    assert prior_call["input"][0]["type"] == "function_call"
+    assert prior_call["input"][0]["call_id"] == "call_1"
+    assert prior_call["input"][0]["arguments"] == '{"ticker": "NVDA"}'
+
+
+def test_codex_oauth_structured_output_returns_pydantic_instance():
+    class FakeStructuredCodex(CodexOAuthChatModel):
+        def _post(self, payload):
+            assert "JSON Schema" in payload["instructions"]
+            return {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": '{"rating":"Buy","rationale":"strong setup"}',
+                            }
+                        ],
+                    }
+                ]
+            }
+
+    structured = FakeStructuredCodex().with_structured_output(SampleStructuredOutput)
+
+    result = structured.invoke("Analyze")
+
+    assert isinstance(result, SampleStructuredOutput)
+    assert result.rating == "Buy"
+    assert result.rationale == "strong setup"
+
+
+def test_codex_oauth_structured_output_extracts_json_from_fence():
+    class FakeStructuredCodex(CodexOAuthChatModel):
+        def _post(self, payload):
+            return {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": '```json\n{"rating":"Hold","rationale":"balanced"}\n```',
+                            }
+                        ],
+                    }
+                ]
+            }
+
+    result = FakeStructuredCodex().with_structured_output(SampleStructuredOutput).invoke("Analyze")
+
+    assert result.rating == "Hold"
+
+
+def test_codex_oauth_response_maps_text_and_function_calls():
+    llm = CodexOAuthChatModel()
+
+    tool_message = llm._parse_response({
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "get_stock_data",
+                "arguments": '{"ticker":"NVDA"}',
+            }
+        ]
+    })
+
+    assert tool_message.tool_calls[0]["id"] == "call_1"
+    assert tool_message.tool_calls[0]["name"] == "get_stock_data"
+    assert tool_message.tool_calls[0]["args"] == {"ticker": "NVDA"}
+
+    text_message = llm._parse_response({
+        "usage": {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "analysis"}],
+            }
+        ]
+    })
+
+    assert text_message.content == "analysis"
+    assert text_message.usage_metadata == {
+        "input_tokens": 10,
+        "output_tokens": 3,
+        "total_tokens": 13,
+    }
+
+
+def test_codex_oauth_decodes_sse_response():
+    class Response:
+        headers = {"Content-Type": "text/event-stream"}
+        text = "\n".join([
+            'data: {"type":"response.output_text.delta","delta":"ana"}',
+            'data: {"type":"response.output_text.delta","delta":"lysis"}',
+            "data: [DONE]",
+        ])
+
+    payload = CodexOAuthChatModel()._decode_response(Response())
+
+    assert payload == {
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "analysis"}],
+            }
+        ]
+    }
+
+
+def test_codex_oauth_decodes_sse_when_completed_output_is_empty():
+    class Response:
+        headers = {}
+        text = "\n".join([
+            'event: response.output_text.delta',
+            'data: {"type":"response.output_text.delta","delta":"ok"}',
+            'event: response.completed',
+            'data: {"type":"response.completed","response":{"output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+        ])
+
+    payload = CodexOAuthChatModel()._decode_response(Response())
+
+    assert payload == {
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "ok"}],
+            }
+        ],
+        "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+    }
+
+
+def test_codex_oauth_post_uses_account_header_and_endpoint():
+    calls = []
+
+    class Response:
+        status_code = 200
+        text = ""
+        headers = {"Content-Type": "application/json"}
+
+        def json(self):
+            return {"output_text": "ok"}
+
+    def fake_post(url, json, headers, timeout):
+        calls.append(SimpleNamespace(url=url, json=json, headers=headers, timeout=timeout))
+        return Response()
+
+    with (
+        patch(
+            "tradingagents.llm_clients.codex_oauth_client.get_valid_tokens",
+            return_value=CodexOAuthTokens("access", "refresh", time.time() + 100, "acct_123"),
+        ),
+        patch("tradingagents.llm_clients.codex_oauth_client.requests.post", side_effect=fake_post),
+    ):
+        payload = CodexOAuthChatModel(base_url="https://chatgpt.example/backend-api")._post({"input": []})
+
+    assert payload == {"output_text": "ok"}
+    assert calls[0].url == f"https://chatgpt.example/backend-api{CODEX_RESPONSES_PATH}"
+    assert calls[0].headers["Authorization"] == "Bearer access"
+    assert calls[0].headers["ChatGPT-Account-ID"] == "acct_123"
+    assert calls[0].headers["OpenAI-Beta"] == "responses=experimental"
+
+
+def test_codex_oauth_post_refreshes_on_401():
+    calls = []
+
+    class Response401:
+        status_code = 401
+        text = "expired"
+        headers = {"Content-Type": "application/json"}
+
+    class Response200:
+        status_code = 200
+        text = ""
+        headers = {"Content-Type": "application/json"}
+
+        def json(self):
+            return {"output_text": "ok"}
+
+    def fake_post(url, json, headers, timeout):
+        calls.append(headers["Authorization"])
+        return Response401() if len(calls) == 1 else Response200()
+
+    store = SimpleNamespace(
+        load=lambda: CodexOAuthTokens("old", "refresh", time.time() + 100, "acct_old"),
+        save=lambda tokens: None,
+    )
+
+    with (
+        patch(
+            "tradingagents.llm_clients.codex_oauth_client.get_valid_tokens",
+            return_value=CodexOAuthTokens("old", "refresh", time.time() + 100, "acct_old"),
+        ),
+        patch("tradingagents.llm_clients.codex_oauth_client.CodexOAuthStore", return_value=store),
+        patch(
+            "tradingagents.llm_clients.codex_oauth_client.refresh_tokens",
+            return_value=CodexOAuthTokens("new", "refresh2", time.time() + 100, "acct_new"),
+        ),
+        patch("tradingagents.llm_clients.codex_oauth_client.requests.post", side_effect=fake_post),
+    ):
+        payload = CodexOAuthChatModel()._post({"input": []})
+
+    assert payload == {"output_text": "ok"}
+    assert calls == ["Bearer old", "Bearer new"]

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -81,6 +81,63 @@ def test_codex_oauth_tokens_round_trip_shape():
     assert restored.id_token == "id"
 
 
+def test_cli_codex_login_is_skipped_when_tokens_are_valid():
+    from cli.utils import ensure_codex_oauth_login
+
+    with (
+        patch("tradingagents.llm_clients.codex_oauth.get_valid_tokens") as get_valid_tokens_mock,
+        patch("cli.utils.questionary.select") as select_mock,
+    ):
+        ensure_codex_oauth_login()
+
+    get_valid_tokens_mock.assert_called_once()
+    select_mock.assert_not_called()
+
+
+def test_cli_codex_login_starts_browser_flow_when_tokens_are_missing():
+    from cli.utils import ensure_codex_oauth_login
+
+    tokens = CodexOAuthTokens("access", "refresh", time.time() + 100, "acct_123")
+
+    with (
+        patch(
+            "tradingagents.llm_clients.codex_oauth.get_valid_tokens",
+            side_effect=RuntimeError("missing"),
+        ),
+        patch(
+            "cli.utils.questionary.select",
+            return_value=SimpleNamespace(ask=lambda: "browser"),
+        ),
+        patch("tradingagents.llm_clients.codex_oauth.run_login_flow", return_value=tokens) as login_mock,
+        patch("tradingagents.llm_clients.codex_oauth.run_device_login_flow") as device_login_mock,
+    ):
+        ensure_codex_oauth_login()
+
+    login_mock.assert_called_once()
+    device_login_mock.assert_not_called()
+
+
+def test_cli_codex_login_cancel_exits():
+    from cli.utils import ensure_codex_oauth_login
+
+    with (
+        patch(
+            "tradingagents.llm_clients.codex_oauth.get_valid_tokens",
+            side_effect=RuntimeError("missing"),
+        ),
+        patch(
+            "cli.utils.questionary.select",
+            return_value=SimpleNamespace(ask=lambda: "cancel"),
+        ),
+    ):
+        try:
+            ensure_codex_oauth_login()
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("ensure_codex_oauth_login should exit when login is cancelled")
+
+
 def test_codex_models_to_options_uses_live_payload_shape():
     options = codex_models_to_options({
         "models": [

--- a/tradingagents/llm_clients/codex_oauth.py
+++ b/tradingagents/llm_clients/codex_oauth.py
@@ -260,7 +260,10 @@ def run_login_flow(
     if open_browser:
         webbrowser.open(url)
 
-    server = HTTPServer(("127.0.0.1", 1455), Handler)
+    try:
+        server = HTTPServer(("127.0.0.1", 1455), Handler)
+    except OSError as e:
+        raise RuntimeError(f"Failed to start OAuth callback server on port 1455: {e}") from e
     server.timeout = 1
     deadline = time.time() + timeout_seconds
     while "code" not in result:

--- a/tradingagents/llm_clients/codex_oauth.py
+++ b/tradingagents/llm_clients/codex_oauth.py
@@ -1,0 +1,332 @@
+"""OAuth helpers for ChatGPT/Codex subscription access."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import time
+import webbrowser
+from dataclasses import asdict, dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests
+
+
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+TOKEN_URL = "https://auth.openai.com/oauth/token"
+REDIRECT_URI = "http://localhost:1455/auth/callback"
+DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback"
+SCOPE = "openid profile email offline_access"
+ACCOUNT_CLAIM = "https://api.openai.com/auth"
+DEVICE_USER_CODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode"
+DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token"
+
+
+@dataclass
+class CodexOAuthTokens:
+    access_token: str
+    refresh_token: str
+    expires_at: float
+    account_id: str | None = None
+    id_token: str | None = None
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any]) -> "CodexOAuthTokens":
+        return cls(
+            access_token=str(payload["access_token"]),
+            refresh_token=str(payload["refresh_token"]),
+            expires_at=float(payload["expires_at"]),
+            account_id=payload.get("account_id"),
+            id_token=payload.get("id_token"),
+        )
+
+
+def default_token_path() -> Path:
+    configured = os.getenv("TRADINGAGENTS_CODEX_OAUTH_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    return Path(os.getenv("TRADINGAGENTS_CACHE_DIR", "~/.tradingagents/cache")).expanduser() / "codex_oauth.json"
+
+
+class CodexOAuthStore:
+    def __init__(self, path: Path | None = None):
+        self.path = path or default_token_path()
+
+    def load(self) -> CodexOAuthTokens:
+        if not self.path.exists():
+            raise RuntimeError(
+                "Codex OAuth is not configured. Run "
+                "`python scripts/codex_oauth_login.py` first."
+            )
+        return CodexOAuthTokens.from_json(json.loads(self.path.read_text(encoding="utf-8")))
+
+    def save(self, tokens: CodexOAuthTokens) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(asdict(tokens), indent=2), encoding="utf-8")
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+
+
+def decode_jwt_payload(token: str) -> dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        return json.loads(base64.urlsafe_b64decode(payload.encode()).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+
+
+def extract_account_id(access_token: str) -> str | None:
+    return extract_account_id_from_claims(decode_jwt_payload(access_token))
+
+
+def extract_account_id_from_claims(payload: dict[str, Any]) -> str | None:
+    claim = payload.get(ACCOUNT_CLAIM)
+    candidates: list[Any] = []
+    if isinstance(claim, dict):
+        candidates.extend([
+            claim.get("chatgpt_account_id"),
+            claim.get("account_id"),
+            claim.get("accountId"),
+        ])
+        organizations = claim.get("organizations")
+        if isinstance(organizations, list) and organizations:
+            first_org = organizations[0]
+            if isinstance(first_org, dict):
+                candidates.append(first_org.get("id"))
+    candidates.extend([
+        payload.get("chatgpt_account_id"),
+        payload.get("account_id"),
+        payload.get("accountId"),
+    ])
+    organizations = payload.get("organizations")
+    if isinstance(organizations, list) and organizations:
+        first_org = organizations[0]
+        if isinstance(first_org, dict):
+            candidates.append(first_org.get("id"))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def extract_account_id_from_tokens(access_token: str, id_token: str | None = None) -> str | None:
+    if id_token:
+        account_id = extract_account_id_from_claims(decode_jwt_payload(id_token))
+        if account_id:
+            return account_id
+    return extract_account_id(access_token)
+
+
+def refresh_tokens(refresh_token: str) -> CodexOAuthTokens:
+    response = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLIENT_ID,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Codex OAuth refresh failed: HTTP {response.status_code} {response.text}")
+    payload = response.json()
+    access = payload["access_token"]
+    id_token = payload.get("id_token")
+    return CodexOAuthTokens(
+        access_token=access,
+        refresh_token=payload["refresh_token"],
+        expires_at=time.time() + int(payload["expires_in"]),
+        account_id=extract_account_id_from_tokens(access, id_token),
+        id_token=id_token,
+    )
+
+
+def get_valid_tokens(store: CodexOAuthStore | None = None) -> CodexOAuthTokens:
+    store = store or CodexOAuthStore()
+    tokens = store.load()
+    if tokens.expires_at > time.time() + 60:
+        if tokens.account_id is None:
+            tokens.account_id = extract_account_id_from_tokens(tokens.access_token, tokens.id_token)
+            store.save(tokens)
+        return tokens
+    refreshed = refresh_tokens(tokens.refresh_token)
+    store.save(refreshed)
+    return refreshed
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip("=")
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+def create_authorization_url() -> tuple[str, str, str]:
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_hex(16)
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "originator": "opencode",
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}", verifier, state
+
+
+def exchange_authorization_code(code: str, verifier: str) -> CodexOAuthTokens:
+    return exchange_authorization_code_for_redirect(code, verifier, REDIRECT_URI)
+
+
+def exchange_authorization_code_for_redirect(
+    code: str,
+    verifier: str,
+    redirect_uri: str,
+) -> CodexOAuthTokens:
+    response = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": code,
+            "code_verifier": verifier,
+            "redirect_uri": redirect_uri,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Codex OAuth exchange failed: HTTP {response.status_code} {response.text}")
+    payload = response.json()
+    access = payload["access_token"]
+    id_token = payload.get("id_token")
+    return CodexOAuthTokens(
+        access_token=access,
+        refresh_token=payload["refresh_token"],
+        expires_at=time.time() + int(payload["expires_in"]),
+        account_id=extract_account_id_from_tokens(access, id_token),
+        id_token=id_token,
+    )
+
+
+def run_login_flow(
+    store: CodexOAuthStore | None = None,
+    open_browser: bool = True,
+    timeout_seconds: int = 300,
+) -> CodexOAuthTokens:
+    store = store or CodexOAuthStore()
+    url, verifier, expected_state = create_authorization_url()
+    result: dict[str, str] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib callback name
+            parsed = urlparse(self.path)
+            if parsed.path != "/auth/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            result["code"] = params.get("code", [""])[0]
+            result["state"] = params.get("state", [""])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"<html><body>TradingAgents Codex OAuth login complete. You can close this tab.</body></html>")
+
+        def log_message(self, format, *args):  # noqa: A002, D401 - silence stdlib access log
+            return
+
+    print("Open this URL to sign in with ChatGPT/Codex:", flush=True)
+    print(url, flush=True)
+    if open_browser:
+        webbrowser.open(url)
+
+    server = HTTPServer(("127.0.0.1", 1455), Handler)
+    server.timeout = 1
+    deadline = time.time() + timeout_seconds
+    while "code" not in result:
+        if time.time() > deadline:
+            raise RuntimeError("Timed out waiting for Codex OAuth callback.")
+        server.handle_request()
+
+    if result.get("state") != expected_state:
+        raise RuntimeError("Codex OAuth state mismatch; refusing token exchange.")
+    tokens = exchange_authorization_code(result["code"], verifier)
+    store.save(tokens)
+    return tokens
+
+
+def run_device_login_flow(
+    store: CodexOAuthStore | None = None,
+    timeout_seconds: int = 300,
+) -> CodexOAuthTokens:
+    store = store or CodexOAuthStore()
+    response = requests.post(
+        DEVICE_USER_CODE_URL,
+        json={"client_id": CLIENT_ID},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "TradingAgents",
+        },
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to initiate Codex device authorization: HTTP {response.status_code} {response.text}")
+    device_data = response.json()
+    device_auth_id = device_data["device_auth_id"]
+    user_code = device_data["user_code"]
+    interval = max(int(device_data.get("interval") or 5), 1)
+
+    print("Open this URL to sign in with ChatGPT/Codex:", flush=True)
+    print("https://auth.openai.com/codex/device", flush=True)
+    print(f"Enter code: {user_code}", flush=True)
+
+    deadline = time.time() + timeout_seconds
+    while time.time() <= deadline:
+        token_response = requests.post(
+            DEVICE_TOKEN_URL,
+            json={
+                "device_auth_id": device_auth_id,
+                "user_code": user_code,
+            },
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "TradingAgents",
+            },
+            timeout=30,
+        )
+        if token_response.status_code == 200:
+            token_payload = token_response.json()
+            tokens = exchange_authorization_code_for_redirect(
+                token_payload["authorization_code"],
+                token_payload["code_verifier"],
+                DEVICE_REDIRECT_URI,
+            )
+            store.save(tokens)
+            return tokens
+        if token_response.status_code not in {403, 404}:
+            raise RuntimeError(
+                f"Codex device authorization failed: HTTP {token_response.status_code} {token_response.text}"
+            )
+        time.sleep(interval + 3)
+
+    raise RuntimeError("Timed out waiting for Codex device authorization.")

--- a/tradingagents/llm_clients/codex_oauth_client.py
+++ b/tradingagents/llm_clients/codex_oauth_client.py
@@ -160,7 +160,7 @@ class CodexOAuthChatModel(BaseChatModel):
             "Authorization": f"Bearer {tokens.access_token}",
             "Content-Type": "application/json",
             "Accept": "text/event-stream, application/json",
-            "User-Agent": "codex_cli_rs/0.0.1 (TradingAgents)",
+            "User-Agent": "codex_cli_rs/1.0.0 (TradingAgents)",
             "originator": "codex_cli_rs",
             "OpenAI-Beta": "responses=experimental",
         }

--- a/tradingagents/llm_clients/codex_oauth_client.py
+++ b/tradingagents/llm_clients/codex_oauth_client.py
@@ -1,0 +1,397 @@
+"""LangChain chat model for ChatGPT/Codex OAuth subscription access."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from typing import Any, Optional
+
+import requests
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import Field
+from pydantic import BaseModel as PydanticBaseModel
+
+from .base_client import BaseLLMClient
+from .codex_oauth import CodexOAuthStore, get_valid_tokens, refresh_tokens
+
+
+CODEX_BASE_URL = "https://chatgpt.com/backend-api"
+CODEX_RESPONSES_PATH = "/codex/responses"
+CODEX_MODELS_PATH = "/codex/models"
+CODEX_MODELS_CLIENT_VERSION = "1.0.0"
+
+
+class CodexOAuthChatModel(BaseChatModel):
+    model_name: str = Field(default="gpt-5.4-mini")
+    base_url: str = Field(default=CODEX_BASE_URL)
+    timeout: float = Field(default=300.0)
+    reasoning_effort: str = Field(default="medium")
+    text_verbosity: str = Field(default="medium")
+    bound_tools: list[Any] = Field(default_factory=list)
+
+    @property
+    def _llm_type(self) -> str:
+        return "codex-oauth"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "reasoning_effort": self.reasoning_effort,
+            "text_verbosity": self.text_verbosity,
+        }
+
+    def bind_tools(self, tools, **kwargs):
+        return self.model_copy(update={"bound_tools": list(tools)})
+
+    def with_structured_output(self, schema, *, method=None, **kwargs):
+        if not isinstance(schema, type) or not issubclass(schema, PydanticBaseModel):
+            raise NotImplementedError("Codex OAuth structured output currently requires a Pydantic schema")
+        return CodexOAuthStructuredModel(llm=self, schema=schema)
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager=None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        payload = self._build_payload(messages, stop=stop)
+        response_payload = self._post(payload)
+        message = self._parse_response(response_payload)
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _build_payload(self, messages: list[BaseMessage], stop: Optional[list[str]] = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self.model_name,
+            "input": self._messages_to_input(messages),
+            "instructions": self._messages_to_instructions(messages),
+            "store": False,
+            "stream": True,
+            "reasoning": {"effort": self.reasoning_effort, "summary": "auto"},
+            "text": {"verbosity": self.text_verbosity},
+            "include": ["reasoning.encrypted_content"],
+        }
+        if stop:
+            payload["stop"] = stop
+        if self.bound_tools:
+            payload["tools"] = [self._tool_to_response_tool(tool) for tool in self.bound_tools]
+            payload["tool_choice"] = "auto"
+        return payload
+
+    def _messages_to_instructions(self, messages: list[BaseMessage]) -> str:
+        instructions = [
+            self._content_to_text(message.content)
+            for message in messages
+            if isinstance(message, SystemMessage)
+        ]
+        if instructions:
+            return "\n\n".join(instructions)
+        return "You are the LLM backend for TradingAgents. Follow the user's request exactly."
+
+    def _messages_to_input(self, messages: list[BaseMessage]) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        for message in messages:
+            if isinstance(message, ToolMessage):
+                items.append({
+                    "type": "function_call_output",
+                    "call_id": message.tool_call_id,
+                    "output": self._content_to_text(message.content),
+                })
+                continue
+
+            role = "user"
+            if isinstance(message, SystemMessage):
+                continue
+            elif isinstance(message, AIMessage):
+                role = "assistant"
+            elif isinstance(message, HumanMessage):
+                role = "user"
+
+            text = self._content_to_text(message.content)
+            tool_calls = getattr(message, "tool_calls", None)
+            if tool_calls:
+                for tool_call in tool_calls:
+                    items.append({
+                        "type": "function_call",
+                        "call_id": tool_call.get("id"),
+                        "name": tool_call.get("name"),
+                        "arguments": json.dumps(tool_call.get("args", {})),
+                    })
+            if text:
+                items.append({
+                    "role": role,
+                    "content": [{"type": "input_text", "text": text}],
+                })
+        return items
+
+    def _content_to_text(self, content: Any) -> str:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "\n".join(
+                item.get("text", "") if isinstance(item, dict) else str(item)
+                for item in content
+            )
+        return str(content)
+
+    def _tool_to_response_tool(self, tool: Any) -> dict[str, Any]:
+        args_schema = getattr(tool, "args_schema", None)
+        if args_schema is not None and hasattr(args_schema, "model_json_schema"):
+            parameters = args_schema.model_json_schema()
+        else:
+            parameters = getattr(tool, "args", {})
+        return {
+            "type": "function",
+            "name": getattr(tool, "name", tool.__class__.__name__),
+            "description": getattr(tool, "description", "") or "",
+            "parameters": parameters or {"type": "object", "properties": {}},
+        }
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        tokens = get_valid_tokens(CodexOAuthStore())
+        headers = {
+            "Authorization": f"Bearer {tokens.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream, application/json",
+            "User-Agent": "codex_cli_rs/0.0.1 (TradingAgents)",
+            "originator": "codex_cli_rs",
+            "OpenAI-Beta": "responses=experimental",
+        }
+        if tokens.account_id:
+            headers["ChatGPT-Account-ID"] = tokens.account_id
+
+        response = requests.post(
+            f"{self.base_url.rstrip('/')}{CODEX_RESPONSES_PATH}",
+            json=payload,
+            headers=headers,
+            timeout=self.timeout,
+        )
+        if response.status_code == 401:
+            store = CodexOAuthStore()
+            refreshed = refresh_tokens(store.load().refresh_token)
+            store.save(refreshed)
+            headers["Authorization"] = f"Bearer {refreshed.access_token}"
+            if refreshed.account_id:
+                headers["ChatGPT-Account-ID"] = refreshed.account_id
+            response = requests.post(
+                f"{self.base_url.rstrip('/')}{CODEX_RESPONSES_PATH}",
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        if response.status_code >= 400:
+            raise RuntimeError(f"Codex OAuth request failed: HTTP {response.status_code} {response.text}")
+        return self._decode_response(response)
+
+    def _decode_response(self, response: requests.Response) -> dict[str, Any]:
+        content_type = response.headers.get("Content-Type", "")
+        body = response.text
+        looks_like_sse = body.lstrip().startswith(("event:", "data:"))
+        if "text/event-stream" not in content_type and not looks_like_sse:
+            return response.json()
+
+        completed: dict[str, Any] | None = None
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        for raw_line in body.splitlines():
+            line = raw_line.strip()
+            if not line.startswith("data:"):
+                continue
+            data = line.removeprefix("data:").strip()
+            if not data or data == "[DONE]":
+                continue
+            try:
+                event = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            event_type = event.get("type")
+            if event_type == "response.completed" and isinstance(event.get("response"), dict):
+                completed = event["response"]
+            elif event_type == "response.output_text.delta" and isinstance(event.get("delta"), str):
+                text_parts.append(event["delta"])
+            elif event_type == "response.output_item.done" and isinstance(event.get("item"), dict):
+                item = event["item"]
+                if item.get("type") == "function_call":
+                    tool_calls.append(item)
+
+        if completed is not None and completed.get("output"):
+            return completed
+        output: list[dict[str, Any]] = []
+        if text_parts:
+            output.append({
+                "type": "message",
+                "content": [{"type": "output_text", "text": "".join(text_parts)}],
+            })
+        output.extend(tool_calls)
+        payload = {"output": output}
+        if completed is not None and completed.get("usage"):
+            payload["usage"] = completed["usage"]
+        return payload
+
+    def _parse_response(self, payload: dict[str, Any]) -> AIMessage:
+        tool_calls: list[dict[str, Any]] = []
+        text_parts: list[str] = []
+
+        for item in payload.get("output", []) or []:
+            item_type = item.get("type")
+            if item_type == "function_call":
+                arguments = item.get("arguments") or "{}"
+                try:
+                    args = json.loads(arguments) if isinstance(arguments, str) else arguments
+                except json.JSONDecodeError:
+                    args = {"input": arguments}
+                tool_calls.append({
+                    "name": item.get("name", ""),
+                    "args": args if isinstance(args, dict) else {"input": args},
+                    "id": item.get("call_id") or item.get("id") or f"codex_call_{uuid.uuid4().hex}",
+                    "type": "tool_call",
+                })
+            if item_type == "message":
+                for content in item.get("content", []) or []:
+                    if content.get("type") in {"output_text", "text"} and content.get("text"):
+                        text_parts.append(content["text"])
+
+        if not text_parts and isinstance(payload.get("output_text"), str):
+            text_parts.append(payload["output_text"])
+
+        return AIMessage(
+            content="\n".join(text_parts),
+            tool_calls=tool_calls,
+            usage_metadata=self._usage_metadata(payload),
+        )
+
+    def _usage_metadata(self, payload: dict[str, Any]) -> dict[str, int] | None:
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            return None
+        input_tokens = usage.get("input_tokens", 0) or 0
+        output_tokens = usage.get("output_tokens", 0) or 0
+        total_tokens = usage.get("total_tokens", input_tokens + output_tokens) or 0
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+        }
+
+
+def _codex_auth_headers(tokens) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {tokens.access_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "codex_cli_rs/1.0.0 (TradingAgents)",
+        "originator": "codex_cli_rs",
+        "OpenAI-Beta": "responses=experimental",
+    }
+    if tokens.account_id:
+        headers["ChatGPT-Account-ID"] = tokens.account_id
+    return headers
+
+
+def codex_models_to_options(payload: dict[str, Any]) -> list[tuple[str, str]]:
+    """Convert Codex model-list payloads into questionary display/value pairs."""
+    options: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for model in payload.get("models", []) or []:
+        if not isinstance(model, dict):
+            continue
+        slug = model.get("slug")
+        if not isinstance(slug, str) or not slug or slug in seen:
+            continue
+        if slug.startswith("codex-auto-"):
+            continue
+        display_name = model.get("display_name") or model.get("title") or slug
+        if not isinstance(display_name, str) or not display_name:
+            display_name = slug
+        options.append((f"{display_name} - ChatGPT OAuth", slug))
+        seen.add(slug)
+    return options
+
+
+def fetch_codex_model_options(
+    base_url: str | None = None,
+    timeout: float = 10,
+) -> list[tuple[str, str]]:
+    """Fetch currently available ChatGPT/Codex OAuth models for this account."""
+    store = CodexOAuthStore()
+    tokens = get_valid_tokens(store)
+    endpoint = f"{(base_url or os.getenv('TRADINGAGENTS_CODEX_BASE_URL', CODEX_BASE_URL)).rstrip('/')}{CODEX_MODELS_PATH}"
+    params = {
+        "client_version": os.getenv("TRADINGAGENTS_CODEX_CLIENT_VERSION", CODEX_MODELS_CLIENT_VERSION),
+    }
+    response = requests.get(
+        endpoint,
+        params=params,
+        headers=_codex_auth_headers(tokens),
+        timeout=timeout,
+    )
+    if response.status_code == 401:
+        refreshed = refresh_tokens(store.load().refresh_token)
+        store.save(refreshed)
+        response = requests.get(
+            endpoint,
+            params=params,
+            headers=_codex_auth_headers(refreshed),
+            timeout=timeout,
+        )
+    if response.status_code >= 400:
+        raise RuntimeError(f"Codex OAuth model fetch failed: HTTP {response.status_code} {response.text}")
+    return codex_models_to_options(response.json())
+
+
+class CodexOAuthClient(BaseLLMClient):
+    def get_llm(self) -> Any:
+        return CodexOAuthChatModel(
+            model_name=self.model,
+            base_url=self.base_url or os.getenv("TRADINGAGENTS_CODEX_BASE_URL", CODEX_BASE_URL),
+            timeout=float(self.kwargs.get("timeout", os.getenv("TRADINGAGENTS_CODEX_TIMEOUT", "300"))),
+            reasoning_effort=self.kwargs.get("reasoning_effort", os.getenv("TRADINGAGENTS_CODEX_REASONING_EFFORT", "medium")),
+            text_verbosity=self.kwargs.get("text_verbosity", os.getenv("TRADINGAGENTS_CODEX_TEXT_VERBOSITY", "medium")),
+        )
+
+    def validate_model(self) -> bool:
+        return True
+
+
+class CodexOAuthStructuredModel:
+    """Small structured-output adapter for Pydantic schemas."""
+
+    def __init__(self, llm: CodexOAuthChatModel, schema: type[PydanticBaseModel]):
+        self.llm = llm
+        self.schema = schema
+
+    def invoke(self, input, config=None, **kwargs):
+        messages = self.llm._convert_input(input).to_messages()
+        instructions = self._structured_instructions()
+        structured_messages = [SystemMessage(content=instructions), *messages]
+        response = self.llm.invoke(structured_messages, config=config, **kwargs)
+        parsed = self._extract_json(response.content)
+        return self.schema.model_validate(parsed)
+
+    def _structured_instructions(self) -> str:
+        schema_json = json.dumps(self.schema.model_json_schema(), indent=2)
+        return (
+            "Return only a single valid JSON object that conforms to this JSON Schema. "
+            "Do not include markdown fences, prose, comments, or extra keys.\n\n"
+            f"{schema_json}"
+        )
+
+    def _extract_json(self, text: str) -> Any:
+        stripped = text.strip()
+        if stripped.startswith("```"):
+            stripped = re.sub(r"^```(?:json)?\s*", "", stripped)
+            stripped = re.sub(r"\s*```$", "", stripped)
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", stripped, flags=re.DOTALL)
+            if not match:
+                raise
+            return json.loads(match.group(0))

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -50,4 +50,8 @@ def create_llm_client(
         from .azure_client import AzureOpenAIClient
         return AzureOpenAIClient(model, base_url, **kwargs)
 
+    if provider_lower in {"codex", "codex-oauth", "openai-codex"}:
+        from .codex_oauth_client import CodexOAuthClient
+        return CodexOAuthClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")


### PR DESCRIPTION
## Summary

- Add an experimental `codex` LLM provider backed by ChatGPT/Codex OAuth instead of an OpenAI Platform API key
- Add browser login, device-code login, logout, and live smoke-test helper scripts
- Fetch the available Codex model list dynamically from the ChatGPT Codex backend for the logged-in account
- Add support for LangChain tool calls, free-text structured-output adaptation, token usage metadata, and OAuth refresh handling

## Why

Some users have ChatGPT/Codex subscription access but do not want to route TradingAgents through separate OpenAI Platform API credits. This adds an opt-in provider path for that use case while keeping the existing provider behavior unchanged.

The Codex OAuth path is documented as experimental because it relies on ChatGPT/Codex backend behavior rather than the public OpenAI Platform API surface.

## User impact

Users can choose `Codex OAuth (ChatGPT subscription)` in the CLI after running:

```bash
python scripts/codex_oauth_login.py
python scripts/codex_oauth_smoke.py
```

Headless environments can use:

```bash
python scripts/codex_oauth_login.py --device
```

The CLI fetches the current account-specific Codex model list at selection time, so newly available models do not require catalog updates.

## Testing

- `python -m compileall tradingagents/llm_clients cli scripts/codex_oauth_login.py scripts/codex_oauth_logout.py scripts/codex_oauth_smoke.py tests/test_codex_oauth.py tests/test_model_validation.py`
- `uv run --frozen --with pytest pytest tests/test_codex_oauth.py tests/test_model_validation.py`
- `python scripts/codex_oauth_smoke.py`

