### PR TITLE
fix(main): use explicit dotenv path; add Anthropic provider example

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,17 @@
+from pathlib import Path
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+load_dotenv(Path(__file__).parent / ".env")
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-5.4-mini"  # Use a different model
-config["quick_think_llm"] = "gpt-5.4-mini"  # Use a different model
-config["max_debate_rounds"] = 1  # Increase debate rounds
+config["llm_provider"] = "anthropic"
+config["deep_think_llm"] = "claude-opus-4-6"
+config["quick_think_llm"] = "claude-sonnet-4-6"
+config["max_debate_rounds"] = 1
 
 # Configure data vendors (default uses yfinance, no extra API keys needed)
 config["data_vendors"] = {


### PR DESCRIPTION
## Summary

- **Fix `load_dotenv()` path resolution**: `load_dotenv()` without arguments resolves `.env` relative to the current working directory, so running the script from any directory other than the project root silently skips the env file and leaves all API keys unset. This fix anchors the path to `__file__` so it always finds `.env` regardless of CWD.
- **Add Anthropic provider example**: Updates the example config in `main.py` to demonstrate using `llm_provider = "anthropic"` with `claude-opus-4-6` (deep think) and `claude-sonnet-4-6` (quick think), alongside the existing data vendor config.

## Test plan

- [ ] Run `python main.py` from the project root — env vars load correctly
- [ ] Run `python main.py` from a parent directory — env vars still load correctly
- [ ] Anthropic API key is picked up and the agent runs without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)