### PR TITLE
fix: prefer repo dotenv for provider API keys

### DIFF
--- a/tests/test_deepseek_reasoning.py
+++ b/tests/test_deepseek_reasoning.py
@@ -19,8 +19,56 @@ from langchain_core.prompt_values import ChatPromptValue
 from tradingagents.llm_clients.openai_client import (
     DeepSeekChatOpenAI,
     NormalizedChatOpenAI,
+    OpenAIClient,
     _input_to_messages,
+    _provider_api_key,
 )
+
+
+# ---------------------------------------------------------------------------
+# Provider API-key precedence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_provider_api_key_prefers_repo_env_over_stale_shell(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=sk-live-repo-key-90fe\n", encoding="utf-8")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-stale-shell-key-3f4A")
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.openai_client._repo_env_path",
+        lambda: env_file,
+    )
+
+    assert _provider_api_key("DEEPSEEK_API_KEY") == "sk-live-repo-key-90fe"
+
+
+@pytest.mark.unit
+def test_openai_client_uses_repo_env_key_for_deepseek(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("DEEPSEEK_API_KEY=sk-live-repo-key-90fe\n", encoding="utf-8")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-stale-shell-key-3f4A")
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.openai_client._repo_env_path",
+        lambda: env_file,
+    )
+
+    captured = {}
+
+    class _FakeDeepSeekChat:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.openai_client.DeepSeekChatOpenAI",
+        _FakeDeepSeekChat,
+    )
+
+    OpenAIClient("deepseek-v4-flash", provider="deepseek").get_llm()
+
+    assert captured["api_key"] == "sk-live-repo-key-90fe"
+    assert captured["base_url"] == "https://api.deepseek.com"
+    assert captured["model"] == "deepseek-v4-flash"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deepseek_reasoning.py
+++ b/tests/test_deepseek_reasoning.py
@@ -11,6 +11,7 @@ Two pieces verified:
 """
 
 import os
+from pathlib import Path
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -31,10 +32,29 @@ from tradingagents.llm_clients.openai_client import (
 
 
 @pytest.mark.unit
-def test_provider_api_key_prefers_repo_env_over_stale_shell(monkeypatch, tmp_path):
+def test_provider_api_key_prefers_cwd_env_over_stale_shell(monkeypatch, tmp_path):
     env_file = tmp_path / ".env"
-    env_file.write_text("DEEPSEEK_API_KEY=sk-live-repo-key-90fe\n", encoding="utf-8")
+    env_file.write_text("DEEPSEEK_API_KEY=sk-live-cwd-key-90fe\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-stale-shell-key-3f4A")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "missing-home")
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.openai_client._repo_env_path",
+        lambda: tmp_path / "missing-repo.env",
+    )
+
+    assert _provider_api_key("DEEPSEEK_API_KEY") == "sk-live-cwd-key-90fe"
+
+
+@pytest.mark.unit
+def test_provider_api_key_prefers_repo_env_over_stale_shell(monkeypatch, tmp_path):
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    env_file = tmp_path / "repo.env"
+    env_file.write_text("DEEPSEEK_API_KEY=sk-live-repo-key-90fe\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-stale-shell-key-3f4A")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "missing-home")
     monkeypatch.setattr(
         "tradingagents.llm_clients.openai_client._repo_env_path",
         lambda: env_file,
@@ -47,7 +67,9 @@ def test_provider_api_key_prefers_repo_env_over_stale_shell(monkeypatch, tmp_pat
 def test_openai_client_uses_repo_env_key_for_deepseek(monkeypatch, tmp_path):
     env_file = tmp_path / ".env"
     env_file.write_text("DEEPSEEK_API_KEY=sk-live-repo-key-90fe\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-stale-shell-key-3f4A")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "missing-home")
     monkeypatch.setattr(
         "tradingagents.llm_clients.openai_client._repo_env_path",
         lambda: env_file,

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -126,16 +126,33 @@ def _repo_env_path() -> Path:
     return Path(__file__).resolve().parents[2] / ".env"
 
 
-def _provider_api_key(api_key_env: str) -> Optional[str]:
-    """Return provider key, preferring this checkout's .env over stale shells.
+def _dotenv_candidates() -> list[Path]:
+    """Candidate dotenv files, ordered from local runtime to package checkout."""
+    candidates = [
+        Path.cwd() / ".env",
+        Path.home() / ".env",
+        _repo_env_path(),
+    ]
+    seen = set()
+    unique = []
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(path)
+    return unique
 
-    Local TradingAgents runs often happen from long-lived terminals. A stale
-    exported DEEPSEEK_API_KEY can otherwise beat the repo .env and cause 401s
-    for an old key suffix even when .env is correct.
-    """
-    repo_env = _repo_env_path()
-    if repo_env.exists():
-        env_value = dotenv_values(repo_env).get(api_key_env)
+
+def _provider_api_key(api_key_env: str) -> Optional[str]:
+    """Return provider key, preferring local dotenv files over stale shells."""
+    for env_path in _dotenv_candidates():
+        if not env_path.exists():
+            continue
+        env_value = dotenv_values(env_path).get(api_key_env)
         if env_value:
             return env_value
     return os.environ.get(api_key_env)

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 from typing import Any, Optional
 
+from dotenv import dotenv_values
 from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
 
@@ -120,6 +122,25 @@ _PROVIDER_CONFIG = {
 }
 
 
+def _repo_env_path() -> Path:
+    return Path(__file__).resolve().parents[2] / ".env"
+
+
+def _provider_api_key(api_key_env: str) -> Optional[str]:
+    """Return provider key, preferring this checkout's .env over stale shells.
+
+    Local TradingAgents runs often happen from long-lived terminals. A stale
+    exported DEEPSEEK_API_KEY can otherwise beat the repo .env and cause 401s
+    for an old key suffix even when .env is correct.
+    """
+    repo_env = _repo_env_path()
+    if repo_env.exists():
+        env_value = dotenv_values(repo_env).get(api_key_env)
+        if env_value:
+            return env_value
+    return os.environ.get(api_key_env)
+
+
 class OpenAIClient(BaseLLMClient):
     """Client for OpenAI, Ollama, OpenRouter, and xAI providers.
 
@@ -151,7 +172,7 @@ class OpenAIClient(BaseLLMClient):
             default_base, api_key_env = _PROVIDER_CONFIG[self.provider]
             llm_kwargs["base_url"] = self.base_url or default_base
             if api_key_env:
-                api_key = os.environ.get(api_key_env)
+                api_key = _provider_api_key(api_key_env)
                 if api_key:
                     llm_kwargs["api_key"] = api_key
             else:


### PR DESCRIPTION
## Summary
- Prefer this checkout's `.env` provider API key over a stale exported shell value when constructing OpenAI-compatible provider clients.
- Preserve the existing environment fallback when the repo `.env` does not define the selected provider key.
- Add regression coverage for the DeepSeek stale-shell-key case, including the `OpenAIClient.get_llm()` wiring path.

## Why
`python-dotenv` defaults to `override=False`, so a long-lived shell with an old `DEEPSEEK_API_KEY` can silently beat the key configured in the repo `.env`. The resulting DeepSeek failure reports the stale key suffix, which is confusing when `.env` is correct.

## Test plan
- [x] `UV_PROJECT_ENVIRONMENT=.venv-wsl uv run --with pytest python -m pytest tests/test_deepseek_reasoning.py -q`
- [x] `UV_PROJECT_ENVIRONMENT=.venv-wsl DEEPSEEK_API_KEY='sk-invalid-demo-3f4A' uv run python - <<'PY' ... OpenAIClient('deepseek-v4-flash', provider='deepseek').get_llm().invoke('Reply with OK only.') ... PY`

Related to issue #641.