### PR TITLE
Add ESG analyst workflow

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -26,6 +26,7 @@ from rich.rule import Rule
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.dataflows.utils import safe_ticker_component
 from cli.models import AnalystType
 from cli.utils import *
 from cli.announcements import fetch_announcements, display_announcements
@@ -56,6 +57,7 @@ class MessageBuffer:
         "social": "Social Analyst",
         "news": "News Analyst",
         "fundamentals": "Fundamentals Analyst",
+        "esg": "ESG Analyst",
     }
 
     # Report section mapping: section -> (analyst_key for filtering, finalizing_agent)
@@ -66,6 +68,7 @@ class MessageBuffer:
         "sentiment_report": ("social", "Social Analyst"),
         "news_report": ("news", "News Analyst"),
         "fundamentals_report": ("fundamentals", "Fundamentals Analyst"),
+        "esg_report": ("esg", "ESG Analyst"),
         "investment_plan": (None, "Research Manager"),
         "trader_investment_plan": (None, "Trader"),
         "final_trade_decision": (None, "Portfolio Manager"),
@@ -174,6 +177,7 @@ class MessageBuffer:
                 "sentiment_report": "Social Sentiment",
                 "news_report": "News Analysis",
                 "fundamentals_report": "Fundamentals Analysis",
+                "esg_report": "ESG Analysis",
                 "investment_plan": "Research Team Decision",
                 "trader_investment_plan": "Trading Team Plan",
                 "final_trade_decision": "Portfolio Management Decision",
@@ -189,7 +193,7 @@ class MessageBuffer:
         report_parts = []
 
         # Analyst Team Reports - use .get() to handle missing sections
-        analyst_sections = ["market_report", "sentiment_report", "news_report", "fundamentals_report"]
+        analyst_sections = ["market_report", "sentiment_report", "news_report", "fundamentals_report", "esg_report"]
         if any(self.report_sections.get(section) for section in analyst_sections):
             report_parts.append("## Analyst Team Reports")
             if self.report_sections.get("market_report"):
@@ -207,6 +211,10 @@ class MessageBuffer:
             if self.report_sections.get("fundamentals_report"):
                 report_parts.append(
                     f"### Fundamentals Analysis\n{self.report_sections['fundamentals_report']}"
+                )
+            if self.report_sections.get("esg_report"):
+                report_parts.append(
+                    f"### ESG Analysis\n{self.report_sections['esg_report']}"
                 )
 
         # Research Team Reports
@@ -287,6 +295,7 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
             "Social Analyst",
             "News Analyst",
             "Fundamentals Analyst",
+            "ESG Analyst",
         ],
         "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
         "Trading Team": ["Trader"],
@@ -660,6 +669,10 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
         analysts_dir.mkdir(exist_ok=True)
         (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
         analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
+    if final_state.get("esg_report"):
+        analysts_dir.mkdir(exist_ok=True)
+        (analysts_dir / "esg.md").write_text(final_state["esg_report"], encoding="utf-8")
+        analyst_parts.append(("ESG Analyst", final_state["esg_report"]))
     if analyst_parts:
         content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
         sections.append(f"## I. Analyst Team Reports\n\n{content}")
@@ -741,6 +754,8 @@ def display_complete_report(final_state):
         analysts.append(("News Analyst", final_state["news_report"]))
     if final_state.get("fundamentals_report"):
         analysts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
+    if final_state.get("esg_report"):
+        analysts.append(("ESG Analyst", final_state["esg_report"]))
     if analysts:
         console.print(Panel("[bold]I. Analyst Team Reports[/bold]", border_style="cyan"))
         for title, content in analysts:
@@ -795,18 +810,20 @@ def update_research_team_status(status):
 
 
 # Ordered list of analysts for status transitions
-ANALYST_ORDER = ["market", "social", "news", "fundamentals"]
+ANALYST_ORDER = ["market", "social", "news", "fundamentals", "esg"]
 ANALYST_AGENT_NAMES = {
     "market": "Market Analyst",
     "social": "Social Analyst",
     "news": "News Analyst",
     "fundamentals": "Fundamentals Analyst",
+    "esg": "ESG Analyst",
 }
 ANALYST_REPORT_MAP = {
     "market": "market_report",
     "social": "sentiment_report",
     "news": "news_report",
     "fundamentals": "fundamentals_report",
+    "esg": "esg_report",
 }
 
 
@@ -967,7 +984,8 @@ def run_analysis(checkpoint: bool = False):
     start_time = time.time()
 
     # Create result directory
-    results_dir = Path(config["results_dir"]) / selections["ticker"] / selections["analysis_date"]
+    safe_ticker = safe_ticker_component(selections["ticker"])
+    results_dir = Path(config["results_dir"]) / safe_ticker / selections["analysis_date"]
     results_dir.mkdir(parents=True, exist_ok=True)
     report_dir = results_dir / "reports"
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -1033,7 +1051,7 @@ def run_analysis(checkpoint: bool = False):
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
         # Update agent status to in_progress for the first analyst
-        first_analyst = f"{selections['analysts'][0].value.capitalize()} Analyst"
+        first_analyst = ANALYST_AGENT_NAMES[selected_analyst_keys[0]]
         message_buffer.update_agent_status(first_analyst, "in_progress")
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 

--- a/cli/models.py
+++ b/cli/models.py
@@ -8,3 +8,4 @@ class AnalystType(str, Enum):
     SOCIAL = "social"
     NEWS = "news"
     FUNDAMENTALS = "fundamentals"
+    ESG = "esg"

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -15,6 +15,7 @@ ANALYST_ORDER = [
     ("Social Media Analyst", AnalystType.SOCIAL),
     ("News Analyst", AnalystType.NEWS),
     ("Fundamentals Analyst", AnalystType.FUNDAMENTALS),
+    ("ESG Analyst", AnalystType.ESG),
 ]
 
 

--- a/tests/test_esg_integration.py
+++ b/tests/test_esg_integration.py
@@ -3,10 +3,12 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
 from langgraph.prebuilt import ToolNode
 from cli.main import ANALYST_AGENT_NAMES, ANALYST_ORDER, ANALYST_REPORT_MAP
 from cli.models import AnalystType
 from cli.utils import ANALYST_ORDER as CLI_ANALYST_ORDER
+from tradingagents.agents.analysts.esg_analyst import create_esg_analyst
 from tradingagents.agents.utils.esg_data_tools import get_esg_news, get_esg_scores
 from tradingagents.graph.conditional_logic import ConditionalLogic
 from tradingagents.graph.propagation import Propagator
@@ -52,6 +54,36 @@ def test_esg_conditional_logic_and_graph_compile():
         conditional_logic=logic,
     )
     setup.setup_graph(["esg"]).compile()
+
+
+class _PromptCaptureLLM:
+    def __init__(self):
+        self.system_content = None
+
+    def bind_tools(self, tools):
+        def capture(prompt_value):
+            self.system_content = prompt_value.to_messages()[0].content
+            return AIMessage(content="ESG report", tool_calls=[])
+
+        return RunnableLambda(capture)
+
+
+def test_esg_analyst_system_message_is_rendered_as_string():
+    llm = _PromptCaptureLLM()
+    node = create_esg_analyst(llm)
+
+    result = node(
+        {
+            "messages": [("human", "AAPL")],
+            "company_of_interest": "AAPL",
+            "trade_date": "2025-01-01",
+        }
+    )
+
+    assert result["esg_report"] == "ESG report"
+    assert "You are an ESG" in llm.system_content
+    assert "('You are an ESG" not in llm.system_content
+    assert "',)" not in llm.system_content
 
 def test_esg_news_parses_nested_yfinance_articles():
     nested_article = {

--- a/tests/test_esg_integration.py
+++ b/tests/test_esg_integration.py
@@ -1,0 +1,136 @@
+from datetime import date
+from unittest.mock import Mock, patch
+
+import pandas as pd
+from langchain_core.messages import AIMessage
+from langgraph.prebuilt import ToolNode
+from cli.main import ANALYST_AGENT_NAMES, ANALYST_ORDER, ANALYST_REPORT_MAP
+from cli.models import AnalystType
+from cli.utils import ANALYST_ORDER as CLI_ANALYST_ORDER
+from tradingagents.agents.utils.esg_data_tools import get_esg_news, get_esg_scores
+from tradingagents.graph.conditional_logic import ConditionalLogic
+from tradingagents.graph.propagation import Propagator
+from tradingagents.graph.setup import ANALYST_NODE_NAMES, GraphSetup
+
+
+def test_esg_is_selectable_in_cli():
+    assert AnalystType.ESG.value == "esg"
+    assert ("ESG Analyst", AnalystType.ESG) in CLI_ANALYST_ORDER
+    assert "esg" in ANALYST_ORDER
+    assert ANALYST_AGENT_NAMES["esg"] == "ESG Analyst"
+    assert ANALYST_REPORT_MAP["esg"] == "esg_report"
+
+
+def test_esg_initial_state_and_graph_names_are_consistent():
+    init_state = Propagator().create_initial_state("AAPL", "2025-01-01")
+    assert init_state["esg_report"] == ""
+    assert ANALYST_NODE_NAMES["esg"] == "ESG Analyst"
+
+
+
+class _FakeLLM:
+    def invoke(self, prompt):
+        return AIMessage(content="fake response")
+
+    def with_structured_output(self, schema):
+        raise NotImplementedError("structured output not needed for graph compile")
+
+
+def test_esg_conditional_logic_and_graph_compile():
+    logic = ConditionalLogic()
+    tool_state = {"messages": [AIMessage(content="", tool_calls=[{"name": "get_esg_scores", "args": {"ticker": "AAPL", "curr_date": "2025-01-01"}, "id": "call-1"}])]}
+    final_state = {"messages": [AIMessage(content="done", tool_calls=[])]}
+
+    assert logic.should_continue_esg(tool_state) == "tools_esg"
+    assert logic.should_continue_esg(final_state) == "Msg Clear ESG"
+
+    llm = _FakeLLM()
+    setup = GraphSetup(
+        quick_thinking_llm=llm,
+        deep_thinking_llm=llm,
+        tool_nodes={"esg": ToolNode([get_esg_scores, get_esg_news])},
+        conditional_logic=logic,
+    )
+    setup.setup_graph(["esg"]).compile()
+
+def test_esg_news_parses_nested_yfinance_articles():
+    nested_article = {
+        "content": {
+            "title": "Company expands carbon reduction program",
+            "summary": "The new sustainability program targets emissions and climate risk.",
+            "provider": {"displayName": "Example News"},
+            "canonicalUrl": {"url": "https://example.com/esg"},
+            "pubDate": "2025-01-01T12:00:00Z",
+        }
+    }
+    ticker = Mock()
+    ticker.get_news.return_value = [nested_article]
+
+    with patch("tradingagents.agents.utils.esg_data_tools.yf.Ticker", return_value=ticker), patch(
+        "tradingagents.agents.utils.esg_data_tools.yf_retry", side_effect=lambda call: call()
+    ):
+        result = get_esg_news.invoke({"ticker": "AAPL", "curr_date": "2025-01-01"})
+
+    assert "Company expands carbon reduction program" in result
+    assert "Example News" in result
+    assert "https://example.com/esg" in result
+
+
+def test_esg_news_filters_articles_after_analysis_date():
+    past_article = {
+        "content": {
+            "title": "Company publishes sustainability plan",
+            "summary": "A governance and emissions update.",
+            "provider": {"displayName": "Past News"},
+            "canonicalUrl": {"url": "https://example.com/past"},
+            "pubDate": "2025-01-01T12:00:00Z",
+        }
+    }
+    future_article = {
+        "content": {
+            "title": "Company faces climate investigation",
+            "summary": "A future controversy that should not leak into the run.",
+            "provider": {"displayName": "Future News"},
+            "canonicalUrl": {"url": "https://example.com/future"},
+            "pubDate": "2025-01-03T12:00:00Z",
+        }
+    }
+    ticker = Mock()
+    ticker.get_news.return_value = [past_article, future_article]
+
+    with patch("tradingagents.agents.utils.esg_data_tools.yf.Ticker", return_value=ticker), patch(
+        "tradingagents.agents.utils.esg_data_tools.yf_retry", side_effect=lambda call: call()
+    ):
+        result = get_esg_news.invoke({"ticker": "AAPL", "curr_date": "2025-01-01"})
+
+    assert "Company publishes sustainability plan" in result
+    assert "Company faces climate investigation" not in result
+    assert "Filtered out 1 future-dated" in result
+
+
+def test_esg_scores_skip_current_scores_for_historical_dates():
+    with patch("tradingagents.agents.utils.esg_data_tools.yf.Ticker") as ticker_cls:
+        result = get_esg_scores.invoke({"ticker": "AAPL", "curr_date": "2000-01-01"})
+
+    ticker_cls.assert_not_called()
+    assert "Point-in-time ESG scores are not available" in result
+    assert "look-ahead bias" in result
+
+
+def test_esg_scores_extracts_scalar_values_from_dataframe_rows():
+    sustainability = pd.DataFrame(
+        {"Value": [18.2, 4.3], "Source": ["Sustainalytics", "Sustainalytics"]},
+        index=["totalEsg", "environmentScore"],
+    )
+    ticker = Mock()
+    ticker.sustainability = sustainability
+
+    with patch("tradingagents.agents.utils.esg_data_tools.date") as date_cls, patch(
+        "tradingagents.agents.utils.esg_data_tools.yf.Ticker", return_value=ticker
+    ):
+        date_cls.today.return_value = date(2025, 1, 1)
+        result = get_esg_scores.invoke({"ticker": "AAPL", "curr_date": "2025-01-01"})
+
+    assert "Total ESG Score: 18.2" in result
+    assert "Environment Score: 4.3" in result
+    assert "dtype:" not in result

--- a/tradingagents/agents/__init__.py
+++ b/tradingagents/agents/__init__.py
@@ -5,6 +5,7 @@ from .analysts.fundamentals_analyst import create_fundamentals_analyst
 from .analysts.market_analyst import create_market_analyst
 from .analysts.news_analyst import create_news_analyst
 from .analysts.social_media_analyst import create_social_media_analyst
+from .analysts.esg_analyst import create_esg_analyst
 
 from .researchers.bear_researcher import create_bear_researcher
 from .researchers.bull_researcher import create_bull_researcher
@@ -35,4 +36,5 @@ __all__ = [
     "create_conservative_debator",
     "create_social_media_analyst",
     "create_trader",
+    "create_esg_analyst",
 ]

--- a/tradingagents/agents/analysts/esg_analyst.py
+++ b/tradingagents/agents/analysts/esg_analyst.py
@@ -1,0 +1,84 @@
+"""ESG (Environmental, Social, Governance) Analyst agent module."""
+
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.agents.utils.agent_utils import (
+    build_instrument_context,
+    get_language_instruction,
+)
+from tradingagents.agents.utils.esg_data_tools import (
+    get_esg_scores,
+    get_esg_news,
+)
+
+
+def create_esg_analyst(llm):
+    """Create an ESG (Environmental, Social, Governance) analyst agent.
+
+    This agent analyzes a company's sustainability performance and ESG risk factors,
+    covering environmental impact, social responsibility, and governance quality.
+
+    Args:
+        llm: The language model instance to use for analysis.
+
+    Returns:
+        A node function that processes graph state and returns ESG report updates.
+    """
+    def esg_analyst_node(state):
+        current_date = state["trade_date"]
+        instrument_context = build_instrument_context(state["company_of_interest"])
+
+        tools = [get_esg_scores, get_esg_news]
+
+        system_message = (
+            "You are an ESG (Environmental, Social, Governance) analyst tasked with "
+            "analyzing a company's sustainability performance and ESG risk factors. "
+            "Please write a comprehensive report covering: "
+            "1) Environmental impact: carbon emissions, resource usage, climate risks, environmental compliance; "
+            "2) Social responsibility: labor practices, employee relations, community impact, diversity and inclusion; "
+            "3) Governance: board structure, executive compensation, transparency, ethics and compliance programs. "
+            "Use the available tools to retrieve ESG scores and ESG-related news. "
+            "Provide specific, actionable insights on how ESG factors affect "
+            "long-term investment value and risk profile. "
+            "Highlight any controversies or red flags that could impact stock performance."
+            + " Make sure to append a Markdown table at the end of the report to organize key points, making it easy to read."
+            + " Use the available tools: `get_esg_scores` for ESG ratings and scores, `get_esg_news` for ESG-related news and controversies."
+            + get_language_instruction(),
+        )
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are a helpful AI assistant, collaborating with other assistants."
+                    " Use the provided tools to progress towards answering the question."
+                    " If you are unable to fully answer, that's OK; another assistant with different tools"
+                    " will help where you left off. Execute what you can to make progress."
+                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    "For your reference, the current date is {current_date}. {instrument_context}",
+                ),
+                MessagesPlaceholder(variable_name="messages"),
+            ]
+        )
+
+        prompt = prompt.partial(system_message=system_message)
+        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
+        prompt = prompt.partial(current_date=current_date)
+        prompt = prompt.partial(instrument_context=instrument_context)
+
+        chain = prompt | llm.bind_tools(tools)
+
+        result = chain.invoke(state["messages"])
+
+        report = ""
+
+        if len(result.tool_calls) == 0:
+            report = result.content
+
+        return {
+            "messages": [result],
+            "esg_report": report,
+        }
+
+    return esg_analyst_node

--- a/tradingagents/agents/analysts/esg_analyst.py
+++ b/tradingagents/agents/analysts/esg_analyst.py
@@ -42,7 +42,7 @@ def create_esg_analyst(llm):
             "Highlight any controversies or red flags that could impact stock performance."
             + " Make sure to append a Markdown table at the end of the report to organize key points, making it easy to read."
             + " Use the available tools: `get_esg_scores` for ESG ratings and scores, `get_esg_news` for ESG-related news and controversies."
-            + get_language_instruction(),
+            + get_language_instruction()
         )
 
         prompt = ChatPromptTemplate.from_messages(

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -11,6 +11,7 @@ def create_bear_researcher(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        esg_report = state.get("esg_report", "")
 
         prompt = f"""You are a Bear Analyst making the case against investing in the stock. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
 
@@ -28,6 +29,7 @@ Market research report: {market_research_report}
 Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 Company fundamentals report: {fundamentals_report}
+ESG sustainability report: {esg_report}
 Conversation history of the debate: {history}
 Last bull argument: {current_response}
 Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the stock.

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -11,6 +11,7 @@ def create_bull_researcher(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        esg_report = state.get("esg_report", "")
 
         prompt = f"""You are a Bull Analyst advocating for investing in the stock. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
 
@@ -26,6 +27,7 @@ Market research report: {market_research_report}
 Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 Company fundamentals report: {fundamentals_report}
+ESG sustainability report: {esg_report}
 Conversation history of the debate: {history}
 Last bear argument: {current_response}
 Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -56,6 +56,7 @@ class AgentState(MessagesState):
         str, "Report from the News Researcher of current world affairs"
     ]
     fundamentals_report: Annotated[str, "Report from the Fundamentals Researcher"]
+    esg_report: Annotated[str, "Report from the ESG Analyst"]
 
     # researcher team discussion step
     investment_debate_state: Annotated[

--- a/tradingagents/agents/utils/esg_data_tools.py
+++ b/tradingagents/agents/utils/esg_data_tools.py
@@ -1,0 +1,180 @@
+"""ESG (Environmental, Social, Governance) data tools for analyst agents."""
+
+from datetime import date, datetime, timedelta
+from typing import Annotated, Any
+
+from langchain_core.tools import tool
+import pandas as pd
+import yfinance as yf
+
+from tradingagents.dataflows.stockstats_utils import yf_retry
+from tradingagents.dataflows.yfinance_news import _extract_article_data
+
+
+def _parse_trade_date(curr_date: str) -> date | None:
+    try:
+        return datetime.strptime(curr_date, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_historical_date(curr_date: str) -> bool:
+    trade_date = _parse_trade_date(curr_date)
+    return trade_date is not None and trade_date < date.today()
+
+
+def _scalar_esg_value(value: Any) -> Any:
+    """Convert yfinance ESG row/cell values into a concise scalar when possible."""
+    if isinstance(value, pd.Series):
+        non_empty = value.dropna()
+        if len(non_empty) == 1:
+            return non_empty.iloc[0]
+        if "Value" in value.index and pd.notna(value["Value"]):
+            return value["Value"]
+        if len(non_empty) > 1:
+            return non_empty.to_dict()
+        return "N/A"
+    if isinstance(value, pd.DataFrame):
+        return value.to_dict()
+    return value
+
+
+@tool
+def get_esg_scores(
+    ticker: Annotated[str, "ticker symbol"],
+    curr_date: Annotated[str, "current date you are trading at, yyyy-mm-dd"],
+) -> str:
+    """Retrieve current ESG scores and sustainability metrics for a company.
+
+    Yahoo Finance does not expose point-in-time historical ESG ratings through
+    yfinance. For historical analysis dates, this tool refuses to return current
+    ESG scores to avoid look-ahead bias.
+    """
+    if _is_historical_date(curr_date):
+        return (
+            f"Point-in-time ESG scores are not available for {ticker} on {curr_date}. "
+            "Yahoo Finance only exposes current sustainability scores, so this tool "
+            "does not return them for historical analysis dates to avoid look-ahead bias."
+        )
+
+    try:
+        stock = yf.Ticker(ticker)
+        sustainability = stock.sustainability
+
+        if sustainability is None or sustainability.empty:
+            return f"No ESG sustainability data available for {ticker}. This may indicate the company is not covered by Yahoo Finance ESG ratings, or the data provider (Sustainalytics) has not assessed this company."
+
+        report = f"ESG Sustainability Scores for {ticker}:\n"
+        report += "=" * 50 + "\n\n"
+
+        metrics = [
+            ("totalEsg", "Total ESG Score"),
+            ("environmentScore", "Environment Score"),
+            ("socialScore", "Social Score"),
+            ("governanceScore", "Governance Score"),
+            ("highestControversy", "Highest Controversy Level"),
+            ("peerGroup", "Peer Group"),
+        ]
+
+        matched = False
+        for key, label in metrics:
+            if key in sustainability.index:
+                matched = True
+                report += f"{label}: {_scalar_esg_value(sustainability.loc[key])}\n"
+            elif key in sustainability.columns:
+                matched = True
+                report += f"{label}: {_scalar_esg_value(sustainability[key])}\n"
+
+        if not matched:
+            report += sustainability.to_string()
+
+        report += "\n" + "=" * 50 + "\n"
+        report += "Note: Lower ESG scores indicate lower ESG risk. Scores are based on Sustainalytics methodology."
+        return report
+
+    except Exception as e:
+        return f"Error fetching ESG data for {ticker}: {str(e)}"
+
+
+@tool
+def get_esg_news(
+    ticker: Annotated[str, "ticker symbol"],
+    curr_date: Annotated[str, "current date you are trading at, yyyy-mm-dd"],
+) -> str:
+    """Retrieve ESG-related news and controversies for a company.
+
+    yfinance returns a latest-news feed rather than a historical archive. The
+    tool filters out articles published after ``curr_date`` and skips undated
+    articles for historical runs, so old analyses do not consume future news.
+    """
+    try:
+        stock = yf.Ticker(ticker)
+        news = yf_retry(lambda: stock.get_news(count=20))
+
+        if news is None or len(news) == 0:
+            return f"No recent news available for {ticker}."
+
+        trade_date = _parse_trade_date(curr_date)
+        cutoff = datetime.combine(trade_date + timedelta(days=1), datetime.min.time()) if trade_date else None
+        historical = _is_historical_date(curr_date)
+
+        esg_keywords = [
+            'esg', 'environment', 'sustainability', 'carbon', 'climate',
+            'green', 'emissions', 'social', 'diversity', 'governance',
+            'board', 'ethics', 'compliance', 'labor', 'worker', 'employee',
+            'community', 'controversy', 'scandal', 'investigation', 'regulation'
+        ]
+
+        esg_news_items = []
+        skipped_future = 0
+        skipped_undated = 0
+        for item in news:
+            article = _extract_article_data(item)
+            pub_date = article.get("pub_date")
+            if pub_date is not None:
+                pub_date = pub_date.replace(tzinfo=None)
+                if cutoff and pub_date >= cutoff:
+                    skipped_future += 1
+                    continue
+            elif historical:
+                skipped_undated += 1
+                continue
+
+            title = article["title"].lower()
+            summary = article["summary"].lower()
+
+            if any(keyword in title or keyword in summary for keyword in esg_keywords):
+                article_summary = article["summary"] or "No summary available"
+                esg_news_items.append({
+                    'title': article["title"],
+                    'publisher': article["publisher"],
+                    'link': article["link"],
+                    'summary': article_summary[:200] + '...' if len(article_summary) > 200 else article_summary,
+                })
+
+        if len(esg_news_items) == 0:
+            suffix = ""
+            if skipped_future or skipped_undated:
+                suffix = f" Filtered out {skipped_future} future-dated and {skipped_undated} undated article(s) for point-in-time safety."
+            return f"No ESG-specific news found for {ticker} up to {curr_date}. General market news may still contain relevant information.{suffix}"
+
+        report = f"ESG-Related News for {ticker} up to {curr_date}:\n"
+        report += "=" * 50 + "\n\n"
+
+        for i, item in enumerate(esg_news_items[:10], 1):
+            report += f"{i}. {item['title']}\n"
+            report += f"   Source: {item['publisher']}\n"
+            report += f"   Summary: {item['summary']}\n"
+            if item['link']:
+                report += f"   Link: {item['link']}\n"
+            report += "\n"
+
+        report += "=" * 50 + "\n"
+        report += f"Total ESG-related articles found: {len(esg_news_items)}\n"
+        if skipped_future or skipped_undated:
+            report += f"Filtered out {skipped_future} future-dated and {skipped_undated} undated article(s) for point-in-time safety.\n"
+
+        return report
+
+    except Exception as e:
+        return f"Error fetching ESG news for {ticker}: {str(e)}"

--- a/tradingagents/graph/conditional_logic.py
+++ b/tradingagents/graph/conditional_logic.py
@@ -43,6 +43,14 @@ class ConditionalLogic:
             return "tools_fundamentals"
         return "Msg Clear Fundamentals"
 
+    def should_continue_esg(self, state: AgentState):
+        """Determine if ESG analysis should continue."""
+        messages = state["messages"]
+        last_message = messages[-1]
+        if last_message.tool_calls:
+            return "tools_esg"
+        return "Msg Clear ESG"
+
     def should_continue_debate(self, state: AgentState) -> str:
         """Determine if debate should continue."""
 

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -52,6 +52,7 @@ class Propagator:
             "fundamentals_report": "",
             "sentiment_report": "",
             "news_report": "",
+            "esg_report": "",
         }
 
     def get_graph_args(self, callbacks: Optional[List] = None) -> Dict[str, Any]:

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -10,6 +10,15 @@ from tradingagents.agents.utils.agent_states import AgentState
 from .conditional_logic import ConditionalLogic
 
 
+ANALYST_NODE_NAMES = {
+    "market": "Market Analyst",
+    "social": "Social Analyst",
+    "news": "News Analyst",
+    "fundamentals": "Fundamentals Analyst",
+    "esg": "ESG Analyst",
+}
+
+
 class GraphSetup:
     """Handles the setup and configuration of the agent graph."""
 
@@ -37,6 +46,7 @@ class GraphSetup:
                 - "social": Social media analyst
                 - "news": News analyst
                 - "fundamentals": Fundamentals analyst
+                - "esg": ESG analyst
         """
         if len(selected_analysts) == 0:
             raise ValueError("Trading Agents Graph Setup Error: no analysts selected!")
@@ -74,6 +84,13 @@ class GraphSetup:
             delete_nodes["fundamentals"] = create_msg_delete()
             tool_nodes["fundamentals"] = self.tool_nodes["fundamentals"]
 
+        if "esg" in selected_analysts:
+            analyst_nodes["esg"] = create_esg_analyst(
+                self.quick_thinking_llm
+            )
+            delete_nodes["esg"] = create_msg_delete()
+            tool_nodes["esg"] = self.tool_nodes["esg"]
+
         # Create researcher and manager nodes
         bull_researcher_node = create_bull_researcher(self.quick_thinking_llm)
         bear_researcher_node = create_bear_researcher(self.quick_thinking_llm)
@@ -91,10 +108,10 @@ class GraphSetup:
 
         # Add analyst nodes to the graph
         for analyst_type, node in analyst_nodes.items():
-            workflow.add_node(f"{analyst_type.capitalize()} Analyst", node)
-            workflow.add_node(
-                f"Msg Clear {analyst_type.capitalize()}", delete_nodes[analyst_type]
-            )
+            analyst_node = ANALYST_NODE_NAMES[analyst_type]
+            clear_node = f"Msg Clear {analyst_node.removesuffix(' Analyst')}"
+            workflow.add_node(analyst_node, node)
+            workflow.add_node(clear_node, delete_nodes[analyst_type])
             workflow.add_node(f"tools_{analyst_type}", tool_nodes[analyst_type])
 
         # Add other nodes
@@ -110,13 +127,13 @@ class GraphSetup:
         # Define edges
         # Start with the first analyst
         first_analyst = selected_analysts[0]
-        workflow.add_edge(START, f"{first_analyst.capitalize()} Analyst")
+        workflow.add_edge(START, ANALYST_NODE_NAMES[first_analyst])
 
         # Connect analysts in sequence
         for i, analyst_type in enumerate(selected_analysts):
-            current_analyst = f"{analyst_type.capitalize()} Analyst"
+            current_analyst = ANALYST_NODE_NAMES[analyst_type]
             current_tools = f"tools_{analyst_type}"
-            current_clear = f"Msg Clear {analyst_type.capitalize()}"
+            current_clear = f"Msg Clear {current_analyst.removesuffix(' Analyst')}"
 
             # Add conditional edges for current analyst
             workflow.add_conditional_edges(
@@ -128,7 +145,7 @@ class GraphSetup:
 
             # Connect to next analyst or to Bull Researcher if this is the last analyst
             if i < len(selected_analysts) - 1:
-                next_analyst = f"{selected_analysts[i+1].capitalize()} Analyst"
+                next_analyst = ANALYST_NODE_NAMES[selected_analysts[i + 1]]
                 workflow.add_edge(current_clear, next_analyst)
             else:
                 workflow.add_edge(current_clear, "Bull Researcher")

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -36,7 +36,11 @@ from tradingagents.agents.utils.agent_utils import (
     get_income_statement,
     get_news,
     get_insider_transactions,
-    get_global_news
+    get_global_news,
+)
+from tradingagents.agents.utils.esg_data_tools import (
+    get_esg_scores,
+    get_esg_news,
 )
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
@@ -184,6 +188,13 @@ class TradingAgentsGraph:
                     get_balance_sheet,
                     get_cashflow,
                     get_income_statement,
+                ]
+            ),
+            "esg": ToolNode(
+                [
+                    # ESG analysis tools
+                    get_esg_scores,
+                    get_esg_news,
                 ]
             ),
         }
@@ -356,6 +367,7 @@ class TradingAgentsGraph:
             "sentiment_report": final_state["sentiment_report"],
             "news_report": final_state["news_report"],
             "fundamentals_report": final_state["fundamentals_report"],
+            "esg_report": final_state.get("esg_report", ""),
             "investment_debate_state": {
                 "bull_history": final_state["investment_debate_state"]["bull_history"],
                 "bear_history": final_state["investment_debate_state"]["bear_history"],


### PR DESCRIPTION
## Summary

Add an optional ESG analyst to the TradingAgents workflow and wire ESG analysis through CLI selection, graph state, report persistence, and downstream research prompts.

## Changes

- Add ESG analyst selection, progress display, report rendering, and saved report output.
- Add `esg_report` to graph state, initial propagation, and final graph results.
- Add `create_esg_analyst` plus ESG score/news data tools.
- Wire ESG tool nodes and normalize analyst graph node names so ESG consistently uses `ESG Analyst`.
- Include ESG context in bull/bear researcher prompts.
- Harden ticker-derived CLI result paths with `safe_ticker_component`.
- Avoid ESG look-ahead bias by refusing current ESG scores for historical dates and filtering ESG news by `curr_date`.
- Add ESG integration tests for CLI registration, graph routing/compile, prompt rendering, yfinance nested news parsing, future-news filtering, and ESG DataFrame score extraction.

## Testing

Remote server (`eddc2d887321a8715a63ccb5ebafafaa.bayesdl.com`):

```bash
python -m py_compile tradingagents/agents/analysts/esg_analyst.py tests/test_esg_integration.py
python -m pytest tests/test_esg_integration.py -q
python -m pytest tests -q
```

Results:

```text
8 passed, 1 warning
116 passed, 1 warning, 42 subtests passed
```

Runtime smoke from the previous latest-version validation:

```text
tradingagents --help
tradingagents analyze --help
ESG analyst node execution
ESG-only graph compile
runtime-smoke-ok
```

The remaining warning is an upstream LangGraph pending deprecation warning unrelated to this change.
