### PR TITLE
fix: pass max_recur_limit from config to Propagator

### DIFF
--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -116,7 +116,7 @@ class TradingAgentsGraph:
             self.conditional_logic,
         )
 
-        self.propagator = Propagator()
+        self.propagator = Propagator(max_recur_limit=self.config.get("max_recur_limit", 100))
         self.reflector = Reflector(self.quick_thinking_llm)
         self.signal_processor = SignalProcessor(self.quick_thinking_llm)
 


### PR DESCRIPTION
Propagator was always instantiated with its default of 100, ignoring the "max_recur_limit" value in DEFAULT_CONFIG.
This caused a GraphRecursionError.