### PR TITLE
cli: support remote Ollama endpoints and custom model IDs

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,3 +1,5 @@
+import os
+
 import questionary
 from typing import List, Optional, Tuple, Dict
 
@@ -241,7 +243,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
-        ("Ollama", "ollama", "http://localhost:11434/v1"),
+        ("Ollama", "ollama", os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")),
     ]
 
     choice = questionary.select(

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -107,11 +107,13 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Qwen3:latest (8B, local)", "qwen3:latest"),
             ("GPT-OSS:latest (20B, local)", "gpt-oss:latest"),
             ("GLM-4.7-Flash:latest (30B, local)", "glm-4.7-flash:latest"),
+            ("Custom model ID", "custom"),
         ],
         "deep": [
             ("GLM-4.7-Flash:latest (30B, local)", "glm-4.7-flash:latest"),
             ("GPT-OSS:latest (20B, local)", "gpt-oss:latest"),
             ("Qwen3:latest (8B, local)", "qwen3:latest"),
+            ("Custom model ID", "custom"),
         ],
     },
 }


### PR DESCRIPTION
## Summary

Two minimal changes that let users point TradingAgents at an Ollama instance running on another host (LAN, VPN, dedicated GPU box) and run any model that has been pulled there, not only the three hardcoded presets.

## Why

The current Ollama support assumes Ollama is running on `localhost` and limits the model picker to three presets (`qwen3:latest`, `gpt-oss:latest`, `glm-4.7-flash:latest`). Many users run Ollama on a dedicated GPU machine and pull models that are not in the preset list. There is no way to use that setup from the TUI today.

## Changes

1. **`cli/utils.py`** — read the Ollama base URL from the `OLLAMA_BASE_URL` environment variable, falling back to `http://localhost:11434/v1` so the existing local-only flow is unchanged. The variable is read at function-call time, after `load_dotenv()` has run in `cli/main.py`, so a value in `.env` is picked up automatically.

2. **`tradingagents/llm_clients/model_catalog.py`** — add a `"Custom model ID"` entry to the Ollama quick/deep model lists. The CLI's `_select_model()` already handles the `"custom"` sentinel (used today by GLM and OpenRouter) and prompts for a free-form model name. The Ollama validator in `validators.py` already accepts any model string, so no further plumbing is needed.

## Usage

```bash
# .env (loaded by cli/main.py before the provider menu is shown)
OLLAMA_BASE_URL=http://192.168.35.100:11434/v1
```

```text
$ tradingagents
Select your LLM Provider:        -> Ollama
Select Quick-Thinking LLM:       -> Custom model ID
Enter model ID:                  -> qwen3.6:27b
Select Deep-Thinking LLM:        -> Custom model ID
Enter model ID:                  -> qwen3.6:27b
```

## Backwards compatibility

Users who don't set `OLLAMA_BASE_URL` and pick one of the three preset models see no change in behaviour.

## Tested

End-to-end against a remote Ollama at `192.168.35.100:11434` running `qwen3.6:27b`. Pre-flight `ChatOpenAI` invocation through the OpenAI-compatible endpoint returns successfully, and the TUI now offers the Custom-model-ID flow under Ollama.

Refs #760
