### PR TITLE
fixes #771 - Issue: PermissionError: [Errno 13] Permission denied: '/home/appuser/.tradingagents/cache' when running via docker compose run --rm tradingagent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN useradd --create-home appuser \
-    && mkdir -p /home/appuser/.tradingagents \
-    && chown appuser:appuser /home/appuser/.tradingagents
+    && mkdir -p /home/appuser/.tradingagents /home/appuser/app \
+    && chown -R appuser:appuser /home/appuser
 
 USER appuser
 WORKDIR /home/appuser/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser \
+    && mkdir -p /home/appuser/.tradingagents \
+    && chown appuser:appuser /home/appuser/.tradingagents
+
 USER appuser
 WORKDIR /home/appuser/app
 


### PR DESCRIPTION
**Issue**: PermissionError: [Errno 13] Permission denied: '/home/appuser/.tradingagents/cache' when running via docker compose run --rm tradingagents

**Root cause**: The docker-compose.yml mounts a named volume tradingagents_data at /home/appuser/.tradingagents. In the Dockerfile, appuser is created via useradd --create-home (which creates /home/appuser/ owned by appuser), but the .tradingagents subdirectory is never created inside the image. When Docker mounts a named volume onto a non-existent path, it creates that directory as root. Since the container runs as appuser, writes to that directory fail with PermissionError.


**Fix (Dockerfile)**: Create /home/appuser/.tradingagents with the correct owner before switching to appuser:
RUN useradd --create-home appuser \
    && mkdir -p /home/appuser/.tradingagents \
    && chown appuser:appuser /home/appuser/.tradingagents
USER appuser