### PR TITLE
Add OPENAI_BASE_URL support for OpenAI-compatible gateways

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # LLM Providers (set the one you use)
 OPENAI_API_KEY=
+OPENAI_BASE_URL=
 GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=
 XAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ TradingAgents supports multiple LLM providers. Set the API key for your chosen p
 
 ```bash
 export OPENAI_API_KEY=...          # OpenAI (GPT)
+export OPENAI_BASE_URL=...         # Optional OpenAI-compatible proxy/gateway
 export GOOGLE_API_KEY=...          # Google (Gemini)
 export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
 export XAI_API_KEY=...             # xAI (Grok)

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,3 +1,4 @@
+import os
 import questionary
 from typing import List, Optional, Tuple, Dict
 
@@ -265,6 +266,35 @@ def select_llm_provider() -> tuple[str, str | None]:
         exit(1)
 
     provider, url = choice
+    if provider == "openai":
+        url = os.getenv("OPENAI_BASE_URL", url)
+
+    if provider == "openai":
+        use_custom_url = questionary.confirm(
+            "Use a custom OpenAI-compatible base URL?",
+            default=False,
+            style=questionary.Style(
+                [
+                    ("selected", "fg:magenta noinherit"),
+                    ("highlighted", "fg:magenta noinherit"),
+                    ("pointer", "fg:magenta noinherit"),
+                ]
+            ),
+        ).ask()
+        if use_custom_url:
+            custom_url = questionary.text(
+                "Enter the OpenAI-compatible base URL:",
+                default=url or "",
+                validate=lambda x: len(x.strip()) > 0 or "Please enter a valid base URL.",
+                style=questionary.Style(
+                    [
+                        ("text", "fg:green"),
+                        ("highlighted", "noinherit"),
+                    ]
+                ),
+            ).ask()
+            url = custom_url.strip()
+
     return provider, url
 
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -268,8 +268,6 @@ def select_llm_provider() -> tuple[str, str | None]:
     provider, url = choice
     if provider == "openai":
         url = os.getenv("OPENAI_BASE_URL", url)
-
-    if provider == "openai":
         use_custom_url = questionary.confirm(
             "Use a custom OpenAI-compatible base URL?",
             default=False,
@@ -293,6 +291,9 @@ def select_llm_provider() -> tuple[str, str | None]:
                     ]
                 ),
             ).ask()
+            if custom_url is None:
+                console.print("\n[red]No base URL provided. Exiting...[/red]")
+                exit(1)
             url = custom_url.strip()
 
     return provider, url

--- a/tests/test_cli_provider_selection.py
+++ b/tests/test_cli_provider_selection.py
@@ -72,6 +72,26 @@ class CliProviderSelectionTests(unittest.TestCase):
         self.assertEqual(backend_url, "https://env-proxy.example/v1")
         mock_text.assert_not_called()
 
+    @patch("cli.utils.console.print")
+    @patch("cli.utils.questionary.text")
+    @patch("cli.utils.questionary.confirm")
+    @patch("cli.utils.questionary.select")
+    def test_openai_exits_when_custom_backend_url_prompt_is_cancelled(
+        self,
+        mock_select,
+        mock_confirm,
+        mock_text,
+        mock_print,
+    ):
+        mock_select.return_value = _PromptResult(("openai", "https://api.openai.com/v1"))
+        mock_confirm.return_value = _PromptResult(True)
+        mock_text.return_value = _PromptResult(None)
+
+        with self.assertRaises(SystemExit):
+            select_llm_provider()
+
+        mock_print.assert_called_with("\n[red]No base URL provided. Exiting...[/red]")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_provider_selection.py
+++ b/tests/test_cli_provider_selection.py
@@ -1,0 +1,77 @@
+import unittest
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cli.utils import select_llm_provider
+
+
+class _PromptResult:
+    def __init__(self, value):
+        self.value = value
+
+    def ask(self):
+        return self.value
+
+
+@pytest.mark.unit
+class CliProviderSelectionTests(unittest.TestCase):
+    @patch("cli.utils.questionary.text")
+    @patch("cli.utils.questionary.confirm")
+    @patch("cli.utils.questionary.select")
+    def test_openai_keeps_default_backend_url_when_no_override(
+        self,
+        mock_select,
+        mock_confirm,
+        mock_text,
+    ):
+        mock_select.return_value = _PromptResult(("openai", "https://api.openai.com/v1"))
+        mock_confirm.return_value = _PromptResult(False)
+
+        provider, backend_url = select_llm_provider()
+
+        self.assertEqual(provider, "openai")
+        self.assertEqual(backend_url, "https://api.openai.com/v1")
+        mock_text.assert_not_called()
+
+    @patch("cli.utils.questionary.text")
+    @patch("cli.utils.questionary.confirm")
+    @patch("cli.utils.questionary.select")
+    def test_openai_allows_custom_backend_url_override(
+        self,
+        mock_select,
+        mock_confirm,
+        mock_text,
+    ):
+        mock_select.return_value = _PromptResult(("openai", "https://api.openai.com/v1"))
+        mock_confirm.return_value = _PromptResult(True)
+        mock_text.return_value = _PromptResult("https://example-proxy.test/v1")
+
+        provider, backend_url = select_llm_provider()
+
+        self.assertEqual(provider, "openai")
+        self.assertEqual(backend_url, "https://example-proxy.test/v1")
+
+    @patch.dict(os.environ, {"OPENAI_BASE_URL": "https://env-proxy.example/v1"}, clear=False)
+    @patch("cli.utils.questionary.text")
+    @patch("cli.utils.questionary.confirm")
+    @patch("cli.utils.questionary.select")
+    def test_openai_uses_environment_backend_url_by_default(
+        self,
+        mock_select,
+        mock_confirm,
+        mock_text,
+    ):
+        mock_select.return_value = _PromptResult(("openai", "https://api.openai.com/v1"))
+        mock_confirm.return_value = _PromptResult(False)
+
+        provider, backend_url = select_llm_provider()
+
+        self.assertEqual(provider, "openai")
+        self.assertEqual(backend_url, "https://env-proxy.example/v1")
+        mock_text.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_default_config_env.py
+++ b/tests/test_default_config_env.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from tradingagents.llm_clients.openai_client import OpenAIClient
+
+
+@pytest.mark.unit
+class DefaultConfigEnvironmentTests(unittest.TestCase):
+    @patch.dict(os.environ, {"OPENAI_BASE_URL": "https://env-proxy.example/v1"}, clear=False)
+    @patch("tradingagents.llm_clients.openai_client.NormalizedChatOpenAI")
+    def test_openai_base_url_env_populates_openai_client_default(
+        self,
+        mock_chat,
+    ):
+        client = OpenAIClient("gpt-5.4")
+        client.get_llm()
+
+        self.assertEqual(
+            mock_chat.call_args.kwargs["base_url"],
+            "https://env-proxy.example/v1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -119,6 +119,8 @@ _PROVIDER_CONFIG = {
     "ollama": ("http://localhost:11434/v1", None),
 }
 
+_OPENAI_BASE_URL_ENV_VAR = "OPENAI_BASE_URL"
+
 
 class OpenAIClient(BaseLLMClient):
     """Client for OpenAI, Ollama, OpenRouter, and xAI providers.
@@ -156,6 +158,11 @@ class OpenAIClient(BaseLLMClient):
                     llm_kwargs["api_key"] = api_key
             else:
                 llm_kwargs["api_key"] = "ollama"
+        elif self.provider == "openai":
+            llm_kwargs["base_url"] = self.base_url or os.environ.get(
+                _OPENAI_BASE_URL_ENV_VAR,
+                "https://api.openai.com/v1",
+            )
         elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 


### PR DESCRIPTION
## Summary
- add `OPENAI_BASE_URL` support for native OpenAI provider requests
- prefill the OpenAI CLI flow from `OPENAI_BASE_URL` while still allowing an interactive override
- document the new environment variable in `.env.example` and the README
- add tests for both the CLI selection flow and the OpenAI client fallback behavior

## Why
This makes it easier to use OpenAI-compatible gateways and proxies without patching local config for every run.

## Testing
- `uv run --with pytest pytest /Users/wwcome/work/demo/TradingAgents/tests/test_cli_provider_selection.py /Users/wwcome/work/demo/TradingAgents/tests/test_default_config_env.py /Users/wwcome/work/demo/TradingAgents/tests/test_ticker_symbol_handling.py`
