### PR TITLE
feat: Add pip-audit as an optional dependency and introduce cve_scan_local script

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,21 @@
+name: CVE Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 8 * * 1"  # every Monday at 08:00 UTC
+
+jobs:
+  cve-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run CVE scan
+        run: bash scripts/cve_scan_local.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
     "yfinance>=0.2.63",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pip-audit>=2.6.0",
+]
+
 [project.scripts]
 tradingagents = "cli.main:app"
 

--- a/scripts/cve_scan_local.sh
+++ b/scripts/cve_scan_local.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Isolated venv so pip-audit only sees TradingAgents deps (matches CI), not your global/site packages.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV="${ROOT}/.venv/cve-scan"
+if [[ ! -x "${VENV}/bin/python" ]]; then
+  python3 -m venv "${VENV}"
+fi
+"${VENV}/bin/python" -m pip install --upgrade pip -q
+"${VENV}/bin/pip" install -q pip-audit
+"${VENV}/bin/pip" install -q -e "${ROOT}"
+# Another venv may be active in the shell (e.g. ./venv); pip-audit warns if VIRTUAL_ENV
+# disagrees with the interpreter we audit. We always audit this script's isolated venv.
+env -u VIRTUAL_ENV "${VENV}/bin/pip-audit" --desc --skip-editable "$@"


### PR DESCRIPTION
This commit adds `pip-audit` as an optional dependency for development in `pyproject.toml`. Additionally, a new script `cve_scan_local.sh` is created to facilitate isolated vulnerability scanning of the TradingAgents dependencies using `pip-audit` in a dedicated virtual environment.