### PR TITLE
fix(docker): pre-create ~/.tradingagents in image so named volume inh…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN useradd --create-home appuser
+RUN useradd --create-home appuser \
+    && mkdir -p /home/appuser/.tradingagents \
+    && chown -R appuser:appuser /home/appuser/.tradingagents
 USER appuser
 WORKDIR /home/appuser/app
 


### PR DESCRIPTION
…erits appuser ownership

When docker compose first creates the tradingagents_data named volume on /home/appuser/.tradingagents, Docker initializes the mountpoint as root:root because the path doesn't exist in the image. The container runs as appuser and fails on os.makedirs(...cache...) with PermissionError [Errno 13].

Create the directory in the Dockerfile and chown to appuser before the USER switch, so the volume picks up the correct ownership on first mount.