### PR TITLE
feat(llm): add OpenCode Go provider

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -239,6 +239,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("DeepSeek", "deepseek", "https://api.deepseek.com"),
         ("Qwen", "qwen", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
+        ("OpenCode Go", "opencode-go", "https://opencode.ai/zen/go/v1"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", "http://localhost:11434/v1"),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -228,28 +228,29 @@ def select_deep_thinking_agent(provider) -> str:
     """Select deep thinking llm engine using an interactive selection."""
     return _select_model(provider, "deep")
 
+# (display_name, provider_key, base_url)
+LLM_PROVIDERS: list[tuple[str, str, str | None]] = [
+    ("OpenAI", "openai", "https://api.openai.com/v1"),
+    ("Google", "google", None),
+    ("Anthropic", "anthropic", "https://api.anthropic.com/"),
+    ("xAI", "xai", "https://api.x.ai/v1"),
+    ("DeepSeek", "deepseek", "https://api.deepseek.com"),
+    ("Qwen", "qwen", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
+    ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
+    ("OpenCode Go", "opencode-go", "https://opencode.ai/zen/go/v1"),
+    ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
+    ("Azure OpenAI", "azure", None),
+    ("Ollama", "ollama", "http://localhost:11434/v1"),
+]
+
+
 def select_llm_provider() -> tuple[str, str | None]:
     """Select the LLM provider and its API endpoint."""
-    # (display_name, provider_key, base_url)
-    PROVIDERS = [
-        ("OpenAI", "openai", "https://api.openai.com/v1"),
-        ("Google", "google", None),
-        ("Anthropic", "anthropic", "https://api.anthropic.com/"),
-        ("xAI", "xai", "https://api.x.ai/v1"),
-        ("DeepSeek", "deepseek", "https://api.deepseek.com"),
-        ("Qwen", "qwen", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
-        ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
-        ("OpenCode Go", "opencode-go", "https://opencode.ai/zen/go/v1"),
-        ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
-        ("Azure OpenAI", "azure", None),
-        ("Ollama", "ollama", "http://localhost:11434/v1"),
-    ]
-
     choice = questionary.select(
         "Select your LLM Provider:",
         choices=[
             questionary.Choice(display, value=(provider_key, url))
-            for display, provider_key, url in PROVIDERS
+            for display, provider_key, url in LLM_PROVIDERS
         ],
         instruction="\n- Use arrow keys to navigate\n- Press Enter to select",
         style=questionary.Style(

--- a/tests/test_opencode_go_provider.py
+++ b/tests/test_opencode_go_provider.py
@@ -86,16 +86,8 @@ class OpenCodeGoCatalogTests(unittest.TestCase):
 @pytest.mark.unit
 class OpenCodeGoCLIRegistrationTests(unittest.TestCase):
     def test_cli_providers_list_includes_opencode_go(self):
-        from cli.utils import select_llm_provider
+        from cli.utils import LLM_PROVIDERS
 
-        rows = [
-            row
-            for const in select_llm_provider.__code__.co_consts
-            if isinstance(const, tuple)
-            for row in const
-            if isinstance(row, tuple)
-            and len(row) == 3
-            and row[0:2] == ("OpenCode Go", "opencode-go")
-        ]
+        rows = [row for row in LLM_PROVIDERS if row[1] == "opencode-go"]
         self.assertEqual(len(rows), 1, f"expected exactly one OpenCode Go row, found {rows}")
-        self.assertEqual(rows[0][2], "https://opencode.ai/zen/go/v1")
+        self.assertEqual(rows[0], ("OpenCode Go", "opencode-go", "https://opencode.ai/zen/go/v1"))

--- a/tests/test_opencode_go_provider.py
+++ b/tests/test_opencode_go_provider.py
@@ -1,0 +1,101 @@
+"""Tests for OpenCode Go provider wiring."""
+import os
+import unittest
+from unittest import mock
+
+import pytest
+
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.model_catalog import (
+    MODEL_OPTIONS,
+    get_known_models,
+    get_model_options,
+)
+from tradingagents.llm_clients.openai_client import (
+    OpenAIClient,
+    DeepSeekChatOpenAI,
+)
+from tradingagents.llm_clients.validators import validate_model
+
+
+OPENCODE_GO_MODELS = {
+    "glm-5.1", "glm-5",
+    "kimi-k2.5", "kimi-k2.6",
+    "deepseek-v4-pro", "deepseek-v4-flash",
+    "mimo-v2.5", "mimo-v2.5-pro",
+    "minimax-m2.7", "minimax-m2.5",
+    "qwen3.6-plus", "qwen3.5-plus",
+}
+
+
+@pytest.mark.unit
+class OpenCodeGoFactoryWiringTests(unittest.TestCase):
+    def test_factory_returns_openai_client_for_opencode_go(self):
+        client = create_llm_client("opencode-go", "kimi-k2.6")
+        self.assertIsInstance(client, OpenAIClient)
+        self.assertEqual(client.provider, "opencode-go")
+        self.assertEqual(client.model, "kimi-k2.6")
+
+    def test_get_llm_uses_opencode_go_base_url_and_api_key_env(self):
+        client = create_llm_client("opencode-go", "kimi-k2.6")
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-test-123"}):
+            llm = client.get_llm()
+        self.assertEqual(str(llm.openai_api_base), "https://opencode.ai/zen/go/v1")
+        self.assertEqual(llm.openai_api_key.get_secret_value(), "sk-test-123")
+
+    def test_get_llm_returns_reasoning_content_subclass(self):
+        client = create_llm_client("opencode-go", "deepseek-v4-pro")
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-test-123"}):
+            llm = client.get_llm()
+        self.assertIsInstance(llm, DeepSeekChatOpenAI)
+
+    def test_explicit_base_url_overrides_default(self):
+        client = create_llm_client(
+            "opencode-go", "kimi-k2.6", base_url="https://proxy.example.com/v1"
+        )
+        with mock.patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "sk-test-123"}):
+            llm = client.get_llm()
+        self.assertEqual(str(llm.openai_api_base), "https://proxy.example.com/v1")
+
+
+@pytest.mark.unit
+class OpenCodeGoCatalogTests(unittest.TestCase):
+    def test_catalog_has_opencode_go_with_quick_and_deep_modes(self):
+        self.assertIn("opencode-go", MODEL_OPTIONS)
+        self.assertIn("quick", MODEL_OPTIONS["opencode-go"])
+        self.assertIn("deep", MODEL_OPTIONS["opencode-go"])
+
+    def test_all_twelve_models_appear_in_catalog(self):
+        catalog_models = set(get_known_models()["opencode-go"])
+        self.assertEqual(catalog_models, OPENCODE_GO_MODELS)
+
+    def test_every_opencode_go_model_passes_validator(self):
+        for model in OPENCODE_GO_MODELS:
+            with self.subTest(model=model):
+                self.assertTrue(validate_model("opencode-go", model))
+
+    def test_quick_and_deep_modes_each_contain_six_models(self):
+        quick = {value for _, value in get_model_options("opencode-go", "quick")}
+        deep = {value for _, value in get_model_options("opencode-go", "deep")}
+        self.assertEqual(quick & deep, set())
+        self.assertEqual(quick | deep, OPENCODE_GO_MODELS)
+        self.assertEqual(len(quick), 6)
+        self.assertEqual(len(deep), 6)
+
+
+@pytest.mark.unit
+class OpenCodeGoCLIRegistrationTests(unittest.TestCase):
+    def test_cli_providers_list_includes_opencode_go(self):
+        from cli.utils import select_llm_provider
+
+        rows = [
+            row
+            for const in select_llm_provider.__code__.co_consts
+            if isinstance(const, tuple)
+            for row in const
+            if isinstance(row, tuple)
+            and len(row) == 3
+            and row[0:2] == ("OpenCode Go", "opencode-go")
+        ]
+        self.assertEqual(len(rows), 1, f"expected exactly one OpenCode Go row, found {rows}")
+        self.assertEqual(rows[0][2], "https://opencode.ai/zen/go/v1")

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -5,6 +5,7 @@ from .base_client import BaseLLMClient
 # Providers that use the OpenAI-compatible chat completions API
 _OPENAI_COMPATIBLE = (
     "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
+    "opencode-go",
 )
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -101,6 +101,24 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Custom model ID", "custom"),
         ],
     },
+    "opencode-go": {
+        "quick": [
+            ("DeepSeek V4 Flash via OpenCode Go", "deepseek-v4-flash"),
+            ("Kimi K2.5 via OpenCode Go", "kimi-k2.5"),
+            ("GLM-5 via OpenCode Go", "glm-5"),
+            ("Qwen 3.5 Plus via OpenCode Go", "qwen3.5-plus"),
+            ("MiniMax M2.5 via OpenCode Go", "minimax-m2.5"),
+            ("MiMo V2.5 via OpenCode Go", "mimo-v2.5"),
+        ],
+        "deep": [
+            ("DeepSeek V4 Pro via OpenCode Go", "deepseek-v4-pro"),
+            ("Kimi K2.6 via OpenCode Go", "kimi-k2.6"),
+            ("GLM-5.1 via OpenCode Go", "glm-5.1"),
+            ("Qwen 3.6 Plus via OpenCode Go", "qwen3.6-plus"),
+            ("MiniMax M2.7 via OpenCode Go", "minimax-m2.7"),
+            ("MiMo V2.5 Pro via OpenCode Go", "mimo-v2.5-pro"),
+        ],
+    },
     # OpenRouter: fetched dynamically. Azure: any deployed model name.
     "ollama": {
         "quick": [

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -57,8 +57,10 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
     1. **Thinking-mode round-trip.** When DeepSeek's thinking models return
        a response with ``reasoning_content``, that field must be echoed
        back as part of the assistant message on the next turn or the API
-       fails with HTTP 400. ``_create_chat_result`` captures the field on
-       receive and ``_get_request_payload`` re-attaches it on send.
+       fails with HTTP 400. ``_create_chat_result`` captures it on the
+       non-streaming path, ``_convert_chunk_to_generation_chunk`` captures
+       it on the streaming path, and ``_get_request_payload`` re-attaches
+       it on send.
 
     2. **deepseek-reasoner has no tool_choice.** Structured output via
        function-calling is unavailable, so we raise NotImplementedError
@@ -76,6 +78,25 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
             if reasoning is not None:
                 message_dict["reasoning_content"] = reasoning
         return payload
+
+    def _convert_chunk_to_generation_chunk(self, chunk, default_chunk_class, base_generation_info):
+        # langchain-openai's stream path drops ``reasoning_content`` from
+        # deltas (see "are not extracted" in its docstring). We rescue it
+        # into ``additional_kwargs`` so the round-trip on the next turn —
+        # see ``_get_request_payload`` — has it. Chunk aggregation in
+        # langchain-core concatenates string additional_kwargs, yielding a
+        # complete reasoning_content on the final aggregated AIMessage.
+        gen_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk, default_chunk_class, base_generation_info
+        )
+        if gen_chunk is None:
+            return None
+        choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
+        if choices:
+            reasoning = (choices[0].get("delta") or {}).get("reasoning_content")
+            if reasoning:
+                gen_chunk.message.additional_kwargs["reasoning_content"] = reasoning
+        return gen_chunk
 
     def _create_chat_result(self, response, generation_info=None):
         chat_result = super()._create_chat_result(response, generation_info)
@@ -116,6 +137,7 @@ _PROVIDER_CONFIG = {
     "qwen": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "DASHSCOPE_API_KEY"),
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
+    "opencode-go": ("https://opencode.ai/zen/go/v1", "OPENCODE_GO_API_KEY"),
     "ollama": ("http://localhost:11434/v1", None),
 }
 
@@ -169,9 +191,22 @@ class OpenAIClient(BaseLLMClient):
         if self.provider == "openai":
             llm_kwargs["use_responses_api"] = True
 
+        # OpenCode Go drops the connection on long non-streamed responses
+        # (~3 min idle timeout on the gateway). Streaming keeps the socket
+        # active. Aggregation back to a single AIMessage is transparent.
+        if self.provider == "opencode-go":
+            llm_kwargs.setdefault("streaming", True)
+
         # DeepSeek's thinking-mode quirks live in their own subclass so the
         # base NormalizedChatOpenAI stays free of provider-specific branches.
-        chat_cls = DeepSeekChatOpenAI if self.provider == "deepseek" else NormalizedChatOpenAI
+        # OpenCode Go's gateway proxies DeepSeek backends and inherits the
+        # same reasoning_content round-trip requirement, so it reuses the
+        # same subclass.
+        reasoning_providers = {"deepseek", "opencode-go"}
+        chat_cls = (
+            DeepSeekChatOpenAI if self.provider in reasoning_providers
+            else NormalizedChatOpenAI
+        )
         return chat_cls(**llm_kwargs)
 
     def validate_model(self) -> bool:


### PR DESCRIPTION
## Summary

Wires OpenCode Go (https://opencode.ai/zen/go/v1) as a selectable LLM provider alongside the existing OpenAI-compatible providers. OpenCode Go is a paid subscription tier ($5/$10 per month) routing to ~12 open-source coding models via an OpenAI-compatible chat-completions endpoint.

## Changes

- Register `opencode-go` in the OpenAI-compatible factory branch and `_PROVIDER_CONFIG` (base URL + `OPENCODE_GO_API_KEY` env var).
- Catalog all 12 routed models (`deepseek-v4-{flash,pro}`, `kimi-k2.{5,6}`, `glm-{5,5.1}`, `qwen3.{5,6}-plus`, `minimax-m2.{5,7}`, `mimo-v2.5{,-pro}`), partitioned into quick/deep modes by family tier.
- Add to interactive CLI provider selector.
- Enable streaming for `opencode-go`: the gateway closes connections on long non-streamed responses (~3 min idle timeout); streaming keeps the socket active.
- Reuse `DeepSeekChatOpenAI` for `opencode-go` (its gateway proxies DeepSeek backends, so it inherits the same `reasoning_content` round-trip requirement). Add streaming-path capture via `_convert_chunk_to_generation_chunk` since langchain-openai's stream parser drops `reasoning_content` from deltas, which would otherwise cause HTTP 400 on the next turn.
- Add unit tests covering provider wiring, catalog coverage for all 12 models, validator approval, and CLI registration.

Verified end-to-end against `opencode-go/deepseek-v4-flash` with multi-turn tool-calling.

## Test Plan

- [ ] `pytest -m unit` passes (54 tests, including 8 new in `tests/test_opencode_go_provider.py`)
- [ ] CLI flow: `python -m cli.main` lists "OpenCode Go" in the provider menu and surfaces the 12 models under quick/deep
- [ ] End-to-end: with `OPENCODE_GO_API_KEY` set, `python main.py` (with `llm_provider=opencode-go`, e.g. `quick_think_llm=deepseek-v4-flash`, `deep_think_llm=deepseek-v4-pro`) completes a full SPY analysis without connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)