### PR TITLE
Add MiniMax LLM provider support

### DIFF
--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -4,7 +4,14 @@ from .base_client import BaseLLMClient
 
 # Providers that use the OpenAI-compatible chat completions API
 _OPENAI_COMPATIBLE = (
-    "openai", "xai", "deepseek", "qwen", "glm", "ollama", "openrouter",
+    "openai",
+    "xai",
+    "deepseek",
+    "qwen",
+    "glm",
+    "ollama",
+    "openrouter",
+    "minimax",
 )
 
 
@@ -36,18 +43,22 @@ def create_llm_client(
 
     if provider_lower in _OPENAI_COMPATIBLE:
         from .openai_client import OpenAIClient
+
         return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)
 
     if provider_lower == "anthropic":
         from .anthropic_client import AnthropicClient
+
         return AnthropicClient(model, base_url, **kwargs)
 
     if provider_lower == "google":
         from .google_client import GoogleClient
+
         return GoogleClient(model, base_url, **kwargs)
 
     if provider_lower == "azure":
         from .azure_client import AzureOpenAIClient
+
         return AzureOpenAIClient(model, base_url, **kwargs)
 
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -20,19 +20,31 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("GPT-5.4 - Latest frontier, 1M context", "gpt-5.4"),
             ("GPT-5.2 - Strong reasoning, cost-effective", "gpt-5.2"),
             ("GPT-5.4 Mini - Fast, strong coding and tool use", "gpt-5.4-mini"),
-            ("GPT-5.4 Pro - Most capable, expensive ($30/$180 per 1M tokens)", "gpt-5.4-pro"),
+            (
+                "GPT-5.4 Pro - Most capable, expensive ($30/$180 per 1M tokens)",
+                "gpt-5.4-pro",
+            ),
         ],
     },
     "anthropic": {
         "quick": [
-            ("Claude Sonnet 4.6 - Best speed and intelligence balance", "claude-sonnet-4-6"),
+            (
+                "Claude Sonnet 4.6 - Best speed and intelligence balance",
+                "claude-sonnet-4-6",
+            ),
             ("Claude Haiku 4.5 - Fast, near-instant responses", "claude-haiku-4-5"),
             ("Claude Sonnet 4.5 - Agents and coding", "claude-sonnet-4-5"),
         ],
         "deep": [
-            ("Claude Opus 4.6 - Most intelligent, agents and coding", "claude-opus-4-6"),
+            (
+                "Claude Opus 4.6 - Most intelligent, agents and coding",
+                "claude-opus-4-6",
+            ),
             ("Claude Opus 4.5 - Premium, max intelligence", "claude-opus-4-5"),
-            ("Claude Sonnet 4.6 - Best speed and intelligence balance", "claude-sonnet-4-6"),
+            (
+                "Claude Sonnet 4.6 - Best speed and intelligence balance",
+                "claude-sonnet-4-6",
+            ),
             ("Claude Sonnet 4.5 - Agents and coding", "claude-sonnet-4-5"),
         ],
     },
@@ -40,11 +52,17 @@ MODEL_OPTIONS: ProviderModeOptions = {
         "quick": [
             ("Gemini 3 Flash - Next-gen fast", "gemini-3-flash-preview"),
             ("Gemini 2.5 Flash - Balanced, stable", "gemini-2.5-flash"),
-            ("Gemini 3.1 Flash Lite - Most cost-efficient", "gemini-3.1-flash-lite-preview"),
+            (
+                "Gemini 3.1 Flash Lite - Most cost-efficient",
+                "gemini-3.1-flash-lite-preview",
+            ),
             ("Gemini 2.5 Flash Lite - Fast, low-cost", "gemini-2.5-flash-lite"),
         ],
         "deep": [
-            ("Gemini 3.1 Pro - Reasoning-first, complex workflows", "gemini-3.1-pro-preview"),
+            (
+                "Gemini 3.1 Pro - Reasoning-first, complex workflows",
+                "gemini-3.1-pro-preview",
+            ),
             ("Gemini 3 Flash - Next-gen fast", "gemini-3-flash-preview"),
             ("Gemini 2.5 Pro - Stable pro model", "gemini-2.5-pro"),
             ("Gemini 2.5 Flash - Balanced, stable", "gemini-2.5-flash"),
@@ -52,15 +70,30 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "xai": {
         "quick": [
-            ("Grok 4.1 Fast (Non-Reasoning) - Speed optimized, 2M ctx", "grok-4-1-fast-non-reasoning"),
-            ("Grok 4 Fast (Non-Reasoning) - Speed optimized", "grok-4-fast-non-reasoning"),
-            ("Grok 4.1 Fast (Reasoning) - High-performance, 2M ctx", "grok-4-1-fast-reasoning"),
+            (
+                "Grok 4.1 Fast (Non-Reasoning) - Speed optimized, 2M ctx",
+                "grok-4-1-fast-non-reasoning",
+            ),
+            (
+                "Grok 4 Fast (Non-Reasoning) - Speed optimized",
+                "grok-4-fast-non-reasoning",
+            ),
+            (
+                "Grok 4.1 Fast (Reasoning) - High-performance, 2M ctx",
+                "grok-4-1-fast-reasoning",
+            ),
         ],
         "deep": [
             ("Grok 4 - Flagship model", "grok-4-0709"),
-            ("Grok 4.1 Fast (Reasoning) - High-performance, 2M ctx", "grok-4-1-fast-reasoning"),
+            (
+                "Grok 4.1 Fast (Reasoning) - High-performance, 2M ctx",
+                "grok-4-1-fast-reasoning",
+            ),
             ("Grok 4 Fast (Reasoning) - High-performance", "grok-4-fast-reasoning"),
-            ("Grok 4.1 Fast (Non-Reasoning) - Speed optimized, 2M ctx", "grok-4-1-fast-non-reasoning"),
+            (
+                "Grok 4.1 Fast (Non-Reasoning) - Speed optimized, 2M ctx",
+                "grok-4-1-fast-non-reasoning",
+            ),
         ],
     },
     "deepseek": {
@@ -114,6 +147,26 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Qwen3:latest (8B, local)", "qwen3:latest"),
         ],
     },
+    "minimax": {
+        "quick": [
+            ("MiniMax-M2.7 - 60 TPS", "MiniMax-M2.7"),
+            ("MiniMax-M2.5 - 60 TPS", "MiniMax-M2.5"),
+            ("MiniMax-M2.1 - 60 TPS", "MiniMax-M2.1"),
+            ("MiniMax-M2.7-highspeed - 100 TPS", "MiniMax-M2.7-highspeed"),
+            ("MiniMax-M2.5-highspeed - 100 TPS", "MiniMax-M2.5-highspeed"),
+            ("MiniMax-M2.1-highspeed - 100 TPS", "MiniMax-M2.1-highspeed"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("MiniMax-M2.7 - 204K context", "MiniMax-M2.7"),
+            ("MiniMax-M2.5 - 204K context", "MiniMax-M2.5"),
+            ("MiniMax-M2.1 - 204K context", "MiniMax-M2.1"),
+            ("MiniMax-M2.7-highspeed - Fast", "MiniMax-M2.7-highspeed"),
+            ("MiniMax-M2.5-highspeed - Fast", "MiniMax-M2.5-highspeed"),
+            ("MiniMax-M2.1-highspeed - Fast", "MiniMax-M2.1-highspeed"),
+            ("Custom model ID", "custom"),
+        ],
+    },
 }
 
 
@@ -126,11 +179,7 @@ def get_known_models() -> Dict[str, List[str]]:
     """Build known model names from the shared CLI catalog."""
     return {
         provider: sorted(
-            {
-                value
-                for options in mode_options.values()
-                for _, value in options
-            }
+            {value for options in mode_options.values() for _, value in options}
         )
         for provider, mode_options in MODEL_OPTIONS.items()
     }

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -103,20 +103,30 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
             )
         return super().with_structured_output(schema, method=method, **kwargs)
 
+
 # Kwargs forwarded from user config to ChatOpenAI
 _PASSTHROUGH_KWARGS = (
-    "timeout", "max_retries", "reasoning_effort",
-    "api_key", "callbacks", "http_client", "http_async_client",
+    "timeout",
+    "max_retries",
+    "reasoning_effort",
+    "api_key",
+    "callbacks",
+    "http_client",
+    "http_async_client",
 )
 
 # Provider base URLs and API key env vars
 _PROVIDER_CONFIG = {
     "xai": ("https://api.x.ai/v1", "XAI_API_KEY"),
     "deepseek": ("https://api.deepseek.com", "DEEPSEEK_API_KEY"),
-    "qwen": ("https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "DASHSCOPE_API_KEY"),
+    "qwen": (
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        "DASHSCOPE_API_KEY",
+    ),
     "glm": ("https://api.z.ai/api/paas/v4/", "ZHIPU_API_KEY"),
     "openrouter": ("https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"),
     "ollama": ("http://localhost:11434/v1", None),
+    "minimax": ("https://api.minimaxi.com/v1", "MINIMAX_API_KEY"),
 }
 
 
@@ -171,7 +181,9 @@ class OpenAIClient(BaseLLMClient):
 
         # DeepSeek's thinking-mode quirks live in their own subclass so the
         # base NormalizedChatOpenAI stays free of provider-specific branches.
-        chat_cls = DeepSeekChatOpenAI if self.provider == "deepseek" else NormalizedChatOpenAI
+        chat_cls = (
+            DeepSeekChatOpenAI if self.provider == "deepseek" else NormalizedChatOpenAI
+        )
         return chat_cls(**llm_kwargs)
 
     def validate_model(self) -> bool:


### PR DESCRIPTION
- Add minimax to OpenAI-compatible providers in factory.py
- Add MiniMax base URL (https://api.minimaxi.com/v1) and MINIMAX_API_KEY env var in openai_client.py
- Add MiniMax models (M2.7, M2.5, M2.1 + highspeed variants) to model_catalog.py
- Support both regular speed (60 TPS) and highspeed (100 TPS) models