### PR TITLE
feat: write run_config.md alongside each analysis (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+- **Run configuration report.** Each saved analysis now includes `run_config.md`
+  alongside `complete_report.md`, capturing the tradingagents version, ticker,
+  analysis date, selected analysts, research depth, LLM provider and models,
+  debate/risk round counts, and any provider-specific reasoning parameters
+  (OpenAI reasoning effort, Google thinking level, Anthropic effort) that are
+  set. Useful for comparing runs across providers, models, and tradingagents
+  versions. Also exposes `tradingagents.__version__` via `importlib.metadata`. (#752)
+
 ## [0.2.4] — 2026-04-25
 
 ### Added

--- a/cli/main.py
+++ b/cli/main.py
@@ -638,8 +638,19 @@ def get_analysis_date():
             )
 
 
-def save_report_to_disk(final_state, ticker: str, save_path: Path):
-    """Save complete analysis report to disk with organized subfolders."""
+def save_report_to_disk(
+    final_state,
+    ticker: str,
+    save_path: Path,
+    selections: dict | None = None,
+    config: dict | None = None,
+):
+    """Save complete analysis report to disk with organized subfolders.
+
+    When ``selections`` and ``config`` are both provided, also writes a
+    ``run_config.md`` capturing the run parameters (Issue #752). Backwards
+    compatible: callers that omit them get the original behaviour.
+    """
     save_path.mkdir(parents=True, exist_ok=True)
     sections = []
 
@@ -725,6 +736,19 @@ def save_report_to_disk(final_state, ticker: str, save_path: Path):
     # Write consolidated report
     header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
     (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
+
+    # Run configuration report (Issue #752)
+    if selections is not None and config is not None:
+        from tradingagents import __version__ as _ta_version
+        from cli.run_config_report import build_run_config_markdown
+
+        run_config_md = build_run_config_markdown(
+            selections=selections,
+            config=config,
+            version=_ta_version,
+        )
+        (save_path / "run_config.md").write_text(run_config_md, encoding="utf-8")
+
     return save_path / "complete_report.md"
 
 
@@ -1187,9 +1211,16 @@ def run_analysis(checkpoint: bool = False):
         ).strip()
         save_path = Path(save_path_str)
         try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
+            report_file = save_report_to_disk(
+                final_state,
+                selections["ticker"],
+                save_path,
+                selections=selections,
+                config=config,
+            )
             console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
             console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
+            console.print(f"  [dim]Run config:[/dim] run_config.md")
         except Exception as e:
             console.print(f"[red]Error saving report: {e}[/red]")
 

--- a/cli/run_config_report.py
+++ b/cli/run_config_report.py
@@ -1,0 +1,103 @@
+"""Builds a human-readable run configuration report.
+
+Captures package version, user selections, and effective config so each
+analysis report records which parameters produced it. Useful for comparing
+runs across LLM providers, research depths, or tradingagents versions.
+
+Issue: https://github.com/TauricResearch/TradingAgents/issues/752
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+# Provider-specific reasoning keys: only render when set to avoid noise on
+# providers that don't expose the field (e.g. Ollama has no "thinking level").
+_PROVIDER_SPECIFIC_FIELDS: tuple[tuple[str, str], ...] = (
+    ("openai_reasoning_effort", "OpenAI reasoning effort"),
+    ("google_thinking_level", "Google thinking level"),
+    ("anthropic_effort", "Anthropic effort"),
+)
+
+
+def _row(label: str, value: Any) -> str:
+    """Render a markdown table row, escaping pipes inside the value."""
+    if value in (None, ""):
+        rendered = "—"
+    else:
+        rendered = str(value).replace("|", "\\|")
+    return f"| {label} | {rendered} |"
+
+
+def build_run_config_markdown(
+    selections: Mapping[str, Any],
+    config: Mapping[str, Any],
+    version: str,
+) -> str:
+    """Build a markdown run-configuration report.
+
+    Args:
+        selections: dict produced by ``cli.utils.get_user_selections``
+            (ticker, analysis_date, analysts, research_depth, llm_provider,
+            shallow_thinker, deep_thinker, backend_url, *_effort, etc.).
+        config: effective tradingagents config dict (DEFAULT_CONFIG merged
+            with overrides applied in ``cli/main.py:run_analysis``).
+        version: package version string (e.g. ``"0.2.4"``).
+
+    Returns:
+        A markdown string. Caller writes it to disk.
+    """
+    analyst_names = ", ".join(
+        getattr(a, "value", str(a)) for a in selections.get("analysts", []) or []
+    ) or "—"
+
+    base_rows = [
+        _row("tradingagents version", version),
+        _row("Ticker", selections.get("ticker")),
+        _row("Analysis date", selections.get("analysis_date")),
+        _row("Analysts", analyst_names),
+        _row("Research depth", selections.get("research_depth")),
+        _row("Output language", selections.get("output_language")),
+        _row("LLM provider", selections.get("llm_provider")),
+        _row("Quick-thinking model", selections.get("shallow_thinker")),
+        _row("Deep-thinking model", selections.get("deep_thinker")),
+        _row("Backend URL", selections.get("backend_url")),
+        _row("Max debate rounds", config.get("max_debate_rounds")),
+        _row("Max risk discuss rounds", config.get("max_risk_discuss_rounds")),
+        _row("Checkpoint enabled", config.get("checkpoint_enabled")),
+    ]
+
+    provider_rows = []
+    for key, label in _PROVIDER_SPECIFIC_FIELDS:
+        value = selections.get(key)
+        if value not in (None, ""):
+            provider_rows.append(_row(label, value))
+
+    lines = [
+        "# Run Configuration",
+        "",
+        (
+            "Captures the parameters used to generate this analysis. "
+            "Useful for comparing runs across LLM providers, research depths, "
+            "or tradingagents versions."
+        ),
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        *base_rows,
+    ]
+
+    if provider_rows:
+        lines.extend(
+            [
+                "",
+                "## Provider-specific reasoning parameters",
+                "",
+                "| Field | Value |",
+                "|-------|-------|",
+                *provider_rows,
+            ]
+        )
+
+    lines.append("")  # trailing newline
+    return "\n".join(lines)

--- a/tests/test_run_config_report.py
+++ b/tests/test_run_config_report.py
@@ -1,0 +1,92 @@
+"""Unit tests for cli.run_config_report (Issue #752)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cli.run_config_report import build_run_config_markdown
+
+
+@pytest.mark.unit
+def test_includes_version_and_ticker_header():
+    selections = {
+        "ticker": "NVDA",
+        "analysis_date": "2026-05-04",
+        "analysts": [],
+        "research_depth": 1,
+        "llm_provider": "openai",
+        "shallow_thinker": "gpt-5.4-mini",
+        "deep_thinker": "gpt-5.4",
+        "backend_url": None,
+        "openai_reasoning_effort": "medium",
+        "google_thinking_level": None,
+        "anthropic_effort": None,
+        "output_language": "English",
+    }
+    config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+
+    md = build_run_config_markdown(selections, config, version="0.2.4")
+
+    assert "# Run Configuration" in md
+    assert "NVDA" in md
+    assert "2026-05-04" in md
+    assert "0.2.4" in md
+    assert "gpt-5.4-mini" in md
+    assert "gpt-5.4" in md
+
+
+@pytest.mark.unit
+def test_omits_unset_provider_specific_keys():
+    """When provider-specific reasoning keys are None, they should not render as 'None'."""
+    selections = {
+        "ticker": "AAPL",
+        "analysis_date": "2026-05-04",
+        "analysts": [],
+        "research_depth": 1,
+        "llm_provider": "ollama",
+        "shallow_thinker": "qwen3:latest",
+        "deep_thinker": "gpt-oss:latest",
+        "backend_url": "http://localhost:11434/v1",
+        "openai_reasoning_effort": None,
+        "google_thinking_level": None,
+        "anthropic_effort": None,
+        "output_language": "English",
+    }
+    config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+
+    md = build_run_config_markdown(selections, config, version="0.2.4")
+
+    # Ollama selections shouldn't surface a "Provider-specific reasoning parameters" section
+    assert "Provider-specific reasoning parameters" not in md
+    assert "ollama" in md
+    assert "qwen3:latest" in md
+    assert "gpt-oss:latest" in md
+
+
+@pytest.mark.unit
+def test_includes_debate_and_risk_rounds_and_provider_specific_section():
+    selections = {
+        "ticker": "MSFT",
+        "analysis_date": "2026-05-04",
+        "analysts": [],
+        "research_depth": 3,
+        "llm_provider": "anthropic",
+        "shallow_thinker": "claude-haiku-4",
+        "deep_thinker": "claude-opus-4",
+        "backend_url": None,
+        "openai_reasoning_effort": None,
+        "google_thinking_level": None,
+        "anthropic_effort": "high",
+        "output_language": "English",
+    }
+    config = {"max_debate_rounds": 3, "max_risk_discuss_rounds": 2}
+
+    md = build_run_config_markdown(selections, config, version="0.2.4")
+
+    assert "Provider-specific reasoning parameters" in md
+    assert "Anthropic effort" in md
+    assert "high" in md
+    # research_depth and rounds should appear
+    assert "| Research depth | 3 |" in md
+    assert "| Max debate rounds | 3 |" in md
+    assert "| Max risk discuss rounds | 2 |" in md

--- a/tradingagents/__init__.py
+++ b/tradingagents/__init__.py
@@ -1,0 +1,10 @@
+"""TradingAgents — multi-agent LLM financial trading framework."""
+
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("tradingagents")
+except PackageNotFoundError:  # pragma: no cover - fallback when not installed
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Closes #752.

Each saved analysis now includes a `run_config.md` at the report root, capturing:

- `tradingagents` package version (exposed via `importlib.metadata`)
- Ticker, analysis date, selected analysts, research depth, output language
- LLM provider, quick-thinking model, deep-thinking model, backend URL
- Max debate rounds, max risk discuss rounds, checkpoint flag
- Provider-specific reasoning params (OpenAI reasoning effort, Google thinking level, Anthropic effort) — only rendered when set

## Why

Issue #752 describes comparing runs across LLM families (OpenAI vs Google vs Ollama) and over time as models and tradingagents itself evolve. Without persisted config, you can't tell from disk which parameters produced which report.

## Implementation

- New `tradingagents.__version__` via `importlib.metadata.version("tradingagents")`
- New `cli/run_config_report.py` with one pure function: `build_run_config_markdown(selections, config, version) -> str`
- `cli/main.py:save_report_to_disk()` gains optional `selections`/`config` kwargs; when both are passed, writes `run_config.md`. Backwards compatible — existing callers that don't pass them still work.
- 3 unit tests in `tests/test_run_config_report.py` (`@pytest.mark.unit`)
- CHANGELOG updated under `[Unreleased] / Added`

## Sample output

```markdown
# Run Configuration

| Field | Value |
|-------|-------|
| tradingagents version | 0.2.4 |
| Ticker | NVDA |
| Analysis date | 2026-05-04 |
| Analysts | market, news, fundamentals |
| Research depth | 1 |
| LLM provider | ollama |
| Quick-thinking model | qwen3:latest |
| Deep-thinking model | gpt-oss:latest |
| Backend URL | http://localhost:11434/v1 |
| Max debate rounds | 1 |
| Max risk discuss rounds | 1 |
| Checkpoint enabled | False |
```

## Tests

```
$ python -m pytest -m unit
====================== 48 passed, 63 deselected in 1.24s =======================
```

(45 existing + 3 new for the markdown builder.)