### PR TITLE
chore: add .env.enterprise and reports/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ activemq-data/
 
 # Environments
 .env
+.env.enterprise
 .envrc
 .venv
 env/
@@ -217,3 +218,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Generated reports
+reports/


### PR DESCRIPTION
Closes #787

## Summary
- Adds `.env.enterprise` to prevent accidental commit of enterprise environment secrets
- Adds `reports/` to prevent committing generated report output files

## Test plan
- [ ] Verify `.env.enterprise` is ignored by git
- [ ] Verify `reports/` directory is ignored by git