### PR TITLE
feat: structured output for Social Media Analyst (#796)

### DIFF
--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tradingagents.agents.analysts.social_media_analyst import create_social_media_analyst
+from tradingagents.agents.analysts.sentiment_analyst import create_sentiment_analyst
 from tradingagents.agents.managers.research_manager import create_research_manager
 from tradingagents.agents.schemas import (
     PortfolioRating,
@@ -308,39 +308,32 @@ class TestRenderSentimentReport:
 
 
 # ---------------------------------------------------------------------------
-# Social Media Analyst node
+# Sentiment Analyst node
 # ---------------------------------------------------------------------------
 
 
-def _make_analyst_state(tool_calls=None):
-    from langchain_core.messages import AIMessage, HumanMessage
-    msgs = [HumanMessage(content="Analyze TSLA sentiment.")]
-    if tool_calls is not None:
-        msgs.append(AIMessage(content="", tool_calls=tool_calls))
+def _make_analyst_state():
+    from langchain_core.messages import HumanMessage
     return {
-        "messages": msgs,
+        "messages": [HumanMessage(content="Analyze TSLA sentiment.")],
         "company_of_interest": "TSLA",
         "trade_date": "2024-01-15",
     }
 
 
-def _structured_analyst_llm(structured_result):
-    """LLM mock that returns no tool calls on final call, then structured result on extraction.
+def _make_analyst_llm(structured_result):
+    """LLM mock for the sentiment analyst.
 
-    LangChain coerces the bound LLM into a RunnableLambda and calls it as a
-    callable (not .invoke()), so we set .return_value on the bound mock.
+    The analyst uses format_messages then invoke_structured_or_freetext, which
+    calls structured_llm.invoke(formatted_messages) directly.
     """
-    from langchain_core.messages import AIMessage
-    tool_response = AIMessage(content="Full prose report about TSLA.", tool_calls=[])
     llm = MagicMock()
     llm.with_structured_output.return_value.invoke.return_value = structured_result
-    # LangChain calls bound_llm(input), not bound_llm.invoke(input)
-    llm.bind_tools.return_value.return_value = tool_response
     return llm
 
 
 @pytest.mark.unit
-class TestSocialMediaAnalystStructured:
+class TestSentimentAnalystStructured:
     def test_structured_output_populates_sentiment_report(self):
         structured = SentimentReport(
             overall_score=7.2,
@@ -348,35 +341,30 @@ class TestSocialMediaAnalystStructured:
             confidence="high",
             narrative="Retail very bullish on TSLA this week.",
         )
-        llm = _structured_analyst_llm(structured)
-        analyst = create_social_media_analyst(llm)
+        llm = _make_analyst_llm(structured)
+        analyst = create_sentiment_analyst(llm)
         result = analyst(_make_analyst_state())
         assert "Score: 7.2/10" in result["sentiment_report"]
         assert "Bullish" in result["sentiment_report"]
         assert "Retail very bullish" in result["sentiment_report"]
 
-    def test_tool_calls_return_empty_report(self):
-        """During the tool loop (tool_calls present), sentiment_report stays empty."""
-        from langchain_core.messages.tool import ToolCall
-        from langchain_core.messages import AIMessage
-        tool_response = AIMessage(
-            content="",
-            tool_calls=[ToolCall(name="get_news", args={}, id="1")],
+    def test_sentiment_report_in_messages(self):
+        """The rendered report should also appear in the messages state."""
+        structured = SentimentReport(
+            overall_score=5.0,
+            overall_band=SentimentBand.NEUTRAL,
+            confidence="medium",
+            narrative="Mixed signals this week.",
         )
-        llm = MagicMock()
-        llm.with_structured_output.return_value = MagicMock()
-        llm.bind_tools.return_value.return_value = tool_response
-        analyst = create_social_media_analyst(llm)
+        llm = _make_analyst_llm(structured)
+        analyst = create_sentiment_analyst(llm)
         result = analyst(_make_analyst_state())
-        assert result["sentiment_report"] == ""
+        assert result["messages"][-1].content == result["sentiment_report"]
 
     def test_falls_back_to_freetext_when_structured_unavailable(self):
-        from langchain_core.messages import AIMessage
-        tool_response = AIMessage(content="Raw prose fallback report.", tool_calls=[])
         llm = MagicMock()
         llm.with_structured_output.side_effect = NotImplementedError("unsupported")
-        llm.bind_tools.return_value.return_value = tool_response
         llm.invoke.return_value = MagicMock(content="Raw prose fallback report.")
-        analyst = create_social_media_analyst(llm)
+        analyst = create_sentiment_analyst(llm)
         result = analyst(_make_analyst_state())
         assert "Raw prose fallback report." in result["sentiment_report"]

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -11,13 +11,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tradingagents.agents.analysts.social_media_analyst import create_social_media_analyst
 from tradingagents.agents.managers.research_manager import create_research_manager
 from tradingagents.agents.schemas import (
     PortfolioRating,
     ResearchPlan,
+    SentimentBand,
+    SentimentReport,
     TraderAction,
     TraderProposal,
     render_research_plan,
+    render_sentiment_report,
     render_trader_proposal,
 )
 from tradingagents.agents.trader.trader import create_trader
@@ -230,3 +234,149 @@ class TestResearchManagerAgent:
         rm = create_research_manager(llm)
         result = rm(_make_rm_state())
         assert result["investment_plan"] == plain_response
+
+
+# ---------------------------------------------------------------------------
+# SentimentReport schema and render
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRenderSentimentReport:
+    def test_required_fields_present(self):
+        r = SentimentReport(
+            overall_score=7.2,
+            overall_band=SentimentBand.BULLISH,
+            confidence="high",
+            narrative="TSLA sentiment is strongly positive driven by retail enthusiasm.",
+        )
+        md = render_sentiment_report(r)
+        assert "**Overall Sentiment:** **Bullish**" in md
+        assert "Score: 7.2/10" in md
+        assert "Confidence: high" in md
+        assert "TSLA sentiment is strongly positive" in md
+
+    def test_score_formatted_to_one_decimal(self):
+        r = SentimentReport(
+            overall_score=6.0,
+            overall_band=SentimentBand.MILDLY_BULLISH,
+            confidence="medium",
+            narrative="Mixed signals.",
+        )
+        md = render_sentiment_report(r)
+        assert "6.0/10" in md
+
+    def test_all_bands_render(self):
+        for band in SentimentBand:
+            r = SentimentReport(
+                overall_score=5.0,
+                overall_band=band,
+                confidence="low",
+                narrative="Test.",
+            )
+            md = render_sentiment_report(r)
+            assert band.value in md
+
+    def test_narrative_preserved_intact(self):
+        narrative = "Line one.\n\nLine two.\n\n| Col | Val |\n|-----|-----|\n| A   | B   |"
+        r = SentimentReport(
+            overall_score=4.5,
+            overall_band=SentimentBand.NEUTRAL,
+            confidence="medium",
+            narrative=narrative,
+        )
+        md = render_sentiment_report(r)
+        assert narrative in md
+
+    def test_score_bounds(self):
+        import pytest as _pytest
+        from pydantic import ValidationError
+        with _pytest.raises(ValidationError):
+            SentimentReport(
+                overall_score=11.0,
+                overall_band=SentimentBand.BULLISH,
+                confidence="high",
+                narrative="Out of range.",
+            )
+        with _pytest.raises(ValidationError):
+            SentimentReport(
+                overall_score=-1.0,
+                overall_band=SentimentBand.BEARISH,
+                confidence="low",
+                narrative="Out of range.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Social Media Analyst node
+# ---------------------------------------------------------------------------
+
+
+def _make_analyst_state(tool_calls=None):
+    from langchain_core.messages import AIMessage, HumanMessage
+    msgs = [HumanMessage(content="Analyze TSLA sentiment.")]
+    if tool_calls is not None:
+        msgs.append(AIMessage(content="", tool_calls=tool_calls))
+    return {
+        "messages": msgs,
+        "company_of_interest": "TSLA",
+        "trade_date": "2024-01-15",
+    }
+
+
+def _structured_analyst_llm(structured_result):
+    """LLM mock that returns no tool calls on final call, then structured result on extraction.
+
+    LangChain coerces the bound LLM into a RunnableLambda and calls it as a
+    callable (not .invoke()), so we set .return_value on the bound mock.
+    """
+    from langchain_core.messages import AIMessage
+    tool_response = AIMessage(content="Full prose report about TSLA.", tool_calls=[])
+    llm = MagicMock()
+    llm.with_structured_output.return_value.invoke.return_value = structured_result
+    # LangChain calls bound_llm(input), not bound_llm.invoke(input)
+    llm.bind_tools.return_value.return_value = tool_response
+    return llm
+
+
+@pytest.mark.unit
+class TestSocialMediaAnalystStructured:
+    def test_structured_output_populates_sentiment_report(self):
+        structured = SentimentReport(
+            overall_score=7.2,
+            overall_band=SentimentBand.BULLISH,
+            confidence="high",
+            narrative="Retail very bullish on TSLA this week.",
+        )
+        llm = _structured_analyst_llm(structured)
+        analyst = create_social_media_analyst(llm)
+        result = analyst(_make_analyst_state())
+        assert "Score: 7.2/10" in result["sentiment_report"]
+        assert "Bullish" in result["sentiment_report"]
+        assert "Retail very bullish" in result["sentiment_report"]
+
+    def test_tool_calls_return_empty_report(self):
+        """During the tool loop (tool_calls present), sentiment_report stays empty."""
+        from langchain_core.messages.tool import ToolCall
+        from langchain_core.messages import AIMessage
+        tool_response = AIMessage(
+            content="",
+            tool_calls=[ToolCall(name="get_news", args={}, id="1")],
+        )
+        llm = MagicMock()
+        llm.with_structured_output.return_value = MagicMock()
+        llm.bind_tools.return_value.return_value = tool_response
+        analyst = create_social_media_analyst(llm)
+        result = analyst(_make_analyst_state())
+        assert result["sentiment_report"] == ""
+
+    def test_falls_back_to_freetext_when_structured_unavailable(self):
+        from langchain_core.messages import AIMessage
+        tool_response = AIMessage(content="Raw prose fallback report.", tool_calls=[])
+        llm = MagicMock()
+        llm.with_structured_output.side_effect = NotImplementedError("unsupported")
+        llm.bind_tools.return_value.return_value = tool_response
+        llm.invoke.return_value = MagicMock(content="Raw prose fallback report.")
+        analyst = create_social_media_analyst(llm)
+        result = analyst(_make_analyst_state())
+        assert "Raw prose fallback report." in result["sentiment_report"]

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -21,12 +21,15 @@ See: https://github.com/TauricResearch/TradingAgents/issues/557
 
 from datetime import datetime, timedelta
 
+from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.agents.schemas import SentimentReport, render_sentiment_report
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_language_instruction,
     get_news,
 )
+from tradingagents.agents.utils.structured import bind_structured, invoke_structured_or_freetext
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
 
@@ -39,9 +42,11 @@ def create_sentiment_analyst(llm):
     """Create a sentiment analyst node for the trading graph.
 
     Pre-fetches news + StockTwits + Reddit data, injects them into the
-    prompt as structured blocks, and produces a sentiment report in a
-    single LLM call.
+    prompt as structured blocks, and produces a structured sentiment report
+    in a single LLM call. Falls back to free-text when the provider does
+    not support structured output.
     """
+    structured_llm = bind_structured(llm, SentimentReport, "Sentiment Analyst")
 
     def sentiment_analyst_node(state):
         ticker = state["company_of_interest"]
@@ -51,7 +56,7 @@ def create_sentiment_analyst(llm):
 
         # Pre-fetch all three sources. Each fetcher degrades gracefully and
         # returns a string (no exceptions surface from here), so the LLM
-        # always sees something — either real data or a clear placeholder.
+        # always sees something - either real data or a clear placeholder.
         news_block = get_news.func(ticker, start_date, end_date)
         stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
         reddit_block = fetch_reddit_posts(ticker)
@@ -83,14 +88,20 @@ def create_sentiment_analyst(llm):
         prompt = prompt.partial(current_date=end_date)
         prompt = prompt.partial(instrument_context=instrument_context)
 
-        # No bind_tools — the data is already in the prompt; a single LLM
-        # call produces the report directly.
-        chain = prompt | llm
-        result = chain.invoke(state["messages"])
+        # No bind_tools - the data is already in the prompt. Use structured
+        # output directly since there is no tool-calling phase to work around.
+        formatted = prompt.format_messages(messages=state["messages"])
+        report = invoke_structured_or_freetext(
+            structured_llm,
+            llm,
+            formatted,
+            render_sentiment_report,
+            "Sentiment Analyst",
+        )
 
         return {
-            "messages": [result],
-            "sentiment_report": result.content,
+            "messages": [AIMessage(content=report)],
+            "sentiment_report": report,
         }
 
     return sentiment_analyst_node

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -19,7 +19,7 @@ so that:
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -226,3 +226,75 @@ def render_pm_decision(decision: PortfolioDecision) -> str:
     if decision.time_horizon:
         parts.extend(["", f"**Time Horizon**: {decision.time_horizon}"])
     return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Social Media / Sentiment Analyst
+# ---------------------------------------------------------------------------
+
+
+class SentimentBand(str, Enum):
+    """Categorical sentiment label used by the Social Media Analyst."""
+
+    BULLISH = "Bullish"
+    MILDLY_BULLISH = "Mildly Bullish"
+    NEUTRAL = "Neutral"
+    MIXED = "Mixed"
+    MILDLY_BEARISH = "Mildly Bearish"
+    BEARISH = "Bearish"
+
+
+class SentimentReport(BaseModel):
+    """Structured sentiment output produced by the Social Media Analyst.
+
+    The analyst collects data via tool calls (get_news), writes a free-form
+    research narrative, then this schema is used to extract deterministic
+    summary fields from that narrative. The narrative field preserves the
+    full prose so downstream debate agents receive the same rich context
+    they always have.
+    """
+
+    overall_score: float = Field(
+        ge=0,
+        le=10,
+        description=(
+            "Numeric sentiment score from 0 (most bearish) to 10 (most bullish). "
+            "Use one decimal place, e.g. 7.2."
+        ),
+    )
+    overall_band: SentimentBand = Field(
+        description=(
+            "Categorical sentiment label. Pick the band that best matches the "
+            "overall_score: Bullish (7-10), Mildly Bullish (5.5-7), Neutral/Mixed "
+            "(4.5-5.5), Mildly Bearish (3-4.5), Bearish (0-3)."
+        ),
+    )
+    confidence: Literal["low", "medium", "high"] = Field(
+        description=(
+            "Confidence in the sentiment assessment based on data availability and "
+            "signal clarity. Use 'low' when sources are sparse or contradictory, "
+            "'medium' for moderate signal, 'high' for strong consistent signal."
+        ),
+    )
+    narrative: str = Field(
+        description=(
+            "The full analyst report in markdown. Include all research findings, "
+            "social media analysis, news insights, and a summary table. "
+            "This is what downstream agents read as context."
+        ),
+    )
+
+
+def render_sentiment_report(report: SentimentReport) -> str:
+    """Render a SentimentReport to markdown for state storage and downstream agents.
+
+    The narrative (full prose report) is preserved intact so bull/bear researchers
+    and risk debate agents continue to receive the same rich context. The structured
+    fields are appended as a summary header for quick downstream parsing.
+    """
+    header = "\n".join([
+        f"**Overall Sentiment:** **{report.overall_band.value}** "
+        f"(Score: {report.overall_score:.1f}/10, Confidence: {report.confidence})",
+        "",
+    ])
+    return header + report.narrative

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -265,8 +265,10 @@ class SentimentReport(BaseModel):
     overall_band: SentimentBand = Field(
         description=(
             "Categorical sentiment label. Pick the band that best matches the "
-            "overall_score: Bullish (7-10), Mildly Bullish (5.5-7), Neutral/Mixed "
-            "(4.5-5.5), Mildly Bearish (3-4.5), Bearish (0-3)."
+            "overall_score: Bullish (7.1-10), Mildly Bullish (5.6-7.0), Neutral "
+            "(4.5-5.5, flat outlook with no strong signal), Mixed "
+            "(4.5-5.5, high-volume but conflicting signals), "
+            "Mildly Bearish (3.0-4.4), Bearish (0-2.9)."
         ),
     )
     confidence: Literal["low", "medium", "high"] = Field(
@@ -295,6 +297,7 @@ def render_sentiment_report(report: SentimentReport) -> str:
     header = "\n".join([
         f"**Overall Sentiment:** **{report.overall_band.value}** "
         f"(Score: {report.overall_score:.1f}/10, Confidence: {report.confidence})",
+        "",
         "",
     ])
     return header + report.narrative


### PR DESCRIPTION
Fixes #796.

`social_media_analyst` outputs vary wildly between runs - some include a numeric score, some only a band, some neither. Downstream agents and dashboards either degrade silently or maintain growing piles of fallback regexes.

Added `SentimentReport` schema (score, band, confidence, narrative) and `render_sentiment_report` to `schemas.py`, following the same pattern used for the Trader, Portfolio Manager, and Research Manager in #434. Since the analyst uses tool calls for its research phase, structured output is applied in a separate extraction call after the tool loop finishes rather than on the tool-calling chain directly. Falls back to free-text if the provider does not support structured output.

8 new unit tests covering schema validation, render output, structured path, and fallback. All 19 tests pass.