### PR TITLE
fix: add .env.enterprise and reports/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ activemq-data/
 
 # Environments
 .env
+.env.enterprise
 .envrc
 .venv
 env/
@@ -217,3 +218,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Generated report output
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,7 @@ activemq-data/
 
 # Environments
 .env
-.env.enterprise
+.env.*
 .envrc
 .venv
 env/
@@ -220,4 +220,4 @@ __marimo__/
 **/data_cache/
 
 # Generated report output
-reports/
+/reports/


### PR DESCRIPTION
Closes #787.

`.env.enterprise` contains enterprise credentials and should never be committed. `reports/` is generated at runtime (the framework writes analysis reports there) and has no place in version control.

**Changes:**
- Added `.env.enterprise` to the Environments section alongside the existing `.env` entry
- Added `reports/` at the bottom under a new "Generated report output" comment