### PR TITLE
docs: add AgentFloor self-hosted web UI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ ta = TradingAgentsGraph(config=config)
 _, decision = ta.propagate("NVDA", "2026-01-15")
 ```
 
+## Web Interface
+
+[**AgentFloor**](https://github.com/saketnayak/trading-command-center) — A self-hosted web UI for TradingAgents. One-command Docker install on Windows, macOS, and Linux (only dependency: Docker Desktop). Adds portfolio tracking, automated daily briefings, cron-based watchlist scheduling, outcome tracking at +7/14/30/90 days, and multi-user support — no Python setup required for end users.
+
+![AgentFloor demo](https://raw.githubusercontent.com/saketnayak/trading-command-center/main/docs/demo.gif)
+
 ## Contributing
 
 We welcome contributions from the community! Whether it's fixing a bug, improving documentation, or suggesting a new feature, your input helps make this project better. If you are interested in this line of research, please consider joining our open-source financial AI research community [Tauric Research](https://tauric.ai/).

--- a/README.md
+++ b/README.md
@@ -255,9 +255,11 @@ _, decision = ta.propagate("NVDA", "2026-01-15")
 
 ## Web Interface
 
-[**AgentFloor**](https://github.com/saketnayak/trading-command-center) — A self-hosted web UI for TradingAgents. One-command Docker install on Windows, macOS, and Linux (only dependency: Docker Desktop). Adds portfolio tracking, automated daily briefings, cron-based watchlist scheduling, outcome tracking at +7/14/30/90 days, and multi-user support — no Python setup required for end users.
+[**AgentFloor**](https://github.com/saketnayak/trading-command-center) — A self-hosted web UI for TradingAgents. One-command Docker install on Windows, macOS, and Linux (only dependency: Docker). Adds portfolio tracking, automated daily briefings, cron-based watchlist scheduling, outcome tracking at +7/14/30/90 days, and multi-user support — no Python setup required for end users.
 
-![AgentFloor demo](https://raw.githubusercontent.com/saketnayak/trading-command-center/main/docs/demo.gif)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/saketnayak/trading-command-center/main/docs/demo.gif" alt="AgentFloor demo" style="width: 100%; height: auto;">
+</p>
 
 ## Contributing
 


### PR DESCRIPTION
Hi! I've built **AgentFloor**, a self-hosted web UI for TradingAgents, and wanted to propose adding it to the README so users who find TradingAgents can discover it.

**Repo:** https://github.com/saketnayak/trading-command-center

**What it adds on top of the Python framework:**
- Full web UI (Next.js 14 + FastAPI)
- One-command Docker install — Windows, macOS, Linux (only dependency: Docker Desktop)
- Portfolio tracker with live prices, AI morning briefings, earnings calendar, news feed
- Multi-user with invite-based registration; each user's API keys stored encrypted
- APScheduler-based watchlist scheduling — runs without the browser open
- Outcome tracking at +7/14/30/90 days
- Export to PDF, Markdown, JSON

Works with OpenAI, Anthropic, Gemini, Groq, DeepSeek, Ollama (fully local), vLLM, and more.

I also opened #815 (a small `.gitignore` fix) as a separate contribution.

Happy to adjust the wording or placement — just let me know what works best for your README structure.