### PR TITLE
feat(etf): improve ETF analysis with holdings, drill-down, and risk guidance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,11 +39,15 @@ def _dummy_api_keys(monkeypatch):
 def _reset_etf_quote_cache():
     """ETF detection caches yfinance quoteType in an LRU. Clear between tests
     so a mock from one test cannot bleed into another that exercises the same
-    ticker with a different quote type."""
+    ticker with a different quote type. Also clears the Alpha Vantage
+    ETF_PROFILE LRU for the same isolation reason."""
     from tradingagents.dataflows.etf_utils import clear_etf_cache
+    from tradingagents.dataflows.alpha_vantage_etf import clear_etf_profile_cache
     clear_etf_cache()
+    clear_etf_profile_cache()
     yield
     clear_etf_cache()
+    clear_etf_profile_cache()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,17 @@ def _dummy_api_keys(monkeypatch):
         monkeypatch.setenv(env_var, os.environ.get(env_var, "placeholder"))
 
 
+@pytest.fixture(autouse=True)
+def _reset_etf_quote_cache():
+    """ETF detection caches yfinance quoteType in an LRU. Clear between tests
+    so a mock from one test cannot bleed into another that exercises the same
+    ticker with a different quote type."""
+    from tradingagents.dataflows.etf_utils import clear_etf_cache
+    clear_etf_cache()
+    yield
+    clear_etf_cache()
+
+
 @pytest.fixture()
 def mock_llm_client():
     client = MagicMock()

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -623,3 +623,259 @@ class FundamentalsAnalystEtfToolsWiringTests(unittest.TestCase):
         registered = {t.name for t in nodes["fundamentals"].tools_by_name.values()}
         self.assertIn("get_etf_profile", registered)
         self.assertIn("get_etf_holdings", registered)
+        self.assertIn("get_etf_top_holdings_drilldown", registered)
+
+
+# ---------------------------------------------------------------------------
+# Top-holdings extractors — structured (vendor → list of tuples)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class YfinanceTopHoldingTickersTests(unittest.TestCase):
+    def _ticker_with_top_holdings(self, df):
+        m = MagicMock()
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        m.funds_data = funds_data
+        return m
+
+    def test_returns_normalized_tuples_with_percent_weights(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        df = pd.DataFrame(
+            {"Name": ["Apple Inc.", "Microsoft Corp."], "Holding Percent": [0.072, 0.065]},
+            index=["AAPL", "MSFT"],
+        )
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._ticker_with_top_holdings(df),
+        ):
+            out = yfinance_etf.get_top_holding_tickers("SPY", top_n=2)
+        self.assertEqual(out[0][0], "AAPL")
+        self.assertEqual(out[0][1], "Apple Inc.")
+        # 0.072 decimal must be converted to 7.2 percent for downstream display.
+        self.assertAlmostEqual(out[0][2], 7.2, places=2)
+        self.assertEqual(out[1][0], "MSFT")
+
+    def test_normalizes_bare_hk_codes_to_dot_hk(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        df = pd.DataFrame(
+            {"Name": ["Alibaba", "Tencent"], "Holding Percent": [0.10, 0.09]},
+            index=["09988", "00700"],
+        )
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._ticker_with_top_holdings(df),
+        ):
+            out = yfinance_etf.get_top_holding_tickers("2800.HK", top_n=2)
+        # 5-digit numeric → ".HK" suffix appended
+        self.assertEqual(out[0][0], "09988.HK")
+        self.assertEqual(out[1][0], "00700.HK")
+
+    def test_returns_empty_when_funds_data_missing(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        m = MagicMock()
+        m.funds_data = None
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=m):
+            out = yfinance_etf.get_top_holding_tickers("WEIRD", top_n=3)
+        self.assertEqual(out, [])
+
+    def test_handles_yfinance_already_percent_weight(self):
+        """yfinance is inconsistent: usually returns decimal but sometimes
+        the value is already in percent form (e.g. 7.2). The 1.5 threshold
+        treats >=1.5 as already-percent."""
+        from tradingagents.dataflows import yfinance_etf
+
+        df = pd.DataFrame(
+            {"Name": ["X Co"], "Holding Percent": [7.2]},
+            index=["XYZ"],
+        )
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._ticker_with_top_holdings(df),
+        ):
+            out = yfinance_etf.get_top_holding_tickers("SOMEONE", top_n=1)
+        self.assertAlmostEqual(out[0][2], 7.2, places=2)  # not 720
+
+
+@pytest.mark.unit
+class AlphaVantageTopHoldingTickersTests(unittest.TestCase):
+    _SAMPLE = {
+        "symbol": "QQQ",
+        "holdings": [
+            {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.092"},
+            {"symbol": "MSFT", "description": "Microsoft Corp", "weight": "0.085"},
+            {"symbol": "NVDA", "description": "Nvidia Corp", "weight": "0.064"},
+        ],
+    }
+
+    def test_returns_top_n_tuples_with_percent_weights(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(alpha_vantage_etf, "_make_api_request", return_value=self._SAMPLE):
+            out = alpha_vantage_etf.get_top_holding_tickers("QQQ", top_n=2)
+        self.assertEqual([t[0] for t in out], ["AAPL", "MSFT"])
+        self.assertAlmostEqual(out[0][2], 9.2, places=2)  # 0.092 → 9.2%
+        self.assertAlmostEqual(out[1][2], 8.5, places=2)
+
+    def test_returns_empty_on_missing_holdings(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(alpha_vantage_etf, "_make_api_request", return_value={"symbol": "X"}):
+            out = alpha_vantage_etf.get_top_holding_tickers("X", top_n=3)
+        self.assertEqual(out, [])
+
+
+# ---------------------------------------------------------------------------
+# Drill-down orchestration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class EtfDrilldownTests(unittest.TestCase):
+    def _patch_etf_yes(self):
+        return patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        )
+
+    def test_non_etf_ticker_returns_redirect_message(self):
+        """Drill-down should refuse non-ETF tickers without paying the
+        constituent API calls."""
+        from tradingagents.dataflows import etf_drilldown
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="EQUITY",
+        ):
+            out = etf_drilldown.get_etf_top_holdings_drilldown(
+                "AAPL", "2025-01-01", "2025-01-31"
+            )
+        self.assertIn("regular stock", out)
+        self.assertIn("get_fundamentals", out)
+
+    def test_renders_one_section_per_constituent(self):
+        from tradingagents.dataflows import etf_drilldown, interface
+
+        def fake_route(method, *args, **kwargs):
+            if method == "get_top_holding_tickers":
+                return [
+                    ("AAPL", "Apple Inc.", 7.2),
+                    ("MSFT", "Microsoft Corp.", 6.5),
+                ]
+            if method == "get_fundamentals":
+                return f"FUNDAMENTALS_FOR_{args[0]}"
+            if method == "get_news":
+                return f"NEWS_FOR_{args[0]}"
+            raise AssertionError(f"unexpected method {method}")
+
+        with self._patch_etf_yes(), \
+             patch.object(interface, "route_to_vendor", side_effect=fake_route):
+            out = etf_drilldown.get_etf_top_holdings_drilldown(
+                "SPY", "2025-01-01", "2025-01-31", top_n=2
+            )
+        self.assertIn("Top-2 holdings drill-down for ETF SPY", out)
+        self.assertIn("## Apple Inc. (AAPL) — weight: 7.20%", out)
+        self.assertIn("FUNDAMENTALS_FOR_AAPL", out)
+        self.assertIn("NEWS_FOR_AAPL", out)
+        self.assertIn("## Microsoft Corp. (MSFT) — weight: 6.50%", out)
+        self.assertIn("FUNDAMENTALS_FOR_MSFT", out)
+        self.assertIn("\n\n---\n\n", out)  # blocks separated by horizontal rule
+
+    def test_empty_holdings_returns_friendly_message(self):
+        from tradingagents.dataflows import etf_drilldown, interface
+
+        with self._patch_etf_yes(), \
+             patch.object(interface, "route_to_vendor", return_value=[]):
+            out = etf_drilldown.get_etf_top_holdings_drilldown(
+                "WEIRD", "2025-01-01", "2025-01-31"
+            )
+        self.assertIn("No top holdings could be resolved", out)
+
+    def test_per_constituent_exception_does_not_kill_report(self):
+        """If one constituent's fundamentals call blows up, the rest of
+        the report must still render — surface the failure inline."""
+        from tradingagents.dataflows import etf_drilldown, interface
+
+        def fake_route(method, *args, **kwargs):
+            if method == "get_top_holding_tickers":
+                return [
+                    ("BAD", "Bad Co", 5.0),
+                    ("GOOD", "Good Co", 3.0),
+                ]
+            if method == "get_fundamentals" and args[0] == "BAD":
+                raise RuntimeError("API exploded")
+            if method == "get_fundamentals":
+                return f"FUNDAMENTALS_FOR_{args[0]}"
+            if method == "get_news":
+                return f"NEWS_FOR_{args[0]}"
+
+        with self._patch_etf_yes(), \
+             patch.object(interface, "route_to_vendor", side_effect=fake_route):
+            out = etf_drilldown.get_etf_top_holdings_drilldown(
+                "SPY", "2025-01-01", "2025-01-31", top_n=2
+            )
+        self.assertIn("BAD", out)
+        self.assertIn("API exploded", out)
+        self.assertIn("FUNDAMENTALS_FOR_GOOD", out)
+        self.assertIn("NEWS_FOR_GOOD", out)
+
+    def test_truncates_long_fundamentals_and_news_blocks(self):
+        """Each constituent section caps fundamentals at 1500 and news at
+        1200 chars to keep the LLM's context window manageable."""
+        from tradingagents.dataflows import etf_drilldown, interface
+
+        big_fund = "F" * 5000
+        big_news = "N" * 5000
+
+        def fake_route(method, *args, **kwargs):
+            if method == "get_top_holding_tickers":
+                return [("AAPL", "Apple Inc.", 7.2)]
+            if method == "get_fundamentals":
+                return big_fund
+            if method == "get_news":
+                return big_news
+
+        with self._patch_etf_yes(), \
+             patch.object(interface, "route_to_vendor", side_effect=fake_route):
+            out = etf_drilldown.get_etf_top_holdings_drilldown(
+                "SPY", "2025-01-01", "2025-01-31", top_n=1
+            )
+        self.assertIn("…(truncated, full length 5000)", out)
+        self.assertNotIn(big_fund, out)
+        self.assertNotIn(big_news, out)
+
+
+# ---------------------------------------------------------------------------
+# Drill-down routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TopHoldingTickersRoutingTests(unittest.TestCase):
+    def test_routes_to_yfinance_by_default(self):
+        from tradingagents.dataflows import interface
+
+        sentinel = [("AAPL", "Apple", 7.2)]
+        with patch.dict(
+            interface.VENDOR_METHODS["get_top_holding_tickers"],
+            {"yfinance": MagicMock(return_value=sentinel)},
+        ):
+            out = interface.route_to_vendor("get_top_holding_tickers", "SPY", 3)
+        self.assertEqual(out, sentinel)
+
+    def test_routes_to_alpha_vantage_when_configured(self):
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows.config import get_config, set_config
+
+        cfg = get_config()
+        cfg["data_vendors"]["etf_data"] = "alpha_vantage"
+        set_config(cfg)
+
+        sentinel = [("AAPL", "Apple", 9.2)]
+        with patch.dict(
+            interface.VENDOR_METHODS["get_top_holding_tickers"],
+            {"alpha_vantage": MagicMock(return_value=sentinel)},
+        ):
+            out = interface.route_to_vendor("get_top_holding_tickers", "QQQ", 3)
+        self.assertEqual(out, sentinel)

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -1056,3 +1056,225 @@ class RiskDebatorsInjectEtfBlockTests(unittest.TestCase):
 
         prompt = self._run(create_aggressive_debator, "AAPL", is_etf=False)
         self.assertNotIn("ETF-specific risk dimensions", prompt)
+# ---------------------------------------------------------------------------
+# Leveraged / inverse ETF detection + structural warning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class LeverageDescriptorTests(unittest.TestCase):
+    """``leverage_descriptor`` returns one of ``""``, ``"Leveraged"``,
+    ``"Inverse"``, ``"Leveraged Inverse"`` based on yfinance category."""
+
+    def _patch(self, quote_type: str, category: str):
+        # Patch both LRU-cached helpers so the descriptor short-circuit and
+        # the actual category lookup are deterministic.
+        return patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: quote_type,
+            _yfinance_etf_category=lambda t: category,
+        )
+
+    def test_leveraged_equity_returns_leveraged(self):
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Trading--Leveraged Equity"):
+            self.assertEqual(leverage_descriptor("TQQQ"), "Leveraged")
+
+    def test_inverse_equity_returns_inverse(self):
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Trading--Inverse Equity"):
+            self.assertEqual(leverage_descriptor("PSQ"), "Inverse")
+
+    def test_leveraged_inverse_combo(self):
+        """SQQQ / SDS / SPXS are Leveraged Inverse — yfinance encodes this
+        as ``Trading--Leveraged Inverse Equity``."""
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Trading--Leveraged Inverse Equity"):
+            self.assertEqual(
+                leverage_descriptor("SQQQ"), "Leveraged Inverse"
+            )
+
+    def test_leveraged_commodities_works(self):
+        """The ``Trading--`` prefix isn't equity-only; gold leverage products
+        (UGL, AGQ) carry the same convention."""
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Trading--Leveraged Commodities"):
+            self.assertEqual(leverage_descriptor("UGL"), "Leveraged")
+
+    def test_ordinary_etf_returns_empty(self):
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Large Blend"):
+            self.assertEqual(leverage_descriptor("SPY"), "")
+
+    def test_long_term_bond_does_not_false_positive(self):
+        """Category strings without the ``Trading--`` prefix must NOT trip
+        the detection — "Long-Term Bond" contains neither keyword but we
+        also need to confirm "Trading--" gating."""
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("ETF", "Long-Term Bond"):
+            self.assertEqual(leverage_descriptor("TLT"), "")
+
+    def test_non_etf_returns_empty(self):
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        with self._patch("EQUITY", "Software"):
+            self.assertEqual(leverage_descriptor("AAPL"), "")
+
+    def test_non_string_inputs(self):
+        from tradingagents.dataflows.etf_utils import leverage_descriptor
+
+        for value in (None, 123, "", "   "):
+            self.assertEqual(leverage_descriptor(value), "")
+
+
+@pytest.mark.unit
+class BuildInstrumentContextLeverageWarningTests(unittest.TestCase):
+    def _patch_leveraged(self):
+        return patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "ETF",
+            _yfinance_etf_category=lambda t: "Trading--Leveraged Equity",
+        )
+
+    def _patch_ordinary_etf(self):
+        return patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "ETF",
+            _yfinance_etf_category=lambda t: "Large Blend",
+        )
+
+    def test_leveraged_etf_gets_structural_warning(self):
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        with self._patch_leveraged():
+            ctx = build_instrument_context("TQQQ")
+        self.assertIn("STRUCTURAL WARNING — Leveraged ETF", ctx)
+        self.assertIn("daily reset", ctx)
+        self.assertIn("INAPPROPRIATE", ctx)
+
+    def test_ordinary_etf_does_NOT_get_structural_warning(self):
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        with self._patch_ordinary_etf():
+            ctx = build_instrument_context("SPY")
+        self.assertNotIn("STRUCTURAL WARNING", ctx)
+
+    def test_stock_does_NOT_get_structural_warning(self):
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        with patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "EQUITY",
+            _yfinance_etf_category=lambda t: "Software",
+        ):
+            ctx = build_instrument_context("AAPL")
+        self.assertNotIn("STRUCTURAL WARNING", ctx)
+
+
+@pytest.mark.unit
+class BuildEtfRiskBlockLeverageWarningTests(unittest.TestCase):
+    def test_leveraged_etf_warning_at_top_of_risk_block(self):
+        """The structural warning must lead the risk block so debators
+        can't miss it scrolling past the six general axes."""
+        from tradingagents.agents.utils.agent_utils import build_etf_risk_block
+
+        with patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "ETF",
+            _yfinance_etf_category=lambda t: "Trading--Leveraged Inverse Equity",
+        ):
+            block = build_etf_risk_block("SQQQ")
+        # Warning appears, and appears before the general axes header
+        self.assertIn("STRUCTURAL WARNING — Leveraged Inverse ETF", block)
+        warning_pos = block.find("STRUCTURAL WARNING")
+        axes_pos = block.find("ETF-specific risk dimensions")
+        self.assertLess(warning_pos, axes_pos)
+
+    def test_ordinary_etf_risk_block_has_no_structural_warning(self):
+        from tradingagents.agents.utils.agent_utils import build_etf_risk_block
+
+        with patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "ETF",
+            _yfinance_etf_category=lambda t: "Large Blend",
+        ):
+            block = build_etf_risk_block("SPY")
+        self.assertNotIn("STRUCTURAL WARNING", block)
+        # The general ETF axes block must still be present
+        self.assertIn("ETF-specific risk dimensions", block)
+
+
+@pytest.mark.unit
+class RiskDebatorsSurfaceLeverageWarningTests(unittest.TestCase):
+    """Each of the three debators must propagate the structural warning to
+    its LLM prompt when handed a leveraged ETF ticker."""
+
+    def _state(self, ticker: str) -> dict:
+        return {
+            "risk_debate_state": {"history": "", "count": 0},
+            "market_report": "M",
+            "sentiment_report": "S",
+            "news_report": "N",
+            "fundamentals_report": "F",
+            "trader_investment_plan": "PLAN",
+            "company_of_interest": ticker,
+        }
+
+    def _run(self, factory, ticker: str):
+        llm = MagicMock()
+        llm.invoke.return_value = MagicMock(content="reply")
+        node = factory(llm)
+        with patch.multiple(
+            "tradingagents.dataflows.etf_utils",
+            _yfinance_quote_type=lambda t: "ETF",
+            _yfinance_etf_category=lambda t: "Trading--Leveraged Equity",
+        ):
+            node(self._state(ticker))
+        return llm.invoke.call_args[0][0]
+
+    def test_aggressive_sees_leverage_warning(self):
+        from tradingagents.agents.risk_mgmt.aggressive_debator import (
+            create_aggressive_debator,
+        )
+
+        prompt = self._run(create_aggressive_debator, "TQQQ")
+        self.assertIn("STRUCTURAL WARNING — Leveraged ETF", prompt)
+
+    def test_conservative_sees_leverage_warning(self):
+        from tradingagents.agents.risk_mgmt.conservative_debator import (
+            create_conservative_debator,
+        )
+
+        prompt = self._run(create_conservative_debator, "TQQQ")
+        self.assertIn("STRUCTURAL WARNING — Leveraged ETF", prompt)
+
+    def test_neutral_sees_leverage_warning(self):
+        from tradingagents.agents.risk_mgmt.neutral_debator import (
+            create_neutral_debator,
+        )
+
+        prompt = self._run(create_neutral_debator, "TQQQ")
+        self.assertIn("STRUCTURAL WARNING — Leveraged ETF", prompt)
+
+
+@pytest.mark.unit
+class ClearEtfCacheClearsBothCachesTests(unittest.TestCase):
+    """``clear_etf_cache`` must reset the new category cache too, otherwise
+    test isolation breaks for the leverage detection path."""
+
+    def test_clears_category_cache(self):
+        from tradingagents.dataflows import etf_utils
+
+        # Prime the category cache with a stub
+        with patch("yfinance.Ticker") as yt:
+            yt.return_value.info = {"category": "Large Blend"}
+            etf_utils._yfinance_etf_category("CACHED")
+        # Confirm cache is populated
+        self.assertGreater(etf_utils._yfinance_etf_category.cache_info().currsize, 0)
+        etf_utils.clear_etf_cache()
+        self.assertEqual(etf_utils._yfinance_etf_category.cache_info().currsize, 0)

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -879,3 +879,180 @@ class TopHoldingTickersRoutingTests(unittest.TestCase):
         ):
             out = interface.route_to_vendor("get_top_holding_tickers", "QQQ", 3)
         self.assertEqual(out, sentinel)
+
+
+# ---------------------------------------------------------------------------
+# Concentration metrics (etf_utils.concentration_summary)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class ConcentrationSummaryTests(unittest.TestCase):
+    def test_basic_render_includes_all_three_metrics(self):
+        from tradingagents.dataflows.etf_utils import concentration_summary
+
+        # 3 holdings at 6%, 4%, 2% → largest 6.00%, sum 12.00%,
+        # Herfindahl = 0.06² + 0.04² + 0.02² = 0.0036 + 0.0016 + 0.0004 = 0.0056
+        out = concentration_summary([6.0, 4.0, 2.0])
+        self.assertIn("Largest single holding: 6.00%", out)
+        self.assertIn("Top-3 aggregate weight: 12.00%", out)
+        self.assertIn("Herfindahl index (top-3): 0.0056", out)
+
+    def test_empty_input_returns_empty_string(self):
+        from tradingagents.dataflows.etf_utils import concentration_summary
+
+        self.assertEqual(concentration_summary([]), "")
+
+    def test_filters_invalid_and_zero_weights(self):
+        """NaN / None / 0 / negative weights should be silently dropped so a
+        partial-data ETF still renders the metrics from the valid rows."""
+        from tradingagents.dataflows.etf_utils import concentration_summary
+
+        out = concentration_summary([5.0, None, 3.0, 0, -1, "garbage"])
+        # Only 5.0 and 3.0 survive
+        self.assertIn("Top-2 aggregate weight: 8.00%", out)
+        self.assertIn("Largest single holding: 5.00%", out)
+
+    def test_high_concentration_thematic_etf(self):
+        """A concentrated thematic ETF (top-1 = 25%) shows it in the metric."""
+        from tradingagents.dataflows.etf_utils import concentration_summary
+
+        out = concentration_summary([25.0, 10.0, 5.0])
+        self.assertIn("Largest single holding: 25.00%", out)
+        # 0.25² + 0.1² + 0.05² = 0.0625 + 0.01 + 0.0025 = 0.075
+        self.assertIn("0.0750", out)
+
+
+@pytest.mark.unit
+class HoldingsRendererIncludesConcentrationTests(unittest.TestCase):
+    """End-to-end: get_etf_holdings must surface the concentration block."""
+
+    def test_yfinance_holdings_includes_concentration(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        df = pd.DataFrame(
+            {"Name": ["Apple", "Microsoft", "Nvidia"], "Holding Percent": [0.06, 0.05, 0.04]},
+            index=["AAPL", "MSFT", "NVDA"],
+        )
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        ticker_obj = MagicMock(funds_data=funds_data)
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=ticker_obj):
+            out = yfinance_etf.get_etf_holdings("SPY", top_n=3)
+        self.assertIn("Concentration metrics", out)
+        self.assertIn("Largest single holding: 6.00%", out)
+        self.assertIn("Top-3 aggregate weight: 15.00%", out)
+
+    def test_alpha_vantage_holdings_includes_concentration(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        payload = {
+            "holdings": [
+                {"symbol": "AAPL", "description": "Apple", "weight": "0.092"},
+                {"symbol": "MSFT", "description": "Microsoft", "weight": "0.085"},
+            ]
+        }
+        with patch.object(alpha_vantage_etf, "_make_api_request", return_value=payload):
+            out = alpha_vantage_etf.get_etf_holdings("QQQ", top_n=2)
+        self.assertIn("Concentration metrics", out)
+        self.assertIn("Largest single holding: 9.20%", out)
+        self.assertIn("Top-2 aggregate weight: 17.70%", out)
+
+
+# ---------------------------------------------------------------------------
+# ETF risk-debate dimension (build_etf_risk_block + 3 debators)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class BuildEtfRiskBlockTests(unittest.TestCase):
+    def test_returns_block_for_etf_ticker(self):
+        from tradingagents.agents.utils.agent_utils import build_etf_risk_block
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        ):
+            block = build_etf_risk_block("SPY")
+        # Spot-check the axes that matter for each debator role.
+        self.assertIn("ETF-specific risk dimensions", block)
+        self.assertIn("Liquidity", block)        # conservative
+        self.assertIn("Concentration", block)    # neutral
+        self.assertIn("Structure risk", block)   # aggressive (leveraged)
+        self.assertIn("Premium/discount to NAV", block)
+
+    def test_returns_empty_for_stock_ticker(self):
+        from tradingagents.agents.utils.agent_utils import build_etf_risk_block
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="EQUITY",
+        ):
+            self.assertEqual(build_etf_risk_block("AAPL"), "")
+
+    def test_returns_empty_for_empty_input(self):
+        from tradingagents.agents.utils.agent_utils import build_etf_risk_block
+
+        # Empty / non-string input must short-circuit to "" so debators
+        # never inject a stale ETF block when state["company_of_interest"]
+        # is missing.
+        self.assertEqual(build_etf_risk_block(""), "")
+        self.assertEqual(build_etf_risk_block(None), "")
+
+
+@pytest.mark.unit
+class RiskDebatorsInjectEtfBlockTests(unittest.TestCase):
+    """Each of the 3 debators must inject the ETF block into the prompt
+    sent to the LLM. We mock the LLM and inspect the call-args to confirm."""
+
+    def _state(self, ticker: str) -> dict:
+        return {
+            "risk_debate_state": {"history": "", "count": 0},
+            "market_report": "M",
+            "sentiment_report": "S",
+            "news_report": "N",
+            "fundamentals_report": "F",
+            "trader_investment_plan": "PLAN",
+            "company_of_interest": ticker,
+        }
+
+    def _run(self, factory, ticker: str, is_etf: bool):
+        llm = MagicMock()
+        llm.invoke.return_value = MagicMock(content="reply")
+        node = factory(llm)
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF" if is_etf else "EQUITY",
+        ):
+            node(self._state(ticker))
+        return llm.invoke.call_args[0][0]
+
+    def test_aggressive_debator_includes_etf_block_for_etf(self):
+        from tradingagents.agents.risk_mgmt.aggressive_debator import (
+            create_aggressive_debator,
+        )
+
+        prompt = self._run(create_aggressive_debator, "SPY", is_etf=True)
+        self.assertIn("ETF-specific risk dimensions", prompt)
+
+    def test_conservative_debator_includes_etf_block_for_etf(self):
+        from tradingagents.agents.risk_mgmt.conservative_debator import (
+            create_conservative_debator,
+        )
+
+        prompt = self._run(create_conservative_debator, "SPY", is_etf=True)
+        self.assertIn("ETF-specific risk dimensions", prompt)
+
+    def test_neutral_debator_includes_etf_block_for_etf(self):
+        from tradingagents.agents.risk_mgmt.neutral_debator import (
+            create_neutral_debator,
+        )
+
+        prompt = self._run(create_neutral_debator, "SPY", is_etf=True)
+        self.assertIn("ETF-specific risk dimensions", prompt)
+
+    def test_debators_omit_etf_block_for_stock(self):
+        from tradingagents.agents.risk_mgmt.aggressive_debator import (
+            create_aggressive_debator,
+        )
+
+        prompt = self._run(create_aggressive_debator, "AAPL", is_etf=False)
+        self.assertNotIn("ETF-specific risk dimensions", prompt)

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -1,0 +1,551 @@
+"""Unit tests for yfinance-backed ETF support.
+
+Covers ETF detection, the yfinance ETF vendor functions, routing through
+``interface.py``, the ``@etf_placeholder`` decorator behavior on
+company-financial tools, ETF-aware ``build_instrument_context``, and a
+smoke check confirming news tools do NOT route through ETF detection.
+
+All network calls (yfinance) are mocked.
+"""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_dataflows_config():
+    """Reset dataflows config to defaults so each test sees predictable routing."""
+    import copy
+    import tradingagents.default_config as default_config
+    from tradingagents.dataflows.config import set_config
+    set_config(copy.deepcopy(default_config.DEFAULT_CONFIG))
+
+
+# ---------------------------------------------------------------------------
+# ETF detection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class IsEtfTickerTests(unittest.TestCase):
+    def test_us_etf_via_yfinance_quote_type(self):
+        from tradingagents.dataflows.etf_utils import is_etf_ticker
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        ):
+            self.assertTrue(is_etf_ticker("SPY"))
+
+    def test_us_stock_via_yfinance_quote_type(self):
+        from tradingagents.dataflows.etf_utils import is_etf_ticker
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="EQUITY",
+        ):
+            self.assertFalse(is_etf_ticker("AAPL"))
+
+    def test_hk_etf_via_yfinance_quote_type(self):
+        from tradingagents.dataflows.etf_utils import is_etf_ticker
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        ):
+            self.assertTrue(is_etf_ticker("2800.HK"))
+
+    def test_non_string_inputs(self):
+        from tradingagents.dataflows.etf_utils import is_etf_ticker
+
+        for bad in (None, 0, 123, [], {}, b"SPY"):
+            self.assertFalse(is_etf_ticker(bad))
+
+    def test_empty_string(self):
+        from tradingagents.dataflows.etf_utils import is_etf_ticker
+
+        self.assertFalse(is_etf_ticker(""))
+        self.assertFalse(is_etf_ticker("   "))
+
+    def test_quote_type_lookup_cached(self):
+        """The lru_cache must prevent repeated yfinance ``.info`` calls."""
+        from tradingagents.dataflows.etf_utils import _yfinance_quote_type
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"quoteType": "ETF"}
+        with patch("yfinance.Ticker", return_value=mock_ticker) as yt:
+            _yfinance_quote_type("SPY")
+            _yfinance_quote_type("SPY")
+            _yfinance_quote_type("SPY")
+        self.assertEqual(yt.call_count, 1)
+
+    def test_quote_type_returns_none_on_network_error(self):
+        from tradingagents.dataflows.etf_utils import _yfinance_quote_type
+
+        with patch("yfinance.Ticker", side_effect=RuntimeError("network down")):
+            self.assertIsNone(_yfinance_quote_type("WEIRD-TICKER-9999"))
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class EtfRoutingTests(unittest.TestCase):
+    def test_get_etf_profile_routes_to_yfinance(self):
+        from tradingagents.dataflows import interface
+
+        sentinel = "YFIN_ETF_PROFILE_RESULT"
+        with patch.dict(
+            interface.VENDOR_METHODS["get_etf_profile"],
+            {"yfinance": MagicMock(return_value=sentinel)},
+        ):
+            result = interface.route_to_vendor("get_etf_profile", "SPY")
+        self.assertEqual(result, sentinel)
+
+    def test_get_etf_holdings_routes_to_yfinance(self):
+        from tradingagents.dataflows import interface
+
+        sentinel = "YFIN_ETF_HOLDINGS_RESULT"
+        with patch.dict(
+            interface.VENDOR_METHODS["get_etf_holdings"],
+            {"yfinance": MagicMock(return_value=sentinel)},
+        ):
+            result = interface.route_to_vendor("get_etf_holdings", "SPY", 5)
+        self.assertEqual(result, sentinel)
+
+    def test_route_falls_back_when_etf_data_key_missing_from_config(self):
+        """Old user configs predate the etf_data category; route must still work."""
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows import config as df_config
+
+        # Simulate a legacy config that has no etf_data key. Bypass set_config
+        # because it merges-in rather than replaces, so we install the legacy
+        # mapping directly into the module-level _config.
+        legacy = copy.deepcopy(df_config._config)
+        legacy["data_vendors"].pop("etf_data", None)
+        df_config._config = legacy
+
+        sentinel = "FALLBACK_OK"
+        with patch.dict(
+            interface.VENDOR_METHODS["get_etf_profile"],
+            {"yfinance": MagicMock(return_value=sentinel)},
+        ):
+            # get_vendor returns "default" → not in VENDOR_METHODS → loop
+            # then tries each registered vendor; yfinance hits.
+            result = interface.route_to_vendor("get_etf_profile", "SPY")
+        self.assertEqual(result, sentinel)
+
+    def test_route_falls_back_when_configured_vendor_has_no_impl(self):
+        """If the configured vendor is unregistered for this method, the
+        fallback chain must keep trying other registered vendors."""
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows.config import set_config, get_config
+
+        cfg = get_config()
+        cfg["data_vendors"]["etf_data"] = "phantom_vendor_with_no_impl"
+        set_config(cfg)
+
+        sentinel = "FALLBACK_TO_YFIN"
+        # Replace the whole impls dict so only yfinance is registered for
+        # this method during the test.
+        original = interface.VENDOR_METHODS["get_etf_profile"]
+        interface.VENDOR_METHODS["get_etf_profile"] = {
+            "yfinance": MagicMock(return_value=sentinel)
+        }
+        try:
+            result = interface.route_to_vendor("get_etf_profile", "SPY")
+        finally:
+            interface.VENDOR_METHODS["get_etf_profile"] = original
+        self.assertEqual(result, sentinel)
+
+
+# ---------------------------------------------------------------------------
+# yfinance ETF vendor rendering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class YfinanceEtfVendorTests(unittest.TestCase):
+    def _make_ticker_mock(self, info=None, funds_data=None):
+        """Build a yfinance.Ticker mock with explicit ``info`` and ``funds_data``.
+
+        Pass ``funds_data=None`` to simulate the common "no funds_data
+        available" case (HK ETFs, new listings) — both vendor functions
+        treat None as "skip / no holdings disclosed".
+        """
+        m = MagicMock()
+        m.info = info or {}
+        m.funds_data = funds_data
+        return m
+
+    def test_profile_renders_key_info_fields(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        info = {
+            "longName": "SPDR S&P 500 ETF Trust",
+            "quoteType": "ETF",
+            "category": "Large Blend",
+            "fundFamily": "SPDR State Street Global Advisors",
+            "totalAssets": 600_000_000_000,
+            "navPrice": 580.12,
+            "annualReportExpenseRatio": 0.0009,
+            "yield": 0.013,
+        }
+        funds_data = MagicMock()
+        funds_data.description = "Tracks the S&P 500 index."
+        funds_data.asset_classes = {"stocks": 0.99, "cash": 0.01}
+        funds_data.sector_weightings = {"Technology": 0.30, "Financials": 0.13}
+
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info=info, funds_data=funds_data),
+        ):
+            out = yfinance_etf.get_etf_profile("SPY")
+
+        self.assertIn("SPDR S&P 500 ETF Trust", out)
+        self.assertIn("Total Assets (AUM)", out)
+        self.assertIn("## Strategy", out)
+        self.assertIn("## Asset Class Breakdown", out)
+        self.assertIn("## Sector Weightings", out)
+        self.assertIn("Technology", out)
+
+    def test_profile_degrades_when_funds_data_missing(self):
+        """HK ETFs frequently expose .info but not funds_data — must not raise."""
+        from tradingagents.dataflows import yfinance_etf
+
+        info = {"longName": "Tracker Fund of Hong Kong ETF", "quoteType": "ETF"}
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info=info, funds_data=None),
+        ):
+            out = yfinance_etf.get_etf_profile("2800.HK")
+        self.assertIn("Tracker Fund of Hong Kong ETF", out)
+        self.assertNotIn("## Sector Weightings", out)
+        self.assertNotIn("## Asset Class Breakdown", out)
+
+    def test_profile_degrades_when_sector_weightings_empty(self):
+        """funds_data exists but sector_weightings is empty — render basics, skip section."""
+        from tradingagents.dataflows import yfinance_etf
+
+        info = {"longName": "Some ETF", "quoteType": "ETF"}
+        funds_data = MagicMock()
+        funds_data.description = None
+        funds_data.asset_classes = None
+        funds_data.sector_weightings = {}
+
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info=info, funds_data=funds_data),
+        ):
+            out = yfinance_etf.get_etf_profile("XYZ")
+        self.assertIn("Some ETF", out)
+        self.assertNotIn("## Sector Weightings", out)
+
+    def test_holdings_renders_top_n_with_weights(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        holdings = pd.DataFrame(
+            {
+                "Name": ["Apple Inc.", "Microsoft Corp.", "Nvidia Corp."],
+                "Holding Percent": [0.072, 0.065, 0.061],
+            },
+            index=["AAPL", "MSFT", "NVDA"],
+        )
+        funds_data = MagicMock()
+        funds_data.top_holdings = holdings
+
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info={}, funds_data=funds_data),
+        ):
+            out = yfinance_etf.get_etf_holdings("SPY", top_n=2)
+        self.assertIn("AAPL", out)
+        self.assertIn("MSFT", out)
+        # top_n=2 — NVDA must be filtered out
+        self.assertNotIn("NVDA", out)
+        # Weight column was converted from decimal to percent string.
+        self.assertIn("7.2%", out)
+
+    def test_holdings_degrades_when_funds_data_missing(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info={}, funds_data=None),
+        ):
+            out = yfinance_etf.get_etf_holdings("2800.HK")
+        self.assertIn("No holdings disclosed", out)
+
+    def test_holdings_degrades_when_top_holdings_none(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        funds_data = MagicMock()
+        funds_data.top_holdings = None
+        with patch.object(
+            yfinance_etf.yf, "Ticker",
+            return_value=self._make_ticker_mock(info={}, funds_data=funds_data),
+        ):
+            out = yfinance_etf.get_etf_holdings("SPY")
+        self.assertIn("No holdings disclosed", out)
+
+
+# ---------------------------------------------------------------------------
+# Alpha Vantage ETF vendor rendering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class AlphaVantageEtfVendorTests(unittest.TestCase):
+    """Mock the Alpha Vantage HTTP layer (``_make_api_request``) and verify
+    ``alpha_vantage_etf`` renders the documented ``ETF_PROFILE`` payload."""
+
+    _SAMPLE_PROFILE = {
+        "symbol": "QQQ",
+        "name": "Invesco QQQ Trust Series 1",
+        "net_assets": "350000000000",
+        "net_expense_ratio": "0.002",
+        "portfolio_turnover": "0.06",
+        "dividend_yield": "0.006",
+        "inception_date": "1999-03-10",
+        "leveraged": "NO",
+        "asset_class": "EQUITY",
+        "sectors": [
+            {"sector": "Information Technology", "weight": "0.51"},
+            {"sector": "Communication Services", "weight": "0.16"},
+        ],
+        "holdings": [
+            {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.092"},
+            {"symbol": "MSFT", "description": "Microsoft Corp", "weight": "0.085"},
+            {"symbol": "NVDA", "description": "Nvidia Corp", "weight": "0.064"},
+        ],
+    }
+
+    def test_profile_renders_key_fields(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(
+            alpha_vantage_etf, "_make_api_request",
+            return_value=self._SAMPLE_PROFILE,
+        ):
+            out = alpha_vantage_etf.get_etf_profile("QQQ")
+        self.assertIn("Invesco QQQ Trust", out)
+        self.assertIn("Net Assets (AUM)", out)
+        self.assertIn("Net Expense Ratio", out)
+        self.assertIn("## Sector Weightings", out)
+        self.assertIn("Information Technology", out)
+
+    def test_profile_accepts_json_string_payload(self):
+        """``_make_api_request`` may return raw text — must still parse."""
+        import json
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(
+            alpha_vantage_etf, "_make_api_request",
+            return_value=json.dumps(self._SAMPLE_PROFILE),
+        ):
+            out = alpha_vantage_etf.get_etf_profile("QQQ")
+        self.assertIn("Invesco QQQ Trust", out)
+
+    def test_profile_degrades_on_empty_response(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(alpha_vantage_etf, "_make_api_request", return_value={}):
+            out = alpha_vantage_etf.get_etf_profile("WEIRD")
+        self.assertIn("No ETF profile available", out)
+
+    def test_holdings_renders_top_n(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(
+            alpha_vantage_etf, "_make_api_request",
+            return_value=self._SAMPLE_PROFILE,
+        ):
+            out = alpha_vantage_etf.get_etf_holdings("QQQ", top_n=2)
+        self.assertIn("AAPL", out)
+        self.assertIn("MSFT", out)
+        # top_n=2 means NVDA must be cropped
+        self.assertNotIn("NVDA", out)
+        self.assertIn("Top 2 positions", out)
+
+    def test_holdings_degrades_when_holdings_missing(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        with patch.object(
+            alpha_vantage_etf, "_make_api_request",
+            return_value={"symbol": "XYZ"},  # profile present, holdings missing
+        ):
+            out = alpha_vantage_etf.get_etf_holdings("XYZ")
+        self.assertIn("No holdings disclosed", out)
+
+
+# ---------------------------------------------------------------------------
+# Alpha Vantage ETF routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class AlphaVantageEtfRoutingTests(unittest.TestCase):
+    def test_etf_profile_routes_to_alpha_vantage_when_configured(self):
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows.config import get_config, set_config
+
+        cfg = get_config()
+        cfg["data_vendors"]["etf_data"] = "alpha_vantage"
+        set_config(cfg)
+
+        sentinel = "AV_ETF_PROFILE_RESULT"
+        with patch.dict(
+            interface.VENDOR_METHODS["get_etf_profile"],
+            {"alpha_vantage": MagicMock(return_value=sentinel)},
+        ):
+            result = interface.route_to_vendor("get_etf_profile", "QQQ")
+        self.assertEqual(result, sentinel)
+
+    def test_etf_holdings_routes_to_alpha_vantage_when_configured(self):
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows.config import get_config, set_config
+
+        cfg = get_config()
+        cfg["data_vendors"]["etf_data"] = "alpha_vantage"
+        set_config(cfg)
+
+        sentinel = "AV_ETF_HOLDINGS_RESULT"
+        with patch.dict(
+            interface.VENDOR_METHODS["get_etf_holdings"],
+            {"alpha_vantage": MagicMock(return_value=sentinel)},
+        ):
+            result = interface.route_to_vendor("get_etf_holdings", "QQQ", 5)
+        self.assertEqual(result, sentinel)
+
+
+# ---------------------------------------------------------------------------
+# ETF placeholder applied at the dispatch layer (interface.route_to_vendor)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class EtfPlaceholderViaRoutingTests(unittest.TestCase):
+    """ETF protection lives at the dispatch layer, so it applies uniformly
+    across every registered vendor (yfinance, alpha_vantage, ...). These
+    tests go through ``route_to_vendor`` — the way real callers reach
+    these methods — rather than calling vendor functions directly.
+
+    Direct calls to ``y_finance.get_fundamentals(...)`` intentionally
+    bypass the placeholder; that's the cleaner separation (vendor
+    modules stay vendor-pure)."""
+
+    def _patch_etf(self, is_etf: bool):
+        return patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF" if is_etf else "EQUITY",
+        )
+
+    def test_fundamentals_returns_placeholder_for_etf_via_yfinance(self):
+        from tradingagents.dataflows import interface
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_fundamentals", "SPY", "2025-01-01")
+        self.assertIn("SPY", out)
+        self.assertIn("ETF", out)
+        self.assertIn("get_etf_profile", out)
+        self.assertIn("get_etf_holdings", out)
+
+    def test_balance_sheet_returns_placeholder_for_etf(self):
+        from tradingagents.dataflows import interface
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_balance_sheet", "SPY")
+        self.assertIn("balance sheet", out)
+        self.assertIn("get_etf_profile", out)
+
+    def test_cashflow_returns_placeholder_for_etf(self):
+        from tradingagents.dataflows import interface
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_cashflow", "SPY")
+        self.assertIn("cash flow statement", out)
+
+    def test_income_statement_returns_placeholder_for_etf(self):
+        from tradingagents.dataflows import interface
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_income_statement", "SPY")
+        self.assertIn("income statement", out)
+
+    def test_insider_transactions_returns_placeholder_for_etf(self):
+        from tradingagents.dataflows import interface
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_insider_transactions", "SPY")
+        self.assertIn("insider transactions", out)
+
+    def test_placeholder_also_applies_to_alpha_vantage_vendor(self):
+        """The dispatch-layer decoration must protect every vendor, not just
+        yfinance. Switch the configured vendor to alpha_vantage and confirm
+        an ETF ticker still gets the placeholder — never a malformed
+        Alpha Vantage OVERVIEW response."""
+        from tradingagents.dataflows import interface
+        from tradingagents.dataflows.config import get_config, set_config
+
+        cfg = get_config()
+        cfg["data_vendors"]["fundamental_data"] = "alpha_vantage"
+        set_config(cfg)
+
+        with self._patch_etf(True):
+            out = interface.route_to_vendor("get_fundamentals", "SPY", "2025-01-01")
+        self.assertIn("ETF", out)
+        self.assertIn("get_etf_profile", out)
+
+    def test_stock_ticker_passes_through_to_vendor_impl(self):
+        """Non-ETF ticker must reach the underlying yfinance call."""
+        from tradingagents.dataflows import interface, y_finance
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"longName": "Apple Inc."}
+        with self._patch_etf(False), \
+             patch.object(y_finance.yf, "Ticker", return_value=mock_ticker) as yt:
+            out = interface.route_to_vendor("get_fundamentals", "AAPL", "2025-01-01")
+        yt.assert_called_once()
+        self.assertIn("Apple Inc.", out)
+        self.assertNotIn("get_etf_profile", out)
+
+    def test_direct_vendor_call_bypasses_placeholder(self):
+        """By design: y_finance.get_fundamentals stays a thin yfinance
+        wrapper. Placeholder lives at the dispatch layer, not in vendors."""
+        from tradingagents.dataflows import y_finance
+
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"longName": "Some Fund"}
+        with self._patch_etf(True), \
+             patch.object(y_finance.yf, "Ticker", return_value=mock_ticker):
+            out = y_finance.get_fundamentals("SPY")
+        # Direct call returns yfinance data, not the placeholder.
+        self.assertNotIn("get_etf_profile", out)
+        self.assertIn("Some Fund", out)
+
+
+# ---------------------------------------------------------------------------
+# Smoke check: news tools are unaffected by ETF detection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class EtfDoesNotLeakToNewsTests(unittest.TestCase):
+    """ETF detection only sits on company-financial paths; news must flow
+    through untouched even for ETF tickers."""
+
+    def test_get_news_yfinance_does_not_return_etf_placeholder(self):
+        from tradingagents.dataflows import yfinance_news
+
+        mock_ticker = MagicMock()
+        mock_ticker.get_news.return_value = []  # empty list; call must reach yfinance
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        ), patch.object(yfinance_news.yf, "Ticker", return_value=mock_ticker) as yt:
+            out = yfinance_news.get_news_yfinance("SPY", "2025-01-01", "2025-01-31")
+        yt.assert_called()  # yfinance was reached — no ETF short-circuit
+        # And the result is the regular news path (empty-news message), not
+        # the ETF placeholder.
+        self.assertNotIn("get_etf_profile", out)

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -1263,18 +1263,179 @@ class RiskDebatorsSurfaceLeverageWarningTests(unittest.TestCase):
 
 
 @pytest.mark.unit
-class ClearEtfCacheClearsBothCachesTests(unittest.TestCase):
-    """``clear_etf_cache`` must reset the new category cache too, otherwise
-    test isolation breaks for the leverage detection path."""
+class ClearEtfCacheClearsInfoCacheTests(unittest.TestCase):
+    """``clear_etf_cache`` must reset the consolidated ``_yfinance_info``
+    cache that both ``_yfinance_quote_type`` and ``_yfinance_etf_category``
+    now delegate to. Without this, test isolation breaks for both the
+    detection path and the leverage path."""
 
-    def test_clears_category_cache(self):
+    def test_clears_consolidated_info_cache(self):
         from tradingagents.dataflows import etf_utils
 
-        # Prime the category cache with a stub
+        # Prime the consolidated cache via either delegator — both share
+        # the same underlying ``_yfinance_info`` LRU.
         with patch("yfinance.Ticker") as yt:
-            yt.return_value.info = {"category": "Large Blend"}
+            yt.return_value.info = {"category": "Large Blend", "quoteType": "ETF"}
             etf_utils._yfinance_etf_category("CACHED")
-        # Confirm cache is populated
-        self.assertGreater(etf_utils._yfinance_etf_category.cache_info().currsize, 0)
+        self.assertGreater(etf_utils._yfinance_info.cache_info().currsize, 0)
         etf_utils.clear_etf_cache()
-        self.assertEqual(etf_utils._yfinance_etf_category.cache_info().currsize, 0)
+        self.assertEqual(etf_utils._yfinance_info.cache_info().currsize, 0)
+
+    def test_quote_type_and_category_share_one_network_call(self):
+        """The whole point of consolidation: asking for two fields off the
+        same ticker should hit ``yf.Ticker(...).info`` exactly once."""
+        from tradingagents.dataflows import etf_utils
+
+        etf_utils.clear_etf_cache()
+        with patch("yfinance.Ticker") as yt:
+            yt.return_value.info = {"quoteType": "ETF", "category": "Large Blend"}
+            etf_utils._yfinance_quote_type("SPY")
+            etf_utils._yfinance_etf_category("SPY")
+            etf_utils._yfinance_quote_type("SPY")  # 3rd call, still cached
+        # One yf.Ticker(...) construction, one .info read
+        self.assertEqual(yt.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Vendor parsing robustness — review feedback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class AlphaVantageHoldingsCsvQuotingTests(unittest.TestCase):
+    """Description fields can contain commas (e.g. "Berkshire Hathaway Inc,
+    Class B"). The renderer must produce valid CSV that the LLM downstream
+    can parse, not a row with the wrong number of columns."""
+
+    def test_commas_in_description_are_quoted(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        payload = {
+            "holdings": [
+                {"symbol": "BRK.B", "description": "Berkshire Hathaway Inc, Class B", "weight": "0.05"},
+                {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.07"},
+            ]
+        }
+        with patch.object(alpha_vantage_etf, "_make_api_request", return_value=payload):
+            out = alpha_vantage_etf.get_etf_holdings("XYZ", top_n=2)
+
+        # The CSV reader can round-trip the body and recover 3 columns per row
+        # despite the comma inside the description.
+        import csv, io
+        # Strip the markdown comment header before parsing
+        body = out.split("\n\n", 1)[1] if "\n\n" in out else out
+        # Stop at the concentration block (starts with "## ")
+        if "\n## " in body:
+            body = body.split("\n## ", 1)[0]
+        rows = list(csv.reader(io.StringIO(body)))
+        # Header + 2 holdings, all with exactly 3 columns
+        self.assertGreaterEqual(len(rows), 3)
+        for row in rows[:3]:
+            self.assertEqual(len(row), 3, f"row should have 3 columns, got: {row}")
+        # Description with the comma survived intact
+        self.assertEqual(rows[1][1], "Berkshire Hathaway Inc, Class B")
+
+
+@pytest.mark.unit
+class YfinanceWeightHeuristicTests(unittest.TestCase):
+    """yfinance ships ``Holding Percent`` as either a decimal (0.07) or a
+    percentage (7.0). Both renderer and structured extractor must apply the
+    same threshold heuristic, otherwise the holdings table and the
+    drill-down disagree on weight scaling for the same ETF."""
+
+    def _make_holdings(self, weight_value: float):
+        return pd.DataFrame(
+            {"Name": ["Apple", "Microsoft"], "Holding Percent": [weight_value, weight_value]},
+            index=["AAPL", "MSFT"],
+        )
+
+    def test_get_etf_holdings_treats_high_values_as_percent(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        # 7.5 is already percent; without the heuristic this becomes 750%.
+        df = self._make_holdings(7.5)
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        ticker_obj = MagicMock(funds_data=funds_data)
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=ticker_obj):
+            out = yfinance_etf.get_etf_holdings("SPY", top_n=2)
+        self.assertIn("7.5%", out)
+        self.assertNotIn("750.0%", out)
+        # Concentration metric reflects the same scale
+        self.assertIn("Largest single holding: 7.50%", out)
+
+    def test_get_etf_holdings_treats_low_values_as_decimal(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        df = self._make_holdings(0.075)  # decimal — 7.5%
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        ticker_obj = MagicMock(funds_data=funds_data)
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=ticker_obj):
+            out = yfinance_etf.get_etf_holdings("SPY", top_n=2)
+        self.assertIn("7.5%", out)
+        self.assertIn("Largest single holding: 7.50%", out)
+
+    def test_top_holding_tickers_uses_same_heuristic(self):
+        """Same input → same percent scaling in the structured extractor."""
+        from tradingagents.dataflows import yfinance_etf
+
+        df = self._make_holdings(7.5)  # already percent
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        ticker_obj = MagicMock(funds_data=funds_data)
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=ticker_obj):
+            holdings = yfinance_etf.get_top_holding_tickers("SPY", top_n=2)
+        # All weights should be 7.5%, not 750%
+        for _, _, weight in holdings:
+            self.assertEqual(weight, 7.5)
+
+
+@pytest.mark.unit
+class YfinanceWeightColumnLookupTests(unittest.TestCase):
+    """Both renderer and extractor must locate the weight column by
+    keyword (``weight`` / ``percent``) rather than hardcoded names —
+    yfinance can ship it under variant labels (e.g. ``Weight``)."""
+
+    def test_top_holding_tickers_finds_weight_column_by_keyword(self):
+        from tradingagents.dataflows import yfinance_etf
+
+        # Column is "Weight", not "Holding Percent"
+        df = pd.DataFrame(
+            {"Name": ["Apple"], "Weight": [0.07]},
+            index=["AAPL"],
+        )
+        funds_data = MagicMock()
+        funds_data.top_holdings = df
+        ticker_obj = MagicMock(funds_data=funds_data)
+        with patch.object(yfinance_etf.yf, "Ticker", return_value=ticker_obj):
+            holdings = yfinance_etf.get_top_holding_tickers("SPY", top_n=1)
+        # Weight should be 7.0%, not 0.0% (which is the old hardcoded-fallback bug)
+        self.assertEqual(len(holdings), 1)
+        ticker, name, weight = holdings[0]
+        self.assertEqual(ticker, "AAPL")
+        self.assertAlmostEqual(weight, 7.0, places=6)
+
+
+@pytest.mark.unit
+class AlphaVantageProfileCachingTests(unittest.TestCase):
+    """The three Alpha Vantage entry points must share one API call per
+    ticker. Without the cache, analyzing a single ETF burns three separate
+    Alpha Vantage requests and risks the free-tier daily quota."""
+
+    def test_profile_holdings_and_top_holdings_hit_api_once(self):
+        from tradingagents.dataflows import alpha_vantage_etf
+
+        payload = {
+            "name": "Test ETF",
+            "net_assets": "1000000000",
+            "holdings": [
+                {"symbol": "AAPL", "description": "Apple Inc", "weight": "0.05"},
+            ],
+        }
+        with patch.object(
+            alpha_vantage_etf, "_make_api_request", return_value=payload
+        ) as mock_req:
+            alpha_vantage_etf.get_etf_profile("XYZ")
+            alpha_vantage_etf.get_etf_holdings("XYZ", top_n=1)
+            alpha_vantage_etf.get_top_holding_tickers("XYZ", top_n=1)
+        self.assertEqual(mock_req.call_count, 1)

--- a/tests/test_etf_support.py
+++ b/tests/test_etf_support.py
@@ -549,3 +549,77 @@ class EtfDoesNotLeakToNewsTests(unittest.TestCase):
         # And the result is the regular news path (empty-news message), not
         # the ETF placeholder.
         self.assertNotIn("get_etf_profile", out)
+
+
+# ---------------------------------------------------------------------------
+# ETF-aware build_instrument_context
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class BuildInstrumentContextEtfTests(unittest.TestCase):
+    def test_etf_ticker_gets_etf_block(self):
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="ETF",
+        ):
+            ctx = build_instrument_context("SPY")
+        self.assertIn("ETF", ctx)
+        self.assertIn("get_etf_profile", ctx)
+        self.assertIn("get_etf_holdings", ctx)
+        # Redirects the LLM away from the company-financial tools that would
+        # otherwise return placeholders.
+        self.assertIn("get_fundamentals", ctx)
+
+    def test_stock_ticker_unaffected(self):
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        with patch(
+            "tradingagents.dataflows.etf_utils._yfinance_quote_type",
+            return_value="EQUITY",
+        ):
+            ctx = build_instrument_context("AAPL")
+        self.assertNotIn("ETF", ctx)
+        self.assertNotIn("get_etf_profile", ctx)
+
+    def test_non_string_input_does_not_raise(self):
+        """``state["company_of_interest"]`` should always be a string in
+        practice, but the helper must not crash on a non-string sentinel."""
+        from tradingagents.agents.utils.agent_utils import build_instrument_context
+
+        # Should not raise; the f-string can format None / ints / etc.
+        ctx = build_instrument_context(None)
+        self.assertIn("None", ctx)
+        self.assertNotIn("ETF", ctx)
+
+
+# ---------------------------------------------------------------------------
+# Analyst + ToolNode wiring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class FundamentalsAnalystEtfToolsWiringTests(unittest.TestCase):
+    def test_etf_tools_imported_into_agent_utils_namespace(self):
+        """``from tradingagents.agents.utils.agent_utils import get_etf_profile``
+        must resolve so the analyst and trading_graph can pull them from the
+        same place as the other tools."""
+        from tradingagents.agents.utils import agent_utils
+
+        self.assertTrue(hasattr(agent_utils, "get_etf_profile"))
+        self.assertTrue(hasattr(agent_utils, "get_etf_holdings"))
+
+    def test_trading_graph_fundamentals_toolnode_registers_etf_tools(self):
+        """ToolNode must list every tool the analyst can bind — otherwise the
+        LLM's tool call fails with "not a valid tool" at runtime."""
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        # _create_tool_nodes is an instance method but doesn't depend on
+        # __init__ state; bind it through a lightweight proxy to avoid
+        # construction cost.
+        tg = TradingAgentsGraph.__new__(TradingAgentsGraph)
+        nodes = TradingAgentsGraph._create_tool_nodes(tg)
+
+        registered = {t.name for t in nodes["fundamentals"].tools_by_name.values()}
+        self.assertIn("get_etf_profile", registered)
+        self.assertIn("get_etf_holdings", registered)

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -5,6 +5,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_cashflow,
     get_etf_holdings,
     get_etf_profile,
+    get_etf_top_holdings_drilldown,
     get_fundamentals,
     get_income_statement,
     get_insider_transactions,
@@ -29,13 +30,14 @@ def create_fundamentals_analyst(llm):
             get_income_statement,
             get_etf_profile,
             get_etf_holdings,
+            get_etf_top_holdings_drilldown,
         ]
 
         if is_etf_ticker(ticker):
             system_message = (
                 "You are a researcher tasked with analyzing an ETF over the past week. ETFs are funds, not companies — write a comprehensive report covering the ETF's tracking strategy, top-holding concentration, sector / asset-class breakdown, AUM, expense ratio, and any premium / discount to NAV. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
                 + " Make sure to append a Markdown table at the end of the report to organize key points, organized and easy to read."
-                + " Use the available tools: `get_etf_profile` for the ETF's profile and sector weightings, and `get_etf_holdings` for the top constituents. The company-financial tools (`get_fundamentals`, `get_balance_sheet`, `get_cashflow`, `get_income_statement`) will return ETF-not-applicable placeholders — do not rely on them for ETF tickers."
+                + " Use the available tools: `get_etf_profile` for the ETF's profile and sector weightings, and `get_etf_holdings` for the top constituents. When name-level catalysts matter, call `get_etf_top_holdings_drilldown` to fetch fundamentals + recent news for the top constituents (keep top_n ≤ 5 — each holding costs one fundamentals call plus one news call). The company-financial tools (`get_fundamentals`, `get_balance_sheet`, `get_cashflow`, `get_income_statement`) will return ETF-not-applicable placeholders — do not rely on them for ETF tickers."
                 + get_language_instruction(),
             )
         else:

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -3,10 +3,13 @@ from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_balance_sheet,
     get_cashflow,
+    get_etf_holdings,
+    get_etf_profile,
     get_fundamentals,
     get_income_statement,
     get_insider_transactions,
     get_language_instruction,
+    is_etf_ticker,
 )
 from tradingagents.dataflows.config import get_config
 
@@ -14,21 +17,34 @@ from tradingagents.dataflows.config import get_config
 def create_fundamentals_analyst(llm):
     def fundamentals_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        ticker = state["company_of_interest"]
+        instrument_context = build_instrument_context(ticker)
 
+        # Bind both toolsets; the system_message tells the LLM which to use.
+        # Keeping the bound set fixed avoids per-call ToolNode reconfiguration.
         tools = [
             get_fundamentals,
             get_balance_sheet,
             get_cashflow,
             get_income_statement,
+            get_etf_profile,
+            get_etf_holdings,
         ]
 
-        system_message = (
-            "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
-            + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
-            + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
-            + get_language_instruction(),
-        )
+        if is_etf_ticker(ticker):
+            system_message = (
+                "You are a researcher tasked with analyzing an ETF over the past week. ETFs are funds, not companies — write a comprehensive report covering the ETF's tracking strategy, top-holding concentration, sector / asset-class breakdown, AUM, expense ratio, and any premium / discount to NAV. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+                + " Make sure to append a Markdown table at the end of the report to organize key points, organized and easy to read."
+                + " Use the available tools: `get_etf_profile` for the ETF's profile and sector weightings, and `get_etf_holdings` for the top constituents. The company-financial tools (`get_fundamentals`, `get_balance_sheet`, `get_cashflow`, `get_income_statement`) will return ETF-not-applicable placeholders — do not rely on them for ETF tickers."
+                + get_language_instruction(),
+            )
+        else:
+            system_message = (
+                "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+                + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
+                + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
+                + get_language_instruction(),
+            )
 
         prompt = ChatPromptTemplate.from_messages(
             [

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    build_etf_risk_block,
+    get_language_instruction,
+)
 
 
 def create_aggressive_debator(llm):
@@ -14,6 +17,7 @@ def create_aggressive_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        etf_risk_block = build_etf_risk_block(state.get("company_of_interest", ""))
 
         trader_decision = state["trader_investment_plan"]
 
@@ -26,7 +30,7 @@ Your task is to create a compelling case for the trader's decision by questionin
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+Company Fundamentals Report: {fundamentals_report}{etf_risk_block}
 Here is the current conversation history: {history} Here are the last arguments from the conservative analyst: {current_conservative_response} Here are the last arguments from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    build_etf_risk_block,
+    get_language_instruction,
+)
 
 
 def create_conservative_debator(llm):
@@ -14,6 +17,7 @@ def create_conservative_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        etf_risk_block = build_etf_risk_block(state.get("company_of_interest", ""))
 
         trader_decision = state["trader_investment_plan"]
 
@@ -26,7 +30,7 @@ Your task is to actively counter the arguments of the Aggressive and Neutral Ana
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+Company Fundamentals Report: {fundamentals_report}{etf_risk_block}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    build_etf_risk_block,
+    get_language_instruction,
+)
 
 
 def create_neutral_debator(llm):
@@ -14,6 +17,7 @@ def create_neutral_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        etf_risk_block = build_etf_risk_block(state.get("company_of_interest", ""))
 
         trader_decision = state["trader_investment_plan"]
 
@@ -26,7 +30,7 @@ Your task is to challenge both the Aggressive and Conservative Analysts, pointin
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+Company Fundamentals Report: {fundamentals_report}{etf_risk_block}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the conservative analyst: {current_conservative_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -72,6 +72,42 @@ def build_instrument_context(ticker: str) -> str:
         )
     return base
 
+def build_etf_risk_block(ticker: str) -> str:
+    """Risk-debate-specific ETF axes, returned as a markdown block.
+
+    The three risk debators (aggressive / conservative / neutral) consume
+    the analyst reports but otherwise have no ETF awareness — without this
+    block they argue about "company financials" of a fund. Each axis below
+    matters to a different debator:
+
+    - liquidity / structure → conservative emphasis
+    - leverage / sector momentum → aggressive emphasis
+    - concentration / diversification fit → neutral emphasis
+
+    Returns an empty string for non-ETF tickers so debators can append
+    unconditionally without branching.
+    """
+    if not is_etf_ticker(ticker):
+        return ""
+    return (
+        "\n\n**ETF-specific risk dimensions** (this instrument is an exchange-traded "
+        "fund, not a company — weigh these axes alongside the analyst reports):\n"
+        "- **Liquidity**: AUM size and daily turnover; small-AUM ETFs slip on "
+        "moderate sizes and can trade at persistent discounts to NAV.\n"
+        "- **Concentration**: top-10 aggregate weight and Herfindahl index "
+        "(see the holdings report). High concentration means the ETF inherits "
+        "single-name risk from a few large positions.\n"
+        "- **Tracking risk**: expense-ratio drag and tracking error vs the stated "
+        "benchmark erode long-horizon returns.\n"
+        "- **Structure risk**: leveraged or inverse ETFs decay daily — long-term "
+        "framing is inappropriate. Synthetic / swap-based ETFs add counterparty risk.\n"
+        "- **Premium/discount to NAV**: persistent divergence signals "
+        "authorized-participant or arbitrage friction.\n"
+        "- **Underlying-name catalysts**: see the drill-down section in the "
+        "fundamentals report (if present) for top-constituent news and fundamentals."
+    )
+
+
 def create_msg_delete():
     def delete_messages(state):
         """Clear messages and add placeholder for Anthropic compatibility"""

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -18,6 +18,13 @@ from tradingagents.agents.utils.news_data_tools import (
     get_insider_transactions,
     get_global_news
 )
+from tradingagents.agents.utils.etf_tools import (
+    get_etf_profile,
+    get_etf_holdings,
+)
+# Re-export so analyst modules don't have to reach into dataflows for the
+# detection helper — keeps the agent-layer import surface in one place.
+from tradingagents.dataflows.etf_utils import is_etf_ticker  # noqa: F401
 
 
 def get_language_instruction() -> str:
@@ -37,12 +44,32 @@ def get_language_instruction() -> str:
 
 
 def build_instrument_context(ticker: str) -> str:
-    """Describe the exact instrument so agents preserve exchange-qualified tickers."""
-    return (
+    """Describe the exact instrument so agents preserve exchange-qualified tickers.
+
+    For ETF tickers the prompt is augmented with ETF-specific analysis
+    guidance — top-holding concentration, tracking strategy, expense ratio,
+    NAV / premium-discount — and a redirect away from the company-financial
+    tools (which now return ETF-not-applicable placeholders).
+    """
+    base = (
         f"The instrument to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
         "preserving any exchange suffix (e.g. `.TO`, `.L`, `.HK`, `.T`)."
     )
+
+    if is_etf_ticker(ticker):
+        base += (
+            "\n\n**This instrument is an ETF (exchange-traded fund), not a company.**"
+            "\n- Analyze it by top-holding concentration, tracking index / underlying basket, "
+            "expense ratio, AUM trend, premium/discount to NAV, and the underlying sector "
+            "or index momentum."
+            "\n- Do NOT analyze it as a company — it has no income statement, balance sheet, "
+            "or cash flow of its own. The company-financial tools (`get_fundamentals`, "
+            "`get_balance_sheet`, `get_cashflow`, `get_income_statement`, `get_insider_transactions`) "
+            "will return ETF-not-applicable placeholders for this ticker."
+            "\n- Use `get_etf_profile` and `get_etf_holdings` for ETF-relevant data."
+        )
+    return base
 
 def create_msg_delete():
     def delete_messages(state):

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -21,6 +21,7 @@ from tradingagents.agents.utils.news_data_tools import (
 from tradingagents.agents.utils.etf_tools import (
     get_etf_profile,
     get_etf_holdings,
+    get_etf_top_holdings_drilldown,
 )
 # Re-export so analyst modules don't have to reach into dataflows for the
 # detection helper — keeps the agent-layer import surface in one place.

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -24,8 +24,29 @@ from tradingagents.agents.utils.etf_tools import (
     get_etf_top_holdings_drilldown,
 )
 # Re-export so analyst modules don't have to reach into dataflows for the
-# detection helper — keeps the agent-layer import surface in one place.
-from tradingagents.dataflows.etf_utils import is_etf_ticker  # noqa: F401
+# detection helpers — keeps the agent-layer import surface in one place.
+from tradingagents.dataflows.etf_utils import (  # noqa: F401
+    is_etf_ticker,
+    leverage_descriptor,
+)
+
+
+def _leverage_warning(descriptor: str) -> str:
+    """Render the structural warning for a leveraged or inverse ETF.
+
+    Centralized so ``build_instrument_context`` and ``build_etf_risk_block``
+    surface the identical text — one place to tune the wording, no risk of
+    drift between the analyst's prompt and the risk debators' prompt.
+    """
+    return (
+        f"\n\n**⚠️ STRUCTURAL WARNING — {descriptor} ETF**: This product uses "
+        "**daily reset** to deliver its leverage / inverse exposure. "
+        "**Long-term hold framing is INAPPROPRIATE** because path-dependent "
+        "decay erodes the return relationship vs the underlying over multi-day "
+        "periods (a flat underlying can still produce a negative ETF return). "
+        "Any recommendation to hold beyond a few sessions must explicitly "
+        "justify why path decay is acceptable for the trade thesis."
+    )
 
 
 def get_language_instruction() -> str:
@@ -70,6 +91,9 @@ def build_instrument_context(ticker: str) -> str:
             "will return ETF-not-applicable placeholders for this ticker."
             "\n- Use `get_etf_profile` and `get_etf_holdings` for ETF-relevant data."
         )
+        descriptor = leverage_descriptor(ticker)
+        if descriptor:
+            base += _leverage_warning(descriptor)
     return base
 
 def build_etf_risk_block(ticker: str) -> str:
@@ -89,7 +113,11 @@ def build_etf_risk_block(ticker: str) -> str:
     """
     if not is_etf_ticker(ticker):
         return ""
-    return (
+    # Surface the structural warning at the very top of the risk block so
+    # the debators see it before any of the more general axes.
+    descriptor = leverage_descriptor(ticker)
+    leverage_block = _leverage_warning(descriptor) if descriptor else ""
+    return leverage_block + (
         "\n\n**ETF-specific risk dimensions** (this instrument is an exchange-traded "
         "fund, not a company — weigh these axes alongside the analyst reports):\n"
         "- **Liquidity**: AUM size and daily turnover; small-AUM ETFs slip on "

--- a/tradingagents/agents/utils/etf_tools.py
+++ b/tradingagents/agents/utils/etf_tools.py
@@ -3,6 +3,9 @@
 from langchain_core.tools import tool
 from typing import Annotated
 
+from tradingagents.dataflows.etf_drilldown import (
+    get_etf_top_holdings_drilldown as _drilldown_impl,
+)
 from tradingagents.dataflows.interface import route_to_vendor
 
 
@@ -42,3 +45,32 @@ def get_etf_holdings(
         str: Markdown CSV with the top holdings and weights.
     """
     return route_to_vendor("get_etf_holdings", ticker, top_n)
+
+
+@tool
+def get_etf_top_holdings_drilldown(
+    ticker: Annotated[str, "ETF ticker symbol (e.g. SPY, 2800.HK)"],
+    start_date: Annotated[str, "Start date for constituent news, YYYY-MM-DD"],
+    end_date: Annotated[str, "End date (also used as the fundamentals look-ahead cutoff), YYYY-MM-DD"],
+    top_n: Annotated[int, "Number of top holdings to drill into (keep ≤5 to control cost)"] = 3,
+) -> str:
+    """Drill into an ETF's top-N constituents: for each, fetch real
+    fundamentals and recent news so the analyst can reason about
+    underlying-name catalysts, not just aggregate weights.
+
+    Use sparingly — each constituent costs one fundamentals call plus one
+    news call, so the default ``top_n=3`` keeps token and latency budgets
+    sane. Holdings are resolved through the configured ``etf_data`` vendor
+    (yfinance / alpha_vantage), and each constituent's fundamentals and
+    news flow through their normal vendor (a US holding gets US-vendor
+    data, a HK holding gets HK-vendor data).
+
+    Args:
+        ticker (str): ETF ticker. Examples: SPY, QQQ, 2800.HK.
+        start_date (str): Start date for the news window.
+        end_date (str): End date / fundamentals look-ahead cutoff.
+        top_n (int): Number of top holdings to drill into (default 3).
+    Returns:
+        str: Markdown report with one section per top-N constituent.
+    """
+    return _drilldown_impl(ticker, start_date, end_date, top_n)

--- a/tradingagents/agents/utils/etf_tools.py
+++ b/tradingagents/agents/utils/etf_tools.py
@@ -1,0 +1,44 @@
+"""LangChain ETF tools — vendor-agnostic via ``route_to_vendor``."""
+
+from langchain_core.tools import tool
+from typing import Annotated
+
+from tradingagents.dataflows.interface import route_to_vendor
+
+
+@tool
+def get_etf_profile(
+    ticker: Annotated[str, "ETF ticker symbol (e.g. SPY, QQQ, 2800.HK)"],
+) -> str:
+    """Retrieve ETF profile: name, category, tracking strategy, AUM, expense
+    ratio, fund family, asset-class breakdown, and sector weightings.
+
+    Use this for ETF instruments instead of get_fundamentals (which targets
+    company financials). The vendor is selected from the configured
+    ``etf_data`` data vendor.
+
+    Args:
+        ticker (str): ETF ticker. Examples: SPY, QQQ, VOO, 2800.HK.
+    Returns:
+        str: Human-readable markdown block with the ETF's key profile fields.
+    """
+    return route_to_vendor("get_etf_profile", ticker)
+
+
+@tool
+def get_etf_holdings(
+    ticker: Annotated[str, "ETF ticker symbol (e.g. SPY, QQQ, 2800.HK)"],
+    top_n: Annotated[int, "Number of top holdings to return"] = 10,
+) -> str:
+    """Retrieve the top-N holdings of an ETF with weight and position size.
+
+    Use this for ETF instruments instead of get_balance_sheet /
+    get_cashflow / get_income_statement (which target company financials).
+
+    Args:
+        ticker (str): ETF ticker. Examples: SPY, QQQ, 2800.HK.
+        top_n (int): Number of largest holdings to show (default 10).
+    Returns:
+        str: Markdown CSV with the top holdings and weights.
+    """
+    return route_to_vendor("get_etf_holdings", ticker, top_n)

--- a/tradingagents/dataflows/alpha_vantage_etf.py
+++ b/tradingagents/dataflows/alpha_vantage_etf.py
@@ -8,18 +8,28 @@ split into the same two-function shape we expose for yfinance.
 
 from __future__ import annotations
 
+import csv
+import functools
+import io
 import json
 from datetime import datetime
 
 from .alpha_vantage_common import _make_api_request
 
 
+@functools.lru_cache(maxsize=128)
 def _fetch_etf_profile_raw(ticker: str) -> dict:
-    """Fetch and parse the raw ``ETF_PROFILE`` payload.
+    """Fetch and parse the raw ``ETF_PROFILE`` payload (cached).
 
     ``_make_api_request`` returns the response body verbatim — JSON for
-    this endpoint. Returns an empty dict when Alpha Vantage responds with
-    a non-JSON body (e.g. rate-limit notes that slipped past detection).
+    this endpoint. Cached because three public entry points
+    (``get_etf_profile`` / ``get_etf_holdings`` / ``get_top_holding_tickers``)
+    each pull the same payload; without the cache, analyzing a single ETF
+    burns three separate Alpha Vantage calls and risks the free-tier
+    daily limit. The payload is read-only at all call sites.
+
+    Returns an empty dict when Alpha Vantage responds with a non-JSON
+    body (e.g. rate-limit notes that slipped past detection).
     """
     raw = _make_api_request("ETF_PROFILE", {"symbol": ticker})
     if isinstance(raw, dict):
@@ -28,6 +38,11 @@ def _fetch_etf_profile_raw(ticker: str) -> dict:
         return json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return {}
+
+
+def clear_etf_profile_cache() -> None:
+    """Reset the ``_fetch_etf_profile_raw`` LRU. Used by tests."""
+    _fetch_etf_profile_raw.cache_clear()
 
 
 def get_etf_profile(ticker: str) -> str:
@@ -93,12 +108,21 @@ def get_etf_holdings(ticker: str, top_n: int = 10) -> str:
         "# Source: Alpha Vantage ETF_PROFILE.holdings\n"
         f"# Top {len(rows)} positions\n"
         f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
-        "\nsymbol,description,weight\n"
+        "\n"
     )
-    body = "\n".join(
-        f"{row.get('symbol', '')},{row.get('description', '')},{row.get('weight', '')}"
-        for row in rows
-    )
+
+    # Build the CSV via the standard library so fields containing commas
+    # (e.g. "Berkshire Hathaway Inc, Class B") are properly quoted rather
+    # than producing a row with mismatched column counts.
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(["symbol", "description", "weight"])
+    for row in rows:
+        writer.writerow([
+            row.get("symbol", ""),
+            row.get("description", ""),
+            row.get("weight", ""),
+        ])
 
     # Alpha Vantage emits weight as a decimal string (``"0.092"`` = 9.2%).
     weights_pct: list[float] = []
@@ -108,7 +132,7 @@ def get_etf_holdings(ticker: str, top_n: int = 10) -> str:
         except (TypeError, ValueError):
             continue
     from .etf_utils import concentration_summary
-    return header + body + "\n" + concentration_summary(weights_pct)
+    return header + buf.getvalue() + concentration_summary(weights_pct)
 
 
 def get_top_holding_tickers(

--- a/tradingagents/dataflows/alpha_vantage_etf.py
+++ b/tradingagents/dataflows/alpha_vantage_etf.py
@@ -100,3 +100,31 @@ def get_etf_holdings(ticker: str, top_n: int = 10) -> str:
         for row in rows
     )
     return header + body + "\n"
+
+
+def get_top_holding_tickers(
+    etf_ticker: str, top_n: int = 3
+) -> list[tuple[str, str, float]]:
+    """Structured top-N holdings: ``[(ticker, name, weight_pct), ...]``.
+
+    Alpha Vantage emits weight as a decimal string (``"0.092"`` = 9.2%).
+    Returns ``[]`` when the endpoint returns no payload so the
+    orchestrator can degrade gracefully.
+    """
+    data = _fetch_etf_profile_raw(etf_ticker)
+    holdings = (data or {}).get("holdings") or []
+    if not holdings:
+        return []
+
+    out: list[tuple[str, str, float]] = []
+    for row in holdings[:top_n]:
+        symbol = str(row.get("symbol") or "").strip()
+        if not symbol:
+            continue
+        name = str(row.get("description") or symbol)
+        try:
+            weight_pct = float(row.get("weight") or 0.0) * 100
+        except (TypeError, ValueError):
+            weight_pct = 0.0
+        out.append((symbol, name, weight_pct))
+    return out

--- a/tradingagents/dataflows/alpha_vantage_etf.py
+++ b/tradingagents/dataflows/alpha_vantage_etf.py
@@ -99,7 +99,16 @@ def get_etf_holdings(ticker: str, top_n: int = 10) -> str:
         f"{row.get('symbol', '')},{row.get('description', '')},{row.get('weight', '')}"
         for row in rows
     )
-    return header + body + "\n"
+
+    # Alpha Vantage emits weight as a decimal string (``"0.092"`` = 9.2%).
+    weights_pct: list[float] = []
+    for row in rows:
+        try:
+            weights_pct.append(float(row.get("weight") or 0.0) * 100)
+        except (TypeError, ValueError):
+            continue
+    from .etf_utils import concentration_summary
+    return header + body + "\n" + concentration_summary(weights_pct)
 
 
 def get_top_holding_tickers(

--- a/tradingagents/dataflows/alpha_vantage_etf.py
+++ b/tradingagents/dataflows/alpha_vantage_etf.py
@@ -1,0 +1,102 @@
+"""Alpha Vantage ETF profile and holdings.
+
+Alpha Vantage's ``ETF_PROFILE`` endpoint returns the ETF's net assets,
+expense ratio, dividend yield, inception date, leveraged flag, sector
+allocation, and top holdings in a single JSON payload — convenient to
+split into the same two-function shape we expose for yfinance.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from .alpha_vantage_common import _make_api_request
+
+
+def _fetch_etf_profile_raw(ticker: str) -> dict:
+    """Fetch and parse the raw ``ETF_PROFILE`` payload.
+
+    ``_make_api_request`` returns the response body verbatim — JSON for
+    this endpoint. Returns an empty dict when Alpha Vantage responds with
+    a non-JSON body (e.g. rate-limit notes that slipped past detection).
+    """
+    raw = _make_api_request("ETF_PROFILE", {"symbol": ticker})
+    if isinstance(raw, dict):
+        return raw
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def get_etf_profile(ticker: str) -> str:
+    """Profile snapshot for an ETF via Alpha Vantage ``ETF_PROFILE``.
+
+    Renders the core fields (AUM / expense ratio / dividend yield / sectors)
+    in the same markdown shape as the yfinance variant so the downstream
+    analyst prompt doesn't have to branch on vendor.
+    """
+    data = _fetch_etf_profile_raw(ticker)
+    if not data:
+        return f"No ETF profile available for {ticker} (Alpha Vantage returned no data)"
+
+    fields = [
+        ("Name", data.get("name")),
+        ("Net Assets (AUM)", data.get("net_assets")),
+        ("Net Expense Ratio", data.get("net_expense_ratio")),
+        ("Portfolio Turnover", data.get("portfolio_turnover")),
+        ("Dividend Yield", data.get("dividend_yield")),
+        ("Inception Date", data.get("inception_date")),
+        ("Leveraged", data.get("leveraged")),
+        ("Asset Class", data.get("asset_class")),
+    ]
+
+    lines = [
+        f"# ETF Profile for {ticker.upper()}",
+        "# Source: Alpha Vantage ETF_PROFILE",
+        f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        "",
+    ]
+    for label, value in fields:
+        if value not in (None, "", "None"):
+            lines.append(f"- **{label}**: {value}")
+
+    sectors = data.get("sectors") or []
+    if sectors:
+        lines.append("")
+        lines.append("## Sector Weightings")
+        for entry in sectors:
+            sector = entry.get("sector")
+            weight = entry.get("weight")
+            if sector and weight is not None:
+                lines.append(f"- {sector}: {weight}")
+
+    return "\n".join(lines)
+
+
+def get_etf_holdings(ticker: str, top_n: int = 10) -> str:
+    """Top-N ETF holdings via Alpha Vantage ``ETF_PROFILE``.
+
+    Alpha Vantage bundles the holdings inside the same payload as the
+    profile. We slice to ``top_n`` and render as CSV — matching the
+    yfinance variant's output shape so analyst prompts stay vendor-agnostic.
+    """
+    data = _fetch_etf_profile_raw(ticker)
+    holdings = data.get("holdings") or [] if data else []
+    if not holdings:
+        return f"No holdings disclosed for {ticker.upper()}"
+
+    rows = holdings[:top_n]
+    header = (
+        f"# ETF Holdings for {ticker.upper()}\n"
+        "# Source: Alpha Vantage ETF_PROFILE.holdings\n"
+        f"# Top {len(rows)} positions\n"
+        f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        "\nsymbol,description,weight\n"
+    )
+    body = "\n".join(
+        f"{row.get('symbol', '')},{row.get('description', '')},{row.get('weight', '')}"
+        for row in rows
+    )
+    return header + body + "\n"

--- a/tradingagents/dataflows/etf_drilldown.py
+++ b/tradingagents/dataflows/etf_drilldown.py
@@ -1,0 +1,91 @@
+"""Cross-vendor ETF top-holdings drill-down.
+
+Given an ETF ticker, resolve its top-N constituents via the configured
+``etf_data`` vendor, then call the existing fundamentals / news routes
+for each constituent so the analyst can reason about the underlying
+names instead of just aggregate weights.
+
+This module orchestrates other dispatch calls; it doesn't talk to
+upstream vendors directly. Constituent fundamentals + news flow
+through the normal ``route_to_vendor`` chain, so a US holding gets
+US-vendor data and a HK holding gets HK-vendor data without any
+special casing here.
+"""
+
+from __future__ import annotations
+
+from .etf_utils import is_etf_ticker
+
+# Per-section character caps. The drill-down already costs ``2 * top_n``
+# upstream calls; trimming each section keeps the LLM's context window
+# from being dominated by a single noisy news source.
+_FUNDAMENTALS_CHAR_LIMIT = 1500
+_NEWS_CHAR_LIMIT = 1200
+
+
+def _truncate(value: object, limit: int) -> str:
+    """Render ``value`` as a string and cap to ``limit`` characters with
+    an explicit truncation marker so the LLM doesn't assume the body is
+    complete."""
+    text = value if isinstance(value, str) else str(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + f"\n…(truncated, full length {len(text)})"
+
+
+def get_etf_top_holdings_drilldown(
+    ticker: str,
+    start_date: str,
+    end_date: str,
+    top_n: int = 3,
+) -> str:
+    """Drill into an ETF's top-N constituents and emit a per-name report.
+
+    Each constituent costs one fundamentals call plus one news call, so
+    the default ``top_n=3`` keeps token + latency budgets sane. Callers
+    should generally cap at 5.
+
+    Returns a markdown report with one section per constituent, separated
+    by horizontal rules. Per-constituent errors are caught and rendered
+    inline so one bad ticker can't kill the whole drill-down.
+    """
+    # Local imports defer the route_to_vendor binding so this module
+    # doesn't create an import cycle with interface.py.
+    from .interface import route_to_vendor
+
+    if not is_etf_ticker(ticker):
+        return (
+            f"Drill-down only applies to ETF tickers; {ticker} appears to be a "
+            "regular stock. Use get_fundamentals and get_news directly."
+        )
+
+    try:
+        holdings = route_to_vendor("get_top_holding_tickers", ticker, top_n)
+    except Exception as exc:  # noqa: BLE001 — degrade rather than abort
+        return f"Could not resolve top holdings for {ticker}: {exc}"
+
+    if not holdings:
+        return f"No top holdings could be resolved for {ticker}."
+
+    sections: list[str] = [
+        f"# Top-{len(holdings)} holdings drill-down for ETF {ticker}",
+        f"# Fundamentals + news fetched per constituent at {start_date}..{end_date}",
+        "",
+    ]
+    for h_ticker, h_name, weight in holdings:
+        block = [f"## {h_name} ({h_ticker}) — weight: {weight:.2f}%"]
+        try:
+            fundamentals = route_to_vendor("get_fundamentals", h_ticker, end_date)
+            block.append("### Fundamentals")
+            block.append(_truncate(fundamentals, _FUNDAMENTALS_CHAR_LIMIT))
+        except Exception as exc:  # noqa: BLE001
+            block.append(f"### Fundamentals\n_unavailable: {exc}_")
+        try:
+            news = route_to_vendor("get_news", h_ticker, start_date, end_date)
+            block.append("### Recent News")
+            block.append(_truncate(news, _NEWS_CHAR_LIMIT))
+        except Exception as exc:  # noqa: BLE001
+            block.append(f"### Recent News\n_unavailable: {exc}_")
+        sections.append("\n\n".join(block))
+
+    return "\n\n---\n\n".join(sections)

--- a/tradingagents/dataflows/etf_utils.py
+++ b/tradingagents/dataflows/etf_utils.py
@@ -92,6 +92,48 @@ def _extract_ticker_arg(args: tuple, kwargs: dict) -> object:
     return None
 
 
+def concentration_summary(weights_pct: list[float]) -> str:
+    """Render a concentration block from per-holding weights (in percent).
+
+    Given the top-N holding weights as percentages (e.g. ``[6.2, 5.8, 4.1]``
+    for a 6.20% / 5.80% / 4.10% top-3), produce three signals the analyst
+    can use to distinguish a thematic ETF from a broad index:
+
+    - **Largest single holding** — quick glance at single-name risk.
+    - **Top-N aggregate weight** — reveals "top 10 holds 95%" thematic
+      ETFs vs "top 10 holds 25%" broad indices.
+    - **Herfindahl index across the top-N** — sum of squared decimal
+      weights. Higher = more concentrated. For an N-holding equal-weight
+      slice this equals ``1/N``; a single-name slice would equal 1.0.
+
+    The Herfindahl is computed across the *shown* top-N rather than the
+    full universe (which we don't have), so it's a relative concentration
+    indicator within the visible slice — not the textbook market HHI.
+    Returns an empty string for empty / unparseable input.
+    """
+    cleaned: list[float] = []
+    for w in weights_pct:
+        try:
+            value = float(w)
+        except (TypeError, ValueError):
+            continue
+        if value <= 0:
+            continue
+        cleaned.append(value)
+    if not cleaned:
+        return ""
+
+    largest = max(cleaned)
+    aggregate = sum(cleaned)
+    herfindahl = sum((w / 100) ** 2 for w in cleaned)
+    return (
+        f"\n## Concentration metrics (top-{len(cleaned)} positions shown)\n"
+        f"- Largest single holding: {largest:.2f}%\n"
+        f"- Top-{len(cleaned)} aggregate weight: {aggregate:.2f}%\n"
+        f"- Herfindahl index (top-{len(cleaned)}): {herfindahl:.4f}\n"
+    )
+
+
 def etf_placeholder(report_type: str) -> Callable:
     """Decorator: short-circuit a vendor function to an ETF placeholder.
 

--- a/tradingagents/dataflows/etf_utils.py
+++ b/tradingagents/dataflows/etf_utils.py
@@ -1,0 +1,114 @@
+"""Cross-market ETF detection and placeholder helpers.
+
+ETFs are not companies — they have no income statement, balance sheet, or
+cash flow. Company-financial tools applied to ETF tickers return mostly-empty
+data that confuses the analyst into hallucinating "company margins" for an
+index basket. This module centralizes:
+
+- :func:`is_etf_ticker` — vendor-agnostic detection (yfinance ``quoteType``
+  with LRU caching, since the check runs on every tool invocation).
+- :func:`etf_placeholder` — decorator that short-circuits a vendor function
+  to a polite ETF-not-applicable message when the input is an ETF.
+
+A-share tickers are intentionally not special-cased here; A-share ETF support
+arrives with the AKShare vendor in a separate change.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Optional
+
+
+ETF_PLACEHOLDER = (
+    "This ticker {ticker} is an ETF; company-style {report_type} does not apply. "
+    "Use get_etf_profile and get_etf_holdings for ETF-relevant data instead."
+)
+
+
+# Company-financial method → human label used in the ETF placeholder.
+# ``interface.py`` walks this map at module load and wraps every registered
+# vendor implementation of each method with :func:`etf_placeholder`. New
+# vendors register only their plain implementation in ``VENDOR_METHODS``;
+# they get ETF protection for free, and no vendor module needs to know
+# about ETF semantics.
+ETF_PROTECTED_METHODS = {
+    "get_fundamentals": "fundamentals",
+    "get_balance_sheet": "balance sheet",
+    "get_cashflow": "cash flow statement",
+    "get_income_statement": "income statement",
+    "get_insider_transactions": "insider transactions",
+}
+
+
+@functools.lru_cache(maxsize=512)
+def _yfinance_quote_type(ticker: str) -> Optional[str]:
+    """Cached yfinance ``info.quoteType`` lookup.
+
+    The detection runs from agent prompts and the routing layer, so without
+    the LRU we would hit yfinance ``.info`` (a network call) on every tool
+    invocation. Any network or parse failure collapses to ``None`` so callers
+    treat it as "unknown".
+    """
+    try:
+        import yfinance as yf  # local import: yfinance is heavy
+        info = yf.Ticker(ticker).info or {}
+        return info.get("quoteType")
+    except Exception:  # noqa: BLE001 — any failure is "unknown"
+        return None
+
+
+def is_etf_ticker(value: object) -> bool:
+    """Return True when ``value`` is recognized as an ETF by yfinance.
+
+    Falsy / non-string inputs short-circuit to False so callers can pass
+    user input straight in without pre-checking.
+    """
+    if not isinstance(value, str):
+        return False
+    ticker = value.strip()
+    if not ticker:
+        return False
+    return _yfinance_quote_type(ticker) == "ETF"
+
+
+def clear_etf_cache() -> None:
+    """Reset the quote-type LRU. Tests call this between cases for isolation."""
+    _yfinance_quote_type.cache_clear()
+
+
+def _extract_ticker_arg(args: tuple, kwargs: dict) -> object:
+    """Pull the ticker out of an arbitrary vendor-function call signature.
+
+    Vendor functions take the ticker either as the first positional argument
+    or as ``ticker=``/``symbol=``. We accept both so the decorator stays
+    indifferent to per-vendor naming.
+    """
+    if args:
+        return args[0]
+    for key in ("ticker", "symbol"):
+        if key in kwargs:
+            return kwargs[key]
+    return None
+
+
+def etf_placeholder(report_type: str) -> Callable:
+    """Decorator: short-circuit a vendor function to an ETF placeholder.
+
+    Wraps a company-financial vendor function (``get_fundamentals``,
+    ``get_balance_sheet``, ...) so an ETF ticker returns a uniform
+    placeholder pointing the analyst at ``get_etf_profile`` /
+    ``get_etf_holdings`` instead of an empty financial statement.
+
+    ``report_type`` is the human-readable label woven into the placeholder
+    (e.g. ``"balance sheet"`` → "company-style balance sheet does not apply").
+    """
+    def decorator(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            ticker = _extract_ticker_arg(args, kwargs)
+            if is_etf_ticker(ticker):
+                return ETF_PLACEHOLDER.format(ticker=ticker, report_type=report_type)
+            return fn(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/tradingagents/dataflows/etf_utils.py
+++ b/tradingagents/dataflows/etf_utils.py
@@ -42,38 +42,39 @@ ETF_PROTECTED_METHODS = {
 
 
 @functools.lru_cache(maxsize=512)
-def _yfinance_quote_type(ticker: str) -> Optional[str]:
-    """Cached yfinance ``info.quoteType`` lookup.
+def _yfinance_info(ticker: str) -> dict:
+    """Cached yfinance ``Ticker(ticker).info`` lookup.
 
-    The detection runs from agent prompts and the routing layer, so without
-    the LRU we would hit yfinance ``.info`` (a network call) on every tool
-    invocation. Any network or parse failure collapses to ``None`` so callers
-    treat it as "unknown".
+    Single cache for the whole metadata dict so the per-field accessors
+    (``_yfinance_quote_type``, ``_yfinance_etf_category``) share one
+    network roundtrip per ticker — important because the agent layer hits
+    quote_type from every routed tool call and category from every ETF
+    instrument-context build, so without consolidation a single analysis
+    could trigger multiple ``.info`` fetches for the same symbol.
+
+    Network or parse failures collapse to an empty dict so per-field
+    callers treat missing keys as "unknown" rather than crashing.
     """
     try:
         import yfinance as yf  # local import: yfinance is heavy
-        info = yf.Ticker(ticker).info or {}
-        return info.get("quoteType")
+        return yf.Ticker(ticker).info or {}
     except Exception:  # noqa: BLE001 — any failure is "unknown"
-        return None
+        return {}
 
 
-@functools.lru_cache(maxsize=512)
+def _yfinance_quote_type(ticker: str) -> Optional[str]:
+    """Cached yfinance ``info.quoteType`` accessor (delegates to ``_yfinance_info``)."""
+    return _yfinance_info(ticker).get("quoteType")
+
+
 def _yfinance_etf_category(ticker: str) -> str:
-    """Cached yfinance ``info.category`` lookup for ETF leverage detection.
+    """Cached yfinance ``info.category`` accessor (delegates to ``_yfinance_info``).
 
     ``category`` strings like ``"Trading--Leveraged Equity"`` and
     ``"Trading--Inverse Equity"`` are the most reliable signal that an ETF
     uses daily reset and therefore decays under buy-and-hold framing.
-    Cached for the same reason as ``_yfinance_quote_type``: this fires
-    from agent prompts on every analysis.
     """
-    try:
-        import yfinance as yf
-        info = yf.Ticker(ticker).info or {}
-        return str(info.get("category") or "")
-    except Exception:  # noqa: BLE001
-        return ""
+    return str(_yfinance_info(ticker).get("category") or "")
 
 
 def is_etf_ticker(value: object) -> bool:
@@ -133,9 +134,10 @@ def leverage_descriptor(value: object) -> str:
 
 
 def clear_etf_cache() -> None:
-    """Reset both ETF LRU caches. Tests call this between cases for isolation."""
-    _yfinance_quote_type.cache_clear()
-    _yfinance_etf_category.cache_clear()
+    """Reset the yfinance metadata LRU cache. Tests call this between cases
+    for isolation. ``_yfinance_quote_type`` / ``_yfinance_etf_category``
+    are plain delegators now and share this single cache."""
+    _yfinance_info.cache_clear()
 
 
 def _extract_ticker_arg(args: tuple, kwargs: dict) -> object:

--- a/tradingagents/dataflows/etf_utils.py
+++ b/tradingagents/dataflows/etf_utils.py
@@ -58,6 +58,24 @@ def _yfinance_quote_type(ticker: str) -> Optional[str]:
         return None
 
 
+@functools.lru_cache(maxsize=512)
+def _yfinance_etf_category(ticker: str) -> str:
+    """Cached yfinance ``info.category`` lookup for ETF leverage detection.
+
+    ``category`` strings like ``"Trading--Leveraged Equity"`` and
+    ``"Trading--Inverse Equity"`` are the most reliable signal that an ETF
+    uses daily reset and therefore decays under buy-and-hold framing.
+    Cached for the same reason as ``_yfinance_quote_type``: this fires
+    from agent prompts on every analysis.
+    """
+    try:
+        import yfinance as yf
+        info = yf.Ticker(ticker).info or {}
+        return str(info.get("category") or "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def is_etf_ticker(value: object) -> bool:
     """Return True when ``value`` is recognized as an ETF by yfinance.
 
@@ -72,9 +90,52 @@ def is_etf_ticker(value: object) -> bool:
     return _yfinance_quote_type(ticker) == "ETF"
 
 
+def leverage_descriptor(value: object) -> str:
+    """Classify a ticker as leveraged / inverse / both / not, returning a tag.
+
+    Returns one of:
+    - ``""`` — not an ETF, or an ordinary unleveraged ETF.
+    - ``"Leveraged"`` — daily-reset multiplier (TQQQ 3x, UPRO 3x, SOXL 3x).
+    - ``"Inverse"`` — daily-reset short (PSQ -1x, SH -1x).
+    - ``"Leveraged Inverse"`` — both at once (SQQQ -3x, SDS -2x, SPXS -3x).
+
+    The caller injects a hard structural warning when this returns
+    non-empty: daily reset makes long-term framing inappropriate
+    regardless of which underlying these products track.
+
+    Falsy / non-string / non-ETF inputs short-circuit to ``""`` so call
+    sites can append unconditionally without branching.
+    """
+    if not isinstance(value, str):
+        return ""
+    ticker = value.strip()
+    if not ticker or not is_etf_ticker(ticker):
+        return ""
+    category = _yfinance_etf_category(ticker)
+    if not category:
+        return ""
+    # The yfinance convention is "Trading--<flavor> <asset class>", e.g.
+    # "Trading--Leveraged Equity", "Trading--Inverse Commodities". Match
+    # case-insensitively on the flavor keywords; require the "Trading--"
+    # prefix so we don't false-positive on e.g. "Long-Term Bond".
+    lower = category.lower()
+    if "trading--" not in lower and "trading-" not in lower:
+        return ""
+    is_leveraged = "leveraged" in lower
+    is_inverse = "inverse" in lower
+    if is_leveraged and is_inverse:
+        return "Leveraged Inverse"
+    if is_leveraged:
+        return "Leveraged"
+    if is_inverse:
+        return "Inverse"
+    return ""
+
+
 def clear_etf_cache() -> None:
-    """Reset the quote-type LRU. Tests call this between cases for isolation."""
+    """Reset both ETF LRU caches. Tests call this between cases for isolation."""
     _yfinance_quote_type.cache_clear()
+    _yfinance_etf_category.cache_clear()
 
 
 def _extract_ticker_arg(args: tuple, kwargs: dict) -> object:

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -14,10 +14,12 @@ from .yfinance_news import get_news_yfinance, get_global_news_yfinance
 from .yfinance_etf import (
     get_etf_profile as get_yfinance_etf_profile,
     get_etf_holdings as get_yfinance_etf_holdings,
+    get_top_holding_tickers as get_yfinance_top_holding_tickers,
 )
 from .alpha_vantage_etf import (
     get_etf_profile as get_alpha_vantage_etf_profile,
     get_etf_holdings as get_alpha_vantage_etf_holdings,
+    get_top_holding_tickers as get_alpha_vantage_top_holding_tickers,
 )
 from .alpha_vantage import (
     get_stock as get_alpha_vantage_stock,
@@ -72,6 +74,10 @@ TOOLS_CATEGORIES = {
         "tools": [
             "get_etf_profile",
             "get_etf_holdings",
+            # Structured top-holdings extractor used internally by the
+            # drill-down tool. Same vendor pool as the other etf_data
+            # methods; never exposed to the LLM directly.
+            "get_top_holding_tickers",
         ]
     }
 }
@@ -133,6 +139,13 @@ VENDOR_METHODS = {
     "get_etf_holdings": {
         "yfinance": get_yfinance_etf_holdings,
         "alpha_vantage": get_alpha_vantage_etf_holdings,
+    },
+    # Structured top-holdings extractor — returns ``[(ticker, name, weight_pct)]``
+    # for use by the drill-down orchestrator. Routed like the other ETF methods,
+    # so fallback works the same way (yfinance ↔ alpha_vantage).
+    "get_top_holding_tickers": {
+        "yfinance": get_yfinance_top_holding_tickers,
+        "alpha_vantage": get_alpha_vantage_top_holding_tickers,
     },
 }
 

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -11,6 +11,14 @@ from .y_finance import (
     get_insider_transactions as get_yfinance_insider_transactions,
 )
 from .yfinance_news import get_news_yfinance, get_global_news_yfinance
+from .yfinance_etf import (
+    get_etf_profile as get_yfinance_etf_profile,
+    get_etf_holdings as get_yfinance_etf_holdings,
+)
+from .alpha_vantage_etf import (
+    get_etf_profile as get_alpha_vantage_etf_profile,
+    get_etf_holdings as get_alpha_vantage_etf_holdings,
+)
 from .alpha_vantage import (
     get_stock as get_alpha_vantage_stock,
     get_indicator as get_alpha_vantage_indicator,
@@ -23,6 +31,7 @@ from .alpha_vantage import (
     get_global_news as get_alpha_vantage_global_news,
 )
 from .alpha_vantage_common import AlphaVantageRateLimitError
+from .etf_utils import ETF_PROTECTED_METHODS, etf_placeholder
 
 # Configuration and routing logic
 from .config import get_config
@@ -56,6 +65,13 @@ TOOLS_CATEGORIES = {
             "get_news",
             "get_global_news",
             "get_insider_transactions",
+        ]
+    },
+    "etf_data": {
+        "description": "ETF-specific profile and holdings",
+        "tools": [
+            "get_etf_profile",
+            "get_etf_holdings",
         ]
     }
 }
@@ -107,7 +123,40 @@ VENDOR_METHODS = {
         "alpha_vantage": get_alpha_vantage_insider_transactions,
         "yfinance": get_yfinance_insider_transactions,
     },
+    # etf_data — yfinance covers US and HK ETFs; Alpha Vantage covers any
+    # symbol Alpha Vantage tracks (mostly US). A-share ETF support arrives
+    # with the AKShare vendor in a separate change.
+    "get_etf_profile": {
+        "yfinance": get_yfinance_etf_profile,
+        "alpha_vantage": get_alpha_vantage_etf_profile,
+    },
+    "get_etf_holdings": {
+        "yfinance": get_yfinance_etf_holdings,
+        "alpha_vantage": get_alpha_vantage_etf_holdings,
+    },
 }
+
+
+def _apply_etf_placeholders() -> None:
+    """Wrap every registered vendor impl of a company-financial method with
+    the ETF placeholder.
+
+    Done at the dispatch layer (not on each vendor function) because the
+    placeholder is a *tool-level* semantic — ETF tickers should be
+    redirected to ETF tools — not a vendor concern. Centralizing here means
+    new vendors get ETF protection automatically and the vendor modules
+    stay vendor-pure. Direct calls into vendor modules (bypassing
+    ``route_to_vendor``) intentionally do NOT trigger the placeholder —
+    they remain thin wrappers over the upstream API.
+    """
+    for method, label in ETF_PROTECTED_METHODS.items():
+        for vendor in list(VENDOR_METHODS[method]):
+            VENDOR_METHODS[method][vendor] = etf_placeholder(label)(
+                VENDOR_METHODS[method][vendor]
+            )
+
+
+_apply_etf_placeholders()
 
 def get_category_for_method(method: str) -> str:
     """Get the category that contains the specified method."""

--- a/tradingagents/dataflows/yfinance_etf.py
+++ b/tradingagents/dataflows/yfinance_etf.py
@@ -96,6 +96,36 @@ def get_etf_profile(
         return f"Error retrieving ETF profile for {ticker}: {str(e)}"
 
 
+def _find_weight_column(columns) -> str | None:
+    """Locate the holding-weight column by case-insensitive keyword.
+
+    yfinance ships the weight under varying labels across symbols
+    ("Holding Percent", "Weight", etc.), so a fixed string is brittle.
+    First match on "weight" or "percent" wins.
+    """
+    return next(
+        (c for c in columns if "weight" in str(c).lower() or "percent" in str(c).lower()),
+        None,
+    )
+
+
+def _normalize_weight_pct(value: object) -> float:
+    """Coerce a yfinance ``top_holdings`` weight into a percent float.
+
+    yfinance is inconsistent: usually a decimal (``0.062`` = 6.2%) but
+    occasionally already in percent (``6.2``). 1.5 is a safe threshold —
+    no single holding in a diversified fund exceeds 150%, and no decimal
+    weight reaches 1.5. Both renderers and the structured extractor must
+    apply the *same* heuristic, otherwise the holdings table and the
+    drill-down disagree on weight scaling for the same ETF.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return v * 100 if v < 1.5 else v
+
+
 def get_etf_holdings(
     ticker: Annotated[str, "ETF ticker symbol, e.g. SPY, 2800.HK"],
     top_n: Annotated[int, "Number of top holdings to return"] = 10,
@@ -119,16 +149,14 @@ def get_etf_holdings(
             return f"No holdings disclosed for {ticker.upper()}"
 
         top = holdings.head(top_n).copy()
-        # Convert decimal weight (0.062) → "6.20%" for analyst readability.
-        # Capture the numeric percent values *before* stringifying so the
+        # Normalize each row's weight to percent via the shared heuristic
+        # (yfinance ships either decimal or percent depending on symbol).
+        # Capture the numeric values *before* stringifying so the
         # concentration block can compute its metrics from them.
         weights_pct: list[float] = []
-        weight_col = next(
-            (c for c in top.columns if "weight" in c.lower() or "percent" in c.lower()),
-            None,
-        )
+        weight_col = _find_weight_column(top.columns)
         if weight_col:
-            numeric = top[weight_col].astype(float) * 100
+            numeric = top[weight_col].apply(_normalize_weight_pct)
             weights_pct = numeric.tolist()
             top[weight_col] = numeric.round(2).astype(str) + "%"
 
@@ -171,6 +199,10 @@ def get_top_holding_tickers(
     except Exception:  # noqa: BLE001
         return []
 
+    # Use the same column-lookup + weight-normalization helpers as
+    # ``get_etf_holdings`` so the two views of the same ETF agree on
+    # both the source column and the percent scaling.
+    weight_col = _find_weight_column(df.columns) or "Holding Percent"
     out: list[tuple[str, str, float]] = []
     for sym, row in df.head(top_n).iterrows():
         raw = str(sym).strip()
@@ -180,14 +212,6 @@ def get_top_holding_tickers(
         else:
             normalized = raw
         name = str(row.get("Name", raw))
-        weight = row.get("Holding Percent", 0.0)
-        # yfinance is inconsistent: usually decimal (0.062) but occasionally
-        # already percent (6.2). 1.5 is a safe threshold — no single holding
-        # in a diversified fund exceeds 150%, and no decimal weight reaches 1.5.
-        try:
-            value = float(weight)
-            weight_pct = value * 100 if value < 1.5 else value
-        except (TypeError, ValueError):
-            weight_pct = 0.0
+        weight_pct = _normalize_weight_pct(row.get(weight_col, 0.0))
         out.append((normalized, name, weight_pct))
     return out

--- a/tradingagents/dataflows/yfinance_etf.py
+++ b/tradingagents/dataflows/yfinance_etf.py
@@ -1,0 +1,139 @@
+"""yfinance-backed ETF tools: profile and top holdings.
+
+Separate from ``y_finance.py`` (which handles stock OHLCV and company
+financials) and ``yfinance_news.py`` (which handles news) so each
+yfinance feature surface stays small. Covers US ETFs (SPY, QQQ, VOO, ...)
+and HK ETFs (2800.HK, 3110.HK, ...).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+import yfinance as yf
+
+from .stockstats_utils import yf_retry
+
+
+def get_etf_profile(
+    ticker: Annotated[str, "ETF ticker symbol, e.g. SPY, 2800.HK"],
+) -> str:
+    """ETF profile snapshot from yfinance.
+
+    Surfaces ETF-relevant fields from ``Ticker.info`` (AUM, NAV, expense
+    ratio, fund family, category) plus, when available, the ``funds_data``
+    description, asset-class breakdown, and sector weightings. Any individual
+    field can be missing (HK ETFs in particular often lack ``funds_data``)
+    and the renderer degrades silently rather than raising.
+    """
+    try:
+        ticker_obj = yf.Ticker(ticker.upper())
+        info = yf_retry(lambda: ticker_obj.info) or {}
+
+        fields = [
+            ("Name", info.get("longName") or info.get("shortName")),
+            ("Quote Type", info.get("quoteType")),
+            ("Category", info.get("category")),
+            ("Fund Family", info.get("fundFamily")),
+            ("Total Assets (AUM)", info.get("totalAssets")),
+            ("NAV Price", info.get("navPrice")),
+            ("Annual Expense Ratio", info.get("annualReportExpenseRatio")),
+            ("Net Expense Ratio", info.get("netExpenseRatio")),
+            ("Yield (TTM)", info.get("yield")),
+            ("Trailing PE", info.get("trailingPE")),
+            ("Beta (3Y)", info.get("beta3Year")),
+            ("YTD Return", info.get("ytdReturn")),
+            ("3Y Avg Return", info.get("threeYearAverageReturn")),
+            ("5Y Avg Return", info.get("fiveYearAverageReturn")),
+            ("52 Week High", info.get("fiftyTwoWeekHigh")),
+            ("52 Week Low", info.get("fiftyTwoWeekLow")),
+            ("Inception Date", info.get("fundInceptionDate")),
+        ]
+
+        lines = [
+            f"# ETF Profile for {ticker.upper()}",
+            "# Source: yfinance",
+            f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+        ]
+        for label, value in fields:
+            if value is not None and value != "":
+                lines.append(f"- **{label}**: {value}")
+
+        # Optional richer fields from funds_data — wrapped in try because not
+        # all tickers expose it (HK ETFs frequently do not) and the attribute
+        # is "lazy" in yfinance, so reading it can raise on its own.
+        try:
+            fd = ticker_obj.funds_data
+            if fd is not None:
+                if getattr(fd, "description", None):
+                    desc = str(fd.description).strip()
+                    if desc:
+                        lines.append("")
+                        lines.append("## Strategy")
+                        lines.append(desc[:800] + ("…" if len(desc) > 800 else ""))
+                ac = getattr(fd, "asset_classes", None)
+                if ac:
+                    lines.append("")
+                    lines.append("## Asset Class Breakdown")
+                    for k, v in ac.items():
+                        if v:
+                            lines.append(f"- {k}: {v:.2%}")
+                sw = getattr(fd, "sector_weightings", None)
+                if sw:
+                    lines.append("")
+                    lines.append("## Sector Weightings")
+                    for k, v in sw.items():
+                        if v:
+                            lines.append(f"- {k}: {v:.2%}")
+        except Exception:  # noqa: BLE001 — funds_data is opportunistic; never fatal
+            pass
+
+        return "\n".join(lines)
+
+    except Exception as e:
+        return f"Error retrieving ETF profile for {ticker}: {str(e)}"
+
+
+def get_etf_holdings(
+    ticker: Annotated[str, "ETF ticker symbol, e.g. SPY, 2800.HK"],
+    top_n: Annotated[int, "Number of top holdings to return"] = 10,
+) -> str:
+    """Top-N ETF holdings from yfinance ``funds_data.top_holdings``.
+
+    yfinance returns ~10 rows; ``top_n`` lets the caller crop further.
+    When ``funds_data`` is unavailable (HK ETFs, very new listings) we
+    return a friendly "no holdings disclosed" string so the analyst can
+    move on rather than seeing a stack trace.
+    """
+    try:
+        ticker_obj = yf.Ticker(ticker.upper())
+        try:
+            fd = ticker_obj.funds_data
+        except Exception as exc:  # noqa: BLE001
+            return f"yfinance does not expose holdings for {ticker}: {exc}"
+
+        holdings = getattr(fd, "top_holdings", None)
+        if holdings is None or (hasattr(holdings, "empty") and holdings.empty):
+            return f"No holdings disclosed for {ticker.upper()}"
+
+        top = holdings.head(top_n).copy()
+        # Convert decimal weight (0.062) → "6.20%" for analyst readability.
+        weight_col = next(
+            (c for c in top.columns if "weight" in c.lower() or "percent" in c.lower()),
+            None,
+        )
+        if weight_col:
+            top[weight_col] = (top[weight_col].astype(float) * 100).round(2).astype(str) + "%"
+
+        header = (
+            f"# ETF Holdings for {ticker.upper()}\n"
+            "# Source: yfinance funds_data.top_holdings\n"
+            f"# Top {len(top)} positions\n"
+            f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+        )
+        return header + top.to_csv()
+
+    except Exception as e:
+        return f"Error retrieving ETF holdings for {ticker}: {str(e)}"

--- a/tradingagents/dataflows/yfinance_etf.py
+++ b/tradingagents/dataflows/yfinance_etf.py
@@ -120,12 +120,17 @@ def get_etf_holdings(
 
         top = holdings.head(top_n).copy()
         # Convert decimal weight (0.062) → "6.20%" for analyst readability.
+        # Capture the numeric percent values *before* stringifying so the
+        # concentration block can compute its metrics from them.
+        weights_pct: list[float] = []
         weight_col = next(
             (c for c in top.columns if "weight" in c.lower() or "percent" in c.lower()),
             None,
         )
         if weight_col:
-            top[weight_col] = (top[weight_col].astype(float) * 100).round(2).astype(str) + "%"
+            numeric = top[weight_col].astype(float) * 100
+            weights_pct = numeric.tolist()
+            top[weight_col] = numeric.round(2).astype(str) + "%"
 
         header = (
             f"# ETF Holdings for {ticker.upper()}\n"
@@ -133,7 +138,8 @@ def get_etf_holdings(
             f"# Top {len(top)} positions\n"
             f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
         )
-        return header + top.to_csv()
+        from .etf_utils import concentration_summary
+        return header + top.to_csv() + concentration_summary(weights_pct)
 
     except Exception as e:
         return f"Error retrieving ETF holdings for {ticker}: {str(e)}"

--- a/tradingagents/dataflows/yfinance_etf.py
+++ b/tradingagents/dataflows/yfinance_etf.py
@@ -137,3 +137,51 @@ def get_etf_holdings(
 
     except Exception as e:
         return f"Error retrieving ETF holdings for {ticker}: {str(e)}"
+
+
+def get_top_holding_tickers(
+    etf_ticker: str, top_n: int = 3
+) -> list[tuple[str, str, float]]:
+    """Structured top-N holdings for an ETF: ``[(ticker, name, weight_pct), ...]``.
+
+    The drill-down tool feeds these tuples back through ``route_to_vendor``
+    to fetch per-constituent fundamentals and news. Symbol formatting in
+    yfinance is inconsistent (``9988.HK`` canonical, ``00939`` bare HK,
+    ``HSBA.L`` London cross-listing), so we normalize bare 5-digit numerics
+    to ``.HK`` and pass anything else through unchanged.
+
+    Returns ``[]`` rather than raising when ``funds_data`` is unavailable
+    so the orchestrator can emit a friendly "no constituents resolved"
+    message instead of a stack trace.
+    """
+    try:
+        ticker_obj = yf.Ticker(etf_ticker.upper())
+        fd = getattr(ticker_obj, "funds_data", None)
+        if fd is None:
+            return []
+        df = getattr(fd, "top_holdings", None)
+        if df is None or (hasattr(df, "empty") and df.empty):
+            return []
+    except Exception:  # noqa: BLE001
+        return []
+
+    out: list[tuple[str, str, float]] = []
+    for sym, row in df.head(top_n).iterrows():
+        raw = str(sym).strip()
+        # Bare 5-digit code (HK convention with leading zeros) → append .HK
+        if raw.isdigit() and len(raw) <= 5:
+            normalized = f"{raw.zfill(5)}.HK"
+        else:
+            normalized = raw
+        name = str(row.get("Name", raw))
+        weight = row.get("Holding Percent", 0.0)
+        # yfinance is inconsistent: usually decimal (0.062) but occasionally
+        # already percent (6.2). 1.5 is a safe threshold — no single holding
+        # in a diversified fund exceeds 150%, and no decimal weight reaches 1.5.
+        try:
+            value = float(weight)
+            weight_pct = value * 100 if value < 1.5 else value
+        except (TypeError, ValueError):
+            weight_pct = 0.0
+        out.append((normalized, name, weight_pct))
+    return out

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -96,6 +96,7 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
         "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "etf_data": "yfinance",              # Options: yfinance
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -39,6 +39,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_global_news,
     get_etf_profile,
     get_etf_holdings,
+    get_etf_top_holdings_drilldown,
 )
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
@@ -193,6 +194,7 @@ class TradingAgentsGraph:
                     # the methods the analyst chooses to call.
                     get_etf_profile,
                     get_etf_holdings,
+                    get_etf_top_holdings_drilldown,
                 ]
             ),
         }

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -36,7 +36,9 @@ from tradingagents.agents.utils.agent_utils import (
     get_income_statement,
     get_news,
     get_insider_transactions,
-    get_global_news
+    get_global_news,
+    get_etf_profile,
+    get_etf_holdings,
 )
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
@@ -186,6 +188,11 @@ class TradingAgentsGraph:
                     get_balance_sheet,
                     get_cashflow,
                     get_income_statement,
+                    # ETF-specific tools — must be registered here too because
+                    # ToolNode validates the entire bound toolset, not just
+                    # the methods the analyst chooses to call.
+                    get_etf_profile,
+                    get_etf_holdings,
                 ]
             ),
         }


### PR DESCRIPTION
## Summary

This PR improves ETF analysis by routing ETF tickers through fund-specific profile, holdings, and constituent drill-down tools instead of treating ETFs like operating companies.

ETFs do not have company-style income statements, balance sheets, cash flows, or insider transactions. This change adds ETF-aware tooling and prompt guidance so the fundamentals and risk agents analyze ETFs through fund-specific dimensions such as holdings concentration, tracking strategy, expense ratio, AUM, liquidity, structure risk, and leveraged/inverse ETF decay.

## Changes

- Added ETF detection using yfinance `quoteType`, with cached lookups to avoid repeated metadata calls.
- Added ETF-specific placeholders for company-style financial tools, including:
  - `get_fundamentals`
  - `get_balance_sheet`
  - `get_cashflow`
  - `get_income_statement`
  - `get_insider_transactions`
- Added yfinance-backed ETF profile and holdings support.
- Added Alpha Vantage ETF profile and holdings support through `ETF_PROFILE`.
- Added holdings concentration metrics, including:
  - largest single holding
  - top-N aggregate weight
  - top-N Herfindahl index
- Added ETF top-holdings drill-down to fetch constituent-level fundamentals and news for major ETF holdings.
- Wired ETF tools into the fundamentals analyst and fundamentals ToolNode.
- Updated the fundamentals analyst prompt to use ETF-specific tools for ETF tickers.
- Added ETF-specific risk guidance for aggressive, neutral, and conservative risk debaters.
- Added structural warnings for leveraged and inverse ETFs, including daily reset and path-dependent decay risks.
- Added unit coverage for ETF detection, routing, placeholders, vendor rendering, drill-down, prompt context, ToolNode wiring, concentration metrics, and leveraged/inverse ETF warnings.

## Design notes

- ETF placeholders are applied at the dispatch layer instead of inside individual vendor modules. This keeps vendor modules provider-pure while ensuring routed tool calls consistently redirect ETF tickers to ETF-specific tools.
- News tools are intentionally not blocked for ETF tickers. ETF-related news remains useful and continues through the normal news path.
- The top-holdings drill-down tool is intended for small `top_n` values because each constituent triggers both a fundamentals call and a news call.
- Direct vendor calls remain thin wrappers over upstream provider APIs; ETF-aware behavior is applied through normal routed tool calls.

## Testing

```bash
python -m pytest tests/test_etf_support.py -q