### PR TITLE
fix: inject resolved instrument identity into prompts

### DIFF
--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -674,6 +674,23 @@ class TestPortfolioManagerInjection:
         state = propagator.create_initial_state("NVDA", "2026-01-10")
         assert state["past_context"] == ""
 
+    def test_instrument_context_in_initial_state(self):
+        propagator = Propagator()
+        state = propagator.create_initial_state(
+            "TOTDY",
+            "2026-01-10",
+            instrument_context="Resolved instrument identity: Company: TOTO LTD.",
+        )
+        assert "instrument_context" in state
+        assert state["instrument_context"] == (
+            "Resolved instrument identity: Company: TOTO LTD."
+        )
+
+    def test_instrument_context_defaults_to_empty(self):
+        propagator = Propagator()
+        state = propagator.create_initial_state("NVDA", "2026-01-10")
+        assert state["instrument_context"] == ""
+
     # PM prompt
 
     def test_pm_prompt_includes_past_context(self):

--- a/tests/test_ticker_symbol_handling.py
+++ b/tests/test_ticker_symbol_handling.py
@@ -13,6 +13,9 @@ from tradingagents.agents.utils.agent_utils import (
 
 @pytest.mark.unit
 class TickerSymbolHandlingTests(unittest.TestCase):
+    def setUp(self):
+        resolve_instrument_identity.cache_clear()
+
     def test_normalize_ticker_symbol_preserves_exchange_suffix(self):
         self.assertEqual(normalize_ticker_symbol(" cnc.to "), "CNC.TO")
 
@@ -77,6 +80,19 @@ class TickerSymbolHandlingTests(unittest.TestCase):
                 "quote_type": "EQUITY",
             },
         )
+
+    def test_resolve_instrument_identity_caches_yfinance_metadata(self):
+        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock_ticker:
+            mock_ticker.return_value.info = {
+                "longName": "TOTO LTD.",
+                "sector": "Industrials",
+            }
+
+            first_identity = resolve_instrument_identity("TOTDY")
+            second_identity = resolve_instrument_identity("TOTDY")
+
+        mock_ticker.assert_called_once_with("TOTDY")
+        self.assertEqual(first_identity, second_identity)
 
     def test_resolve_instrument_identity_fails_open(self):
         with patch(

--- a/tests/test_ticker_symbol_handling.py
+++ b/tests/test_ticker_symbol_handling.py
@@ -1,9 +1,14 @@
 import unittest
+from unittest.mock import patch
 
 import pytest
 
 from cli.utils import normalize_ticker_symbol
-from tradingagents.agents.utils.agent_utils import build_instrument_context
+from tradingagents.agents.utils.agent_utils import (
+    build_instrument_context,
+    get_instrument_context_from_state,
+    resolve_instrument_identity,
+)
 
 
 @pytest.mark.unit
@@ -15,6 +20,70 @@ class TickerSymbolHandlingTests(unittest.TestCase):
         context = build_instrument_context("7203.T")
         self.assertIn("7203.T", context)
         self.assertIn("exchange suffix", context)
+
+    def test_build_instrument_context_includes_resolved_identity(self):
+        context = build_instrument_context(
+            "TOTDY",
+            {
+                "company_name": "TOTO LTD.",
+                "sector": "Industrials",
+                "industry": "Building Products & Equipment",
+                "exchange": "PNK",
+                "quote_type": "EQUITY",
+            },
+        )
+
+        self.assertIn("TOTDY", context)
+        self.assertIn("Company: TOTO LTD.", context)
+        self.assertIn(
+            "Business classification: Industrials / Building Products & Equipment",
+            context,
+        )
+        self.assertIn("Exchange: PNK", context)
+        self.assertIn("Do not substitute a different company or ticker", context)
+
+    def test_get_instrument_context_from_state_prefers_precomputed_context(self):
+        state = {
+            "company_of_interest": "TOTDY",
+            "instrument_context": "precomputed identity context",
+        }
+
+        self.assertEqual(
+            get_instrument_context_from_state(state),
+            "precomputed identity context",
+        )
+
+    def test_resolve_instrument_identity_uses_yfinance_metadata(self):
+        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock_ticker:
+            mock_ticker.return_value.info = {
+                "longName": "TOTO LTD.",
+                "shortName": "TOTO",
+                "sector": "Industrials",
+                "industry": "Building Products & Equipment",
+                "exchange": "PNK",
+                "quoteType": "EQUITY",
+            }
+
+            identity = resolve_instrument_identity("totdy")
+
+        mock_ticker.assert_called_once_with("TOTDY")
+        self.assertEqual(
+            identity,
+            {
+                "company_name": "TOTO LTD.",
+                "sector": "Industrials",
+                "industry": "Building Products & Equipment",
+                "exchange": "PNK",
+                "quote_type": "EQUITY",
+            },
+        )
+
+    def test_resolve_instrument_identity_fails_open(self):
+        with patch(
+            "tradingagents.agents.utils.agent_utils.yf.Ticker",
+            side_effect=RuntimeError("rate limited"),
+        ):
+            self.assertEqual(resolve_instrument_identity("TOTDY"), {})
 
 
 if __name__ == "__main__":

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -1,9 +1,9 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
     get_balance_sheet,
     get_cashflow,
     get_fundamentals,
+    get_instrument_context_from_state,
     get_income_statement,
     get_insider_transactions,
     get_language_instruction,
@@ -14,7 +14,7 @@ from tradingagents.dataflows.config import get_config
 def create_fundamentals_analyst(llm):
     def fundamentals_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        instrument_context = get_instrument_context_from_state(state)
 
         tools = [
             get_fundamentals,

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,6 +1,6 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
+    get_instrument_context_from_state,
     get_indicators,
     get_language_instruction,
     get_stock_data,
@@ -12,7 +12,7 @@ def create_market_analyst(llm):
 
     def market_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        instrument_context = get_instrument_context_from_state(state)
 
         tools = [
             get_stock_data,

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,7 +1,7 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
     get_global_news,
+    get_instrument_context_from_state,
     get_language_instruction,
     get_news,
 )
@@ -11,7 +11,7 @@ from tradingagents.dataflows.config import get_config
 def create_news_analyst(llm):
     def news_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        instrument_context = get_instrument_context_from_state(state)
 
         tools = [
             get_news,

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
+    get_instrument_context_from_state,
     get_language_instruction,
     get_news,
 )
@@ -47,7 +47,7 @@ def create_sentiment_analyst(llm):
         ticker = state["company_of_interest"]
         end_date = state["trade_date"]
         start_date = _seven_days_back(end_date)
-        instrument_context = build_instrument_context(ticker)
+        instrument_context = get_instrument_context_from_state(state)
 
         # Pre-fetch all three sources. Each fetcher degrades gracefully and
         # returns a string (no exceptions surface from here), so the LLM

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from tradingagents.agents.schemas import PortfolioDecision, render_pm_decision
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
+    get_instrument_context_from_state,
     get_language_instruction,
 )
 from tradingagents.agents.utils.structured import (
@@ -25,7 +25,7 @@ def create_portfolio_manager(llm):
     structured_llm = bind_structured(llm, PortfolioDecision, "Portfolio Manager")
 
     def portfolio_manager_node(state) -> dict:
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        instrument_context = get_instrument_context_from_state(state)
 
         history = state["risk_debate_state"]["history"]
         risk_debate_state = state["risk_debate_state"]

--- a/tradingagents/agents/managers/research_manager.py
+++ b/tradingagents/agents/managers/research_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from tradingagents.agents.schemas import ResearchPlan, render_research_plan
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
+    get_instrument_context_from_state,
     get_language_instruction,
 )
 from tradingagents.agents.utils.structured import (
@@ -17,7 +17,7 @@ def create_research_manager(llm):
     structured_llm = bind_structured(llm, ResearchPlan, "Research Manager")
 
     def research_manager_node(state) -> dict:
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        instrument_context = get_instrument_context_from_state(state)
         history = state["investment_debate_state"].get("history", "")
 
         investment_debate_state = state["investment_debate_state"]

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
 
 
 def create_bear_researcher(llm):
@@ -12,6 +15,7 @@ def create_bear_researcher(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
 
         prompt = f"""You are a Bear Analyst making the case against investing in the stock. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
 
@@ -25,6 +29,7 @@ Key points to focus on:
 
 Resources available:
 
+Instrument context: {instrument_context}
 Market research report: {market_research_report}
 Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
 
 
 def create_bull_researcher(llm):
@@ -12,6 +15,7 @@ def create_bull_researcher(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
 
         prompt = f"""You are a Bull Analyst advocating for investing in the stock. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
 
@@ -23,6 +27,7 @@ Key points to focus on:
 - Engagement: Present your argument in a conversational style, engaging directly with the bear analyst's points and debating effectively rather than just listing data.
 
 Resources available:
+Instrument context: {instrument_context}
 Market research report: {market_research_report}
 Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
 
 
 def create_aggressive_debator(llm):
@@ -14,6 +17,7 @@ def create_aggressive_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -23,6 +27,7 @@ def create_aggressive_debator(llm):
 
 Your task is to create a compelling case for the trader's decision by questioning and critiquing the conservative and neutral stances to demonstrate why your high-reward perspective offers the best path forward. Incorporate insights from the following sources into your arguments:
 
+Instrument Context: {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
 
 
 def create_conservative_debator(llm):
@@ -14,6 +17,7 @@ def create_conservative_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -23,6 +27,7 @@ def create_conservative_debator(llm):
 
 Your task is to actively counter the arguments of the Aggressive and Neutral Analysts, highlighting where their views may overlook potential threats or fail to prioritize sustainability. Respond directly to their points, drawing from the following data sources to build a convincing case for a low-risk approach adjustment to the trader's decision:
 
+Instrument Context: {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -1,4 +1,7 @@
-from tradingagents.agents.utils.agent_utils import get_language_instruction
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
 
 
 def create_neutral_debator(llm):
@@ -14,6 +17,7 @@ def create_neutral_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -23,6 +27,7 @@ def create_neutral_debator(llm):
 
 Your task is to challenge both the Aggressive and Conservative Analysts, pointing out where each perspective may be overly optimistic or overly cautious. Use insights from the following data sources to support a moderate, sustainable strategy to adjust the trader's decision:
 
+Instrument Context: {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -8,7 +8,7 @@ from langchain_core.messages import AIMessage
 
 from tradingagents.agents.schemas import TraderProposal, render_trader_proposal
 from tradingagents.agents.utils.agent_utils import (
-    build_instrument_context,
+    get_instrument_context_from_state,
     get_language_instruction,
 )
 from tradingagents.agents.utils.structured import (
@@ -22,7 +22,7 @@ def create_trader(llm):
 
     def trader_node(state, name):
         company_name = state["company_of_interest"]
-        instrument_context = build_instrument_context(company_name)
+        instrument_context = get_instrument_context_from_state(state)
         investment_plan = state["investment_plan"]
 
         messages = [

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -46,6 +46,10 @@ class RiskDebateState(TypedDict):
 class AgentState(MessagesState):
     company_of_interest: Annotated[str, "Company that we are interested in trading"]
     trade_date: Annotated[str, "What date we are trading at"]
+    instrument_context: Annotated[
+        str,
+        "Deterministic ticker identity context injected at run start",
+    ]
 
     sender: Annotated[str, "Agent that sent this message"]
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -1,4 +1,5 @@
 import logging
+import functools
 from typing import Any, Mapping
 
 import yfinance as yf
@@ -51,6 +52,7 @@ def _clean_identity_value(value: Any) -> str | None:
     return cleaned
 
 
+@functools.lru_cache(maxsize=128)
 def resolve_instrument_identity(ticker: str) -> dict[str, str]:
     """Resolve deterministic company identity metadata for a ticker.
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -1,3 +1,7 @@
+import logging
+from typing import Any, Mapping
+
+import yfinance as yf
 from langchain_core.messages import HumanMessage, RemoveMessage
 
 # Import tools from separate utility files
@@ -19,6 +23,8 @@ from tradingagents.agents.utils.news_data_tools import (
     get_global_news
 )
 
+logger = logging.getLogger(__name__)
+
 
 def get_language_instruction() -> str:
     """Return a prompt instruction for the configured output language.
@@ -36,13 +42,100 @@ def get_language_instruction() -> str:
     return f" Write your entire response in {lang}."
 
 
-def build_instrument_context(ticker: str) -> str:
+def _clean_identity_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned or cleaned.lower() in {"none", "n/a", "nan", "null"}:
+        return None
+    return cleaned
+
+
+def resolve_instrument_identity(ticker: str) -> dict[str, str]:
+    """Resolve deterministic company identity metadata for a ticker.
+
+    This is intentionally best-effort: if yfinance is unavailable, rate-limited,
+    or does not know the ticker, the graph should still run with ticker-only
+    context rather than fail before analysis starts.
+    """
+    try:
+        info = yf.Ticker(ticker.upper()).info or {}
+    except Exception as exc:
+        logger.debug("Could not resolve instrument identity for %s: %s", ticker, exc)
+        return {}
+
+    identity: dict[str, str] = {}
+    company_name = _clean_identity_value(info.get("longName")) or _clean_identity_value(
+        info.get("shortName")
+    )
+    if company_name:
+        identity["company_name"] = company_name
+
+    for source_key, target_key in (
+        ("sector", "sector"),
+        ("industry", "industry"),
+        ("exchange", "exchange"),
+        ("quoteType", "quote_type"),
+    ):
+        value = _clean_identity_value(info.get(source_key))
+        if value:
+            identity[target_key] = value
+
+    return identity
+
+
+def build_instrument_context(
+    ticker: str,
+    identity: Mapping[str, str] | None = None,
+) -> str:
     """Describe the exact instrument so agents preserve exchange-qualified tickers."""
-    return (
+    context = (
         f"The instrument to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
         "preserving any exchange suffix (e.g. `.TO`, `.L`, `.HK`, `.T`)."
     )
+
+    if not identity:
+        return context
+
+    details = []
+    company_name = identity.get("company_name") or identity.get("name")
+    if company_name:
+        details.append(f"Company: {company_name}")
+
+    sector = identity.get("sector")
+    industry = identity.get("industry")
+    if sector and industry:
+        details.append(f"Business classification: {sector} / {industry}")
+    elif sector:
+        details.append(f"Sector: {sector}")
+    elif industry:
+        details.append(f"Industry: {industry}")
+
+    exchange = identity.get("exchange")
+    if exchange:
+        details.append(f"Exchange: {exchange}")
+
+    quote_type = identity.get("quote_type")
+    if quote_type:
+        details.append(f"Quote type: {quote_type}")
+
+    if not details:
+        return context
+
+    return (
+        f"{context} Resolved instrument identity: {'; '.join(details)}. "
+        "Do not substitute a different company or ticker unless a tool result "
+        "explicitly disproves this resolved identity."
+    )
+
+
+def get_instrument_context_from_state(state: Mapping[str, Any]) -> str:
+    context = state.get("instrument_context")
+    if isinstance(context, str) and context.strip():
+        return context
+    return build_instrument_context(str(state["company_of_interest"]))
+
 
 def create_msg_delete():
     def delete_messages(state):

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -16,7 +16,11 @@ class Propagator:
         self.max_recur_limit = max_recur_limit
 
     def create_initial_state(
-        self, company_name: str, trade_date: str, past_context: str = ""
+        self,
+        company_name: str,
+        trade_date: str,
+        past_context: str = "",
+        instrument_context: str = "",
     ) -> Dict[str, Any]:
         """Create the initial state for the agent graph."""
         return {
@@ -24,6 +28,7 @@ class Propagator:
             "company_of_interest": company_name,
             "trade_date": str(trade_date),
             "past_context": past_context,
+            "instrument_context": instrument_context,
             "investment_debate_state": InvestDebateState(
                 {
                     "bull_history": "",

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -28,6 +28,7 @@ from tradingagents.dataflows.config import set_config
 
 # Import the new abstract tool methods from agent_utils
 from tradingagents.agents.utils.agent_utils import (
+    build_instrument_context,
     get_stock_data,
     get_indicators,
     get_fundamentals,
@@ -36,7 +37,8 @@ from tradingagents.agents.utils.agent_utils import (
     get_income_statement,
     get_news,
     get_insider_transactions,
-    get_global_news
+    get_global_news,
+    resolve_instrument_identity,
 )
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
@@ -291,6 +293,10 @@ class TradingAgentsGraph:
         if updates:
             self.memory_log.batch_update_with_outcomes(updates)
 
+    def _build_instrument_context(self, ticker: str) -> str:
+        identity = resolve_instrument_identity(ticker)
+        return build_instrument_context(ticker, identity)
+
     def propagate(self, company_name, trade_date):
         """Run the trading agents graph for a company on a specific date.
 
@@ -333,8 +339,12 @@ class TradingAgentsGraph:
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM.
         past_context = self.memory_log.get_past_context(company_name)
+        instrument_context = self._build_instrument_context(company_name)
         init_agent_state = self.propagator.create_initial_state(
-            company_name, trade_date, past_context=past_context
+            company_name,
+            trade_date,
+            past_context=past_context,
+            instrument_context=instrument_context,
         )
         args = self.propagator.get_graph_args()
 


### PR DESCRIPTION
## Summary
- Resolve ticker identity once at graph startup using yfinance metadata
- Store the resulting instrument context in the initial agent state
- Reuse that context across analysts, researchers, trader, risk debaters, research manager, and portfolio manager prompts
- Add regression tests for resolved identity context and fail-open identity resolution

Resolves #814

## Testing
- `uv run --with pytest python -m pytest tests/test_ticker_symbol_handling.py tests/test_memory_log.py::TestPortfolioManagerInjection -q`
- `uv run --with pytest python -m pytest -q`