### PR TITLE
feat: 持仓上下文注入 - 基于用户实际持仓增强交易决策

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ OPENAI_API_KEY=
 GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=
 XAI_API_KEY=
-DEEPSEEK_API_KEY=
+DEEPSEEK_API_KEY=sk-9d324eea603b4eddb9c9a618c774e8bb
 DASHSCOPE_API_KEY=
 DASHSCOPE_CN_API_KEY=
 ZHIPU_API_KEY=
@@ -22,20 +22,15 @@ OPENROUTER_API_KEY=
 # Any TRADINGAGENTS_* variable below, when set, replaces the matching key
 # in tradingagents/default_config.py. Values are coerced to the type of
 # the existing default (bool / int / str), so "true"/"3" work as expected.
-#TRADINGAGENTS_LLM_PROVIDER=openai
-#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
-#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+TRADINGAGENTS_LLM_PROVIDER=deepseek
+TRADINGAGENTS_DEEP_THINK_LLM=deepseek-v4-pro
+TRADINGAGENTS_QUICK_THINK_LLM=deepseek-v4-flash
 #TRADINGAGENTS_LLM_BACKEND_URL=
-#TRADINGAGENTS_OUTPUT_LANGUAGE=English
-#TRADINGAGENTS_MAX_DEBATE_ROUNDS=1
-#TRADINGAGENTS_MAX_RISK_ROUNDS=1
-#TRADINGAGENTS_CHECKPOINT_ENABLED=false
+TRADINGAGENTS_OUTPUT_LANGUAGE=Simplified Chinese
+TRADINGAGENTS_MAX_DEBATE_ROUNDS=2
+TRADINGAGENTS_MAX_RISK_ROUNDS=1
+TRADINGAGENTS_CHECKPOINT_ENABLED=true
 
-# ─── Tushare Data Source ───────────────────────────────────────────
-TUSHARE_API_KEY=
-
-# ─── News Service ─────────────────────────────────────────────────
-NEWS_SERVER_BASE_URL=https://news.zehb.cn:228
-NEWS_SERVER_API_KEY=
-# Optional: HTTP proxy for news service (e.g., http://127.0.0.1:7890)
-NEWS_SERVER_PROXY=
+# Data Source API Keys
+TUSHARE_API_KEY=79b1e47fd522b412eb6e6a5ac9615ce08876eb78d84e4679dc865c47
+NEWS_SERVER_API_KEY=PkaRRuy7p7uZZSf3ocSgtk3J2uUs2gNASRJ7Zk8gI18

--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ OPENROUTER_API_KEY=
 #TRADINGAGENTS_MAX_RISK_ROUNDS=1
 #TRADINGAGENTS_CHECKPOINT_ENABLED=false
 
-# ─── Tushare Data Source ───────────────────────────────────────────
-TUSHARE_API_KEY=
+# ─── Tushare Data Source (Optional - only needed if using tushare as fallback) ──
+# TUSHARE_API_KEY=
 
 # ─── News Service ─────────────────────────────────────────────────
 NEWS_SERVER_BASE_URL=https://news.zehb.cn:228

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+reports
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]
@@ -148,7 +150,6 @@ activemq-data/
 *.sage.py
 
 # Environments
-.env
 .envrc
 .venv
 env/

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,133 @@
+# TradingAgents 项目定制记录
+
+本文件记录项目中的定制脚本、配置约定和集成逻辑，供后续 agent 快速理解上下文。
+
+---
+
+## 1. 持仓上下文注入功能
+
+### 功能概述
+
+在原有的多智能体股票分析流程基础上，新增了用户持仓管理能力。系统在分析时会自动将用户的实际持仓信息（成本、仓位、交易历史）注入到 Trader 和 Portfolio Manager 的 Prompt 中，使决策考虑用户的真实持仓状况。
+
+### 核心模块
+
+| 模块 | 路径 | 说明 |
+|------|------|------|
+| 数据模型 | `tradingagents/portfolio/models.py` | PositionRecord, Transaction, Portfolio (Pydantic v2) |
+| 存储层 | `tradingagents/portfolio/store.py` | PortfolioStore - JSON 文件持久化 CRUD |
+| 上下文生成 | `tradingagents/portfolio/context.py` | build_portfolio_context() - 生成 Markdown 格式的持仓上下文 |
+| 状态集成 | `tradingagents/agents/utils/agent_states.py` | AgentState 中的 `portfolio_context` 字段 |
+| Prompt 注入 | `tradingagents/agents/trader/trader.py` | 交易员 Prompt 末尾追加持仓上下文 |
+| Prompt 注入 | `tradingagents/agents/managers/portfolio_manager.py` | 组合经理 Prompt 末尾追加持仓上下文 |
+| 配置项 | `tradingagents/default_config.py` | `portfolio_enabled`, `portfolio_path` |
+| CLI 命令 | `cli/portfolio_cmd.py` | portfolio add/remove/list/clear, portfolio tx add/list |
+| CLI 集成 | `cli/main.py` | 分析前自动检测持仓并提示 |
+
+### 数据存储
+
+- 默认路径: `~/.tradingagents/portfolio/portfolio.json`
+- 环境变量覆盖: `TRADINGAGENTS_PORTFOLIO_PATH`
+- 格式: JSON，包含 positions 数组和 transactions 数组
+
+### 配置项
+
+```python
+# default_config.py 中的相关配置
+"portfolio_enabled": True,   # 是否启用持仓上下文注入
+"portfolio_path": "",        # 自定义持仓文件路径（空=使用默认）
+```
+
+对应环境变量:
+- `TRADINGAGENTS_PORTFOLIO_ENABLED` → portfolio_enabled
+- `TRADINGAGENTS_PORTFOLIO_PATH` → portfolio_path
+
+---
+
+## 2. 持仓同步脚本
+
+### 脚本路径
+
+`scripts/import_portfolio.py`
+
+### 功能
+
+从平级的 `financial-management` 项目一键同步持仓和交易记录到 TradingAgents 的 Portfolio 系统。
+
+### 目录结构约定
+
+两个项目**始终保持平级目录**：
+```
+parent_dir/
+├── TradingAgents/           ← 本项目
+└── financial-management/    ← 持仓数据源
+```
+
+脚本使用相对路径定位 financial-management：
+```python
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+FINANCIAL_MGMT_ROOT = _PROJECT_ROOT.parent / "financial-management"
+```
+
+### 数据源文件
+
+| 文件 | 路径（相对 financial-management） | 用途 |
+|------|------|------|
+| 持仓快照 | `data/parsed/{YYYY-MM}/holdings.json` | 当月持仓明细 |
+| 交易记录 | `data/parsed/{YYYY-MM}/transactions.json` | 当月交易流水 |
+| 组合状态 | `state/portfolio.json` | 精确均价（avg_cost） |
+
+### 同步逻辑
+
+1. 自动扫描 `data/parsed/` 下所有月份目录，选最新月份读取 holdings
+2. 聚合**所有月份**的 transactions（不只是最新月份）
+3. 只导入 `type=="trade"` 的真实买卖记录，过滤逆回购/银证转账等
+4. 优先从 `state/portfolio.json` 获取精确 avg_cost
+5. 根据 market 字段或 symbol 编码规则自动推断 .SH/.SZ 后缀
+6. 全量同步（清空旧数据后重新导入）
+
+### 使用方式
+
+```bash
+cd TradingAgents
+python scripts/import_portfolio.py
+```
+
+---
+
+## 3. 开发分支约定
+
+- 新功能开发使用独立 feature 分支
+- 本功能开发分支: `feature/portfolio-context`
+
+---
+
+## 4. 关键环境变量
+
+| 变量 | 用途 | 示例 |
+|------|------|------|
+| `TRADINGAGENTS_OUTPUT_LANGUAGE` | 控制分析报告输出语言 | `Chinese` |
+| `TRADINGAGENTS_PORTFOLIO_ENABLED` | 启用/禁用持仓注入 | `true` |
+| `TRADINGAGENTS_PORTFOLIO_PATH` | 自定义持仓文件路径 | `/path/to/portfolio.json` |
+| `TRADINGAGENTS_LLM_PROVIDER` | LLM 服务商 | `openai` |
+| `TRADINGAGENTS_DEEP_THINK_LLM` | 深度思考模型 | `gpt-5.4` |
+| `TRADINGAGENTS_QUICK_THINK_LLM` | 快速思考模型 | `gpt-5.4-mini` |
+
+---
+
+## 5. 数据流概览
+
+```
+financial-management (持仓源)
+    │
+    │  python scripts/import_portfolio.py
+    ▼
+~/.tradingagents/portfolio/portfolio.json
+    │
+    │  TradingAgentsGraph.propagate(ticker, date)
+    ▼
+AgentState.portfolio_context (Markdown 文本)
+    │
+    ├──→ Trader Prompt (考虑持仓做交易建议)
+    └──→ Portfolio Manager Prompt (考虑持仓做最终评级)
+```

--- a/cli/main.py
+++ b/cli/main.py
@@ -26,6 +26,7 @@ from cli.models import AnalystType
 from cli.utils import *
 from cli.announcements import fetch_announcements, display_announcements
 from cli.stats_handler import StatsCallbackHandler
+from cli.portfolio_cmd import portfolio_app
 
 console = Console()
 
@@ -34,6 +35,7 @@ app = typer.Typer(
     help="TradingAgents CLI: Multi-Agents LLM Financial Trading Framework",
     add_completion=True,  # Enable shell completion
 )
+app.add_typer(portfolio_app, name="portfolio")
 
 
 # Create a deque to store recent messages with a maximum length
@@ -963,6 +965,23 @@ def format_tool_args(args, max_length=80) -> str:
 def run_analysis(checkpoint: bool = False):
     # First get all user selections
     selections = get_user_selections()
+
+    # Check if ticker is in user's portfolio
+    try:
+        from tradingagents.portfolio import PortfolioStore
+
+        portfolio_store = PortfolioStore()
+        positions = portfolio_store.get_position(selections["ticker"])
+        if positions:
+            total_qty = sum(p.quantity for p in positions)
+            avg_cost = sum(p.entry_price * p.quantity for p in positions) / total_qty
+            console.print(
+                f"\n[bold cyan]\U0001f4cb Portfolio Detection:[/bold cyan] "
+                f"You hold [bold]{selections['ticker']}[/bold] \u2014 {total_qty:,.2f} shares @ avg cost {avg_cost:,.4f}. "
+                f"[dim]This has been included in the analysis context.[/dim]\n"
+            )
+    except Exception:
+        pass  # Silently skip if portfolio check fails
 
     # Create config with selected research depth
     config = DEFAULT_CONFIG.copy()

--- a/cli/portfolio_cmd.py
+++ b/cli/portfolio_cmd.py
@@ -1,0 +1,200 @@
+"""CLI commands for portfolio management."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich.prompt import Prompt, Confirm
+from datetime import datetime
+
+from tradingagents.portfolio import PortfolioStore, PositionRecord, Transaction
+
+portfolio_app = typer.Typer(help="Manage your portfolio positions and transactions.")
+tx_app = typer.Typer(help="Manage transaction records.")
+portfolio_app.add_typer(tx_app, name="tx")
+
+console = Console()
+
+
+def _get_store() -> PortfolioStore:
+    """Get portfolio store instance."""
+    return PortfolioStore()
+
+
+@portfolio_app.command("add")
+def portfolio_add():
+    """Interactively add a new position to your portfolio."""
+    console.print("\n[bold cyan]Add New Position[/bold cyan]\n")
+
+    ticker = Prompt.ask("Stock ticker (e.g., NVDA, 000404.SH)")
+    if not ticker.strip():
+        console.print("[red]Ticker cannot be empty.[/red]")
+        raise typer.Exit(1)
+
+    entry_date = Prompt.ask("Entry date (YYYY-MM-DD)", default=datetime.now().strftime("%Y-%m-%d"))
+    entry_price = float(Prompt.ask("Average entry price"))
+    quantity = float(Prompt.ask("Quantity (shares)"))
+    side = Prompt.ask("Side", choices=["long", "short"], default="long")
+    note = Prompt.ask("Note (optional, press Enter to skip)", default="")
+
+    # Confirm
+    console.print(f"\n[yellow]Confirm:[/yellow] {ticker.upper()} | {side} | {quantity} shares @ {entry_price} | {entry_date}")
+    if not Confirm.ask("Save this position?"):
+        console.print("[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+
+    store = _get_store()
+    position = PositionRecord(
+        ticker=ticker.upper().strip(),
+        entry_date=entry_date,
+        entry_price=entry_price,
+        quantity=quantity,
+        side=side,
+        note=note,
+    )
+    store.add_position(position)
+    console.print("[green]Position added successfully![/green]")
+
+
+@portfolio_app.command("remove")
+def portfolio_remove():
+    """Remove a position from your portfolio."""
+    store = _get_store()
+    positions = store.list_positions()
+
+    if not positions:
+        console.print("[yellow]No positions in portfolio.[/yellow]")
+        raise typer.Exit()
+
+    # Show current positions
+    console.print("\n[bold]Current Positions:[/bold]")
+    for i, p in enumerate(positions, 1):
+        console.print(f"  {i}. {p.ticker} | {p.quantity} shares @ {p.entry_price} | {p.entry_date}")
+
+    ticker = Prompt.ask("\nTicker to remove")
+    if store.remove_position(ticker):
+        console.print(f"[green]Removed all positions for {ticker.upper()}.[/green]")
+    else:
+        console.print(f"[red]No position found for {ticker.upper()}.[/red]")
+
+
+@portfolio_app.command("list")
+def portfolio_list():
+    """List all positions in your portfolio."""
+    store = _get_store()
+    positions = store.list_positions()
+
+    if not positions:
+        console.print("[yellow]Portfolio is empty. Use 'portfolio add' to add positions.[/yellow]")
+        raise typer.Exit()
+
+    table = Table(title="Portfolio Positions", show_lines=True)
+    table.add_column("Ticker", style="cyan", no_wrap=True)
+    table.add_column("Side", style="dim")
+    table.add_column("Quantity", justify="right")
+    table.add_column("Entry Price", justify="right")
+    table.add_column("Cost Basis", justify="right", style="yellow")
+    table.add_column("Entry Date")
+    table.add_column("Note", style="dim")
+
+    total_cost = 0.0
+    for p in positions:
+        cost = p.entry_price * p.quantity
+        total_cost += cost
+        table.add_row(
+            p.ticker,
+            p.side,
+            f"{p.quantity:,.2f}",
+            f"{p.entry_price:,.4f}",
+            f"{cost:,.2f}",
+            p.entry_date,
+            p.note or "-",
+        )
+
+    console.print(table)
+    console.print(f"\n[bold]Total Cost Basis:[/bold] {total_cost:,.2f}")
+    console.print(f"[bold]Total Positions:[/bold] {len(positions)}")
+
+
+@portfolio_app.command("clear")
+def portfolio_clear():
+    """Clear all portfolio data (positions and transactions)."""
+    if not Confirm.ask("[red]Are you sure you want to clear ALL portfolio data?[/red]"):
+        console.print("[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+
+    store = _get_store()
+    store.clear()
+    console.print("[green]Portfolio data cleared.[/green]")
+
+
+# ─── Transaction subcommands ──────────────────────────────────
+
+
+@tx_app.command("add")
+def tx_add():
+    """Add a transaction record."""
+    console.print("\n[bold cyan]Add Transaction[/bold cyan]\n")
+
+    ticker = Prompt.ask("Stock ticker")
+    action = Prompt.ask("Action", choices=["buy", "sell"])
+    date = Prompt.ask("Date (YYYY-MM-DD)", default=datetime.now().strftime("%Y-%m-%d"))
+    price = float(Prompt.ask("Price"))
+    quantity = float(Prompt.ask("Quantity"))
+    note = Prompt.ask("Note (optional)", default="")
+
+    console.print(f"\n[yellow]Confirm:[/yellow] {action.upper()} {ticker.upper()} | {quantity} shares @ {price} | {date}")
+    if not Confirm.ask("Save this transaction?"):
+        console.print("[dim]Cancelled.[/dim]")
+        raise typer.Exit()
+
+    store = _get_store()
+    tx = Transaction(
+        ticker=ticker.upper().strip(),
+        action=action,
+        date=date,
+        price=price,
+        quantity=quantity,
+        note=note,
+    )
+    store.add_transaction(tx)
+    console.print("[green]Transaction recorded![/green]")
+
+
+@tx_app.command("list")
+def tx_list(
+    ticker: str = typer.Option(None, "--ticker", "-t", help="Filter by ticker"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max records to show"),
+):
+    """List transaction records."""
+    store = _get_store()
+    txs = store.list_transactions(ticker=ticker, limit=limit)
+
+    if not txs:
+        msg = "No transactions found"
+        if ticker:
+            msg += f" for {ticker.upper()}"
+        console.print(f"[yellow]{msg}.[/yellow]")
+        raise typer.Exit()
+
+    table = Table(title="Transaction History", show_lines=True)
+    table.add_column("Date", style="dim")
+    table.add_column("Ticker", style="cyan")
+    table.add_column("Action", no_wrap=True)
+    table.add_column("Quantity", justify="right")
+    table.add_column("Price", justify="right")
+    table.add_column("Total", justify="right", style="yellow")
+    table.add_column("Note", style="dim")
+
+    for tx in txs:
+        action_style = "[green]BUY[/green]" if tx.action == "buy" else "[red]SELL[/red]"
+        table.add_row(
+            tx.date,
+            tx.ticker,
+            action_style,
+            f"{tx.quantity:,.2f}",
+            f"{tx.price:,.4f}",
+            f"{tx.price * tx.quantity:,.2f}",
+            tx.note or "-",
+        )
+
+    console.print(table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "setuptools>=80.9.0",
     "stockstats>=0.6.5",
     "tqdm>=4.67.1",
+    "tushare>=1.4.0",
     "typing-extensions>=4.14.0",
     "yfinance>=0.2.63",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "TradingAgents: Multi-Agents LLM Financial Trading Framework"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "akshare>=1.14.0",
     "langchain-core>=0.3.81",
     "backtrader>=1.9.78.123",
     "langchain-anthropic>=0.3.15",
@@ -28,10 +29,13 @@ dependencies = [
     "setuptools>=80.9.0",
     "stockstats>=0.6.5",
     "tqdm>=4.67.1",
-    "tushare>=1.4.0",
     "typing-extensions>=4.14.0",
     "yfinance>=0.2.63",
 ]
+
+[project.optional-dependencies]
+tushare = ["tushare>=1.4.0"]
+
 
 [project.scripts]
 tradingagents = "cli.main:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 .
+akshare>=1.14.0
+tushare>=1.4.0  # optional: only needed if using tushare as fallback

--- a/scripts/import_portfolio.py
+++ b/scripts/import_portfolio.py
@@ -1,0 +1,351 @@
+"""
+一键同步脚本：从 financial-management 项目动态读取持仓和交易记录，
+全量导入到 TradingAgents 的 PortfolioStore 中。
+
+用法:
+    python scripts/import_portfolio.py
+"""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 配置常量 - 两个项目保持平级目录结构
+# TradingAgents/  <-- 本项目
+# financial-management/  <-- 持仓数据源
+# ═══════════════════════════════════════════════════════════════════════════════
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+FINANCIAL_MGMT_ROOT = _PROJECT_ROOT.parent / "financial-management"
+PARSED_DATA_DIR = FINANCIAL_MGMT_ROOT / "data" / "parsed"
+STATE_PORTFOLIO = FINANCIAL_MGMT_ROOT / "state" / "portfolio.json"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tradingagents.portfolio import PortfolioStore, PositionRecord, Transaction
+
+
+def infer_market_suffix(symbol: str, market: str = "") -> str:
+    """根据 market 字段或 symbol 编码规则推断 .SH / .SZ 后缀。
+
+    规则:
+    - market 包含 '上海' → .SH
+    - market 包含 '深圳' → .SZ
+    - 6位 symbol 以 5/6/9 开头 → .SH (上交所)
+    - 6位 symbol 以 0/1/2/3 开头 → .SZ (深交所)
+    - 其他情况不加后缀（如货币基金等）
+    """
+    if "上海" in market:
+        return f"{symbol}.SH"
+    if "深圳" in market:
+        return f"{symbol}.SZ"
+
+    # 根据 symbol 编码规则推断
+    if len(symbol) == 6:
+        first = symbol[0]
+        if first in ("5", "6", "9"):
+            return f"{symbol}.SH"
+        if first in ("0", "1", "2", "3"):
+            return f"{symbol}.SZ"
+
+    # 无法判断，返回原始 symbol
+    return symbol
+
+
+def find_latest_month_dir(parsed_dir: Path) -> Path | None:
+    """扫描 parsed 目录，返回最新月份的子目录路径。
+
+    目录格式: YYYY-MM (如 2026-05)
+    """
+    if not parsed_dir.exists():
+        return None
+
+    month_dirs = []
+    for d in parsed_dir.iterdir():
+        if d.is_dir() and len(d.name) == 7 and d.name[4] == "-":
+            try:
+                # 验证是合法的年-月格式
+                datetime.strptime(d.name, "%Y-%m")
+                month_dirs.append(d)
+            except ValueError:
+                continue
+
+    if not month_dirs:
+        return None
+
+    # 按名称排序，最新的在最后
+    month_dirs.sort(key=lambda x: x.name)
+    return month_dirs[-1]
+
+
+def load_json(path: Path) -> list | dict:
+    """加载 JSON 文件。"""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_avg_cost_map(state_portfolio_path: Path) -> dict[str, float]:
+    """从 portfolio.json 的 buckets 中提取每个持仓的 avg_cost。
+
+    返回 {symbol: avg_cost} 字典。
+    """
+    if not state_portfolio_path.exists():
+        return {}
+
+    try:
+        data = load_json(state_portfolio_path)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    cost_map: dict[str, float] = {}
+    buckets = data.get("buckets", {})
+
+    for bucket_name, bucket_data in buckets.items():
+        if bucket_name.startswith("_"):
+            continue
+        subs = bucket_data.get("sub", {})
+        for sub_name, sub_data in subs.items():
+            for holding in sub_data.get("holdings", []):
+                symbol = holding.get("symbol", "")
+                avg_cost = holding.get("avg_cost", 0.0)
+                if symbol and avg_cost > 0:
+                    cost_map[symbol] = avg_cost
+
+    return cost_map
+
+
+def build_positions(
+    holdings: list[dict],
+    avg_cost_map: dict[str, float],
+    month_str: str,
+) -> list[PositionRecord]:
+    """将 holdings.json 数据映射为 PositionRecord 列表。"""
+    positions = []
+    # 使用月份第一天作为 entry_date
+    entry_date = f"{month_str}-01"
+
+    for h in holdings:
+        symbol = h.get("symbol", "")
+        market = h.get("market", "")
+        qty = h.get("qty", 0.0)
+        name = h.get("name", "")
+        category = h.get("category", "")
+
+        if not symbol or qty <= 0:
+            continue
+
+        ticker = infer_market_suffix(symbol, market)
+
+        # 优先使用 portfolio.json 中的 avg_cost，其次从 cost_basis/qty 计算
+        if symbol in avg_cost_map:
+            entry_price = avg_cost_map[symbol]
+        else:
+            cost_basis = h.get("cost_basis", 0.0)
+            entry_price = cost_basis / qty if qty > 0 else 0.0
+
+        if entry_price <= 0:
+            continue
+
+        note_parts = [name]
+        if category:
+            note_parts.append(category)
+        note = " / ".join(note_parts)
+
+        positions.append(PositionRecord(
+            ticker=ticker,
+            entry_date=entry_date,
+            entry_price=round(entry_price, 6),
+            quantity=qty,
+            side="long",
+            note=note,
+        ))
+
+    return positions
+
+
+def build_transactions(txns: list[dict]) -> list[Transaction]:
+    """将 transactions.json 数据映射为 Transaction 列表。
+
+    只处理 type=="trade" 的记录（真正的买卖交易）。
+    """
+    transactions = []
+
+    for t in txns:
+        tx_type = t.get("type", "")
+        if tx_type != "trade":
+            continue
+
+        symbol = t.get("symbol", "")
+        side = t.get("side", "")
+        price = t.get("price", 0.0)
+        qty = t.get("qty", 0.0)
+        ts_str = t.get("ts", "")
+        name = t.get("name", "")
+
+        if not symbol or not side or price <= 0 or qty <= 0:
+            continue
+
+        # 推断 ticker 后缀（transactions 没有 market 字段）
+        ticker = infer_market_suffix(symbol)
+
+        # 映射 action
+        action = "buy" if side == "buy" else "sell"
+
+        # 提取日期 (从 ISO 时间戳)
+        try:
+            date = datetime.fromisoformat(ts_str).strftime("%Y-%m-%d")
+        except (ValueError, TypeError):
+            date = "unknown"
+
+        # 构建 note
+        note_parts = []
+        if name:
+            note_parts.append(name)
+        memo = t.get("source_file_memo", "") or t.get("memo", "")
+        if memo:
+            note_parts.append(memo)
+        bucket = t.get("bucket", "")
+        if bucket:
+            note_parts.append(f"[{bucket}]")
+        note = " / ".join(note_parts) if note_parts else ""
+
+        transactions.append(Transaction(
+            ticker=ticker,
+            action=action,
+            date=date,
+            price=price,
+            quantity=qty,
+            note=note,
+        ))
+
+    return transactions
+
+
+def main():
+    print("=" * 60)
+    print("  TradingAgents 持仓同步工具")
+    print("  数据源: financial-management")
+    print("=" * 60)
+
+    # ── 1. 检查 financial-management 项目是否存在 ──
+    if not FINANCIAL_MGMT_ROOT.exists():
+        print(f"\n[错误] financial-management 项目不存在:")
+        print(f"  路径: {FINANCIAL_MGMT_ROOT}")
+        print(f"\n请确认路径是否正确，或修改脚本顶部的 FINANCIAL_MGMT_ROOT 常量。")
+        sys.exit(1)
+
+    if not PARSED_DATA_DIR.exists():
+        print(f"\n[错误] 解析数据目录不存在: {PARSED_DATA_DIR}")
+        sys.exit(1)
+
+    # ── 2. 找到最新月份目录 ──
+    month_dir = find_latest_month_dir(PARSED_DATA_DIR)
+    if month_dir is None:
+        print(f"\n[错误] 未找到任何月份目录: {PARSED_DATA_DIR}")
+        sys.exit(1)
+
+    month_str = month_dir.name
+    print(f"\n  最新数据月份: {month_str}")
+    print(f"  数据目录:     {month_dir}")
+
+    # ── 3. 加载 holdings.json ──
+    holdings_path = month_dir / "holdings.json"
+    if not holdings_path.exists():
+        # 尝试查找最近有 holdings.json 的月份
+        print(f"\n  [警告] {month_str} 目录下无 holdings.json，向前查找...")
+        all_dirs = sorted(
+            [d for d in PARSED_DATA_DIR.iterdir() if d.is_dir()],
+            key=lambda x: x.name,
+            reverse=True,
+        )
+        found = False
+        for d in all_dirs:
+            candidate = d / "holdings.json"
+            if candidate.exists():
+                holdings_path = candidate
+                month_dir = d
+                month_str = d.name
+                found = True
+                print(f"  [信息] 使用 {month_str} 的 holdings.json")
+                break
+        if not found:
+            print(f"\n[错误] 所有月份目录中均未找到 holdings.json")
+            sys.exit(1)
+
+    holdings_data = load_json(holdings_path)
+    print(f"  holdings.json: {len(holdings_data)} 条记录")
+
+    # ── 4. 加载所有月份的 transactions.json ──
+    transactions_data = []
+    all_month_dirs = sorted(
+        [d for d in PARSED_DATA_DIR.iterdir()
+         if d.is_dir() and len(d.name) == 7 and d.name[4] == "-"],
+        key=lambda x: x.name,
+    )
+    for m_dir in all_month_dirs:
+        tx_path = m_dir / "transactions.json"
+        if tx_path.exists():
+            month_txns = load_json(tx_path)
+            transactions_data.extend(month_txns)
+            print(f"  transactions.json ({m_dir.name}): {len(month_txns)} 条记录")
+    if not transactions_data:
+        print(f"  transactions.json: 未找到任何交易记录")
+
+    # ── 5. 加载 portfolio.json 获取精确 avg_cost ──
+    avg_cost_map: dict[str, float] = {}
+    if STATE_PORTFOLIO.exists():
+        avg_cost_map = load_avg_cost_map(STATE_PORTFOLIO)
+        print(f"  portfolio.json:  已加载 {len(avg_cost_map)} 个持仓成本")
+    else:
+        print(f"  portfolio.json:  未找到（将从 holdings 计算成本价）")
+
+    # ── 6. 数据映射 ──
+    positions = build_positions(holdings_data, avg_cost_map, month_str)
+    transactions = build_transactions(transactions_data)
+
+    print(f"\n  映射结果:")
+    print(f"    持仓: {len(positions)} 条")
+    print(f"    交易: {len(transactions)} 条 (仅含 trade 类型)")
+
+    # ── 7. 全量同步到 PortfolioStore ──
+    store = PortfolioStore()
+    store.clear()
+
+    for pos in positions:
+        store.add_position(pos)
+
+    for txn in transactions:
+        store.add_transaction(txn)
+
+    # ── 8. 打印导入摘要 ──
+    print(f"\n{'─' * 60}")
+    print(f"  同步完成！数据已写入: {store.path}")
+    print(f"{'─' * 60}")
+
+    print(f"\n  ┌─ 当前持仓 ({len(positions)} 条) ─────────────────────────")
+    total_cost = 0.0
+    for p in positions:
+        cost = p.entry_price * p.quantity
+        total_cost += cost
+        print(f"  │ {p.ticker:<12} {p.quantity:>10,.0f} 份 × {p.entry_price:.4f}"
+              f"  成本 ¥{cost:>12,.2f}  [{p.note}]")
+    print(f"  │{'─' * 56}")
+    print(f"  │ 总成本: ¥{total_cost:,.2f}")
+    print(f"  └{'─' * 56}")
+
+    if transactions:
+        print(f"\n  ┌─ 交易记录 ({len(transactions)} 条) ───────────────────────")
+        for t in transactions:
+            action_str = "买入" if t.action == "buy" else "卖出"
+            print(f"  │ {t.date} {action_str} {t.ticker:<12}"
+                  f" {t.quantity:>8,.0f} 份 × {t.price:.4f}  [{t.note}]")
+        print(f"  └{'─' * 56}")
+
+    print(f"\n  完成时间: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_akshare_dataflow.py
+++ b/tests/test_akshare_dataflow.py
@@ -1,0 +1,527 @@
+"""Unit tests for AKShare data source module."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+import pandas as pd
+
+from tradingagents.dataflows.interface import detect_vendor_for_ticker
+from tradingagents.dataflows.akshare_data import (
+    normalize_akshare_code,
+    _is_fund_or_etf,
+    _is_hk_ticker,
+    _normalize_hk_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. normalize_akshare_code tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeAkshareCode:
+    """Test normalize_akshare_code() for various ticker formats."""
+
+    def test_sh_suffix(self):
+        """600000.SH -> 600000"""
+        assert normalize_akshare_code("600000.SH") == "600000"
+
+    def test_sh_prefix(self):
+        """SH600000 -> 600000"""
+        assert normalize_akshare_code("SH600000") == "600000"
+
+    def test_ss_suffix(self):
+        """600000.SS -> 600000"""
+        assert normalize_akshare_code("600000.SS") == "600000"
+
+    def test_sz_suffix(self):
+        """000001.SZ -> 000001"""
+        assert normalize_akshare_code("000001.SZ") == "000001"
+
+    def test_sz_prefix(self):
+        """SZ000001 -> 000001"""
+        assert normalize_akshare_code("SZ000001") == "000001"
+
+    def test_pure_digits(self):
+        """600000 -> 600000 (no change)"""
+        assert normalize_akshare_code("600000") == "600000"
+
+    def test_hk_suffix(self):
+        """0700.HK -> 0700.HK (not handled by normalize_akshare_code, uses _normalize_hk_code)"""
+        # normalize_akshare_code does NOT handle .HK suffix - it falls through
+        # HK tickers use _normalize_hk_code instead
+        result = _normalize_hk_code("0700.HK")
+        assert result == "00700"
+
+    def test_hk_prefix(self):
+        """HK0700 -> 00700 (via _normalize_hk_code)"""
+        result = _normalize_hk_code("HK0700")
+        assert result == "00700"
+
+
+# ---------------------------------------------------------------------------
+# 2. _is_fund_or_etf tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsFundOrEtf:
+    """Test _is_fund_or_etf() detection logic."""
+
+    def test_shanghai_etf_510050(self):
+        """510050 -> True (上海 ETF)"""
+        assert _is_fund_or_etf("510050") is True
+
+    def test_shanghai_etf_518880(self):
+        """518880 -> True (上海 ETF)"""
+        assert _is_fund_or_etf("518880") is True
+
+    def test_shenzhen_etf_159915(self):
+        """159915 -> True (深圳 ETF)"""
+        assert _is_fund_or_etf("159915") is True
+
+    def test_normal_stock_600000(self):
+        """600000 -> False (普通股票)"""
+        assert _is_fund_or_etf("600000") is False
+
+    def test_normal_stock_000001(self):
+        """000001 -> False (普通股票)"""
+        assert _is_fund_or_etf("000001") is False
+
+    def test_growth_enterprise_300001(self):
+        """300001 -> False (创业板)"""
+        assert _is_fund_or_etf("300001") is False
+
+
+# ---------------------------------------------------------------------------
+# 3. detect_vendor_for_ticker (routing) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetectVendorForTicker:
+    """Test detect_vendor_for_ticker() now returns 'akshare' for A-share/HK."""
+
+    def test_sh_suffix(self):
+        """600000.SH -> akshare"""
+        assert detect_vendor_for_ticker("600000.SH") == "akshare"
+
+    def test_sz_suffix(self):
+        """000001.SZ -> akshare"""
+        assert detect_vendor_for_ticker("000001.SZ") == "akshare"
+
+    def test_sh_prefix(self):
+        """SH600000 -> akshare"""
+        assert detect_vendor_for_ticker("SH600000") == "akshare"
+
+    def test_pure_digits(self):
+        """600000 -> akshare"""
+        assert detect_vendor_for_ticker("600000") == "akshare"
+
+    def test_hk_suffix(self):
+        """0700.HK -> akshare"""
+        assert detect_vendor_for_ticker("0700.HK") == "akshare"
+
+    def test_hk_prefix(self):
+        """HK0700 -> akshare"""
+        assert detect_vendor_for_ticker("HK0700") == "akshare"
+
+    def test_us_stock_not_routed(self):
+        """AAPL -> None (美股不路由)"""
+        assert detect_vendor_for_ticker("AAPL") is None
+
+    def test_us_stock_with_dot_not_routed(self):
+        """BRK.B -> None"""
+        assert detect_vendor_for_ticker("BRK.B") is None
+
+
+# ---------------------------------------------------------------------------
+# 4. get_akshare_stock (mock) tests
+# ---------------------------------------------------------------------------
+
+
+# Shared mock data
+_MOCK_STOCK_DF = pd.DataFrame({
+    "日期": ["2024-01-15", "2024-01-16"],
+    "开盘": [10.30, 10.50],
+    "收盘": [10.40, 10.60],
+    "最高": [10.60, 10.80],
+    "最低": [10.10, 10.20],
+    "成交量": [112340, 123450],
+    "成交额": [1156700.0, 1290000.0],
+    "振幅": [4.85, 5.66],
+    "涨跌幅": [0.97, 1.92],
+    "涨跌额": [0.10, 0.20],
+    "换手率": [0.56, 0.62],
+})
+
+
+@pytest.mark.unit
+class TestGetAkshareStock:
+    """Test get_akshare_stock with mocked AKShare API."""
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_normal_stock_returns_csv(self, mock_ak):
+        """Test fetching A-share stock data returns CSV."""
+        from tradingagents.dataflows.akshare_data import get_akshare_stock
+
+        mock_ak.stock_zh_a_hist.return_value = _MOCK_STOCK_DF.copy()
+
+        result = get_akshare_stock("600000.SH", "2024-01-15", "2024-01-16")
+
+        assert "# Stock data for" in result
+        assert "Date,Open,High,Low,Close,Adj Close,Volume" in result
+        assert "2024-01-15" in result
+        assert "2024-01-16" in result
+        mock_ak.stock_zh_a_hist.assert_called_once()
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_etf_uses_fund_etf_hist_em(self, mock_ak):
+        """Test ETF data fetching uses fund_etf_hist_em API."""
+        from tradingagents.dataflows.akshare_data import get_akshare_stock
+
+        mock_ak.fund_etf_hist_em.return_value = _MOCK_STOCK_DF.copy()
+
+        result = get_akshare_stock("510050", "2024-01-15", "2024-01-16")
+
+        assert "# Stock data for" in result
+        assert "Date,Open,High,Low,Close,Adj Close,Volume" in result
+        mock_ak.fund_etf_hist_em.assert_called_once()
+        mock_ak.stock_zh_a_hist.assert_not_called()
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_hk_stock_uses_stock_hk_hist(self, mock_ak):
+        """Test HK stock data fetching uses stock_hk_hist API."""
+        from tradingagents.dataflows.akshare_data import get_akshare_stock
+
+        mock_hk_df = pd.DataFrame({
+            "日期": ["2024-01-15", "2024-01-16"],
+            "开盘": [300.0, 305.0],
+            "收盘": [305.0, 310.0],
+            "最高": [308.0, 312.0],
+            "最低": [298.0, 303.0],
+            "成交量": [50000000, 55000000],
+            "成交额": [15000000000.0, 17000000000.0],
+        })
+        mock_ak.stock_hk_hist.return_value = mock_hk_df
+
+        result = get_akshare_stock("0700.HK", "2024-01-15", "2024-01-16")
+
+        assert "# Stock data for" in result
+        assert "Date,Open,High,Low,Close,Adj Close,Volume" in result
+        mock_ak.stock_hk_hist.assert_called_once()
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_empty_data_returns_message(self, mock_ak):
+        """Test empty data returns proper message."""
+        from tradingagents.dataflows.akshare_data import get_akshare_stock
+
+        mock_ak.stock_zh_a_hist.return_value = pd.DataFrame()
+
+        result = get_akshare_stock("600000.SH", "2024-01-15", "2024-01-16")
+
+        assert "No stock data found" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_csv_columns_correct(self, mock_ak):
+        """Verify CSV output has correct column header."""
+        from tradingagents.dataflows.akshare_data import get_akshare_stock
+
+        mock_ak.stock_zh_a_hist.return_value = _MOCK_STOCK_DF.copy()
+
+        result = get_akshare_stock("600000", "2024-01-15", "2024-01-16")
+
+        lines = result.strip().split("\n")
+        # Find the header line
+        header_line = None
+        for line in lines:
+            if line.startswith("Date,"):
+                header_line = line
+                break
+        assert header_line == "Date,Open,High,Low,Close,Adj Close,Volume"
+
+
+# ---------------------------------------------------------------------------
+# 5. get_akshare_indicators (mock) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAkshareIndicators:
+    """Test get_akshare_indicators with mocked AKShare API."""
+
+    @patch("tradingagents.dataflows.akshare_data.stockstats_wrap")
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_indicator_returns_formatted(self, mock_ak, mock_wrap):
+        """Test indicator computation returns formatted output."""
+        from tradingagents.dataflows.akshare_data import get_akshare_indicators
+
+        # Build a larger dataframe for indicator calculation
+        dates = pd.date_range("2023-01-01", periods=300, freq="B")
+        mock_df = pd.DataFrame({
+            "日期": dates.strftime("%Y-%m-%d").tolist(),
+            "开盘": [10.0 + i * 0.01 for i in range(300)],
+            "收盘": [10.1 + i * 0.01 for i in range(300)],
+            "最高": [10.2 + i * 0.01 for i in range(300)],
+            "最低": [9.9 + i * 0.01 for i in range(300)],
+            "成交量": [100000 + i * 100 for i in range(300)],
+        })
+        mock_ak.stock_zh_a_hist.return_value = mock_df
+
+        # Mock stockstats wrap to return a DataFrame with the indicator column
+        mock_ss_df = MagicMock()
+        mock_ss_df.__iter__ = MagicMock(return_value=iter([]))
+        # Make it behave like a DataFrame with iterrows
+        result_rows = []
+        for i in range(300):
+            result_rows.append({
+                "date": dates[i].strftime("%Y-%m-%d"),
+                "rsi": 50.0 + i * 0.1 if i > 14 else float("nan"),
+            })
+        mock_ss_df.iterrows.return_value = iter(
+            [(i, pd.Series(row)) for i, row in enumerate(result_rows)]
+        )
+        mock_ss_df.__getitem__ = MagicMock(return_value=None)  # trigger calculation
+        mock_wrap.return_value = mock_ss_df
+
+        result = get_akshare_indicators("600000", "rsi", "2024-01-15", 30)
+
+        assert "rsi" in result.lower()
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_unsupported_indicator_raises(self, mock_ak):
+        """Test that unsupported indicator raises ValueError."""
+        from tradingagents.dataflows.akshare_data import get_akshare_indicators
+
+        with pytest.raises(ValueError, match="not supported"):
+            get_akshare_indicators("600000", "invalid_indicator", "2024-01-15", 30)
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_empty_data_returns_message(self, mock_ak):
+        """Test empty data returns proper message."""
+        from tradingagents.dataflows.akshare_data import get_akshare_indicators
+
+        mock_ak.stock_zh_a_hist.return_value = pd.DataFrame()
+
+        result = get_akshare_indicators("600000", "rsi", "2024-01-15", 30)
+
+        assert "No stock data found" in result
+
+
+# ---------------------------------------------------------------------------
+# 6. get_akshare_fundamentals (mock) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAkshareFundamentals:
+    """Test get_akshare_fundamentals with mocked AKShare API."""
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_returns_company_info(self, mock_ak):
+        """Test fundamentals output includes company name and industry."""
+        from tradingagents.dataflows.akshare_data import get_akshare_fundamentals
+
+        mock_info_df = pd.DataFrame({
+            "item": ["股票简称", "公司名称", "行业", "上市时间", "总股本", "流通股"],
+            "value": ["浦发银行", "上海浦东发展银行", "银行", "19991110", "293.77亿", "286.24亿"],
+        })
+        mock_ak.stock_individual_info_em.return_value = mock_info_df
+
+        mock_quote_df = pd.DataFrame({
+            "代码": ["600000"],
+            "最新价": [7.85],
+            "换手率": [0.23],
+            "市盈率-动态": [4.56],
+            "市净率": [0.42],
+            "总市值": [2305.0e8],
+            "流通市值": [2246.0e8],
+            "60日涨跌幅": [5.23],
+            "年初至今涨跌幅": [8.12],
+        })
+        mock_ak.stock_zh_a_spot_em.return_value = mock_quote_df
+
+        result = get_akshare_fundamentals("600000.SH")
+
+        assert "Company Fundamentals" in result
+        assert "浦发银行" in result
+        assert "银行" in result
+        assert "PE Ratio" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_no_data_returns_message(self, mock_ak):
+        """Test handling when no data is available."""
+        from tradingagents.dataflows.akshare_data import get_akshare_fundamentals
+
+        mock_ak.stock_individual_info_em.return_value = pd.DataFrame()
+        mock_ak.stock_zh_a_spot_em.return_value = pd.DataFrame()
+
+        result = get_akshare_fundamentals("600000")
+
+        assert "No fundamentals data found" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_hk_not_supported(self, mock_ak):
+        """Test that HK stock fundamentals returns not supported message."""
+        from tradingagents.dataflows.akshare_data import get_akshare_fundamentals
+
+        result = get_akshare_fundamentals("0700.HK")
+
+        assert "not yet supported" in result
+
+
+# ---------------------------------------------------------------------------
+# 7. get_akshare_balance_sheet / cashflow / income_statement (mock) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAkshareFinancials:
+    """Test financial statement functions with mocked AKShare API."""
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_balance_sheet_returns_csv(self, mock_ak):
+        """Test balance sheet returns CSV format."""
+        from tradingagents.dataflows.akshare_data import get_akshare_balance_sheet
+
+        mock_df = pd.DataFrame({
+            "REPORT_DATE": ["2024-03-31", "2023-12-31", "2023-09-30", "2023-06-30"],
+            "TOTAL_ASSETS": [1e12, 9.8e11, 9.5e11, 9.2e11],
+            "TOTAL_LIABILITIES": [9e11, 8.8e11, 8.5e11, 8.2e11],
+            "TOTAL_EQUITY": [1e11, 1e11, 1e11, 1e11],
+        })
+        mock_ak.stock_balance_sheet_by_report_em.return_value = mock_df
+
+        result = get_akshare_balance_sheet("600000.SH")
+
+        assert "# Balance Sheet data for 600000" in result
+        assert "TOTAL_ASSETS" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_cashflow_returns_csv(self, mock_ak):
+        """Test cash flow statement returns CSV format."""
+        from tradingagents.dataflows.akshare_data import get_akshare_cashflow
+
+        mock_df = pd.DataFrame({
+            "REPORT_DATE": ["2024-03-31", "2023-12-31"],
+            "OPERATE_CASH_FLOW": [5e9, 20e9],
+            "INVEST_CASH_FLOW": [-3e9, -10e9],
+            "FINANCE_CASH_FLOW": [-1e9, -5e9],
+        })
+        mock_ak.stock_cash_flow_sheet_by_report_em.return_value = mock_df
+
+        result = get_akshare_cashflow("600000.SH")
+
+        assert "# Cash Flow data for 600000" in result
+        assert "OPERATE_CASH_FLOW" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_income_statement_returns_csv(self, mock_ak):
+        """Test income statement returns CSV format."""
+        from tradingagents.dataflows.akshare_data import get_akshare_income_statement
+
+        mock_df = pd.DataFrame({
+            "REPORT_DATE": ["2024-03-31", "2023-12-31"],
+            "TOTAL_OPERATE_INCOME": [50e9, 200e9],
+            "OPERATE_PROFIT": [20e9, 80e9],
+            "TOTAL_PROFIT": [18e9, 75e9],
+            "NETPROFIT": [15e9, 60e9],
+        })
+        mock_ak.stock_profit_sheet_by_report_em.return_value = mock_df
+
+        result = get_akshare_income_statement("600000.SH")
+
+        assert "# Income Statement data for 600000" in result
+        assert "TOTAL_OPERATE_INCOME" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_balance_sheet_empty(self, mock_ak):
+        """Test balance sheet with empty data."""
+        from tradingagents.dataflows.akshare_data import get_akshare_balance_sheet
+
+        mock_ak.stock_balance_sheet_by_report_em.return_value = pd.DataFrame()
+
+        result = get_akshare_balance_sheet("600000")
+
+        assert "No balance sheet data found" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_hk_financials_not_supported(self, mock_ak):
+        """Test that HK stock financials return not supported."""
+        from tradingagents.dataflows.akshare_data import (
+            get_akshare_balance_sheet,
+            get_akshare_cashflow,
+            get_akshare_income_statement,
+        )
+
+        assert "not yet supported" in get_akshare_balance_sheet("0700.HK")
+        assert "not yet supported" in get_akshare_cashflow("0700.HK")
+        assert "not yet supported" in get_akshare_income_statement("0700.HK")
+
+
+# ---------------------------------------------------------------------------
+# 8. get_akshare_insider_transactions (mock) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetAkshareInsiderTransactions:
+    """Test get_akshare_insider_transactions with mocked AKShare API."""
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_returns_formatted_output(self, mock_ak):
+        """Test insider transactions returns formatted CSV output."""
+        from tradingagents.dataflows.akshare_data import get_akshare_insider_transactions
+
+        mock_df = pd.DataFrame({
+            "变动日期": ["2024-01-10", "2024-01-05"],
+            "变动人": ["张三", "李四"],
+            "变动股数": [50000, -30000],
+            "变动方向": ["增持", "减持"],
+            "变动均价": [10.50, 10.80],
+            "变动原因": ["竞价交易", "竞价交易"],
+        })
+        mock_ak.stock_hold_management_detail_em.return_value = mock_df
+
+        result = get_akshare_insider_transactions("600000.SH")
+
+        assert "# Insider Transactions data for 600000" in result
+        assert "Date,Holder Name,Change Volume,Change Type,Price,Change Reason" in result
+        assert "张三" in result
+        assert "增持" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_empty_data(self, mock_ak):
+        """Test empty insider transactions data."""
+        from tradingagents.dataflows.akshare_data import get_akshare_insider_transactions
+
+        mock_ak.stock_hold_management_detail_em.return_value = pd.DataFrame()
+
+        result = get_akshare_insider_transactions("600000")
+
+        assert "No insider transactions data found" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_hk_not_supported(self, mock_ak):
+        """Test that HK insider transactions returns not supported."""
+        from tradingagents.dataflows.akshare_data import get_akshare_insider_transactions
+
+        result = get_akshare_insider_transactions("0700.HK")
+
+        assert "not yet supported" in result
+
+    @patch("tradingagents.dataflows.akshare_data.ak")
+    def test_api_exception_graceful(self, mock_ak):
+        """Test graceful handling when API raises exception."""
+        from tradingagents.dataflows.akshare_data import get_akshare_insider_transactions
+
+        mock_ak.stock_hold_management_detail_em.side_effect = Exception("API error")
+
+        result = get_akshare_insider_transactions("600000")
+
+        assert "not available" in result or "Error" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tushare_dataflow.py
+++ b/tests/test_tushare_dataflow.py
@@ -1,0 +1,321 @@
+"""Unit tests for Tushare data source and news service modules."""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+import pandas as pd
+
+from tradingagents.dataflows.interface import detect_vendor_for_ticker
+from tradingagents.dataflows.tushare_data import (
+    convert_date_to_tushare,
+    convert_date_from_tushare,
+    normalize_ts_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Ticker format detection tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetectVendorForTicker:
+    """Test ticker format detection for auto-routing."""
+
+    def test_a_share_sh_suffix(self):
+        """600000.SH should route to tushare"""
+        assert detect_vendor_for_ticker("600000.SH") == "tushare"
+
+    def test_a_share_sz_suffix(self):
+        """000001.SZ should route to tushare"""
+        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+
+    def test_a_share_sh_prefix(self):
+        """SH600000 should route to tushare"""
+        assert detect_vendor_for_ticker("SH600000") == "tushare"
+
+    def test_a_share_sz_prefix(self):
+        """SZ000001 should route to tushare"""
+        assert detect_vendor_for_ticker("SZ000001") == "tushare"
+
+    def test_a_share_pure_digits(self):
+        """600000 (6-digit) should route to tushare"""
+        assert detect_vendor_for_ticker("600000") == "tushare"
+
+    def test_hk_stock_suffix(self):
+        """0700.HK should route to tushare"""
+        assert detect_vendor_for_ticker("0700.HK") == "tushare"
+
+    def test_hk_stock_prefix(self):
+        """HK0700 should route to tushare"""
+        assert detect_vendor_for_ticker("HK0700") == "tushare"
+
+    def test_us_stock(self):
+        """AAPL should return None (use default)"""
+        assert detect_vendor_for_ticker("AAPL") is None
+
+    def test_us_stock_with_dot(self):
+        """BRK.B should return None"""
+        assert detect_vendor_for_ticker("BRK.B") is None
+
+    def test_empty_string(self):
+        assert detect_vendor_for_ticker("") is None
+
+    def test_none(self):
+        assert detect_vendor_for_ticker(None) is None
+
+    def test_a_share_ss_suffix(self):
+        """600000.SS (yfinance convention) should route to tushare"""
+        assert detect_vendor_for_ticker("600000.SS") == "tushare"
+
+    def test_a_share_ss_prefix(self):
+        """SS600000 should route to tushare"""
+        assert detect_vendor_for_ticker("SS600000") == "tushare"
+
+    def test_case_insensitive(self):
+        """Should handle lowercase"""
+        assert detect_vendor_for_ticker("sh600000") == "tushare"
+        assert detect_vendor_for_ticker("600000.sh") == "tushare"
+        assert detect_vendor_for_ticker("600000.ss") == "tushare"
+
+
+# ---------------------------------------------------------------------------
+# 2. Date conversion tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDateConversion:
+    """Test date format conversion between standard and Tushare format."""
+
+    def test_to_tushare_format(self):
+        assert convert_date_to_tushare("2024-01-15") == "20240115"
+        assert convert_date_to_tushare("2023-12-31") == "20231231"
+
+    def test_from_tushare_format(self):
+        assert convert_date_from_tushare("20240115") == "2024-01-15"
+        assert convert_date_from_tushare("20231231") == "2023-12-31"
+
+    def test_from_tushare_non_8_digit(self):
+        """Non-8-digit strings should pass through unchanged."""
+        assert convert_date_from_tushare("2024-01-15") == "2024-01-15"
+
+
+# ---------------------------------------------------------------------------
+# 3. Ticker normalization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeTsCode:
+    """Test normalization of various ticker formats to Tushare ts_code."""
+
+    def test_pure_digits_sh(self):
+        """6开头 → 上海"""
+        assert normalize_ts_code("600000") == "600000.SH"
+
+    def test_pure_digits_sz(self):
+        """0/3开头 → 深圳"""
+        assert normalize_ts_code("000001") == "000001.SZ"
+        assert normalize_ts_code("300001") == "300001.SZ"
+
+    def test_prefix_format(self):
+        assert normalize_ts_code("SH600000") == "600000.SH"
+        assert normalize_ts_code("SZ000001") == "000001.SZ"
+
+    def test_suffix_format_passthrough(self):
+        assert normalize_ts_code("600000.SH") == "600000.SH"
+        assert normalize_ts_code("000001.SZ") == "000001.SZ"
+
+    def test_hk_stock(self):
+        assert normalize_ts_code("HK0700") == "0700.HK"
+        assert normalize_ts_code("0700.HK") == "0700.HK"
+
+    def test_ss_suffix_converted_to_sh(self):
+        """600000.SS (yfinance convention) should convert to 600000.SH"""
+        assert normalize_ts_code("600000.SS") == "600000.SH"
+
+    def test_ss_prefix_converted_to_sh(self):
+        """SS600000 should convert to 600000.SH"""
+        assert normalize_ts_code("SS600000") == "600000.SH"
+
+    def test_lowercase_normalized(self):
+        """Lowercase input should be uppercased in output."""
+        assert normalize_ts_code("sh600000") == "600000.SH"
+        assert normalize_ts_code("sz000001") == "000001.SZ"
+
+
+# ---------------------------------------------------------------------------
+# 4. Mock Tushare stock data retrieval tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetTushareStock:
+    """Test get_tushare_stock with mocked Tushare API."""
+
+    @patch("tradingagents.dataflows.tushare_data.get_tushare_pro")
+    def test_returns_csv_format(self, mock_pro):
+        """Test that get_tushare_stock returns properly formatted CSV."""
+        from tradingagents.dataflows.tushare_data import get_tushare_stock
+
+        mock_api = MagicMock()
+        mock_pro.return_value = mock_api
+
+        mock_api.daily.return_value = pd.DataFrame({
+            "ts_code": ["600000.SH", "600000.SH"],
+            "trade_date": ["20240116", "20240115"],
+            "open": [10.50, 10.30],
+            "high": [10.80, 10.60],
+            "low": [10.20, 10.10],
+            "close": [10.60, 10.40],
+            "vol": [12345.0, 11234.0],
+        })
+
+        mock_api.adj_factor.return_value = pd.DataFrame({
+            "ts_code": ["600000.SH", "600000.SH"],
+            "trade_date": ["20240116", "20240115"],
+            "adj_factor": [120.5, 120.0],
+        })
+
+        result = get_tushare_stock("600000.SH", "2024-01-15", "2024-01-16")
+
+        assert "# Stock data for" in result
+        assert "Date,Open,High,Low,Close,Adj Close,Volume" in result
+        assert "2024-01-15" in result
+        assert "2024-01-16" in result
+
+    @patch("tradingagents.dataflows.tushare_data.get_tushare_pro")
+    def test_empty_data(self, mock_pro):
+        """Test handling of empty data."""
+        from tradingagents.dataflows.tushare_data import get_tushare_stock
+
+        mock_api = MagicMock()
+        mock_pro.return_value = mock_api
+        mock_api.daily.return_value = pd.DataFrame()
+
+        result = get_tushare_stock("600000.SH", "2024-01-15", "2024-01-16")
+        assert "No stock data found" in result or "Error" in result
+
+    @patch("tradingagents.dataflows.tushare_data.get_tushare_pro")
+    def test_no_adj_factor(self, mock_pro):
+        """Test handling when adj_factor returns empty."""
+        from tradingagents.dataflows.tushare_data import get_tushare_stock
+
+        mock_api = MagicMock()
+        mock_pro.return_value = mock_api
+
+        mock_api.daily.return_value = pd.DataFrame({
+            "ts_code": ["600000.SH"],
+            "trade_date": ["20240115"],
+            "open": [10.30],
+            "high": [10.60],
+            "low": [10.10],
+            "close": [10.40],
+            "vol": [11234.0],
+        })
+        mock_api.adj_factor.return_value = pd.DataFrame()
+
+        result = get_tushare_stock("600000.SH", "2024-01-15", "2024-01-15")
+
+        # adj_close should fall back to close
+        assert "Date,Open,High,Low,Close,Adj Close,Volume" in result
+        assert "2024-01-15" in result
+
+
+# ---------------------------------------------------------------------------
+# 5. Mock news service tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNewsService:
+    """Test news service with mocked HTTP calls."""
+
+    @patch("tradingagents.dataflows.news_service.requests.get")
+    def test_get_news_returns_formatted(self, mock_get):
+        """Test news service returns properly formatted output."""
+        from tradingagents.dataflows.news_service import get_news_service_news
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [{
+                "title": "测试新闻标题",
+                "summary": "这是一条测试新闻摘要",
+                "source_name": "财联社",
+                "url": "https://example.com/news/1",
+                "published_at": "2024-01-15T10:00:00+08:00",
+            }],
+        }
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"NEWS_SERVER_API_KEY": "test_key"}):
+            result = get_news_service_news("600519.SH", "2024-01-15", "2024-01-16")
+
+        assert "News" in result
+        assert "测试新闻标题" in result
+        assert "财联社" in result
+
+    def test_no_api_key_graceful(self):
+        """Test graceful handling when API key is not configured."""
+        from tradingagents.dataflows.news_service import get_news_service_news
+
+        with patch.dict(os.environ, {"NEWS_SERVER_API_KEY": ""}, clear=False):
+            result = get_news_service_news("600519.SH", "2024-01-15", "2024-01-16")
+
+        # Should not crash, should return appropriate message
+        assert "No news" in result or "not configured" in result.lower() or "error" in result.lower()
+
+    @patch("tradingagents.dataflows.news_service.requests.get")
+    def test_connection_error_graceful(self, mock_get):
+        """Test graceful handling of connection errors."""
+        import requests as req
+        from tradingagents.dataflows.news_service import get_news_service_news
+
+        mock_get.side_effect = req.exceptions.ConnectionError("Connection refused")
+
+        with patch.dict(os.environ, {"NEWS_SERVER_API_KEY": "test_key"}):
+            result = get_news_service_news("600519.SH", "2024-01-15", "2024-01-16")
+
+        # Both calls to _make_request will fail, so we expect either no news or error
+        assert "No news" in result or "Error" in result or "error" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 6. Auto-routing tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAutoRouting:
+    """Test auto-routing logic based on ticker format."""
+
+    def test_a_share_routes_to_tushare(self):
+        """A-share ticker should prefer tushare vendor."""
+        assert detect_vendor_for_ticker("600000.SH") == "tushare"
+        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+
+    def test_us_stock_does_not_route_to_tushare(self):
+        """US stock should not route to tushare."""
+        assert detect_vendor_for_ticker("AAPL") is None
+        assert detect_vendor_for_ticker("MSFT") is None
+        assert detect_vendor_for_ticker("TSLA") is None
+
+    def test_hk_stock_routes_to_tushare(self):
+        """HK stock tickers should route to tushare."""
+        assert detect_vendor_for_ticker("0700.HK") == "tushare"
+        assert detect_vendor_for_ticker("HK0700") == "tushare"
+        assert detect_vendor_for_ticker("09988.HK") == "tushare"
+
+    def test_various_sz_formats(self):
+        """Various Shenzhen formats should all route to tushare."""
+        assert detect_vendor_for_ticker("000001") == "tushare"
+        assert detect_vendor_for_ticker("300001") == "tushare"
+        assert detect_vendor_for_ticker("SZ000001") == "tushare"
+        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tushare_dataflow.py
+++ b/tests/test_tushare_dataflow.py
@@ -24,32 +24,32 @@ class TestDetectVendorForTicker:
     """Test ticker format detection for auto-routing."""
 
     def test_a_share_sh_suffix(self):
-        """600000.SH should route to tushare"""
-        assert detect_vendor_for_ticker("600000.SH") == "tushare"
+        """600000.SH should route to akshare"""
+        assert detect_vendor_for_ticker("600000.SH") == "akshare"
 
     def test_a_share_sz_suffix(self):
-        """000001.SZ should route to tushare"""
-        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+        """000001.SZ should route to akshare"""
+        assert detect_vendor_for_ticker("000001.SZ") == "akshare"
 
     def test_a_share_sh_prefix(self):
-        """SH600000 should route to tushare"""
-        assert detect_vendor_for_ticker("SH600000") == "tushare"
+        """SH600000 should route to akshare"""
+        assert detect_vendor_for_ticker("SH600000") == "akshare"
 
     def test_a_share_sz_prefix(self):
-        """SZ000001 should route to tushare"""
-        assert detect_vendor_for_ticker("SZ000001") == "tushare"
+        """SZ000001 should route to akshare"""
+        assert detect_vendor_for_ticker("SZ000001") == "akshare"
 
     def test_a_share_pure_digits(self):
-        """600000 (6-digit) should route to tushare"""
-        assert detect_vendor_for_ticker("600000") == "tushare"
+        """600000 (6-digit) should route to akshare"""
+        assert detect_vendor_for_ticker("600000") == "akshare"
 
     def test_hk_stock_suffix(self):
-        """0700.HK should route to tushare"""
-        assert detect_vendor_for_ticker("0700.HK") == "tushare"
+        """0700.HK should route to akshare"""
+        assert detect_vendor_for_ticker("0700.HK") == "akshare"
 
     def test_hk_stock_prefix(self):
-        """HK0700 should route to tushare"""
-        assert detect_vendor_for_ticker("HK0700") == "tushare"
+        """HK0700 should route to akshare"""
+        assert detect_vendor_for_ticker("HK0700") == "akshare"
 
     def test_us_stock(self):
         """AAPL should return None (use default)"""
@@ -66,18 +66,18 @@ class TestDetectVendorForTicker:
         assert detect_vendor_for_ticker(None) is None
 
     def test_a_share_ss_suffix(self):
-        """600000.SS (yfinance convention) should route to tushare"""
-        assert detect_vendor_for_ticker("600000.SS") == "tushare"
+        """600000.SS (yfinance convention) should route to akshare"""
+        assert detect_vendor_for_ticker("600000.SS") == "akshare"
 
     def test_a_share_ss_prefix(self):
-        """SS600000 should route to tushare"""
-        assert detect_vendor_for_ticker("SS600000") == "tushare"
+        """SS600000 should route to akshare"""
+        assert detect_vendor_for_ticker("SS600000") == "akshare"
 
     def test_case_insensitive(self):
         """Should handle lowercase"""
-        assert detect_vendor_for_ticker("sh600000") == "tushare"
-        assert detect_vendor_for_ticker("600000.sh") == "tushare"
-        assert detect_vendor_for_ticker("600000.ss") == "tushare"
+        assert detect_vendor_for_ticker("sh600000") == "akshare"
+        assert detect_vendor_for_ticker("600000.sh") == "akshare"
+        assert detect_vendor_for_ticker("600000.ss") == "akshare"
 
 
 # ---------------------------------------------------------------------------
@@ -292,10 +292,10 @@ class TestNewsService:
 class TestAutoRouting:
     """Test auto-routing logic based on ticker format."""
 
-    def test_a_share_routes_to_tushare(self):
-        """A-share ticker should prefer tushare vendor."""
-        assert detect_vendor_for_ticker("600000.SH") == "tushare"
-        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+    def test_a_share_routes_to_akshare(self):
+        """A-share ticker should prefer akshare vendor."""
+        assert detect_vendor_for_ticker("600000.SH") == "akshare"
+        assert detect_vendor_for_ticker("000001.SZ") == "akshare"
 
     def test_us_stock_does_not_route_to_tushare(self):
         """US stock should not route to tushare."""
@@ -303,18 +303,18 @@ class TestAutoRouting:
         assert detect_vendor_for_ticker("MSFT") is None
         assert detect_vendor_for_ticker("TSLA") is None
 
-    def test_hk_stock_routes_to_tushare(self):
-        """HK stock tickers should route to tushare."""
-        assert detect_vendor_for_ticker("0700.HK") == "tushare"
-        assert detect_vendor_for_ticker("HK0700") == "tushare"
-        assert detect_vendor_for_ticker("09988.HK") == "tushare"
+    def test_hk_stock_routes_to_akshare(self):
+        """HK stock tickers should route to akshare."""
+        assert detect_vendor_for_ticker("0700.HK") == "akshare"
+        assert detect_vendor_for_ticker("HK0700") == "akshare"
+        assert detect_vendor_for_ticker("09988.HK") == "akshare"
 
     def test_various_sz_formats(self):
-        """Various Shenzhen formats should all route to tushare."""
-        assert detect_vendor_for_ticker("000001") == "tushare"
-        assert detect_vendor_for_ticker("300001") == "tushare"
-        assert detect_vendor_for_ticker("SZ000001") == "tushare"
-        assert detect_vendor_for_ticker("000001.SZ") == "tushare"
+        """Various Shenzhen formats should all route to akshare."""
+        assert detect_vendor_for_ticker("000001") == "akshare"
+        assert detect_vendor_for_ticker("300001") == "akshare"
+        assert detect_vendor_for_ticker("SZ000001") == "akshare"
+        assert detect_vendor_for_ticker("000001.SZ") == "akshare"
 
 
 if __name__ == "__main__":

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -27,12 +27,22 @@ from tradingagents.agents.utils.agent_utils import (
     get_language_instruction,
     get_news,
 )
+from tradingagents.dataflows.interface import detect_vendor_for_ticker
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
+from tradingagents.dataflows.akshare_sentiment import (
+    fetch_akshare_stock_comment,
+    fetch_akshare_hot_rank,
+)
 
 
 def _seven_days_back(trade_date: str) -> str:
     return (datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
+
+
+def _is_chinese_ticker(ticker: str) -> bool:
+    """复用已有的供应商检测逻辑判断是否为A股/港股"""
+    return detect_vendor_for_ticker(ticker) == "akshare"
 
 
 def create_sentiment_analyst(llm):
@@ -53,16 +63,28 @@ def create_sentiment_analyst(llm):
         # returns a string (no exceptions surface from here), so the LLM
         # always sees something — either real data or a clear placeholder.
         news_block = get_news.func(ticker, start_date, end_date)
-        stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+
+        # 社交情绪：根据市场自动选择
+        if _is_chinese_ticker(ticker):
+            social_block_1 = fetch_akshare_stock_comment(ticker)
+            social_block_2 = fetch_akshare_hot_rank(ticker)
+            source1_label = "千股千评(东方财富)"
+            source2_label = "个股人气排名(东方财富)"
+        else:
+            social_block_1 = fetch_stocktwits_messages(ticker, limit=30)
+            social_block_2 = fetch_reddit_posts(ticker)
+            source1_label = "StockTwits"
+            source2_label = "Reddit"
 
         system_message = _build_system_message(
             ticker=ticker,
             start_date=start_date,
             end_date=end_date,
             news_block=news_block,
-            stocktwits_block=stocktwits_block,
-            reddit_block=reddit_block,
+            social_block_1=social_block_1,
+            social_block_2=social_block_2,
+            source1_label=source1_label,
+            source2_label=source2_label,
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -102,48 +124,50 @@ def _build_system_message(
     start_date: str,
     end_date: str,
     news_block: str,
-    stocktwits_block: str,
-    reddit_block: str,
+    social_block_1: str,
+    social_block_2: str,
+    source1_label: str = "StockTwits",
+    source2_label: str = "Reddit",
 ) -> str:
     """Assemble the sentiment-analyst system message with structured data blocks."""
     return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on three complementary data sources that have already been collected for you.
 
 ## Data sources (pre-fetched, in this prompt)
 
-### News headlines — Yahoo Finance, past 7 days
+### News headlines — past 7 days
 Institutional framing. Fact-driven, slower-moving signal.
 
 <start_of_news>
 {news_block}
 <end_of_news>
 
-### StockTwits messages — retail-trader social platform indexed by cashtag
-Fast-moving signal. Each message carries a user-labeled sentiment tag (Bullish / Bearish / no-label) plus the message body.
+### {source1_label} — social sentiment source 1
+Fast-moving signal. Retail/community sentiment posts.
 
-<start_of_stocktwits>
-{stocktwits_block}
-<end_of_stocktwits>
+<start_of_social_1>
+{social_block_1}
+<end_of_social_1>
 
-### Reddit posts — r/wallstreetbets, r/stocks, r/investing (past 7 days)
-Community discussion. Engagement signal via upvote score and comment count. Subreddit character matters (r/wallstreetbets is often contrarian/exuberant; r/stocks more measured; r/investing longer-term).
+### {source2_label} — social sentiment source 2
+Community discussion. Engagement signal via interactions and comment count.
 
-<start_of_reddit>
-{reddit_block}
-<end_of_reddit>
+<start_of_social_2>
+{social_block_2}
+<end_of_social_2>
 
 ## How to analyze this data (best practices)
 
-1. **Read the StockTwits Bullish/Bearish ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
+1. **Read the social sentiment ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
 
-2. **Look for cross-source divergences.** If news framing is bearish but StockTwits is overwhelmingly bullish, that mismatch is itself a signal — it can mean retail is leaning into a thesis the news flow hasn't caught up to (or vice versa, that retail is chasing while institutions are cautious).
+2. **Look for cross-source divergences.** If news framing is bearish but {source1_label} is overwhelmingly bullish, that mismatch is itself a signal — it can mean retail is leaning into a thesis the news flow hasn't caught up to (or vice versa, that retail is chasing while institutions are cautious).
 
-3. **Weight Reddit posts by engagement.** A 400-upvote / 200-comment thread reflects community attention; a 3-upvote post is noise. Read the body excerpts for context — the title alone often misleads.
+3. **Weight {source2_label} posts by engagement.** High-engagement threads reflect community attention; low-engagement posts are noise. Read the body excerpts for context — the title alone often misleads.
 
-4. **Distinguish opinion from event.** A news headline ("Nvidia announces $500M Corning deal") is an event; a StockTwits post ("buying NVDA, this is going to moon") is opinion. Both are inputs but should be weighted differently in your conclusions.
+4. **Distinguish opinion from event.** A news headline is an event; a social post expressing directional sentiment is opinion. Both are inputs but should be weighted differently in your conclusions.
 
 5. **Identify recurring narrative themes.** What topic keeps coming up across sources? That's the dominant narrative driving current sentiment.
 
-6. **Be honest about data limits.** If StockTwits returned only a handful of messages, or one or more sources returned an "<unavailable>" placeholder, the sentiment read is less robust — flag this caveat explicitly. If the sources are silent on a given subreddit, say so.
+6. **Be honest about data limits.** If {source1_label} returned only a handful of messages, or one or more sources returned an "<unavailable>" placeholder, the sentiment read is less robust — flag this caveat explicitly.
 
 7. **Identify catalysts and risks** that emerge across sources — news of upcoming earnings, product launches, competitive threats, macro headlines, etc.
 
@@ -154,7 +178,7 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 Produce a sentiment report covering, in order:
 
 1. **Overall sentiment direction** — Bullish / Bearish / Neutral / Mixed — with a brief confidence note based on data quality and sample size.
-2. **Source-by-source breakdown** — what each of news / StockTwits / Reddit is telling you, with specific evidence (cite message counts, ratios, notable posts).
+2. **Source-by-source breakdown** — what each of news / {source1_label} / {source2_label} is telling you, with specific evidence (cite message counts, ratios, notable posts).
 3. **Divergences, alignments, and key narratives** across sources.
 4. **Catalysts and risks** surfaced by the data.
 5. **Markdown table** at the end summarizing key sentiment signals, their direction, source, and supporting evidence.

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -63,6 +63,16 @@ def create_portfolio_manager(llm):
 
 Be decisive and ground every conclusion in specific evidence from the analysts.{get_language_instruction()}"""
 
+        # Inject portfolio context if available
+        portfolio_context = state.get("portfolio_context", "")
+        if portfolio_context:
+            prompt += f"\n\n---\n{portfolio_context}\n\n"
+            prompt += (
+                "Consider the user's existing position when making your final rating decision. "
+                "If they already hold this stock, factor in their cost basis, current P&L, "
+                "position size, and portfolio concentration when providing your recommendation."
+            )
+
         final_trade_decision = invoke_structured_or_freetext(
             structured_llm,
             llm,

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -48,6 +48,16 @@ def create_trader(llm):
             },
         ]
 
+        # Inject portfolio context if available
+        portfolio_context = state.get("portfolio_context", "")
+        if portfolio_context:
+            messages[1]["content"] += f"\n\n---\n{portfolio_context}\n\n"
+            messages[1]["content"] += (
+                "Consider the user's existing position when making your recommendation. "
+                "If they already hold this stock, factor in their cost basis, current P&L, "
+                "and position size when deciding whether to buy more, hold, or sell."
+            )
+
         trader_plan = invoke_structured_or_freetext(
             structured_llm,
             llm,

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -71,3 +71,4 @@ class AgentState(MessagesState):
     ]
     final_trade_decision: Annotated[str, "Final decision made by the Risk Analysts"]
     past_context: Annotated[str, "Memory log context injected at run start (same-ticker decisions + cross-ticker lessons)"]
+    portfolio_context: Annotated[str, "Portfolio holdings context for the current ticker"]

--- a/tradingagents/dataflows/__init__.py
+++ b/tradingagents/dataflows/__init__.py
@@ -9,7 +9,24 @@ from .tushare_data import (
     get_tushare_news,
     get_tushare_global_news,
 )
+from .akshare_data import (
+    get_akshare_stock,
+    get_akshare_indicators,
+    get_akshare_fundamentals,
+    get_akshare_balance_sheet,
+    get_akshare_cashflow,
+    get_akshare_income_statement,
+    get_akshare_insider_transactions,
+    get_akshare_news,
+    get_akshare_global_news,
+)
 from .news_service import (
     get_news_service_news,
     get_news_service_global_news,
+)
+from .xueqiu import fetch_xueqiu_posts
+from .eastmoney_guba import fetch_eastmoney_guba_posts
+from .akshare_sentiment import (
+    fetch_akshare_stock_comment,
+    fetch_akshare_hot_rank,
 )

--- a/tradingagents/dataflows/__init__.py
+++ b/tradingagents/dataflows/__init__.py
@@ -1,0 +1,15 @@
+from .tushare_data import (
+    get_tushare_stock,
+    get_tushare_indicators,
+    get_tushare_fundamentals,
+    get_tushare_balance_sheet,
+    get_tushare_cashflow,
+    get_tushare_income_statement,
+    get_tushare_insider_transactions,
+    get_tushare_news,
+    get_tushare_global_news,
+)
+from .news_service import (
+    get_news_service_news,
+    get_news_service_global_news,
+)

--- a/tradingagents/dataflows/akshare_data.py
+++ b/tradingagents/dataflows/akshare_data.py
@@ -1,0 +1,975 @@
+"""AKShare data source module for A-share and HK stock markets.
+
+This module implements the 9 standard data functions required by the
+pluggable data-source architecture, using AKShare (free, no API key) as backend.
+Function signatures and output formats are fully compatible with tushare_data.py.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Annotated
+
+import pandas as pd
+
+try:
+    import akshare as ak
+except ImportError:
+    ak = None
+
+try:
+    from stockstats import wrap as stockstats_wrap
+except ImportError:
+    stockstats_wrap = None
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helper / Utility Functions
+# ---------------------------------------------------------------------------
+
+
+def normalize_akshare_code(symbol: str) -> str:
+    """将各种格式转换为 akshare 的 6 位纯数字格式（A股）。
+
+    Examples:
+        '600000.SH' -> '600000'
+        'SH600000'  -> '600000'
+        '600000.SS' -> '600000'
+        '600000.SZ' -> '600000'
+        'SZ000001'  -> '000001'
+        '600000'    -> '600000'
+    """
+    symbol = symbol.strip().upper()
+
+    # Remove known exchange suffixes: .SH, .SS, .SZ
+    for suffix in (".SH", ".SS", ".SZ"):
+        if symbol.endswith(suffix):
+            return symbol[: -len(suffix)]
+
+    # Handle prefix formats: SH600000, SS600000, SZ000001
+    for prefix in ("SH", "SS", "SZ"):
+        if symbol.startswith(prefix) and symbol[len(prefix):].isdigit():
+            return symbol[len(prefix):]
+
+    # Already pure digits
+    if symbol.isdigit():
+        return symbol
+
+    # Fallback: return as-is
+    return symbol
+
+
+def _is_hk_ticker(symbol: str) -> bool:
+    """检测是否为港股代码。"""
+    s = symbol.strip().upper()
+    if s.endswith(".HK"):
+        return True
+    if s.startswith("HK") and s[2:].isdigit():
+        return True
+    return False
+
+
+def _normalize_hk_code(symbol: str) -> str:
+    """将港股代码转换为 akshare 要求的格式（5位数字，前补零）。
+
+    Examples:
+        '0700.HK'  -> '00700'
+        '00700.HK' -> '00700'
+        'HK0700'   -> '00700'
+        'HK00700'  -> '00700'
+    """
+    s = symbol.strip().upper()
+    if s.endswith(".HK"):
+        code = s[:-3]
+    elif s.startswith("HK"):
+        code = s[2:]
+    else:
+        code = s
+    # Pad to 5 digits
+    return code.zfill(5)
+
+
+def _is_fund_or_etf(code: str) -> bool:
+    """判断是否为 ETF/基金代码。
+
+    A股ETF/基金代码规则：
+    - 上海: 5xxxxx (包含 51xxxx, 56xxxx, 58xxxx 等)
+    - 深圳: 15xxxx, 16xxxx
+    """
+    # Strip any suffix first
+    pure_code = code.split(".")[0] if "." in code else code
+    # Remove known prefixes
+    for prefix in ("SH", "SS", "SZ", "HK"):
+        if pure_code.upper().startswith(prefix) and pure_code[len(prefix):].isdigit():
+            pure_code = pure_code[len(prefix):]
+            break
+
+    if not pure_code.isdigit() or len(pure_code) != 6:
+        return False
+
+    if pure_code.startswith("5"):
+        return True
+    if pure_code.startswith("15") or pure_code.startswith("16"):
+        return True
+    return False
+
+
+def _convert_date_input(date_str: str) -> str:
+    """Convert date from YYYY-MM-DD to YYYYMMDD for akshare input."""
+    return date_str.replace("-", "")
+
+
+# ---------------------------------------------------------------------------
+# Tencent Finance Fallback Helper
+# ---------------------------------------------------------------------------
+
+
+def _tencent_fallback_stock(symbol: str, start_date: str, end_date: str) -> str:
+    """Fallback: 使用 akshare 腾讯财经接口获取 A 股/ETF 数据。
+
+    当东方财富历史数据接口(push2his)不可用时，自动降级到腾讯财经数据源。
+    无需代理，国内直连。
+
+    注意：腾讯财经接口不支持复权，且只有成交额(amount)没有成交量(volume)。
+    """
+    if ak is None:
+        return ""
+
+    # 转换代码格式: 600000.SH -> sh600000, 000001.SZ -> sz000001
+    code = normalize_akshare_code(symbol)
+    if code.startswith(('6', '9', '5')):
+        tx_symbol = f"sh{code}"
+    else:
+        tx_symbol = f"sz{code}"
+
+    # 日期格式转换: YYYY-MM-DD -> YYYYMMDD
+    tx_start = start_date.replace("-", "")
+    tx_end = end_date.replace("-", "")
+
+    try:
+        logger.info(f"Falling back to Tencent Finance for {symbol} (as {tx_symbol})")
+        df = ak.stock_zh_a_hist_tx(symbol=tx_symbol, start_date=tx_start, end_date=tx_end)
+
+        if df is None or df.empty:
+            logger.warning(f"Tencent Finance returned no data for {tx_symbol}")
+            return ""
+
+        # 腾讯返回列: date, open, close, high, low, amount
+        # 转换为项目标准格式
+        lines = []
+        lines.append(f"# Stock data for {symbol} from {start_date} to {end_date}")
+        lines.append(f"# Total records: {len(df)}")
+        lines.append(f"# Data source: Tencent Finance (fallback)")
+        lines.append(f"# Note: No adjust data available from this source")
+        lines.append(f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append("")
+        lines.append("Date,Open,High,Low,Close,Adj Close,Volume")
+
+        for _, row in df.iterrows():
+            # 腾讯没有 volume，用 amount 代替（标注在注释中）
+            # Adj Close = Close（无复权数据）
+            date_str = str(row['date'])
+            # 确保日期格式为 YYYY-MM-DD
+            if len(date_str) == 8:  # YYYYMMDD
+                date_str = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}"
+
+            lines.append(
+                f"{date_str},{row['open']:.4f},{row['high']:.4f},"
+                f"{row['low']:.4f},{row['close']:.4f},{row['close']:.4f},"
+                f"{int(row['amount'])}"
+            )
+
+        logger.info(f"Tencent Finance fallback successful for {tx_symbol}: {len(df)} records")
+        return "\n".join(lines)
+    except Exception as e:
+        logger.warning(f"Tencent Finance fallback also failed for {tx_symbol}: {type(e).__name__}: {e}")
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Indicator descriptions (same as tushare_data.py)
+# ---------------------------------------------------------------------------
+
+INDICATOR_DESCRIPTIONS = {
+    "close_50_sma": (
+        "50 SMA: A medium-term trend indicator. "
+        "Usage: Identify trend direction and serve as dynamic support/resistance. "
+        "Tips: It lags price; combine with faster indicators for timely signals."
+    ),
+    "close_200_sma": (
+        "200 SMA: A long-term trend benchmark. "
+        "Usage: Confirm overall market trend and identify golden/death cross setups. "
+        "Tips: It reacts slowly; best for strategic trend confirmation."
+    ),
+    "close_10_ema": (
+        "10 EMA: A responsive short-term average. "
+        "Usage: Capture quick shifts in momentum and potential entry points. "
+        "Tips: Prone to noise in choppy markets; use alongside longer averages."
+    ),
+    "macd": (
+        "MACD: Computes momentum via differences of EMAs. "
+        "Usage: Look for crossovers and divergence as signals of trend changes. "
+        "Tips: Confirm with other indicators in low-volatility or sideways markets."
+    ),
+    "macds": (
+        "MACD Signal: An EMA smoothing of the MACD line. "
+        "Usage: Use crossovers with the MACD line to trigger trades. "
+        "Tips: Should be part of a broader strategy to avoid false positives."
+    ),
+    "macdh": (
+        "MACD Histogram: Shows the gap between the MACD line and its signal. "
+        "Usage: Visualize momentum strength and spot divergence early. "
+        "Tips: Can be volatile; complement with additional filters."
+    ),
+    "rsi": (
+        "RSI: Measures momentum to flag overbought/oversold conditions. "
+        "Usage: Apply 70/30 thresholds and watch for divergence to signal reversals. "
+        "Tips: In strong trends, RSI may remain extreme; cross-check with trend analysis."
+    ),
+    "boll": (
+        "Bollinger Middle: A 20 SMA serving as the basis for Bollinger Bands. "
+        "Usage: Acts as a dynamic benchmark for price movement. "
+        "Tips: Combine with upper and lower bands to spot breakouts or reversals."
+    ),
+    "boll_ub": (
+        "Bollinger Upper Band: Typically 2 standard deviations above the middle line. "
+        "Usage: Signals potential overbought conditions and breakout zones. "
+        "Tips: Confirm signals with other tools; prices may ride the band in strong trends."
+    ),
+    "boll_lb": (
+        "Bollinger Lower Band: Typically 2 standard deviations below the middle line. "
+        "Usage: Indicates potential oversold conditions. "
+        "Tips: Use additional analysis to avoid false reversal signals."
+    ),
+    "atr": (
+        "ATR: Averages true range to measure volatility. "
+        "Usage: Set stop-loss levels and adjust position sizes based on current market volatility. "
+        "Tips: It's a reactive measure; use as part of a broader risk management strategy."
+    ),
+    "vwma": (
+        "VWMA: A moving average weighted by volume. "
+        "Usage: Confirm trends by integrating price action with volume data. "
+        "Tips: Watch for skewed results from volume spikes."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# 9 Core Data Functions
+# ---------------------------------------------------------------------------
+
+
+def get_akshare_stock(
+    symbol: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
+    end_date: Annotated[str, "End date in YYYY-MM-DD format"],
+) -> str:
+    """Get OHLCV stock price data from AKShare with adjusted close price."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        ak_start = _convert_date_input(start_date)
+        ak_end = _convert_date_input(end_date)
+
+        df = None
+        ak_failed = False
+
+        if _is_hk_ticker(symbol):
+            # 港股 (no Tencent Finance fallback for HK via this path)
+            hk_code = _normalize_hk_code(symbol)
+            logger.info(f"Fetching HK stock data for {hk_code}")
+            df = ak.stock_hk_hist(
+                symbol=hk_code,
+                period="daily",
+                start_date=ak_start,
+                end_date=ak_end,
+                adjust="qfq",
+            )
+        elif _is_fund_or_etf(symbol):
+            # ETF/基金
+            code = normalize_akshare_code(symbol)
+            logger.info(f"Detected ETF/fund code {code}, using fund_etf_hist_em API")
+            try:
+                df = ak.fund_etf_hist_em(
+                    symbol=code,
+                    period="daily",
+                    start_date=ak_start,
+                    end_date=ak_end,
+                    adjust="qfq",
+                )
+            except Exception as e:
+                logger.warning(f"akshare fund_etf_hist_em failed for {symbol}: {type(e).__name__}: {e}")
+                ak_failed = True
+        else:
+            # A股
+            code = normalize_akshare_code(symbol)
+            logger.info(f"Fetching A-share stock data for {code}")
+            try:
+                df = ak.stock_zh_a_hist(
+                    symbol=code,
+                    period="daily",
+                    start_date=ak_start,
+                    end_date=ak_end,
+                    adjust="qfq",
+                )
+            except Exception as e:
+                logger.warning(f"akshare stock_zh_a_hist failed for {symbol}: {type(e).__name__}: {e}")
+                ak_failed = True
+
+        # 如果 akshare 调用失败或返回空数据，降级到腾讯财经
+        if ak_failed or df is None or df.empty:
+            if not _is_hk_ticker(symbol):
+                logger.warning(f"akshare returned no data for {symbol}, trying Tencent Finance fallback")
+                fallback_result = _tencent_fallback_stock(symbol, start_date, end_date)
+                if fallback_result:
+                    return fallback_result
+            return (f"No stock data found for symbol '{symbol}' between {start_date} and {end_date}. "
+                    f"Both akshare (eastmoney) and Tencent Finance failed.")
+
+        # Map Chinese column names to English
+        col_map = {
+            "日期": "date",
+            "开盘": "open",
+            "收盘": "close",
+            "最高": "high",
+            "最低": "low",
+            "成交量": "volume",
+            "成交额": "amount",
+        }
+        df = df.rename(columns=col_map)
+
+        # Ensure required columns exist (akshare may return different column names)
+        # Try alternate English column names from HK data
+        alt_col_map = {
+            "Date": "date",
+            "Open": "open",
+            "Close": "close",
+            "High": "high",
+            "Low": "low",
+            "Volume": "volume",
+        }
+        df = df.rename(columns=alt_col_map)
+
+        # Validate required columns
+        required_cols = ["date", "open", "high", "low", "close", "volume"]
+        missing = [c for c in required_cols if c not in df.columns]
+        if missing:
+            return f"Error: Missing columns {missing} in data for {symbol}"
+
+        # Sort by date ascending
+        df["date"] = pd.to_datetime(df["date"])
+        df = df.sort_values("date").reset_index(drop=True)
+
+        # Adj Close = Close in qfq (forward-adjusted) mode
+        df["adj_close"] = df["close"]
+
+        # Format date
+        df["date_fmt"] = df["date"].dt.strftime("%Y-%m-%d")
+
+        # Round price columns
+        for col in ["open", "high", "low", "close", "adj_close"]:
+            df[col] = pd.to_numeric(df[col], errors="coerce").round(2)
+
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce").fillna(0).astype(int)
+
+        # Build CSV output (same format as tushare_data.py)
+        code_display = normalize_akshare_code(symbol) if not _is_hk_ticker(symbol) else _normalize_hk_code(symbol)
+        header = f"# Stock data for {code_display} from {start_date} to {end_date}\n"
+        header += f"# Total records: {len(df)}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        lines = ["Date,Open,High,Low,Close,Adj Close,Volume"]
+        for _, row in df.iterrows():
+            lines.append(
+                f"{row['date_fmt']},{row['open']:.2f},{row['high']:.2f},"
+                f"{row['low']:.2f},{row['close']:.2f},{row['adj_close']:.2f},"
+                f"{row['volume']}"
+            )
+
+        return header + "\n".join(lines) + "\n"
+
+    except Exception as e:
+        # 顶层异常兜底：尝试腾讯财经 fallback
+        if not _is_hk_ticker(symbol):
+            logger.warning(f"akshare top-level exception for {symbol}: {type(e).__name__}: {e}, trying Tencent Finance")
+            fallback_result = _tencent_fallback_stock(symbol, start_date, end_date)
+            if fallback_result:
+                return fallback_result
+        return f"Error retrieving stock data for {symbol}: {str(e)}"
+
+
+def get_akshare_indicators(
+    symbol: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    indicator: Annotated[str, "technical indicator name"],
+    curr_date: Annotated[str, "Current trading date in YYYY-MM-DD format"],
+    look_back_days: Annotated[int, "Number of days to look back"],
+) -> str:
+    """Get technical indicator values computed from AKShare daily data."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    supported_indicators = list(INDICATOR_DESCRIPTIONS.keys())
+    if indicator not in supported_indicators:
+        raise ValueError(
+            f"Indicator '{indicator}' is not supported. "
+            f"Please choose from: {supported_indicators}"
+        )
+
+    if stockstats_wrap is None:
+        return (
+            "Error: stockstats is not installed. "
+            "Please install it with: pip install stockstats"
+        )
+
+    try:
+        # Calculate date range with extra buffer for indicator warm-up
+        curr_date_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+        buffer_days = look_back_days + 300
+        start_date_dt = curr_date_dt - timedelta(days=buffer_days)
+        ak_start = start_date_dt.strftime("%Y%m%d")
+        ak_end = curr_date_dt.strftime("%Y%m%d")
+        tx_start = start_date_dt.strftime("%Y%m%d")
+        tx_end = curr_date_dt.strftime("%Y%m%d")
+
+        df = None
+        ak_failed = False
+
+        if _is_hk_ticker(symbol):
+            hk_code = _normalize_hk_code(symbol)
+            df = ak.stock_hk_hist(
+                symbol=hk_code, period="daily",
+                start_date=ak_start, end_date=ak_end, adjust="qfq",
+            )
+        elif _is_fund_or_etf(symbol):
+            code = normalize_akshare_code(symbol)
+            try:
+                df = ak.fund_etf_hist_em(
+                    symbol=code, period="daily",
+                    start_date=ak_start, end_date=ak_end, adjust="qfq",
+                )
+            except Exception as e:
+                logger.warning(f"akshare fund_etf_hist_em failed for {symbol} (indicators): {type(e).__name__}: {e}")
+                ak_failed = True
+        else:
+            code = normalize_akshare_code(symbol)
+            try:
+                df = ak.stock_zh_a_hist(
+                    symbol=code, period="daily",
+                    start_date=ak_start, end_date=ak_end, adjust="qfq",
+                )
+            except Exception as e:
+                logger.warning(f"akshare stock_zh_a_hist failed for {symbol} (indicators): {type(e).__name__}: {e}")
+                ak_failed = True
+
+        # 腾讯财经 fallback for indicators data
+        if (ak_failed or df is None or df.empty) and not _is_hk_ticker(symbol):
+            tx_code = normalize_akshare_code(symbol)
+            tx_symbol = f"sh{tx_code}" if tx_code.startswith(('6', '9', '5')) else f"sz{tx_code}"
+            logger.warning(f"akshare returned no data for {symbol} (indicators), trying Tencent Finance fallback")
+            try:
+                logger.info(f"Falling back to Tencent Finance for indicators: {tx_symbol}")
+                tx_df = ak.stock_zh_a_hist_tx(symbol=tx_symbol, start_date=tx_start, end_date=tx_end)
+                if tx_df is not None and not tx_df.empty:
+                    # 腾讯返回列: date, open, close, high, low, amount
+                    # amount -> volume（对技术指标计算够用）
+                    df = pd.DataFrame({
+                        "date": tx_df["date"],
+                        "open": tx_df["open"],
+                        "high": tx_df["high"],
+                        "low": tx_df["low"],
+                        "close": tx_df["close"],
+                        "volume": tx_df["amount"],
+                    })
+                    logger.info(f"Tencent Finance fallback successful for indicators {tx_symbol}: {len(df)} records")
+                else:
+                    logger.warning(f"Tencent Finance returned no data for indicators {tx_symbol}")
+            except Exception as tx_e:
+                logger.warning(f"Tencent Finance fallback also failed for indicators {tx_symbol}: {type(tx_e).__name__}: {tx_e}")
+
+        if df is None or df.empty:
+            return f"No stock data found for symbol '{symbol}' to compute indicators"
+
+        # Map columns
+        col_map = {
+            "日期": "date", "开盘": "open", "收盘": "close",
+            "最高": "high", "最低": "low", "成交量": "volume",
+        }
+        alt_col_map = {
+            "Date": "date", "Open": "open", "Close": "close",
+            "High": "high", "Low": "low", "Volume": "volume",
+        }
+        df = df.rename(columns=col_map).rename(columns=alt_col_map)
+
+        # Sort ascending by date
+        df["date"] = pd.to_datetime(df["date"])
+        df = df.sort_values("date").reset_index(drop=True)
+
+        # Build DataFrame for stockstats
+        stock_df = pd.DataFrame({
+            "date": df["date"].dt.strftime("%Y-%m-%d"),
+            "open": pd.to_numeric(df["open"], errors="coerce"),
+            "high": pd.to_numeric(df["high"], errors="coerce"),
+            "low": pd.to_numeric(df["low"], errors="coerce"),
+            "close": pd.to_numeric(df["close"], errors="coerce"),
+            "volume": pd.to_numeric(df["volume"], errors="coerce"),
+        })
+        stock_df = stock_df.dropna(subset=["close"])
+
+        # Wrap with stockstats and calculate indicator
+        ss_df = stockstats_wrap(stock_df)
+        ss_df[indicator]  # Trigger calculation
+
+        # Build date -> value mapping
+        indicator_map = {}
+        for _, row in ss_df.iterrows():
+            date_str = row["date"]
+            val = row[indicator]
+            if pd.isna(val):
+                indicator_map[date_str] = "N/A"
+            else:
+                indicator_map[date_str] = f"{val:.2f}"
+
+        # Generate output for the look_back_days range
+        display_start_dt = curr_date_dt - timedelta(days=look_back_days)
+        lines = []
+        current_dt = display_start_dt
+        while current_dt <= curr_date_dt:
+            date_str = current_dt.strftime("%Y-%m-%d")
+            if date_str in indicator_map:
+                lines.append(f"{date_str}: {indicator_map[date_str]}")
+            else:
+                lines.append(f"{date_str}: N/A: Not a trading day (weekend or holiday)")
+            current_dt += timedelta(days=1)
+
+        result = (
+            f"## {indicator} values from {display_start_dt.strftime('%Y-%m-%d')} to {curr_date}:\n\n"
+            + "\n".join(lines)
+            + "\n\n"
+            + INDICATOR_DESCRIPTIONS.get(indicator, "No description available.")
+        )
+        return result
+
+    except Exception as e:
+        return f"Error retrieving indicators for {symbol}: {str(e)}"
+
+
+def get_akshare_fundamentals(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get company fundamentals from AKShare (PE, PB, market cap, etc.)."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        if _is_hk_ticker(ticker):
+            return f"Fundamentals for HK stocks are not yet supported via AKShare: {ticker}"
+
+        code = normalize_akshare_code(ticker)
+
+        # Get company basic info
+        info_df = None
+        try:
+            info_df = ak.stock_individual_info_em(symbol=code)
+        except Exception as e:
+            logger.debug(f"Failed to get stock_individual_info_em for {code}: {e}")
+
+        # Get realtime quote for PE/PB/market cap
+        quote_df = None
+        try:
+            quote_df = ak.stock_zh_a_spot_em()
+            if quote_df is not None and not quote_df.empty:
+                quote_df = quote_df[quote_df["代码"] == code]
+        except Exception as e:
+            logger.debug(f"Failed to get realtime quote for {code}: {e}")
+
+        if (info_df is None or info_df.empty) and (quote_df is None or quote_df.empty):
+            return f"No fundamentals data found for symbol '{ticker}'"
+
+        # Build output
+        header = f"# Company Fundamentals for {code}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        fields = []
+
+        # Parse info_df (it's a two-column DataFrame: item, value)
+        if info_df is not None and not info_df.empty:
+            info_dict = {}
+            for _, row in info_df.iterrows():
+                key = str(row.iloc[0]) if len(row) >= 2 else ""
+                val = row.iloc[1] if len(row) >= 2 else ""
+                info_dict[key] = val
+
+            fields.append(("Name", info_dict.get("股票简称", info_dict.get("名称"))))
+            fields.append(("Full Name", info_dict.get("公司名称")))
+            fields.append(("Industry", info_dict.get("行业")))
+            fields.append(("List Date", info_dict.get("上市时间")))
+            fields.append(("Total Share", info_dict.get("总股本")))
+            fields.append(("Float Share", info_dict.get("流通股")))
+
+        # Parse realtime quote
+        if quote_df is not None and not quote_df.empty:
+            q = quote_df.iloc[0]
+            col_map = {
+                "最新价": "Close Price",
+                "换手率": "Turnover Rate",
+                "市盈率-动态": "PE Ratio (TTM)",
+                "市净率": "PB Ratio",
+                "总市值": "Total Market Cap",
+                "流通市值": "Float Market Cap",
+                "60日涨跌幅": "60D Change (%)",
+                "年初至今涨跌幅": "YTD Change (%)",
+            }
+            for cn_col, en_label in col_map.items():
+                if cn_col in q.index:
+                    fields.append((en_label, q[cn_col]))
+
+        lines = []
+        for label, value in fields:
+            if value is not None and str(value) != "" and str(value) != "nan":
+                lines.append(f"{label}: {value}")
+
+        if not lines:
+            return f"No fundamentals data found for symbol '{ticker}'"
+
+        return header + "\n".join(lines)
+
+    except Exception as e:
+        return f"Error retrieving fundamentals for {ticker}: {str(e)}"
+
+
+def get_akshare_balance_sheet(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get balance sheet data from AKShare."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        if _is_hk_ticker(ticker):
+            return f"Balance sheet for HK stocks is not yet supported via AKShare: {ticker}"
+
+        code = normalize_akshare_code(ticker)
+        logger.info(f"Fetching balance sheet for {code}")
+
+        df = ak.stock_balance_sheet_by_report_em(symbol=code)
+
+        if df is None or df.empty:
+            return f"No balance sheet data found for symbol '{ticker}'"
+
+        # Filter by curr_date if provided
+        if curr_date and "REPORT_DATE" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["REPORT_DATE"] = pd.to_datetime(df["REPORT_DATE"], errors="coerce")
+            df = df[df["REPORT_DATE"] <= ref_date]
+        elif curr_date and "报告日期" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["报告日期"] = pd.to_datetime(df["报告日期"], errors="coerce")
+            df = df[df["报告日期"] <= ref_date]
+
+        if df.empty:
+            return f"No balance sheet data found for symbol '{ticker}'"
+
+        # Take the most recent 4 periods
+        num_periods = 4
+        df = df.head(num_periods)
+
+        # Transpose: rows become indicators, columns become report periods
+        # Identify the date column
+        date_col = None
+        for candidate in ["REPORT_DATE", "报告日期"]:
+            if candidate in df.columns:
+                date_col = candidate
+                break
+
+        if date_col:
+            col_names = df[date_col].apply(
+                lambda x: pd.to_datetime(x).strftime("%Y-%m-%d") if pd.notna(x) else str(x)
+            ).tolist()
+            df = df.drop(columns=[date_col], errors="ignore")
+        else:
+            col_names = [f"Period_{i}" for i in range(len(df))]
+
+        # Remove non-financial metadata columns
+        skip_cols = ["SECUCODE", "SECURITY_CODE", "SECURITY_NAME_ABBR",
+                     "ORG_CODE", "ORG_TYPE", "REPORT_TYPE", "REPORT_DATE_NAME",
+                     "SECURITY_TYPE_CODE", "NOTICE_DATE", "UPDATE_DATE",
+                     "股票代码", "股票简称"]
+        df = df.drop(columns=[c for c in skip_cols if c in df.columns], errors="ignore")
+
+        result_df = df.T
+        result_df.columns = col_names
+
+        # Remove rows where all values are NaN
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Balance Sheet data for {code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except Exception as e:
+        return f"Error retrieving balance sheet for {ticker}: {str(e)}"
+
+
+def get_akshare_cashflow(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get cash flow statement data from AKShare."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        if _is_hk_ticker(ticker):
+            return f"Cash flow for HK stocks is not yet supported via AKShare: {ticker}"
+
+        code = normalize_akshare_code(ticker)
+        logger.info(f"Fetching cash flow for {code}")
+
+        df = ak.stock_cash_flow_sheet_by_report_em(symbol=code)
+
+        if df is None or df.empty:
+            return f"No cash flow data found for symbol '{ticker}'"
+
+        # Filter by curr_date if provided
+        if curr_date and "REPORT_DATE" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["REPORT_DATE"] = pd.to_datetime(df["REPORT_DATE"], errors="coerce")
+            df = df[df["REPORT_DATE"] <= ref_date]
+        elif curr_date and "报告日期" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["报告日期"] = pd.to_datetime(df["报告日期"], errors="coerce")
+            df = df[df["报告日期"] <= ref_date]
+
+        if df.empty:
+            return f"No cash flow data found for symbol '{ticker}'"
+
+        # Take the most recent 4 periods
+        num_periods = 4
+        df = df.head(num_periods)
+
+        # Identify the date column
+        date_col = None
+        for candidate in ["REPORT_DATE", "报告日期"]:
+            if candidate in df.columns:
+                date_col = candidate
+                break
+
+        if date_col:
+            col_names = df[date_col].apply(
+                lambda x: pd.to_datetime(x).strftime("%Y-%m-%d") if pd.notna(x) else str(x)
+            ).tolist()
+            df = df.drop(columns=[date_col], errors="ignore")
+        else:
+            col_names = [f"Period_{i}" for i in range(len(df))]
+
+        # Remove non-financial metadata columns
+        skip_cols = ["SECUCODE", "SECURITY_CODE", "SECURITY_NAME_ABBR",
+                     "ORG_CODE", "ORG_TYPE", "REPORT_TYPE", "REPORT_DATE_NAME",
+                     "SECURITY_TYPE_CODE", "NOTICE_DATE", "UPDATE_DATE",
+                     "股票代码", "股票简称"]
+        df = df.drop(columns=[c for c in skip_cols if c in df.columns], errors="ignore")
+
+        result_df = df.T
+        result_df.columns = col_names
+
+        # Remove rows where all values are NaN
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Cash Flow data for {code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except Exception as e:
+        return f"Error retrieving cash flow for {ticker}: {str(e)}"
+
+
+def get_akshare_income_statement(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get income statement data from AKShare."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        if _is_hk_ticker(ticker):
+            return f"Income statement for HK stocks is not yet supported via AKShare: {ticker}"
+
+        code = normalize_akshare_code(ticker)
+        logger.info(f"Fetching income statement for {code}")
+
+        df = ak.stock_profit_sheet_by_report_em(symbol=code)
+
+        if df is None or df.empty:
+            return f"No income statement data found for symbol '{ticker}'"
+
+        # Filter by curr_date if provided
+        if curr_date and "REPORT_DATE" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["REPORT_DATE"] = pd.to_datetime(df["REPORT_DATE"], errors="coerce")
+            df = df[df["REPORT_DATE"] <= ref_date]
+        elif curr_date and "报告日期" in df.columns:
+            ref_date = pd.to_datetime(curr_date)
+            df["报告日期"] = pd.to_datetime(df["报告日期"], errors="coerce")
+            df = df[df["报告日期"] <= ref_date]
+
+        if df.empty:
+            return f"No income statement data found for symbol '{ticker}'"
+
+        # Take the most recent 4 periods
+        num_periods = 4
+        df = df.head(num_periods)
+
+        # Identify the date column
+        date_col = None
+        for candidate in ["REPORT_DATE", "报告日期"]:
+            if candidate in df.columns:
+                date_col = candidate
+                break
+
+        if date_col:
+            col_names = df[date_col].apply(
+                lambda x: pd.to_datetime(x).strftime("%Y-%m-%d") if pd.notna(x) else str(x)
+            ).tolist()
+            df = df.drop(columns=[date_col], errors="ignore")
+        else:
+            col_names = [f"Period_{i}" for i in range(len(df))]
+
+        # Remove non-financial metadata columns
+        skip_cols = ["SECUCODE", "SECURITY_CODE", "SECURITY_NAME_ABBR",
+                     "ORG_CODE", "ORG_TYPE", "REPORT_TYPE", "REPORT_DATE_NAME",
+                     "SECURITY_TYPE_CODE", "NOTICE_DATE", "UPDATE_DATE",
+                     "股票代码", "股票简称"]
+        df = df.drop(columns=[c for c in skip_cols if c in df.columns], errors="ignore")
+
+        result_df = df.T
+        result_df.columns = col_names
+
+        # Remove rows where all values are NaN
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Income Statement data for {code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except Exception as e:
+        return f"Error retrieving income statement for {ticker}: {str(e)}"
+
+
+def get_akshare_insider_transactions(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+) -> str:
+    """Get insider (executive) trading records from AKShare."""
+    if ak is None:
+        return "Error: akshare is not installed. Please install it with: pip install akshare"
+
+    try:
+        if _is_hk_ticker(ticker):
+            return f"Insider transactions for HK stocks are not yet supported via AKShare: {ticker}"
+
+        code = normalize_akshare_code(ticker)
+        logger.info(f"Fetching insider transactions for {code}")
+
+        try:
+            df = ak.stock_hold_management_detail_em(symbol=code)
+        except Exception as e:
+            logger.warning(f"stock_hold_management_detail_em not available for {code}: {e}")
+            return (
+                f"Insider transactions data is not available for '{ticker}'. "
+                f"The AKShare interface may have changed or the data is unavailable."
+            )
+
+        if df is None or df.empty:
+            return f"No insider transactions data found for symbol '{ticker}'"
+
+        header = f"# Insider Transactions data for {code}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        # Detect column names (akshare may return Chinese columns)
+        # Common columns: 变动日期, 变动人, 变动股数, 变动方向, 变动均价, 变动原因
+        date_col = None
+        for candidate in ["变动日期", "公告日期", "END_DATE", "ann_date"]:
+            if candidate in df.columns:
+                date_col = candidate
+                break
+
+        holder_col = None
+        for candidate in ["变动人", "董监高姓名", "HOLDER_NAME"]:
+            if candidate in df.columns:
+                holder_col = candidate
+                break
+
+        vol_col = None
+        for candidate in ["变动股数", "变动数量", "CHANGE_SHARES"]:
+            if candidate in df.columns:
+                vol_col = candidate
+                break
+
+        type_col = None
+        for candidate in ["变动方向", "变动类型", "CHANGE_TYPE"]:
+            if candidate in df.columns:
+                type_col = candidate
+                break
+
+        price_col = None
+        for candidate in ["变动均价", "成交均价", "AVERAGE_PRICE"]:
+            if candidate in df.columns:
+                price_col = candidate
+                break
+
+        reason_col = None
+        for candidate in ["变动原因", "变动事由", "CHANGE_REASON"]:
+            if candidate in df.columns:
+                reason_col = candidate
+                break
+
+        lines = ["Date,Holder Name,Change Volume,Change Type,Price,Change Reason"]
+        for _, row in df.iterrows():
+            date_val = str(row.get(date_col, "")) if date_col else ""
+            holder = str(row.get(holder_col, "")) if holder_col else ""
+            vol = str(row.get(vol_col, "")) if vol_col else ""
+            change_type = str(row.get(type_col, "")) if type_col else ""
+            price = str(row.get(price_col, "")) if price_col else ""
+            reason = str(row.get(reason_col, "")) if reason_col else ""
+            lines.append(f"{date_val},{holder},{vol},{change_type},{price},{reason}")
+
+        return header + "\n".join(lines) + "\n"
+
+    except Exception as e:
+        return f"Error retrieving insider transactions for {ticker}: {str(e)}"
+
+
+def get_akshare_news(
+    ticker: Annotated[str, "ticker symbol"],
+    start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
+    end_date: Annotated[str, "End date in YYYY-MM-DD format"],
+) -> str:
+    """Get news for a specific ticker from the news service."""
+    from .news_service import get_news_service_news
+    return get_news_service_news(ticker, start_date, end_date)
+
+
+def get_akshare_global_news(
+    curr_date: Annotated[str, "Current date in YYYY-MM-DD format"],
+    look_back_days: int = None,
+    limit: int = None,
+) -> str:
+    """Get global market news from the news service."""
+    from .news_service import get_news_service_global_news
+    return get_news_service_global_news(curr_date, look_back_days, limit)

--- a/tradingagents/dataflows/akshare_sentiment.py
+++ b/tradingagents/dataflows/akshare_sentiment.py
@@ -1,0 +1,500 @@
+"""AKShare-based sentiment data for A-share stocks.
+
+Provides structured sentiment/popularity data from Eastmoney via AKShare,
+replacing the defunct Xueqiu and Eastmoney Guba scrapers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+try:
+    import akshare as ak
+except ImportError:
+    ak = None
+    logger.warning("akshare is not installed. A-share sentiment data will be unavailable.")
+
+
+# ---------------------------------------------------------------------------
+# Helper / Utility Functions
+# ---------------------------------------------------------------------------
+
+
+def _to_akshare_hot_symbol(ticker: str) -> str:
+    """将各种 ticker 格式转为 akshare 人气排名需要的格式（如 "SZ000001" / "SH600000"）。
+
+    支持的输入格式:
+    - "600000.SH" -> "SH600000"
+    - "000001.SZ" -> "SZ000001"
+    - "SH600000"  -> "SH600000"（已是正确格式）
+    - "600000"    -> "SH600000"（6/9开头默认SH，0/3开头默认SZ）
+    - "518880.SH" -> "SH518880"
+    """
+    ticker = ticker.strip().upper()
+
+    # 格式: 600000.SH / 000001.SZ
+    m = re.match(r"^(\d{6})\.(SH|SZ|SS|BJ)$", ticker)
+    if m:
+        code, exchange = m.group(1), m.group(2)
+        # .SS 也是上海
+        if exchange == "SS":
+            exchange = "SH"
+        return f"{exchange}{code}"
+
+    # 格式: SH600000 / SZ000001（已是正确格式）
+    m = re.match(r"^(SH|SZ|BJ)(\d{6})$", ticker)
+    if m:
+        return ticker
+
+    # 格式: 纯 6 位数字
+    m = re.match(r"^(\d{6})$", ticker)
+    if m:
+        code = m.group(1)
+        if code[0] in ("6", "9", "5"):
+            return f"SH{code}"
+        else:
+            return f"SZ{code}"
+
+    # 无法识别，尝试提取数字部分并推断交易所
+    digits = re.findall(r"\d+", ticker)
+    if digits and len(digits[0]) == 6:
+        code = digits[0]
+        if code[0] in ("6", "9", "5"):
+            return f"SH{code}"
+        else:
+            return f"SZ{code}"
+
+    # Fallback
+    return ticker
+
+
+def _extract_code(ticker: str) -> str:
+    """从 ticker 中提取纯 6 位数字代码。
+
+    支持的输入格式:
+    - "600000.SH" -> "600000"
+    - "SH600000"  -> "600000"
+    - "600000"    -> "600000"
+    """
+    ticker = ticker.strip().upper()
+
+    # 格式: 600000.SH
+    m = re.match(r"^(\d{6})\.[A-Z]{2}$", ticker)
+    if m:
+        return m.group(1)
+
+    # 格式: SH600000
+    m = re.match(r"^[A-Z]{2}(\d{6})$", ticker)
+    if m:
+        return m.group(1)
+
+    # 格式: 纯数字
+    m = re.match(r"^(\d{6})$", ticker)
+    if m:
+        return m.group(1)
+
+    # 尝试提取数字
+    digits = re.findall(r"\d+", ticker)
+    if digits:
+        return digits[0].zfill(6)
+
+    return ticker
+
+
+# ---------------------------------------------------------------------------
+# Public Functions
+# ---------------------------------------------------------------------------
+
+
+def fetch_akshare_stock_comment(ticker: str) -> str:
+    """获取千股千评数据，返回格式化纯文本。
+
+    Parameters
+    ----------
+    ticker : str
+        股票代码，支持多种格式（如 600000、600000.SH、SH600000）。
+
+    Returns
+    -------
+    str
+        格式化的千股千评文本。异常时返回占位符字符串。
+    """
+    if ak is None:
+        logger.warning("akshare 未安装，无法获取千股千评数据")
+        return f"[AKShare stock comment data unavailable for {ticker}]"
+
+    target_code = _extract_code(ticker)
+    logger.info("获取千股千评数据: ticker=%s, code=%s", ticker, target_code)
+
+    try:
+        df = ak.stock_comment_em()
+
+        if df is None or df.empty:
+            logger.warning("stock_comment_em 返回空数据")
+            return f"[AKShare stock comment data unavailable for {ticker}]"
+
+        logger.debug("stock_comment_em 返回 %d 行, 列: %s", len(df), list(df.columns))
+
+        # 查找 Code 列（兼容不同列名）
+        code_col = None
+        for candidate in ("代码", "Code", "code", "股票代码"):
+            if candidate in df.columns:
+                code_col = candidate
+                break
+
+        if code_col is None:
+            # 如果找不到标准列名，尝试第二列（通常是代码）
+            if len(df.columns) >= 2:
+                code_col = df.columns[1]
+            else:
+                logger.warning("无法识别 stock_comment_em 的代码列")
+                return f"[AKShare stock comment data unavailable for {ticker}]"
+
+        # 标准化 Code 列并筛选
+        df["_norm_code"] = df[code_col].apply(lambda x: str(x).strip().zfill(6))
+        row = df[df["_norm_code"] == target_code]
+
+        if row.empty:
+            logger.info("千股千评中未找到 %s 的数据", target_code)
+            return f"[AKShare stock comment data unavailable for {ticker}]"
+
+        row = row.iloc[0]
+
+        # 提取各字段（兼容中英文列名）
+        def _get(keys, default="--"):
+            for k in keys:
+                if k in row.index and pd.notna(row[k]):
+                    return row[k]
+            return default
+
+        name = _get(["名称", "Name", "股票简称"])
+        total_score = _get(["综合得分", "TotalScore", "总分"])
+        ranking = _get(["综合排名", "Ranking", "排名"])
+        focus = _get(["关注指数", "Focus", "关注度"])
+        jgcyd = _get(["机构参与度", "JGCYD"])
+        zlcb = _get(["主力成本", "ZLCB", "主力成本(1日)"])
+        zlcb20 = _get(["ZLCB20R", "主力成本20日", "主力成本(20日)"])
+        zlcb60 = _get(["ZLCB60R", "主力成本60日", "主力成本(60日)"])
+        new_price = _get(["最新价", "New", "最新"])
+        change_pct = _get(["涨跌幅", "ChangePercent", "涨跌幅(%)"])
+        pe = _get(["市盈率", "PERation", "PE"])
+        turnover = _get(["换手率", "TurnoverRate", "换手率(%)"])
+        tdate = _get(["交易日", "TDate", "日期"])
+
+        # 格式化日期
+        if tdate != "--":
+            try:
+                tdate_str = pd.to_datetime(tdate).strftime("%Y-%m-%d")
+            except Exception:
+                tdate_str = str(tdate)
+        else:
+            tdate_str = datetime.now().strftime("%Y-%m-%d")
+
+        # 格式化涨跌幅
+        change_str = "--"
+        if change_pct != "--":
+            try:
+                pct_val = float(change_pct)
+                change_str = f"+{pct_val:.2f}%" if pct_val >= 0 else f"{pct_val:.2f}%"
+            except (ValueError, TypeError):
+                change_str = str(change_pct)
+
+        # 生成分析提示
+        hint_parts = []
+        try:
+            if total_score != "--":
+                score_val = float(total_score)
+                if score_val >= 70:
+                    hint_parts.append("综合评分较高")
+                elif score_val >= 50:
+                    hint_parts.append("综合评分中等")
+                else:
+                    hint_parts.append("综合评分偏低")
+        except (ValueError, TypeError):
+            pass
+
+        try:
+            if jgcyd != "--":
+                jgcyd_val = float(jgcyd)
+                if jgcyd_val >= 60:
+                    hint_parts.append("机构参与度较高")
+                elif jgcyd_val >= 30:
+                    hint_parts.append("机构参与度中等")
+                else:
+                    hint_parts.append("机构参与度偏低")
+        except (ValueError, TypeError):
+            pass
+
+        try:
+            if zlcb != "--" and zlcb60 != "--":
+                zlcb_val = float(zlcb)
+                zlcb60_val = float(zlcb60)
+                hint_parts.append(
+                    f"主力成本集中在{zlcb60_val:.2f}-{zlcb_val:.2f}区间"
+                )
+        except (ValueError, TypeError):
+            pass
+
+        hint = "，".join(hint_parts) + "。" if hint_parts else "暂无分析提示。"
+
+        # 构建输出
+        lines = [
+            f"=== 千股千评数据 ({ticker}) ===",
+            f"股票名称: {name}",
+            f"数据日期: {tdate_str}",
+            "",
+            f"综合评分: {total_score}/100 (排名: 第 {ranking} 名)",
+            f"关注指数: {focus}",
+            f"机构参与度: {jgcyd}%",
+            f"主力成本(1日): {zlcb}",
+            f"主力成本(20日): {zlcb20}",
+            f"主力成本(60日): {zlcb60}",
+            "",
+            f"最新价: {new_price} | 涨跌幅: {change_str}",
+            f"市盈率: {pe} | 换手率: {turnover}%",
+            "",
+            f"分析提示: {hint}",
+        ]
+
+        result = "\n".join(lines)
+        logger.debug("千股千评数据获取成功: %s", target_code)
+        return result
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("获取千股千评数据失败 (%s): %s", ticker, exc)
+        return f"[AKShare stock comment data unavailable for {ticker}]"
+
+
+def fetch_akshare_hot_rank(ticker: str) -> str:
+    """获取个股人气排名和热度趋势，返回格式化纯文本。
+
+    Parameters
+    ----------
+    ticker : str
+        股票代码，支持多种格式（如 600000、600000.SH、SH600000）。
+
+    Returns
+    -------
+    str
+        格式化的人气排名文本。异常时返回占位符字符串。
+    """
+    if ak is None:
+        logger.warning("akshare 未安装，无法获取人气排名数据")
+        return f"[AKShare hot rank data unavailable for {ticker}]"
+
+    symbol = _to_akshare_hot_symbol(ticker)
+    logger.info("获取个股人气排名: ticker=%s, symbol=%s", ticker, symbol)
+
+    try:
+        # 获取最新排名
+        latest_df = ak.stock_hot_rank_latest_em(symbol=symbol)
+
+        if latest_df is None or latest_df.empty:
+            logger.warning("stock_hot_rank_latest_em 返回空数据: %s", symbol)
+            return f"[AKShare hot rank data unavailable for {ticker}]"
+
+        logger.debug(
+            "stock_hot_rank_latest_em 返回 %d 行, 列: %s",
+            len(latest_df), list(latest_df.columns),
+        )
+
+        # latest_df 通常是 item/value 两列
+        latest_dict = {}
+        if "item" in latest_df.columns and "value" in latest_df.columns:
+            for _, r in latest_df.iterrows():
+                latest_dict[str(r["item"])] = r["value"]
+        elif len(latest_df.columns) == 2:
+            for _, r in latest_df.iterrows():
+                latest_dict[str(r.iloc[0])] = r.iloc[1]
+        else:
+            # 单行 DataFrame
+            for col in latest_df.columns:
+                latest_dict[col] = latest_df.iloc[0][col]
+
+        # 提取排名信息
+        def _find_val(keys, default="--"):
+            for k in keys:
+                if k in latest_dict:
+                    return latest_dict[k]
+            return default
+
+        current_rank = _find_val(["当前排名", "排名", "rank", "current_rank"])
+        total_stock = _find_val(["总数", "全市场", "total", "market_total"])
+        rank_change = _find_val(["排名变化", "rank_change", "变化"])
+
+        now_str = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+        # 格式化排名变化文字
+        rank_change_str = "--"
+        if rank_change != "--":
+            try:
+                change_val = int(float(str(rank_change)))
+                if change_val > 0:
+                    rank_change_str = f"上升 {change_val} 位"
+                elif change_val < 0:
+                    rank_change_str = f"下降 {abs(change_val)} 位"
+                else:
+                    rank_change_str = "持平"
+            except (ValueError, TypeError):
+                rank_change_str = str(rank_change)
+
+        # 构建基本信息
+        if total_stock != "--":
+            rank_line = f"当前人气排名: 第 {current_rank} 名 / 全市场 {total_stock} 只"
+        else:
+            rank_line = f"当前人气排名: 第 {current_rank} 名"
+
+        lines = [
+            f"=== 个股人气数据 ({ticker}) ===",
+            f"数据时间: {now_str}",
+            "",
+            rank_line,
+            f"排名变化: {rank_change_str}",
+        ]
+
+        # 尝试获取历史趋势
+        detail_lines = []
+        trend_analysis = ""
+        try:
+            detail_df = ak.stock_hot_rank_detail_em(symbol=symbol)
+
+            if detail_df is not None and not detail_df.empty:
+                logger.debug(
+                    "stock_hot_rank_detail_em 返回 %d 行, 列: %s",
+                    len(detail_df), list(detail_df.columns),
+                )
+
+                # 列: 时间, 排名, 证券代码, 新晋粉丝, 铁杆粉丝
+                time_col = None
+                for c in ("时间", "time", "日期"):
+                    if c in detail_df.columns:
+                        time_col = c
+                        break
+
+                rank_col = None
+                for c in ("排名", "rank"):
+                    if c in detail_df.columns:
+                        rank_col = c
+                        break
+
+                new_fan_col = None
+                for c in ("新晋粉丝", "new_fans", "新晋粉丝占比"):
+                    if c in detail_df.columns:
+                        new_fan_col = c
+                        break
+
+                old_fan_col = None
+                for c in ("铁杆粉丝", "old_fans", "铁杆粉丝占比"):
+                    if c in detail_df.columns:
+                        old_fan_col = c
+                        break
+
+                # 取最近 7 天的数据
+                detail_df = detail_df.tail(7).reset_index(drop=True)
+
+                # 按时间倒序显示（最新在上）
+                detail_df_display = detail_df.iloc[::-1].reset_index(drop=True)
+
+                for _, r in detail_df_display.iterrows():
+                    date_str = "--"
+                    if time_col:
+                        try:
+                            date_str = pd.to_datetime(r[time_col]).strftime("%m-%d")
+                        except Exception:
+                            date_str = str(r[time_col])[:5]
+
+                    r_rank = r[rank_col] if rank_col and pd.notna(r.get(rank_col)) else "--"
+
+                    new_fan_pct = "--"
+                    if new_fan_col and pd.notna(r.get(new_fan_col)):
+                        try:
+                            val = float(r[new_fan_col])
+                            # 如果是0-1区间则转百分比，如果已是百分比则直接用
+                            new_fan_pct = f"{val * 100:.0f}%" if val <= 1 else f"{val:.0f}%"
+                        except (ValueError, TypeError):
+                            new_fan_pct = str(r[new_fan_col])
+
+                    old_fan_pct = "--"
+                    if old_fan_col and pd.notna(r.get(old_fan_col)):
+                        try:
+                            val = float(r[old_fan_col])
+                            old_fan_pct = f"{val * 100:.0f}%" if val <= 1 else f"{val:.0f}%"
+                        except (ValueError, TypeError):
+                            old_fan_pct = str(r[old_fan_col])
+
+                    detail_lines.append(
+                        f"{date_str}: 排名 {r_rank} | 新晋粉丝 {new_fan_pct} | 铁杆粉丝 {old_fan_pct}"
+                    )
+
+                # 生成趋势分析
+                if rank_col and len(detail_df) >= 2:
+                    try:
+                        first_rank = int(float(detail_df.iloc[0][rank_col]))
+                        last_rank = int(float(detail_df.iloc[-1][rank_col]))
+                        rank_diff = first_rank - last_rank
+
+                        if rank_diff > 0:
+                            trend_direction = f"排名从{first_rank}上升至{last_rank}"
+                        elif rank_diff < 0:
+                            trend_direction = f"排名从{first_rank}下降至{last_rank}"
+                        else:
+                            trend_direction = f"排名稳定在{last_rank}"
+
+                        # 粉丝变化分析
+                        fan_hint = ""
+                        if old_fan_col:
+                            try:
+                                first_old = float(detail_df.iloc[0][old_fan_col])
+                                last_old = float(detail_df.iloc[-1][old_fan_col])
+                                if first_old <= 1:
+                                    first_old *= 100
+                                    last_old *= 100
+                                if last_old > first_old:
+                                    fan_hint = (
+                                        f"，铁杆粉丝占比上升({first_old:.0f}%→{last_old:.0f}%)，"
+                                        f"表明市场关注度持续增加且粉丝粘性增强"
+                                    )
+                                elif last_old < first_old:
+                                    fan_hint = (
+                                        f"，铁杆粉丝占比下降({first_old:.0f}%→{last_old:.0f}%)，"
+                                        f"新关注者增多但粘性有所减弱"
+                                    )
+                            except (ValueError, TypeError):
+                                pass
+
+                        trend_analysis = f"近7天{trend_direction}{fan_hint}。"
+                    except (ValueError, TypeError):
+                        trend_analysis = "趋势数据解析异常。"
+                else:
+                    trend_analysis = "趋势数据不足，无法分析。"
+            else:
+                detail_lines = []
+                trend_analysis = "暂无历史趋势数据。"
+
+        except Exception as detail_exc:  # noqa: BLE001
+            logger.debug("获取人气排名历史趋势失败 (%s): %s", symbol, detail_exc)
+            detail_lines = []
+            trend_analysis = "暂无历史趋势数据。"
+
+        # 组装完整输出
+        if detail_lines:
+            lines.append("")
+            lines.append("--- 近 7 天热度趋势 ---")
+            lines.extend(detail_lines)
+
+        lines.append("")
+        lines.append(f"趋势分析: {trend_analysis}")
+
+        result = "\n".join(lines)
+        logger.debug("人气排名数据获取成功: %s", symbol)
+        return result
+
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("获取人气排名数据失败 (%s): %s", ticker, exc)
+        return f"[AKShare hot rank data unavailable for {ticker}]"

--- a/tradingagents/dataflows/eastmoney_guba.py
+++ b/tradingagents/dataflows/eastmoney_guba.py
@@ -1,0 +1,178 @@
+"""东方财富股吧数据源模块，获取个股讨论帖。
+
+通过东方财富股吧公开 API 获取指定股票的讨论帖列表，包括帖子标题、
+阅读量、评论数和发布时间。无需 API Key，公开接口即可访问。
+
+返回格式化的纯文本字符串供 prompt 注入使用。任何异常均优雅降级，
+返回占位符字符串而非抛出异常。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# 东方财富股吧帖子列表 API
+_API_URL = (
+    "http://guba.eastmoney.com/interface/GetData"
+    "?type=0&path=guba%2Flist&ps=20&p=1&code={code}"
+)
+
+# 备用 API（移动端接口，结构更稳定）
+_API_URL_FALLBACK = (
+    "https://gbcdn.dfcfw.com/interfaces/getdata"
+    "?type=0&path=guba%2Flist&ps=20&p=1&code={code}"
+)
+
+# 模拟浏览器 User-Agent，防止被反爬
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+_HEADERS = {
+    "User-Agent": _UA,
+    "Accept": "application/json, text/plain, */*",
+    "Referer": "http://guba.eastmoney.com/",
+}
+
+# 请求超时（秒）
+_TIMEOUT = 10
+
+
+def _normalize_ticker(ticker: str) -> str:
+    """将各种格式的股票代码统一转换为纯数字代码。
+
+    支持的输入格式：
+    - 600519.SH / 000001.SZ -> 600519 / 000001
+    - SH600519 / SZ000001  -> 600519 / 000001
+    - 600519               -> 600519（保持不变）
+    """
+    code = ticker.strip().upper()
+
+    # 格式: 600519.SH 或 000001.SZ
+    match = re.match(r"^(\d{6})\.[A-Z]{2}$", code)
+    if match:
+        return match.group(1)
+
+    # 格式: SH600519 或 SZ000001
+    match = re.match(r"^[A-Z]{2}(\d{6})$", code)
+    if match:
+        return match.group(1)
+
+    # 格式: 纯数字
+    match = re.match(r"^(\d{6})$", code)
+    if match:
+        return match.group(1)
+
+    # 无法识别的格式，尝试提取其中的数字部分
+    digits = re.findall(r"\d+", code)
+    if digits:
+        return digits[0]
+
+    return code
+
+
+def _fetch_posts(code: str) -> list[dict]:
+    """从东方财富股吧 API 获取帖子列表，返回解析后的帖子数据。"""
+    urls = [_API_URL.format(code=code), _API_URL_FALLBACK.format(code=code)]
+
+    for url in urls:
+        try:
+            resp = requests.get(url, headers=_HEADERS, timeout=_TIMEOUT)
+            resp.raise_for_status()
+
+            data = resp.json()
+
+            # API 返回结构：{"re": [...], "ps": 20, ...}
+            posts = data.get("re") or []
+            if isinstance(posts, list) and len(posts) > 0:
+                return posts
+
+        except (
+            requests.RequestException,
+            ValueError,
+            KeyError,
+            TypeError,
+        ) as exc:
+            logger.warning(
+                "东方财富股吧 API 请求失败 [%s]: %s", url, exc
+            )
+            continue
+
+    return []
+
+
+def fetch_eastmoney_guba_posts(ticker: str) -> str:
+    """获取东方财富股吧中指定股票的讨论帖，返回格式化的纯文本字符串。
+
+    Parameters
+    ----------
+    ticker : str
+        股票代码，支持多种格式（如 600519、600519.SH、SH600519）。
+
+    Returns
+    -------
+    str
+        格式化的讨论帖文本。网络或解析异常时返回占位符字符串。
+    """
+    code = _normalize_ticker(ticker)
+
+    try:
+        posts = _fetch_posts(code)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("获取股吧数据时发生未预期错误: %s", exc)
+        return f"[Eastmoney Guba data unavailable for {ticker}]"
+
+    if not posts:
+        return f"[Eastmoney Guba data unavailable for {ticker}]"
+
+    # 格式化输出
+    lines: list[str] = []
+    lines.append(f"=== 东方财富股吧讨论 ({ticker}) ===")
+    lines.append(f"共获取 {len(posts)} 条讨论")
+    lines.append("")
+
+    for idx, post in enumerate(posts, 1):
+        # 提取帖子信息，兼容不同的字段名
+        title = (
+            post.get("post_title")
+            or post.get("title")
+            or post.get("Title")
+            or "无标题"
+        ).replace("\n", " ").strip()
+
+        read_count = (
+            post.get("post_click_count")
+            or post.get("click_count")
+            or post.get("Rc")
+            or 0
+        )
+
+        comment_count = (
+            post.get("post_comment_count")
+            or post.get("comment_count")
+            or post.get("Cc")
+            or 0
+        )
+
+        post_time = (
+            post.get("post_publish_time")
+            or post.get("publish_time")
+            or post.get("Pt")
+            or "未知"
+        )
+        # 只取日期部分（YYYY-MM-DD）
+        if isinstance(post_time, str) and len(post_time) > 10:
+            post_time = post_time[:10]
+
+        lines.append(f"{idx}. [{title}]")
+        lines.append(f"   阅读: {read_count} | 评论: {comment_count} | 时间: {post_time}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated
 
 # Import from vendor-specific modules
@@ -23,6 +24,17 @@ from .alpha_vantage import (
     get_global_news as get_alpha_vantage_global_news,
 )
 from .alpha_vantage_common import AlphaVantageRateLimitError
+from .tushare_data import (
+    get_tushare_stock,
+    get_tushare_indicators,
+    get_tushare_fundamentals,
+    get_tushare_balance_sheet,
+    get_tushare_cashflow,
+    get_tushare_income_statement,
+    get_tushare_insider_transactions,
+    get_tushare_news,
+    get_tushare_global_news,
+)
 
 # Configuration and routing logic
 from .config import get_config
@@ -63,6 +75,7 @@ TOOLS_CATEGORIES = {
 VENDOR_LIST = [
     "yfinance",
     "alpha_vantage",
+    "tushare",
 ]
 
 # Mapping of methods to their vendor-specific implementations
@@ -71,43 +84,85 @@ VENDOR_METHODS = {
     "get_stock_data": {
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
+        "tushare": get_tushare_stock,
     },
     # technical_indicators
     "get_indicators": {
         "alpha_vantage": get_alpha_vantage_indicator,
         "yfinance": get_stock_stats_indicators_window,
+        "tushare": get_tushare_indicators,
     },
     # fundamental_data
     "get_fundamentals": {
         "alpha_vantage": get_alpha_vantage_fundamentals,
         "yfinance": get_yfinance_fundamentals,
+        "tushare": get_tushare_fundamentals,
     },
     "get_balance_sheet": {
         "alpha_vantage": get_alpha_vantage_balance_sheet,
         "yfinance": get_yfinance_balance_sheet,
+        "tushare": get_tushare_balance_sheet,
     },
     "get_cashflow": {
         "alpha_vantage": get_alpha_vantage_cashflow,
         "yfinance": get_yfinance_cashflow,
+        "tushare": get_tushare_cashflow,
     },
     "get_income_statement": {
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
+        "tushare": get_tushare_income_statement,
     },
     # news_data
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "tushare": get_tushare_news,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "tushare": get_tushare_global_news,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,
         "yfinance": get_yfinance_insider_transactions,
+        "tushare": get_tushare_insider_transactions,
     },
 }
+
+def detect_vendor_for_ticker(symbol: str) -> str | None:
+    """
+    Detect the appropriate vendor based on ticker symbol format.
+    Returns "tushare" for A-share/HK tickers, None for others (use config default).
+    """
+    if not symbol or not isinstance(symbol, str):
+        return None
+
+    s = symbol.strip().upper()
+
+    # A股格式: 600000.SH, 600000.SS, 000001.SZ
+    if re.match(r'^\d{6}\.(SH|SS|SZ)$', s):
+        return "tushare"
+
+    # A股格式: SH600000, SS600000, SZ000001
+    if re.match(r'^(SH|SS|SZ)\d{6}$', s):
+        return "tushare"
+
+    # 纯6位数字（A股）
+    if re.match(r'^\d{6}$', s):
+        return "tushare"
+
+    # 港股格式: 0700.HK, 00700.HK
+    if re.match(r'^\d{4,5}\.HK$', s):
+        return "tushare"
+
+    # 港股格式: HK0700, HK00700
+    if re.match(r'^HK\d{4,5}$', s):
+        return "tushare"
+
+    return None
+
 
 def get_category_for_method(method: str) -> str:
     """Get the category that contains the specified method."""
@@ -134,13 +189,31 @@ def get_vendor(category: str, method: str = None) -> str:
 def route_to_vendor(method: str, *args, **kwargs):
     """Route method calls to appropriate vendor implementation with fallback support."""
     category = get_category_for_method(method)
-    vendor_config = get_vendor(category, method)
-    primary_vendors = [v.strip() for v in vendor_config.split(',')]
 
     if method not in VENDOR_METHODS:
         raise ValueError(f"Method '{method}' not supported")
 
-    # Build fallback chain: primary vendors first, then remaining available vendors
+    # Auto-detect vendor based on ticker format
+    auto_vendor = None
+    if method != "get_global_news" and args:
+        # First arg is typically the ticker/symbol
+        auto_vendor = detect_vendor_for_ticker(str(args[0]))
+
+    # Get config-based vendor preferences
+    vendor_config = get_vendor(category, method)
+    config_vendors = [v.strip() for v in vendor_config.split(',')]
+
+    # Build fallback chain
+    if auto_vendor and auto_vendor in VENDOR_METHODS.get(method, {}):
+        # Auto-detected vendor goes first, then config-based, then remaining
+        primary_vendors = [auto_vendor]
+        for v in config_vendors:
+            if v not in primary_vendors:
+                primary_vendors.append(v)
+    else:
+        primary_vendors = config_vendors
+
+    # Append remaining available vendors not yet in the chain
     all_available_vendors = list(VENDOR_METHODS[method].keys())
     fallback_vendors = primary_vendors.copy()
     for vendor in all_available_vendors:
@@ -158,5 +231,9 @@ def route_to_vendor(method: str, *args, **kwargs):
             return impl_func(*args, **kwargs)
         except AlphaVantageRateLimitError:
             continue  # Only rate limits trigger fallback
+        except Exception:
+            if vendor == auto_vendor:
+                continue  # Auto-detected vendor failed, fall through to next
+            raise
 
     raise RuntimeError(f"No available vendor for '{method}'")

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -1,5 +1,8 @@
+import logging
 import re
 from typing import Annotated
+
+logger = logging.getLogger(__name__)
 
 # Import from vendor-specific modules
 from .y_finance import (
@@ -34,6 +37,17 @@ from .tushare_data import (
     get_tushare_insider_transactions,
     get_tushare_news,
     get_tushare_global_news,
+)
+from .akshare_data import (
+    get_akshare_stock,
+    get_akshare_indicators,
+    get_akshare_fundamentals,
+    get_akshare_balance_sheet,
+    get_akshare_cashflow,
+    get_akshare_income_statement,
+    get_akshare_insider_transactions,
+    get_akshare_news,
+    get_akshare_global_news,
 )
 
 # Configuration and routing logic
@@ -76,6 +90,7 @@ VENDOR_LIST = [
     "yfinance",
     "alpha_vantage",
     "tushare",
+    "akshare",
 ]
 
 # Mapping of methods to their vendor-specific implementations
@@ -85,56 +100,65 @@ VENDOR_METHODS = {
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
         "tushare": get_tushare_stock,
+        "akshare": get_akshare_stock,
     },
     # technical_indicators
     "get_indicators": {
         "alpha_vantage": get_alpha_vantage_indicator,
         "yfinance": get_stock_stats_indicators_window,
         "tushare": get_tushare_indicators,
+        "akshare": get_akshare_indicators,
     },
     # fundamental_data
     "get_fundamentals": {
         "alpha_vantage": get_alpha_vantage_fundamentals,
         "yfinance": get_yfinance_fundamentals,
         "tushare": get_tushare_fundamentals,
+        "akshare": get_akshare_fundamentals,
     },
     "get_balance_sheet": {
         "alpha_vantage": get_alpha_vantage_balance_sheet,
         "yfinance": get_yfinance_balance_sheet,
         "tushare": get_tushare_balance_sheet,
+        "akshare": get_akshare_balance_sheet,
     },
     "get_cashflow": {
         "alpha_vantage": get_alpha_vantage_cashflow,
         "yfinance": get_yfinance_cashflow,
         "tushare": get_tushare_cashflow,
+        "akshare": get_akshare_cashflow,
     },
     "get_income_statement": {
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
         "tushare": get_tushare_income_statement,
+        "akshare": get_akshare_income_statement,
     },
     # news_data
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
         "tushare": get_tushare_news,
+        "akshare": get_akshare_news,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
         "tushare": get_tushare_global_news,
+        "akshare": get_akshare_global_news,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,
         "yfinance": get_yfinance_insider_transactions,
         "tushare": get_tushare_insider_transactions,
+        "akshare": get_akshare_insider_transactions,
     },
 }
 
 def detect_vendor_for_ticker(symbol: str) -> str | None:
     """
     Detect the appropriate vendor based on ticker symbol format.
-    Returns "tushare" for A-share/HK tickers, None for others (use config default).
+    Returns "akshare" for A-share/HK tickers, None for others (use config default).
     """
     if not symbol or not isinstance(symbol, str):
         return None
@@ -143,23 +167,23 @@ def detect_vendor_for_ticker(symbol: str) -> str | None:
 
     # A股格式: 600000.SH, 600000.SS, 000001.SZ
     if re.match(r'^\d{6}\.(SH|SS|SZ)$', s):
-        return "tushare"
+        return "akshare"
 
     # A股格式: SH600000, SS600000, SZ000001
     if re.match(r'^(SH|SS|SZ)\d{6}$', s):
-        return "tushare"
+        return "akshare"
 
     # 纯6位数字（A股）
     if re.match(r'^\d{6}$', s):
-        return "tushare"
+        return "akshare"
 
     # 港股格式: 0700.HK, 00700.HK
     if re.match(r'^\d{4,5}\.HK$', s):
-        return "tushare"
+        return "akshare"
 
     # 港股格式: HK0700, HK00700
     if re.match(r'^HK\d{4,5}$', s):
-        return "tushare"
+        return "akshare"
 
     return None
 
@@ -220,9 +244,19 @@ def route_to_vendor(method: str, *args, **kwargs):
         if vendor not in fallback_vendors:
             fallback_vendors.append(vendor)
 
+    errors_collected = {}
+
     for vendor in fallback_vendors:
         if vendor not in VENDOR_METHODS[method]:
             continue
+
+        if vendor == "yfinance" and auto_vendor == "akshare":
+            logger.warning(
+                "Attempting yfinance for A-share ticker '%s' as fallback — "
+                "this will likely fail. Please check your akshare/tushare "
+                "configuration.",
+                args[0] if args else "?"
+            )
 
         vendor_impl = VENDOR_METHODS[method][vendor]
         impl_func = vendor_impl[0] if isinstance(vendor_impl, list) else vendor_impl
@@ -230,10 +264,21 @@ def route_to_vendor(method: str, *args, **kwargs):
         try:
             return impl_func(*args, **kwargs)
         except AlphaVantageRateLimitError:
+            errors_collected[vendor] = "rate limit exceeded"
             continue  # Only rate limits trigger fallback
-        except Exception:
+        except Exception as e:
+            errors_collected[vendor] = str(e)
             if vendor == auto_vendor:
-                continue  # Auto-detected vendor failed, fall through to next
+                logger.warning(
+                    "Auto-detected vendor '%s' failed for %s(%s): %s. "
+                    "Falling through to next vendor.",
+                    vendor, method, args[0] if args else "?", e
+                )
+                continue
             raise
 
-    raise RuntimeError(f"No available vendor for '{method}'")
+    raise RuntimeError(
+        f"All vendors failed for '{method}' "
+        f"(ticker={args[0] if args else '?'}). "
+        f"Tried: {errors_collected}"
+    )

--- a/tradingagents/dataflows/news_service.py
+++ b/tradingagents/dataflows/news_service.py
@@ -1,0 +1,362 @@
+"""News service client for fetching A-share / HK stock news from the news server API."""
+
+import os
+import re
+import requests
+from typing import Optional
+from datetime import datetime, timedelta, timezone
+
+from .config import get_config
+
+# ---------------------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_NEWS_SERVER_BASE_URL = "https://news.zehb.cn:228"
+REQUEST_TIMEOUT = 5  # seconds
+
+# Beijing time zone (UTC+8)
+_BEIJING_TZ = timezone(timedelta(hours=8))
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _get_config() -> dict:
+    """Return news service connection configuration from environment variables."""
+    return {
+        "base_url": os.getenv("NEWS_SERVER_BASE_URL", DEFAULT_NEWS_SERVER_BASE_URL),
+        "api_key": os.getenv("NEWS_SERVER_API_KEY", ""),
+        "proxy": os.getenv("NEWS_SERVER_PROXY", ""),
+    }
+
+
+def _make_request(endpoint: str, params: dict = None) -> dict:
+    """
+    Send a GET request to the news service API.
+
+    Args:
+        endpoint: API endpoint path (e.g. "/api/v1/news/by-stock/600519")
+        params: Optional query parameters
+
+    Returns:
+        Parsed JSON response as dict
+
+    Raises:
+        RuntimeError: On authentication failure, timeout, or connection error
+    """
+    cfg = _get_config()
+    base_url = cfg["base_url"].rstrip("/")
+    api_key = cfg["api_key"]
+    proxy = cfg["proxy"]
+
+    url = f"{base_url}{endpoint}"
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+    proxies = None
+    if proxy:
+        proxies = {"http": proxy, "https": proxy}
+
+    try:
+        resp = requests.get(
+            url,
+            headers=headers,
+            params=params,
+            proxies=proxies,
+            timeout=REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        raise RuntimeError(f"Request timed out: {url}")
+    except requests.exceptions.ConnectionError as e:
+        raise RuntimeError(f"Connection error: {e}")
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Request failed: {e}")
+
+    if resp.status_code == 401 or resp.status_code == 403:
+        raise RuntimeError("Authentication failed: invalid or missing API key")
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"API returned status {resp.status_code}: {resp.text[:200]}"
+        )
+
+    return resp.json()
+
+
+def _format_news_item(item: dict) -> str:
+    """
+    Format a single news item dict into Markdown.
+
+    Expected item keys: title, source_name, summary/content, url.
+    """
+    title = item.get("title", "No title")
+    source_name = item.get("source_name", "Unknown")
+    summary = item.get("summary") or (item.get("content", "") or "")[:200]
+    url = item.get("url", "")
+
+    text = f"### {title} (source: {source_name})\n"
+    if summary:
+        text += f"{summary}\n"
+    if url:
+        text += f"Link: {url}\n"
+    text += "\n"
+    return text
+
+
+def _extract_stock_code(ticker: str) -> str:
+    """
+    Extract pure numeric stock code from various ticker formats.
+
+    Examples:
+        "600519.SH" -> "600519"
+        "SH600519"  -> "600519"
+        "600519"    -> "600519"
+        "000001.SZ" -> "000001"
+    """
+    # Remove known exchange suffixes like .SH, .SZ, .HK, etc.
+    if "." in ticker:
+        code = ticker.split(".")[0]
+        # If the part before dot is numeric, use it directly
+        if code.isdigit():
+            return code
+
+    # Handle prefix formats: SH600519, SZ000001
+    match = re.match(r"^[A-Za-z]{2}(\d+)$", ticker)
+    if match:
+        return match.group(1)
+
+    # If it's already pure digits
+    if ticker.isdigit():
+        return ticker
+
+    # Fallback: extract all digits
+    digits = re.findall(r"\d+", ticker)
+    return digits[0] if digits else ticker
+
+
+def _date_to_iso(date_str: str) -> str:
+    """
+    Convert a yyyy-mm-dd date string to ISO 8601 with Beijing timezone.
+
+    Example: "2024-01-15" -> "2024-01-15T00:00:00+08:00"
+    """
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    dt_bj = dt.replace(tzinfo=_BEIJING_TZ)
+    return dt_bj.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+
+def get_news_service_news(ticker: str, start_date: str, end_date: str) -> str:
+    """
+    Fetch news for a specific stock from the news service API.
+
+    Args:
+        ticker: Stock ticker (e.g. "600519.SH", "SH600519", "600519")
+        start_date: Start date in yyyy-mm-dd format
+        end_date: End date in yyyy-mm-dd format
+
+    Returns:
+        Formatted Markdown string with news articles, or an error/empty message.
+    """
+    # Check API key first
+    cfg = _get_config()
+    if not cfg["api_key"]:
+        return f"No news found for {ticker}: NEWS_SERVER_API_KEY not configured"
+
+    # Determine article limit from project config (fallback to 20)
+    try:
+        project_cfg = get_config()
+        article_limit = project_cfg.get("news_article_limit", 20)
+    except Exception:
+        article_limit = 20
+
+    code = _extract_stock_code(ticker)
+    iso_start = _date_to_iso(start_date)
+    iso_end = _date_to_iso(end_date)
+
+    seen_titles: set = set()
+    all_items: list = []
+
+    try:
+        # 1) Fetch by stock endpoint
+        try:
+            data = _make_request(
+                f"/api/v1/news/by-stock/{code}",
+                params={"limit": article_limit, "sort_by": "published_at"},
+            )
+            items = data if isinstance(data, list) else data.get("data", data.get("items", []))
+            for item in items:
+                title = item.get("title", "")
+                if title and title not in seen_titles:
+                    seen_titles.add(title)
+                    all_items.append(item)
+        except RuntimeError:
+            pass  # Continue to try the date-filtered endpoint
+
+        # 2) Fetch with date range filter
+        try:
+            data = _make_request(
+                "/api/v1/news",
+                params={
+                    "stock_code": code,
+                    "start_date": iso_start,
+                    "end_date": iso_end,
+                    "limit": article_limit,
+                    "sort_by": "importance",
+                },
+            )
+            items = data if isinstance(data, list) else data.get("data", data.get("items", []))
+            for item in items:
+                title = item.get("title", "")
+                if title and title not in seen_titles:
+                    seen_titles.add(title)
+                    all_items.append(item)
+        except RuntimeError:
+            pass
+
+        if not all_items:
+            return f"No news found for {ticker} between {start_date} and {end_date}"
+
+        # Format output
+        news_str = ""
+        for item in all_items[:article_limit]:
+            news_str += _format_news_item(item)
+
+        return f"## {ticker} News, from {start_date} to {end_date}:\n\n{news_str}"
+
+    except Exception as e:
+        return f"Error fetching news for {ticker}: {str(e)}"
+
+
+def get_news_service_global_news(
+    curr_date: str,
+    look_back_days: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> str:
+    """
+    Fetch global/macro market news from the news service API.
+
+    Args:
+        curr_date: Current date in yyyy-mm-dd format
+        look_back_days: Number of days to look back (default from config or 7)
+        limit: Maximum number of articles (default from config or 10)
+
+    Returns:
+        Formatted Markdown string with global news articles, or an error/empty message.
+    """
+    # Check API key first
+    cfg = _get_config()
+    if not cfg["api_key"]:
+        return f"No news found for global market: NEWS_SERVER_API_KEY not configured"
+
+    # Resolve defaults from project config
+    try:
+        project_cfg = get_config()
+        if look_back_days is None:
+            look_back_days = project_cfg.get("global_news_lookback_days", 7)
+        if limit is None:
+            limit = project_cfg.get("global_news_article_limit", 10)
+    except Exception:
+        if look_back_days is None:
+            look_back_days = 7
+        if limit is None:
+            limit = 10
+
+    # Calculate date range
+    curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    start_dt = curr_dt - timedelta(days=look_back_days)
+    start_date = start_dt.strftime("%Y-%m-%d")
+
+    iso_start = _date_to_iso(start_date)
+    iso_end = _date_to_iso(curr_date)
+
+    seen_titles: set = set()
+    all_items: list = []
+
+    try:
+        # 1) Fetch macro/宏观 category news
+        try:
+            data = _make_request(
+                "/api/v1/news",
+                params={
+                    "category": "宏观",
+                    "start_date": iso_start,
+                    "end_date": iso_end,
+                    "limit": limit,
+                    "sort_by": "importance",
+                },
+            )
+            items = data if isinstance(data, list) else data.get("data", data.get("items", []))
+            for item in items:
+                title = item.get("title", "")
+                if title and title not in seen_titles:
+                    seen_titles.add(title)
+                    all_items.append(item)
+        except RuntimeError:
+            pass
+
+        # 2) If not enough results, fetch from summary endpoint
+        if len(all_items) < limit:
+            try:
+                data = _make_request(
+                    "/api/v1/news/summary",
+                    params={
+                        "start_date": iso_start,
+                        "end_date": iso_end,
+                        "sort_by": "importance",
+                    },
+                )
+                summary_items = data if isinstance(data, list) else data.get("data", data.get("items", []))
+
+                # For summary items, fetch detail if they have news_id
+                detail_fetched = 0
+                for summary_item in summary_items:
+                    if len(all_items) >= limit:
+                        break
+
+                    title = summary_item.get("title", "")
+                    if title and title in seen_titles:
+                        continue
+
+                    news_id = summary_item.get("id") or summary_item.get("news_id")
+                    if news_id and detail_fetched < 5:
+                        # Fetch full detail
+                        try:
+                            detail = _make_request(f"/api/v1/news/{news_id}")
+                            detail_item = detail if isinstance(detail, dict) and "title" in detail else detail.get("data", detail)
+                            if isinstance(detail_item, dict):
+                                detail_title = detail_item.get("title", "")
+                                if detail_title and detail_title not in seen_titles:
+                                    seen_titles.add(detail_title)
+                                    all_items.append(detail_item)
+                                    detail_fetched += 1
+                        except RuntimeError:
+                            # Fall back to summary item itself
+                            if title:
+                                seen_titles.add(title)
+                                all_items.append(summary_item)
+                    elif title:
+                        seen_titles.add(title)
+                        all_items.append(summary_item)
+            except RuntimeError:
+                pass
+
+        if not all_items:
+            return f"No global news found for {curr_date}"
+
+        # Format output
+        news_str = ""
+        for item in all_items[:limit]:
+            news_str += _format_news_item(item)
+
+        return f"## Global Market News, from {start_date} to {curr_date}:\n\n{news_str}"
+
+    except Exception as e:
+        return f"Error fetching global news: {str(e)}"

--- a/tradingagents/dataflows/tushare_data.py
+++ b/tradingagents/dataflows/tushare_data.py
@@ -1,0 +1,774 @@
+"""Tushare data source module for A-share and HK stock markets.
+
+This module implements the 9 standard data functions required by the
+pluggable data-source architecture, using Tushare Pro API as backend.
+"""
+
+import os
+import time
+import logging
+from datetime import datetime, timedelta
+from typing import Annotated
+
+import pandas as pd
+
+try:
+    import tushare as ts
+except ImportError:
+    ts = None
+
+try:
+    from stockstats import wrap as stockstats_wrap
+except ImportError:
+    stockstats_wrap = None
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class TushareRateLimitError(Exception):
+    """Raised when Tushare API rate limit is exceeded after all retries."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helper / Utility Functions
+# ---------------------------------------------------------------------------
+
+def get_tushare_pro():
+    """Get a Tushare Pro API instance using the TUSHARE_API_KEY env variable.
+
+    Returns:
+        tushare pro_api instance
+
+    Raises:
+        ValueError: If TUSHARE_API_KEY is not set or tushare is not installed.
+    """
+    if ts is None:
+        raise ValueError(
+            "tushare is not installed. Please install it with: pip install tushare"
+        )
+    key = os.environ.get("TUSHARE_API_KEY", "").strip()
+    if not key:
+        raise ValueError(
+            "TUSHARE_API_KEY environment variable is not set. "
+            "Please set it to your Tushare Pro API token."
+        )
+    return ts.pro_api(key)
+
+
+def normalize_ts_code(symbol: str) -> str:
+    """Normalize various symbol formats to Tushare standard ts_code format.
+
+    Examples:
+        "600000"    -> "600000.SH"
+        "000001"    -> "000001.SZ"
+        "SH600000"  -> "600000.SH"
+        "SZ000001"  -> "000001.SZ"
+        "600000.SH" -> "600000.SH" (unchanged)
+        "0700.HK"   -> "0700.HK" (unchanged)
+        "HK0700"    -> "0700.HK"
+    """
+    symbol = symbol.strip()
+
+    # Already in standard format with suffix
+    upper = symbol.upper()
+    # .SS is yfinance convention for Shanghai; convert to Tushare .SH
+    if upper.endswith(".SS"):
+        return upper[:-3] + ".SH"
+    if upper.endswith(".SH") or upper.endswith(".SZ") or upper.endswith(".HK"):
+        return upper
+
+    # Prefixed format: SH600000, SS600000, SZ000001, HK0700
+    if upper.startswith("SH") and upper[2:].isdigit():
+        return f"{upper[2:]}.SH"
+    if upper.startswith("SS") and upper[2:].isdigit():
+        return f"{upper[2:]}.SH"
+    if upper.startswith("SZ") and upper[2:].isdigit():
+        return f"{upper[2:]}.SZ"
+    if upper.startswith("HK") and upper[2:].isdigit():
+        return f"{upper[2:]}.HK"
+
+    # Pure digit — infer exchange from leading digit
+    if symbol.isdigit():
+        if symbol.startswith("6") or symbol.startswith("9"):
+            return f"{symbol}.SH"
+        elif symbol.startswith("0") or symbol.startswith("3"):
+            return f"{symbol}.SZ"
+        else:
+            # Default to SH for other codes (e.g. 5xxxxx ETFs on Shanghai)
+            return f"{symbol}.SH"
+
+    # Fallback: return as-is uppercased
+    return upper
+
+
+def convert_date_to_tushare(date_str: str) -> str:
+    """Convert date string from 'YYYY-MM-DD' to Tushare format 'YYYYMMDD'.
+
+    Example: "2024-01-15" -> "20240115"
+    """
+    return date_str.replace("-", "")
+
+
+def convert_date_from_tushare(date_str: str) -> str:
+    """Convert date string from Tushare format 'YYYYMMDD' to 'YYYY-MM-DD'.
+
+    Example: "20240115" -> "2024-01-15"
+    """
+    if len(date_str) == 8:
+        return f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}"
+    return date_str
+
+
+def tushare_retry(func, max_retries=3, base_delay=1.0):
+    """Execute a Tushare API call with exponential backoff on rate limits.
+
+    Retries when the exception message contains rate-limit keywords such as
+    "too many requests" or "频率".
+
+    Args:
+        func: Callable to execute.
+        max_retries: Maximum number of retry attempts.
+        base_delay: Base delay in seconds (doubles each retry).
+
+    Returns:
+        The result of func().
+
+    Raises:
+        TushareRateLimitError: If all retries are exhausted.
+    """
+    rate_limit_keywords = ["too many requests", "频率", "每分钟", "限制", "rate limit"]
+
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except Exception as e:
+            err_msg = str(e).lower()
+            is_rate_limit = any(kw in err_msg for kw in rate_limit_keywords)
+
+            if not is_rate_limit:
+                raise  # Not a rate-limit error, propagate immediately
+
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                logger.warning(
+                    f"Tushare rate limited, retrying in {delay:.1f}s "
+                    f"(attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(delay)
+            else:
+                raise TushareRateLimitError(
+                    f"Tushare rate limit exceeded after {max_retries} retries: {e}"
+                ) from e
+
+
+# ---------------------------------------------------------------------------
+# Helper to compute quarterly periods
+# ---------------------------------------------------------------------------
+
+def _get_report_periods(freq: str, curr_date: str = None, count: int = 4):
+    """Generate a list of report period strings (YYYYMMDD) for financial queries.
+
+    Args:
+        freq: "quarterly" or "annual"
+        curr_date: Current date in YYYY-MM-DD format (filter future periods)
+        count: Number of periods to return
+
+    Returns:
+        List of period strings in YYYYMMDD format.
+    """
+    if curr_date:
+        ref_date = datetime.strptime(curr_date, "%Y-%m-%d")
+    else:
+        ref_date = datetime.now()
+
+    periods = []
+    if freq.lower() == "quarterly":
+        # Quarter end dates: 0331, 0630, 0930, 1231
+        quarter_ends = ["0331", "0630", "0930", "1231"]
+        year = ref_date.year
+        # Generate periods going backward
+        for y in range(year, year - 5, -1):
+            for qe in reversed(quarter_ends):
+                period = f"{y}{qe}"
+                period_date = datetime.strptime(period, "%Y%m%d")
+                if period_date <= ref_date:
+                    periods.append(period)
+                if len(periods) >= count:
+                    break
+            if len(periods) >= count:
+                break
+    else:
+        # Annual: use 1231 as period end
+        year = ref_date.year
+        for y in range(year, year - 5, -1):
+            period = f"{y}1231"
+            period_date = datetime.strptime(period, "%Y%m%d")
+            if period_date <= ref_date:
+                periods.append(period)
+            if len(periods) >= count:
+                break
+
+    return periods
+
+
+# ---------------------------------------------------------------------------
+# Indicator descriptions
+# ---------------------------------------------------------------------------
+
+INDICATOR_DESCRIPTIONS = {
+    "close_50_sma": (
+        "50 SMA: A medium-term trend indicator. "
+        "Usage: Identify trend direction and serve as dynamic support/resistance. "
+        "Tips: It lags price; combine with faster indicators for timely signals."
+    ),
+    "close_200_sma": (
+        "200 SMA: A long-term trend benchmark. "
+        "Usage: Confirm overall market trend and identify golden/death cross setups. "
+        "Tips: It reacts slowly; best for strategic trend confirmation."
+    ),
+    "close_10_ema": (
+        "10 EMA: A responsive short-term average. "
+        "Usage: Capture quick shifts in momentum and potential entry points. "
+        "Tips: Prone to noise in choppy markets; use alongside longer averages."
+    ),
+    "macd": (
+        "MACD: Computes momentum via differences of EMAs. "
+        "Usage: Look for crossovers and divergence as signals of trend changes. "
+        "Tips: Confirm with other indicators in low-volatility or sideways markets."
+    ),
+    "macds": (
+        "MACD Signal: An EMA smoothing of the MACD line. "
+        "Usage: Use crossovers with the MACD line to trigger trades. "
+        "Tips: Should be part of a broader strategy to avoid false positives."
+    ),
+    "macdh": (
+        "MACD Histogram: Shows the gap between the MACD line and its signal. "
+        "Usage: Visualize momentum strength and spot divergence early. "
+        "Tips: Can be volatile; complement with additional filters."
+    ),
+    "rsi": (
+        "RSI: Measures momentum to flag overbought/oversold conditions. "
+        "Usage: Apply 70/30 thresholds and watch for divergence to signal reversals. "
+        "Tips: In strong trends, RSI may remain extreme; cross-check with trend analysis."
+    ),
+    "boll": (
+        "Bollinger Middle: A 20 SMA serving as the basis for Bollinger Bands. "
+        "Usage: Acts as a dynamic benchmark for price movement. "
+        "Tips: Combine with upper and lower bands to spot breakouts or reversals."
+    ),
+    "boll_ub": (
+        "Bollinger Upper Band: Typically 2 standard deviations above the middle line. "
+        "Usage: Signals potential overbought conditions and breakout zones. "
+        "Tips: Confirm signals with other tools; prices may ride the band in strong trends."
+    ),
+    "boll_lb": (
+        "Bollinger Lower Band: Typically 2 standard deviations below the middle line. "
+        "Usage: Indicates potential oversold conditions. "
+        "Tips: Use additional analysis to avoid false reversal signals."
+    ),
+    "atr": (
+        "ATR: Averages true range to measure volatility. "
+        "Usage: Set stop-loss levels and adjust position sizes based on current market volatility. "
+        "Tips: It's a reactive measure; use as part of a broader risk management strategy."
+    ),
+    "vwma": (
+        "VWMA: A moving average weighted by volume. "
+        "Usage: Confirm trends by integrating price action with volume data. "
+        "Tips: Watch for skewed results from volume spikes."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# 9 Core Data Functions
+# ---------------------------------------------------------------------------
+
+def get_tushare_stock(
+    symbol: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
+    end_date: Annotated[str, "End date in YYYY-MM-DD format"],
+) -> str:
+    """Get OHLCV stock price data from Tushare with adjusted close price."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(symbol)
+        ts_start = convert_date_to_tushare(start_date)
+        ts_end = convert_date_to_tushare(end_date)
+
+        # Fetch daily price data
+        df = tushare_retry(
+            lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+        )
+
+        if df is None or df.empty:
+            return f"No stock data found for symbol '{symbol}' between {start_date} and {end_date}"
+
+        # Fetch adjustment factor for calculating Adj Close
+        adj_df = tushare_retry(
+            lambda: pro.adj_factor(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+        )
+
+        # Sort by date ascending (tushare returns descending by default)
+        df = df.sort_values("trade_date").reset_index(drop=True)
+
+        # Calculate Adj Close
+        if adj_df is not None and not adj_df.empty:
+            adj_df = adj_df.sort_values("trade_date").reset_index(drop=True)
+            # Merge adjustment factors
+            df = df.merge(adj_df[["trade_date", "adj_factor"]], on="trade_date", how="left")
+            # Latest adj_factor is the most recent one (last row after sort ascending)
+            latest_adj = df["adj_factor"].iloc[-1]
+            df["adj_close"] = (df["close"] * df["adj_factor"] / latest_adj).round(2)
+        else:
+            df["adj_close"] = df["close"]
+
+        # Format date column
+        df["date_fmt"] = df["trade_date"].apply(convert_date_from_tushare)
+
+        # Volume: tushare 'vol' is in lots (手, 100 shares each), convert to shares
+        df["volume_shares"] = (df["vol"] * 100).astype(int)
+
+        # Round price columns
+        for col in ["open", "high", "low", "close"]:
+            df[col] = df[col].round(2)
+
+        # Build CSV output
+        header = f"# Stock data for {ts_code} from {start_date} to {end_date}\n"
+        header += f"# Total records: {len(df)}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        lines = ["Date,Open,High,Low,Close,Adj Close,Volume"]
+        for _, row in df.iterrows():
+            lines.append(
+                f"{row['date_fmt']},{row['open']:.2f},{row['high']:.2f},"
+                f"{row['low']:.2f},{row['close']:.2f},{row['adj_close']:.2f},"
+                f"{row['volume_shares']}"
+            )
+
+        return header + "\n".join(lines) + "\n"
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving stock data for {symbol}: {str(e)}"
+
+
+def get_tushare_indicators(
+    symbol: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    indicator: Annotated[str, "technical indicator name"],
+    curr_date: Annotated[str, "Current trading date in YYYY-MM-DD format"],
+    look_back_days: Annotated[int, "Number of days to look back"],
+) -> str:
+    """Get technical indicator values computed from Tushare daily data."""
+    supported_indicators = list(INDICATOR_DESCRIPTIONS.keys())
+    if indicator not in supported_indicators:
+        raise ValueError(
+            f"Indicator '{indicator}' is not supported. "
+            f"Please choose from: {supported_indicators}"
+        )
+
+    if stockstats_wrap is None:
+        return (
+            "Error: stockstats is not installed. "
+            "Please install it with: pip install stockstats"
+        )
+
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(symbol)
+
+        # Calculate date range with extra buffer for indicator warm-up
+        curr_date_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+        buffer_days = look_back_days + 300  # Extra days for indicator calculation warm-up
+        start_date_dt = curr_date_dt - timedelta(days=buffer_days)
+        ts_start = convert_date_to_tushare(start_date_dt.strftime("%Y-%m-%d"))
+        ts_end = convert_date_to_tushare(curr_date)
+
+        # Fetch daily data
+        df = tushare_retry(
+            lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+        )
+
+        if df is None or df.empty:
+            return f"No stock data found for symbol '{symbol}' to compute indicators"
+
+        # Sort ascending by date
+        df = df.sort_values("trade_date").reset_index(drop=True)
+
+        # Build DataFrame for stockstats (requires: open, high, low, close, volume)
+        stock_df = pd.DataFrame({
+            "date": df["trade_date"].apply(convert_date_from_tushare),
+            "open": pd.to_numeric(df["open"], errors="coerce"),
+            "high": pd.to_numeric(df["high"], errors="coerce"),
+            "low": pd.to_numeric(df["low"], errors="coerce"),
+            "close": pd.to_numeric(df["close"], errors="coerce"),
+            "volume": pd.to_numeric(df["vol"], errors="coerce") * 100,
+        })
+        stock_df = stock_df.dropna(subset=["close"])
+
+        # Wrap with stockstats and calculate indicator
+        ss_df = stockstats_wrap(stock_df)
+        ss_df[indicator]  # Trigger calculation
+
+        # Build date -> value mapping
+        indicator_map = {}
+        for _, row in ss_df.iterrows():
+            date_str = row["date"]
+            val = row[indicator]
+            if pd.isna(val):
+                indicator_map[date_str] = "N/A"
+            else:
+                indicator_map[date_str] = f"{val:.2f}"
+
+        # Generate output for the look_back_days range
+        display_start_dt = curr_date_dt - timedelta(days=look_back_days)
+        lines = []
+        current_dt = display_start_dt
+        while current_dt <= curr_date_dt:
+            date_str = current_dt.strftime("%Y-%m-%d")
+            if date_str in indicator_map:
+                lines.append(f"{date_str}: {indicator_map[date_str]}")
+            else:
+                lines.append(f"{date_str}: N/A: Not a trading day (weekend or holiday)")
+            current_dt += timedelta(days=1)
+
+        result = (
+            f"## {indicator} values from {display_start_dt.strftime('%Y-%m-%d')} to {curr_date}:\n\n"
+            + "\n".join(lines)
+            + "\n\n"
+            + INDICATOR_DESCRIPTIONS.get(indicator, "No description available.")
+        )
+        return result
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving indicators for {symbol}: {str(e)}"
+
+
+def get_tushare_fundamentals(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get company fundamentals from Tushare (PE, PB, market cap, etc.)."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(ticker)
+
+        # Determine trade_date for daily_basic query
+        if curr_date:
+            trade_date = convert_date_to_tushare(curr_date)
+        else:
+            trade_date = datetime.now().strftime("%Y%m%d")
+
+        # Get daily basic metrics (PE, PB, market cap, etc.)
+        basic_df = tushare_retry(
+            lambda: pro.daily_basic(ts_code=ts_code, trade_date=trade_date)
+        )
+
+        # Get stock basic info (name, industry, etc.)
+        stock_info = tushare_retry(
+            lambda: pro.stock_basic(
+                ts_code=ts_code,
+                fields="ts_code,name,area,industry,market,list_date,fullname"
+            )
+        )
+
+        if (basic_df is None or basic_df.empty) and (stock_info is None or stock_info.empty):
+            return f"No fundamentals data found for symbol '{ticker}'"
+
+        # Try to get financial indicators for the most recent period
+        fina_df = None
+        try:
+            periods = _get_report_periods("quarterly", curr_date, count=1)
+            if periods:
+                fina_df = tushare_retry(
+                    lambda: pro.fina_indicator(ts_code=ts_code, period=periods[0])
+                )
+        except Exception:
+            pass  # Financial indicators are optional
+
+        # Build output
+        header = f"# Company Fundamentals for {ts_code}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        fields = []
+
+        # Stock basic info
+        if stock_info is not None and not stock_info.empty:
+            info = stock_info.iloc[0]
+            fields.append(("Name", info.get("name")))
+            fields.append(("Full Name", info.get("fullname")))
+            fields.append(("Area", info.get("area")))
+            fields.append(("Industry", info.get("industry")))
+            fields.append(("Market", info.get("market")))
+            fields.append(("List Date", info.get("list_date")))
+
+        # Daily basic metrics
+        if basic_df is not None and not basic_df.empty:
+            basic = basic_df.iloc[0]
+            fields.append(("Close Price", basic.get("close")))
+            fields.append(("Turnover Rate", basic.get("turnover_rate")))
+            fields.append(("Volume Ratio", basic.get("volume_ratio")))
+            fields.append(("PE Ratio (TTM)", basic.get("pe_ttm")))
+            fields.append(("PE Ratio", basic.get("pe")))
+            fields.append(("PB Ratio", basic.get("pb")))
+            fields.append(("PS Ratio (TTM)", basic.get("ps_ttm")))
+            fields.append(("Total Share", basic.get("total_share")))
+            fields.append(("Float Share", basic.get("float_share")))
+            fields.append(("Total Market Cap (万元)", basic.get("total_mv")))
+            fields.append(("Float Market Cap (万元)", basic.get("circ_mv")))
+
+        # Financial indicators
+        if fina_df is not None and not fina_df.empty:
+            fina = fina_df.iloc[0]
+            fields.append(("ROE", fina.get("roe")))
+            fields.append(("ROA", fina.get("roa")))
+            fields.append(("Gross Profit Margin", fina.get("grossprofit_margin")))
+            fields.append(("Net Profit Margin", fina.get("netprofit_margin")))
+            fields.append(("Debt to Asset Ratio", fina.get("debt_to_assets")))
+            fields.append(("EPS", fina.get("eps")))
+            fields.append(("Revenue YoY (%)", fina.get("revenue_yoy")))
+            fields.append(("Net Profit YoY (%)", fina.get("netprofit_yoy")))
+
+        lines = []
+        for label, value in fields:
+            if value is not None and str(value) != "" and str(value) != "nan":
+                lines.append(f"{label}: {value}")
+
+        if not lines:
+            return f"No fundamentals data found for symbol '{ticker}'"
+
+        return header + "\n".join(lines)
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving fundamentals for {ticker}: {str(e)}"
+
+
+def get_tushare_balance_sheet(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get balance sheet data from Tushare."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(ticker)
+        periods = _get_report_periods(freq, curr_date, count=4)
+
+        if not periods:
+            return f"No balance sheet data found for symbol '{ticker}'"
+
+        all_data = []
+        for period in periods:
+            p = period  # capture for lambda
+            df = tushare_retry(
+                lambda: pro.balancesheet(ts_code=ts_code, period=p, report_type="1")
+            )
+            if df is not None and not df.empty:
+                all_data.append(df.iloc[0])
+
+        if not all_data:
+            return f"No balance sheet data found for symbol '{ticker}'"
+
+        # Build a combined DataFrame with periods as columns
+        result_df = pd.DataFrame(all_data).T
+        # Use formatted period as column names
+        col_names = []
+        for row in all_data:
+            period_str = str(row.get("end_date", row.get("ann_date", "")))
+            col_names.append(convert_date_from_tushare(period_str) if len(period_str) == 8 else period_str)
+        result_df.columns = col_names
+
+        # Remove metadata rows
+        skip_rows = ["ts_code", "ann_date", "f_ann_date", "end_date", "report_type",
+                     "comp_type", "end_type", "update_flag"]
+        result_df = result_df.drop(
+            [r for r in skip_rows if r in result_df.index], errors="ignore"
+        )
+
+        # Remove rows where all values are NaN
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Balance Sheet data for {ts_code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving balance sheet for {ticker}: {str(e)}"
+
+
+def get_tushare_cashflow(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get cash flow statement data from Tushare."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(ticker)
+        periods = _get_report_periods(freq, curr_date, count=4)
+
+        if not periods:
+            return f"No cash flow data found for symbol '{ticker}'"
+
+        all_data = []
+        for period in periods:
+            p = period
+            df = tushare_retry(
+                lambda: pro.cashflow(ts_code=ts_code, period=p, report_type="1")
+            )
+            if df is not None and not df.empty:
+                all_data.append(df.iloc[0])
+
+        if not all_data:
+            return f"No cash flow data found for symbol '{ticker}'"
+
+        result_df = pd.DataFrame(all_data).T
+        col_names = []
+        for row in all_data:
+            period_str = str(row.get("end_date", row.get("ann_date", "")))
+            col_names.append(convert_date_from_tushare(period_str) if len(period_str) == 8 else period_str)
+        result_df.columns = col_names
+
+        skip_rows = ["ts_code", "ann_date", "f_ann_date", "end_date", "report_type",
+                     "comp_type", "end_type", "update_flag"]
+        result_df = result_df.drop(
+            [r for r in skip_rows if r in result_df.index], errors="ignore"
+        )
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Cash Flow data for {ts_code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving cash flow for {ticker}: {str(e)}"
+
+
+def get_tushare_income_statement(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+    freq: Annotated[str, "frequency: 'quarterly' or 'annual'"] = "quarterly",
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+) -> str:
+    """Get income statement data from Tushare."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(ticker)
+        periods = _get_report_periods(freq, curr_date, count=4)
+
+        if not periods:
+            return f"No income statement data found for symbol '{ticker}'"
+
+        all_data = []
+        for period in periods:
+            p = period
+            df = tushare_retry(
+                lambda: pro.income(ts_code=ts_code, period=p, report_type="1")
+            )
+            if df is not None and not df.empty:
+                all_data.append(df.iloc[0])
+
+        if not all_data:
+            return f"No income statement data found for symbol '{ticker}'"
+
+        result_df = pd.DataFrame(all_data).T
+        col_names = []
+        for row in all_data:
+            period_str = str(row.get("end_date", row.get("ann_date", "")))
+            col_names.append(convert_date_from_tushare(period_str) if len(period_str) == 8 else period_str)
+        result_df.columns = col_names
+
+        skip_rows = ["ts_code", "ann_date", "f_ann_date", "end_date", "report_type",
+                     "comp_type", "end_type", "update_flag"]
+        result_df = result_df.drop(
+            [r for r in skip_rows if r in result_df.index], errors="ignore"
+        )
+        result_df = result_df.dropna(how="all")
+
+        csv_string = result_df.to_csv()
+
+        header = f"# Income Statement data for {ts_code} ({freq})\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        return header + csv_string
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving income statement for {ticker}: {str(e)}"
+
+
+def get_tushare_insider_transactions(
+    ticker: Annotated[str, "ticker symbol (e.g. '600000' or '600000.SH')"],
+) -> str:
+    """Get insider (shareholder) trading records from Tushare."""
+    try:
+        pro = get_tushare_pro()
+        ts_code = normalize_ts_code(ticker)
+
+        df = tushare_retry(
+            lambda: pro.stk_holdertrade(ts_code=ts_code)
+        )
+
+        if df is None or df.empty:
+            return f"No insider transactions data found for symbol '{ticker}'"
+
+        header = f"# Insider Transactions data for {ts_code}\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+        lines = ["Date,Holder Name,Change Volume,Change Type,Price,Change Reason"]
+        for _, row in df.iterrows():
+            date_val = str(row.get("ann_date", ""))
+            if len(date_val) == 8:
+                date_val = convert_date_from_tushare(date_val)
+            holder = row.get("holder_name", "")
+            vol = row.get("vol", "")
+            change_type = row.get("in_de", "")
+            price = row.get("price", "")
+            reason = row.get("holder_type", "")
+            lines.append(f"{date_val},{holder},{vol},{change_type},{price},{reason}")
+
+        return header + "\n".join(lines) + "\n"
+
+    except TushareRateLimitError:
+        raise
+    except Exception as e:
+        return f"Error retrieving insider transactions for {ticker}: {str(e)}"
+
+
+def get_tushare_news(
+    ticker: Annotated[str, "ticker symbol"],
+    start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
+    end_date: Annotated[str, "End date in YYYY-MM-DD format"],
+) -> str:
+    """Get news for a specific ticker from the news service."""
+    from .news_service import get_news_service_news
+    return get_news_service_news(ticker, start_date, end_date)
+
+
+def get_tushare_global_news(
+    curr_date: Annotated[str, "Current date in YYYY-MM-DD format"],
+    look_back_days: int = None,
+    limit: int = None,
+) -> str:
+    """Get global market news from the news service."""
+    from .news_service import get_news_service_global_news
+    return get_news_service_global_news(curr_date, look_back_days, limit)

--- a/tradingagents/dataflows/tushare_data.py
+++ b/tradingagents/dataflows/tushare_data.py
@@ -167,6 +167,27 @@ def tushare_retry(func, max_retries=3, base_delay=1.0):
 
 
 # ---------------------------------------------------------------------------
+# Fund / ETF detection
+# ---------------------------------------------------------------------------
+
+def _is_fund_or_etf(ts_code: str) -> bool:
+    """判断标准化后的ts_code是否为基金/ETF。
+
+    A股ETF/基金代码规则：
+    - 上海: 5xxxxx.SH (包含 51xxxx, 56xxxx, 58xxxx 等)
+    - 深圳: 15xxxx.SZ, 16xxxx.SZ 等
+    """
+    code = ts_code.split(".")[0]
+    suffix = ts_code.split(".")[-1] if "." in ts_code else ""
+
+    if suffix == "SH" and code.startswith("5"):
+        return True
+    if suffix == "SZ" and (code.startswith("15") or code.startswith("16")):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Helper to compute quarterly periods
 # ---------------------------------------------------------------------------
 
@@ -300,10 +321,24 @@ def get_tushare_stock(
         ts_start = convert_date_to_tushare(start_date)
         ts_end = convert_date_to_tushare(end_date)
 
-        # Fetch daily price data
-        df = tushare_retry(
-            lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
-        )
+        # 根据代码类型选择接口
+        is_fund = _is_fund_or_etf(ts_code)
+        if is_fund:
+            logger.info(f"Detected ETF/fund code {ts_code}, using fund_daily API")
+            df = tushare_retry(
+                lambda: pro.fund_daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
+        else:
+            df = tushare_retry(
+                lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
+
+        # 如果 daily 返回空且不是已知基金，也尝试 fund_daily 作为 fallback
+        if (df is None or df.empty) and not is_fund:
+            logger.debug(f"pro.daily returned empty for {ts_code}, trying fund_daily as fallback")
+            df = tushare_retry(
+                lambda: pro.fund_daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
 
         if df is None or df.empty:
             return f"No stock data found for symbol '{symbol}' between {start_date} and {end_date}"
@@ -389,10 +424,24 @@ def get_tushare_indicators(
         ts_start = convert_date_to_tushare(start_date_dt.strftime("%Y-%m-%d"))
         ts_end = convert_date_to_tushare(curr_date)
 
-        # Fetch daily data
-        df = tushare_retry(
-            lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
-        )
+        # 根据代码类型选择接口
+        is_fund = _is_fund_or_etf(ts_code)
+        if is_fund:
+            logger.info(f"Detected ETF/fund code {ts_code}, using fund_daily API for indicators")
+            df = tushare_retry(
+                lambda: pro.fund_daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
+        else:
+            df = tushare_retry(
+                lambda: pro.daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
+
+        # fallback: 如果 daily 返回空，尝试 fund_daily
+        if (df is None or df.empty) and not is_fund:
+            logger.debug(f"pro.daily returned empty for {ts_code}, trying fund_daily as fallback for indicators")
+            df = tushare_retry(
+                lambda: pro.fund_daily(ts_code=ts_code, start_date=ts_start, end_date=ts_end)
+            )
 
         if df is None or df.empty:
             return f"No stock data found for symbol '{symbol}' to compute indicators"

--- a/tradingagents/dataflows/xueqiu.py
+++ b/tradingagents/dataflows/xueqiu.py
@@ -1,0 +1,165 @@
+"""雪球社区讨论帖抓取模块。
+
+通过雪球公开 API 获取 A 股个股讨论帖，用于情感分析等下游任务。
+雪球接口需要先访问主页获取匿名 cookie（``xq_a_token``），然后才能
+调用搜索 API。
+
+返回格式化纯文本块，可直接注入 prompt。降级处理——遇到任何网络或解析
+错误时返回占位符字符串，调用方无需特殊处理缺失数据。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# 雪球 API 地址
+_HOME_URL = "https://xueqiu.com"
+_SEARCH_API = "https://xueqiu.com/query/v1/search/status.json"
+
+# 模拟浏览器 User-Agent，防止被反爬
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+_TIMEOUT = 10  # 请求超时秒数
+_POST_COUNT = 20  # 每次拉取帖子数
+
+
+def _convert_ticker(ticker: str) -> str:
+    """将常见 A 股代码格式转为雪球搜索关键词。
+
+    支持的输入格式:
+    - ``600519.SH`` / ``000001.SZ`` -> ``SH600519`` / ``SZ000001``
+    - ``SH600519`` -> 原样返回
+    - ``600519`` -> 原样返回（纯数字）
+    """
+    # 匹配 "数字.交易所" 格式，如 600519.SH、000001.SZ
+    m = re.match(r"^(\d{6})\.(SH|SZ|BJ)$", ticker.upper())
+    if m:
+        code, exchange = m.group(1), m.group(2)
+        return f"{exchange}{code}"
+    return ticker
+
+
+def _get_session() -> requests.Session:
+    """创建带匿名 cookie 的请求会话。
+
+    访问雪球主页以获取 ``xq_a_token`` 等必要 cookie，
+    后续 API 调用需携带这些 cookie 才能正常返回数据。
+    """
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": _UA,
+        "Accept": "application/json, text/plain, */*",
+        "Referer": _HOME_URL,
+    })
+    # 访问主页获取匿名 cookie
+    try:
+        session.get(_HOME_URL, timeout=_TIMEOUT)
+    except requests.RequestException as exc:
+        logger.warning("雪球主页访问失败，无法获取 cookie: %s", exc)
+    return session
+
+
+def _format_timestamp(ts: int | float | None) -> str:
+    """将雪球毫秒时间戳转为可读日期字符串。"""
+    if not ts:
+        return "?"
+    try:
+        dt = datetime.fromtimestamp(ts / 1000, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (OSError, ValueError, OverflowError):
+        return "?"
+
+
+def _strip_html(text: str) -> str:
+    """移除 HTML 标签，返回纯文本。"""
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def fetch_xueqiu_posts(ticker: str, count: int = _POST_COUNT) -> str:
+    """获取雪球社区中关于 ``ticker`` 的讨论帖，返回格式化纯文本。
+
+    Parameters
+    ----------
+    ticker : str
+        股票代码，支持 ``600519.SH``、``SH600519``、``600519`` 等格式。
+    count : int
+        拉取帖子数量，默认 20。
+
+    Returns
+    -------
+    str
+        格式化的讨论帖纯文本；网络或解析错误时返回降级占位符。
+    """
+    xq_keyword = _convert_ticker(ticker)
+
+    # 创建带 cookie 的会话
+    try:
+        session = _get_session()
+    except Exception as exc:
+        logger.warning("雪球会话初始化失败: %s", exc)
+        return f"[Xueqiu data unavailable for {ticker}]"
+
+    # 调用搜索 API
+    params = {
+        "q": xq_keyword,
+        "count": count,
+        "sort": "time",
+    }
+    try:
+        resp = session.get(_SEARCH_API, params=params, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("雪球搜索 API 请求失败 (%s): %s", xq_keyword, exc)
+        return f"[Xueqiu data unavailable for {ticker}]"
+    except (ValueError, KeyError) as exc:
+        logger.warning("雪球搜索 API 响应解析失败 (%s): %s", xq_keyword, exc)
+        return f"[Xueqiu data unavailable for {ticker}]"
+
+    # 提取帖子列表
+    posts = data.get("list") or []
+    if not posts:
+        return f"[Xueqiu data unavailable for {ticker}]"
+
+    # 格式化输出
+    lines: list[str] = [
+        f"=== 雪球讨论 ({ticker}) ===",
+        f"共获取 {len(posts)} 条讨论",
+        "",
+    ]
+
+    for idx, post in enumerate(posts, start=1):
+        # 标题或内容摘要
+        title = (post.get("title") or "").strip()
+        description = (post.get("description") or post.get("text") or "").strip()
+        description = _strip_html(description)
+
+        # 优先用标题，无标题则用内容摘要
+        display_text = title if title else description
+        display_text = display_text.replace("\n", " ").strip()
+        if len(display_text) > 200:
+            display_text = display_text[:200] + "…"
+        if not display_text:
+            display_text = "<无内容>"
+
+        # 互动数据
+        likes = post.get("like_count", 0) or 0
+        comments = post.get("reply_count", 0) or 0
+        created = post.get("created_at")
+        created_str = _format_timestamp(created)
+
+        lines.append(f"{idx}. [{display_text}]")
+        lines.append(f"   点赞: {likes} | 评论: {comments} | 时间: {created_str}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -91,11 +91,13 @@ DEFAULT_CONFIG = _apply_env_overrides({
     ],
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)
+    # Note: A-share/HK tickers are auto-routed to akshare via detect_vendor_for_ticker(),
+    # with tushare as fallback. The settings below only affect non-Chinese tickers.
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance, tushare
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance, tushare
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance, tushare
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, tushare
+        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance, tushare, akshare
+        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance, tushare, akshare
+        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance, tushare, akshare
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, tushare, akshare
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -17,6 +17,8 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_MAX_RISK_ROUNDS":      "max_risk_discuss_rounds",
     "TRADINGAGENTS_CHECKPOINT_ENABLED":   "checkpoint_enabled",
     "TRADINGAGENTS_BENCHMARK_TICKER":     "benchmark_ticker",
+    "TRADINGAGENTS_PORTFOLIO_ENABLED":    "portfolio_enabled",
+    "TRADINGAGENTS_PORTFOLIO_PATH":       "portfolio_path",
 }
 
 
@@ -109,6 +111,10 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # based on the ticker's exchange suffix. SPY remains the US default
     # so the reflection label keeps reading "Alpha vs SPY" for US tickers
     # while non-US tickers get their regional index automatically.
+    # Portfolio context injection
+    "portfolio_enabled": True,
+    "portfolio_path": "",
+    # Benchmark for alpha calculation
     "benchmark_ticker": None,
     "benchmark_map": {
         ".NS":  "^NSEI",    # NSE India (Nifty 50)

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -92,10 +92,10 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance, tushare
+        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance, tushare
+        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance, tushare
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, tushare
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -1,11 +1,14 @@
 # TradingAgents/graph/propagation.py
 
+import logging
 from typing import Dict, Any, List, Optional
 from tradingagents.agents.utils.agent_states import (
     AgentState,
     InvestDebateState,
     RiskDebateState,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class Propagator:
@@ -16,14 +19,32 @@ class Propagator:
         self.max_recur_limit = max_recur_limit
 
     def create_initial_state(
-        self, company_name: str, trade_date: str, past_context: str = ""
+        self,
+        company_name: str,
+        trade_date: str,
+        past_context: str = "",
+        config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Create the initial state for the agent graph."""
+        # Build portfolio context
+        portfolio_context = ""
+        _cfg = config or {}
+        if _cfg.get("portfolio_enabled", True):
+            try:
+                from tradingagents.portfolio import PortfolioStore, build_portfolio_context
+                portfolio_path = _cfg.get("portfolio_path", "") or None
+                portfolio_store = PortfolioStore(portfolio_path=portfolio_path)
+                portfolio_context = build_portfolio_context(company_name, portfolio_store)
+            except Exception:
+                logger.debug("Portfolio context unavailable, continuing without it", exc_info=True)
+                portfolio_context = ""
+
         return {
             "messages": [("human", company_name)],
             "company_of_interest": company_name,
             "trade_date": str(trade_date),
             "past_context": past_context,
+            "portfolio_context": portfolio_context,
             "investment_debate_state": InvestDebateState(
                 {
                     "bull_history": "",

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -334,7 +334,7 @@ class TradingAgentsGraph:
         # Initialize state — inject memory log context for PM.
         past_context = self.memory_log.get_past_context(company_name)
         init_agent_state = self.propagator.create_initial_state(
-            company_name, trade_date, past_context=past_context
+            company_name, trade_date, past_context=past_context, config=self.config
         )
         args = self.propagator.get_graph_args()
 

--- a/tradingagents/portfolio/__init__.py
+++ b/tradingagents/portfolio/__init__.py
@@ -1,0 +1,13 @@
+"""Portfolio management module for TradingAgents."""
+
+from .context import build_portfolio_context
+from .models import Portfolio, PositionRecord, Transaction
+from .store import PortfolioStore
+
+__all__ = [
+    "Portfolio",
+    "PositionRecord",
+    "Transaction",
+    "PortfolioStore",
+    "build_portfolio_context",
+]

--- a/tradingagents/portfolio/context.py
+++ b/tradingagents/portfolio/context.py
@@ -1,0 +1,163 @@
+"""Portfolio context generator for LLM prompts.
+
+Converts portfolio data into structured Markdown text that can be
+embedded into analyst/trader agent prompts.
+"""
+
+from typing import List
+
+from .models import PositionRecord, Transaction
+from .store import PortfolioStore
+
+
+def build_portfolio_context(ticker: str, store: PortfolioStore) -> str:
+    """Build a Markdown portfolio context string for the given ticker.
+
+    Args:
+        ticker: The stock ticker being analyzed (e.g., "NVDA", "000404.SH").
+        store: A PortfolioStore instance to read data from.
+
+    Returns:
+        A Markdown string with portfolio context, or empty string if no data
+        or if an error occurs.
+    """
+    try:
+        positions = store.list_positions()
+        ticker_positions = store.get_position(ticker)
+        transactions = store.list_transactions(ticker=ticker, limit=10)
+    except Exception:
+        return ""
+
+    # If there's absolutely no data related to this context, return empty
+    if not positions and not transactions:
+        return ""
+
+    sections: List[str] = []
+    sections.append("## Your Current Portfolio Context")
+
+    # ─── Overall Position Summary ─────────────────────────────────────
+    sections.append(_build_overall_summary(ticker, positions, ticker_positions))
+
+    # ─── Position Detail ──────────────────────────────────────────────
+    if ticker_positions:
+        sections.append(_build_position_detail(ticker, ticker_positions))
+
+    # ─── Recent Transactions ──────────────────────────────────────────
+    if transactions:
+        sections.append(_build_recent_transactions(ticker, transactions))
+
+    # ─── Portfolio Concentration ──────────────────────────────────────
+    if positions:
+        sections.append(_build_concentration(ticker, positions))
+
+    return "\n\n".join(sections)
+
+
+def _build_overall_summary(
+    ticker: str,
+    all_positions: List[PositionRecord],
+    ticker_positions: List[PositionRecord],
+) -> str:
+    """Build the Overall Position Summary section."""
+    total = len(set(p.ticker.upper() for p in all_positions))
+    lines = ["### Overall Position Summary"]
+    lines.append(f"- Total positions: {total} stocks")
+
+    display_ticker = ticker.upper()
+    if ticker_positions:
+        total_qty = sum(p.quantity for p in ticker_positions)
+        total_cost = sum(p.entry_price * p.quantity for p in ticker_positions)
+        avg_cost = total_cost / total_qty if total_qty else 0
+        lines.append(
+            f"- This ticker ({display_ticker}): HOLDING {_fmt_qty(total_qty)} shares "
+            f"@ avg cost ${avg_cost:,.2f}"
+        )
+    else:
+        lines.append(f"- This ticker ({display_ticker}): NOT IN PORTFOLIO")
+
+    return "\n".join(lines)
+
+
+def _build_position_detail(
+    ticker: str, ticker_positions: List[PositionRecord]
+) -> str:
+    """Build the Position Detail section for the ticker."""
+    display_ticker = ticker.upper()
+
+    # Aggregate across multiple lots
+    total_qty = sum(p.quantity for p in ticker_positions)
+    total_cost = sum(p.entry_price * p.quantity for p in ticker_positions)
+    avg_cost = total_cost / total_qty if total_qty else 0
+
+    # Use earliest entry date
+    earliest_date = min(p.entry_date for p in ticker_positions)
+    # Use the side of the first position (should be consistent)
+    side = ticker_positions[0].side.capitalize()
+    # Combine notes
+    notes = [p.note for p in ticker_positions if p.note]
+    note_str = "; ".join(notes) if notes else ""
+
+    lines = [f"### Position Detail for {display_ticker}"]
+    lines.append(f"- Entry Date: {earliest_date}")
+    lines.append(f"- Average Cost: ${avg_cost:,.2f}")
+    lines.append(f"- Quantity: {_fmt_qty(total_qty)} shares")
+    lines.append(f"- Side: {side}")
+    if note_str:
+        lines.append(f"- Note: {note_str}")
+
+    return "\n".join(lines)
+
+
+def _build_recent_transactions(
+    ticker: str, transactions: List[Transaction]
+) -> str:
+    """Build the Recent Transactions section."""
+    display_ticker = ticker.upper()
+    lines = [f"### Recent Transactions for {display_ticker}"]
+
+    # Already sorted by date descending from store
+    for tx in transactions:
+        action = tx.action.upper()
+        lines.append(f"- {tx.date}: {action} {_fmt_qty(tx.quantity)} shares @ ${tx.price:,.2f}")
+
+    return "\n".join(lines)
+
+
+def _build_concentration(
+    ticker: str, all_positions: List[PositionRecord]
+) -> str:
+    """Build the Portfolio Concentration section."""
+    display_ticker = ticker.upper()
+
+    # Calculate cost basis for each ticker
+    ticker_costs: dict = {}
+    for p in all_positions:
+        key = p.ticker.upper()
+        ticker_costs[key] = ticker_costs.get(key, 0) + p.entry_price * p.quantity
+
+    total_cost_basis = sum(ticker_costs.values())
+    if total_cost_basis == 0:
+        return ""
+
+    # Current ticker weight
+    current_weight = ticker_costs.get(display_ticker, 0) / total_cost_basis * 100
+
+    # Top holdings sorted by cost basis descending
+    sorted_holdings = sorted(ticker_costs.items(), key=lambda x: x[1], reverse=True)
+    top_5 = sorted_holdings[:5]
+    top_str = ", ".join(
+        f"{t} ({v / total_cost_basis * 100:.1f}%)" for t, v in top_5
+    )
+
+    lines = ["### Portfolio Concentration"]
+    lines.append(f"- {display_ticker} weight: ~{current_weight:.1f}% of portfolio (by cost basis)")
+    lines.append(f"- Top holdings: {top_str}")
+
+    return "\n".join(lines)
+
+
+def _fmt_qty(qty: float) -> str:
+    """Format quantity: show as int if whole number, else 2 decimal places."""
+    if qty == int(qty):
+        return str(int(qty))
+    return f"{qty:.2f}"

--- a/tradingagents/portfolio/models.py
+++ b/tradingagents/portfolio/models.py
@@ -1,0 +1,31 @@
+"""Data models for portfolio position tracking."""
+
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class PositionRecord(BaseModel):
+    """A single position (holding) in the portfolio."""
+    ticker: str = Field(..., description="Stock ticker symbol (e.g., NVDA, 000404.SH)")
+    entry_date: str = Field(..., description="Entry date in YYYY-MM-DD format")
+    entry_price: float = Field(..., gt=0, description="Average entry price")
+    quantity: float = Field(..., gt=0, description="Number of shares held")
+    side: str = Field(default="long", description="Position side: long or short")
+    note: str = Field(default="", description="Optional note about the position")
+
+
+class Transaction(BaseModel):
+    """A single buy/sell transaction record."""
+    ticker: str = Field(..., description="Stock ticker symbol")
+    action: str = Field(..., description="Transaction action: buy or sell")
+    date: str = Field(..., description="Transaction date in YYYY-MM-DD format")
+    price: float = Field(..., gt=0, description="Execution price")
+    quantity: float = Field(..., gt=0, description="Number of shares")
+    note: str = Field(default="", description="Optional note about the transaction")
+
+
+class Portfolio(BaseModel):
+    """Complete portfolio state with positions and transaction history."""
+    positions: List[PositionRecord] = Field(default_factory=list)
+    transactions: List[Transaction] = Field(default_factory=list)
+    updated_at: str = Field(default="", description="Last update timestamp")

--- a/tradingagents/portfolio/store.py
+++ b/tradingagents/portfolio/store.py
@@ -1,0 +1,131 @@
+"""Portfolio store for persistent position and transaction data."""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from .models import Portfolio, PositionRecord, Transaction
+
+
+class PortfolioStore:
+    """Manages portfolio data persistence using a JSON file."""
+
+    def __init__(self, portfolio_path: Optional[str] = None):
+        """Initialize the portfolio store.
+        
+        Args:
+            portfolio_path: Path to portfolio JSON file. 
+                           Defaults to ~/.tradingagents/portfolio/portfolio.json
+                           Can be overridden by TRADINGAGENTS_PORTFOLIO_PATH env var.
+        """
+        if portfolio_path:
+            self._path = Path(portfolio_path)
+        else:
+            env_path = os.environ.get("TRADINGAGENTS_PORTFOLIO_PATH")
+            if env_path:
+                self._path = Path(env_path)
+            else:
+                self._path = Path.home() / ".tradingagents" / "portfolio" / "portfolio.json"
+        
+        self._ensure_dir()
+
+    def _ensure_dir(self):
+        """Ensure the portfolio directory exists."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> Portfolio:
+        """Load portfolio from disk."""
+        if not self._path.exists():
+            return Portfolio()
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            return Portfolio.model_validate(data)
+        except (json.JSONDecodeError, Exception):
+            return Portfolio()
+
+    def _save(self, portfolio: Portfolio):
+        """Save portfolio to disk."""
+        portfolio.updated_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self._path.write_text(
+            portfolio.model_dump_json(indent=2),
+            encoding="utf-8"
+        )
+
+    # ─── Position CRUD ─────────────────────────────────────────
+
+    def add_position(self, position: PositionRecord) -> None:
+        """Add a new position to the portfolio."""
+        portfolio = self._load()
+        portfolio.positions.append(position)
+        self._save(portfolio)
+
+    def remove_position(self, ticker: str, entry_date: Optional[str] = None) -> bool:
+        """Remove a position by ticker (and optionally entry_date).
+        
+        Returns True if a position was removed, False otherwise.
+        """
+        portfolio = self._load()
+        original_count = len(portfolio.positions)
+        if entry_date:
+            portfolio.positions = [
+                p for p in portfolio.positions
+                if not (p.ticker.upper() == ticker.upper() and p.entry_date == entry_date)
+            ]
+        else:
+            portfolio.positions = [
+                p for p in portfolio.positions
+                if p.ticker.upper() != ticker.upper()
+            ]
+        if len(portfolio.positions) < original_count:
+            self._save(portfolio)
+            return True
+        return False
+
+    def list_positions(self) -> List[PositionRecord]:
+        """List all current positions."""
+        return self._load().positions
+
+    def get_position(self, ticker: str) -> List[PositionRecord]:
+        """Get all positions for a specific ticker."""
+        portfolio = self._load()
+        return [p for p in portfolio.positions if p.ticker.upper() == ticker.upper()]
+
+    # ─── Transaction CRUD ──────────────────────────────────────
+
+    def add_transaction(self, transaction: Transaction) -> None:
+        """Record a new transaction."""
+        portfolio = self._load()
+        portfolio.transactions.append(transaction)
+        self._save(portfolio)
+
+    def list_transactions(self, ticker: Optional[str] = None, limit: int = 20) -> List[Transaction]:
+        """List transactions, optionally filtered by ticker.
+        
+        Args:
+            ticker: If provided, only return transactions for this ticker.
+            limit: Maximum number of transactions to return (most recent first).
+        """
+        portfolio = self._load()
+        txs = portfolio.transactions
+        if ticker:
+            txs = [t for t in txs if t.ticker.upper() == ticker.upper()]
+        # Sort by date descending, return most recent
+        txs.sort(key=lambda t: t.date, reverse=True)
+        return txs[:limit]
+
+    # ─── Portfolio Queries ─────────────────────────────────────
+
+    def get_portfolio(self) -> Portfolio:
+        """Get the full portfolio object."""
+        return self._load()
+
+    def clear(self) -> None:
+        """Clear all portfolio data."""
+        self._save(Portfolio())
+
+    @property
+    def path(self) -> Path:
+        """Return the portfolio file path."""
+        return self._path


### PR DESCRIPTION
## 概述

在现有多智能体股票分析流程基础上，新增用户持仓管理和上下文注入能力。系统在分析时自动将用户的实际持仓信息（成本、仓位比例、交易历史）注入到 Trader 和 Portfolio Manager 的 Prompt 中，使决策能考虑用户的真实持仓状况。

## 新增功能

### 1. Portfolio 模块 (`tradingagents/portfolio/`)
- **数据模型** (`models.py`): PositionRecord, Transaction, Portfolio (Pydantic v2)
- **存储层** (`store.py`): JSON 文件持久化，支持 CRUD 操作
- **上下文生成** (`context.py`): 将持仓数据转换为结构化 Markdown，嵌入 LLM Prompt

### 2. 分析流程集成
- `AgentState` 新增 `portfolio_context` 字段
- `propagation.py` 初始化时自动构建持仓上下文
- Trader 和 Portfolio Manager 的 Prompt 末尾追加持仓信息和决策指引

### 3. CLI 持仓管理命令 (`cli/portfolio_cmd.py`)
- `portfolio add` / `remove` / `list` / `clear`
- `portfolio tx add` / `tx list`
- 分析前自动检测并提示持仓状态

### 4. 同步脚本 (`scripts/import_portfolio.py`)
- 从平级的 `financial-management` 项目一键同步持仓和交易记录
- 聚合所有月份的交易数据，过滤非交易类型
- 使用相对路径（两个项目始终平级）

## 配置项

| 配置 | 默认值 | 环境变量 |
|------|--------|---------|
| `portfolio_enabled` | `True` | `TRADINGAGENTS_PORTFOLIO_ENABLED` |
| `portfolio_path` | `""` (默认路径) | `TRADINGAGENTS_PORTFOLIO_PATH` |

## 设计原则

- **向后兼容**: 无持仓数据时表现与原来完全一致
- **最小侵入**: 不改变现有决策流程，仅追加上下文
- **容错设计**: 持仓相关操作失败静默降级，不影响核心分析

## 文件变更

- 新增 7 个文件 (portfolio 模块 4 个 + CLI 1 个 + 脚本 1 个 + MEMORY.md)
- 修改 7 个文件 (agent_states, trader, portfolio_manager, propagation, trading_graph, default_config, cli/main)