### PR TITLE
feat: add WebUI for real-time analysis monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 <div align="center">
 
-🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
+🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🌐 [WebUI](#webui) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
 
 </div>
 
@@ -184,6 +184,78 @@ An interface will appear showing results as they load, letting you track the age
 <p align="center">
   <img src="assets/cli/cli_transaction.png" width="100%" style="display: inline-block; margin: 0 2%;">
 </p>
+
+## WebUI
+
+TradingAgents includes a web-based UI for real-time analysis monitoring. The WebUI provides a browser interface to configure and run analyses with live progress updates.
+
+<p align="center">
+  <img src="assets/webui/overview.png" width="100%" style="display: inline-block; margin: 0 2%;">
+</p>
+
+### Running the WebUI
+
+Launch the WebUI server:
+```bash
+tradingagents-web          # installed command
+python -m webui            # alternative: run directly from source
+```
+
+The server starts at `http://localhost:8000`. Open this URL in your browser to access the WebUI.
+
+### Features
+
+- **Live Progress**: Watch agent activities, tool calls, and LLM invocations in real-time
+- **Configuration**: Select analysts, LLM provider, models, debate rounds, and output language
+- **Streaming Reports**: View analyst reports and decisions as they are generated
+- **Session Management**: Each analysis runs in a separate session with unique ID
+
+### Configuration Options
+
+The WebUI exposes the same configuration options as the CLI and Python API:
+
+| Option | Description |
+|--------|-------------|
+| **Analysts** | Choose which analysts to run (Market, Social, News, Fundamentals) |
+| **Provider** | Select LLM provider (OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen, GLM, OpenRouter) |
+| **Quick Model** | Model for fast tasks (analysts, trader) |
+| **Deep Model** | Model for complex reasoning (research manager, portfolio manager) |
+| **Debate Rounds** | Number of bull/bear researcher debate iterations |
+| **Language** | Output language for reports and decisions |
+| **Checkpoint** | Enable resume from last successful step on crash/interrupt |
+
+### API Endpoints
+
+The WebUI server exposes these REST endpoints:
+
+- `GET /` - Web UI HTML page
+- `GET /api/models` - Available LLM models by provider
+- `POST /api/analyze` - Start a new analysis (returns run_id)
+- `GET /api/stream/{run_id}` - Server-sent events stream for live progress
+
+Example programmatic usage:
+```python
+import requests
+
+# Start analysis
+response = requests.post("http://localhost:8000/api/analyze", json={
+    "ticker": "NVDA",
+    "date": "2026-01-15",
+    "provider": "openai",
+    "quick_model": "gpt-5.4-mini",
+    "deep_model": "gpt-5.4",
+    "max_debate_rounds": 1,
+    "language": "English"
+})
+run_id = response.json()["run_id"]
+
+# Stream progress (SSE)
+import httpx
+async with httpx.AsyncClient() as client:
+    async with client.stream("GET", f"http://localhost:8000/api/stream/{run_id}") as r:
+        async for line in r.aiter_lines():
+            print(line)
+```
 
 ## TradingAgents Package
 

--- a/webui/__main__.py
+++ b/webui/__main__.py
@@ -1,0 +1,9 @@
+import uvicorn
+
+
+def main():
+    uvicorn.run("webui.server:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/webui/server.py
+++ b/webui/server.py
@@ -1,0 +1,205 @@
+"""FastAPI web UI server for TradingAgents."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import uuid
+from pathlib import Path
+from queue import Empty, Queue
+from typing import Any
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+from pydantic import BaseModel
+
+load_dotenv()
+
+from tradingagents.default_config import DEFAULT_CONFIG  # noqa: E402
+from tradingagents.graph.trading_graph import TradingAgentsGraph  # noqa: E402
+from tradingagents.llm_clients.model_catalog import MODEL_OPTIONS  # noqa: E402
+
+class ProgressCallbackHandler(BaseCallbackHandler):
+    """Pushes live tool/LLM activity events to the SSE queue."""
+
+    def __init__(self, push_fn) -> None:
+        super().__init__()
+        self._push = push_fn
+        self._lock = threading.Lock()
+        self.llm_calls = 0
+        self.tool_calls = 0
+        self.tokens_in = 0
+        self.tokens_out = 0
+
+    def on_chat_model_start(self, serialized, messages, **kwargs):
+        with self._lock:
+            self.llm_calls += 1
+        name = (serialized.get("kwargs", {}).get("model") or
+                serialized.get("kwargs", {}).get("model_name") or "LLM")
+        self._push({"type": "progress", "event": "llm", "name": name})
+
+    def on_llm_start(self, serialized, prompts, **kwargs):
+        with self._lock:
+            self.llm_calls += 1
+
+    def on_llm_end(self, response: LLMResult, **kwargs):
+        try:
+            msg = response.generations[0][0].message
+            usage = getattr(msg, "usage_metadata", None) or {}
+            with self._lock:
+                self.tokens_in  += usage.get("input_tokens", 0)
+                self.tokens_out += usage.get("output_tokens", 0)
+        except Exception:
+            pass
+
+    def on_tool_start(self, serialized, input_str, **kwargs):
+        with self._lock:
+            self.tool_calls += 1
+        name = serialized.get("name", "tool")
+        preview = (input_str or "")[:120]
+        self._push({"type": "progress", "event": "tool", "name": name, "input": preview})
+
+    def on_tool_end(self, output, **kwargs):
+        preview = str(output or "")[:80]
+        self._push({"type": "progress", "event": "tool_done", "preview": preview})
+
+    def get_stats(self) -> dict:
+        with self._lock:
+            return {
+                "llm_calls": self.llm_calls,
+                "tool_calls": self.tool_calls,
+                "tokens_in": self.tokens_in,
+                "tokens_out": self.tokens_out,
+            }
+
+
+app = FastAPI(title="TradingAgents Web UI")
+
+_STATIC = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=str(_STATIC)), name="static")
+
+# run_id → event queue (cleaned up after stream ends)
+_runs: dict[str, Queue] = {}
+
+_REPORT_FIELDS = {
+    "market_report":        "Market Analyst",
+    "sentiment_report":     "Social Analyst",
+    "news_report":          "News Analyst",
+    "fundamentals_report":  "Fundamentals Analyst",
+    "investment_plan":      "Research Manager",
+    "trader_investment_plan": "Trader",
+    "final_trade_decision": "Portfolio Manager",
+}
+
+
+class AnalyzeRequest(BaseModel):
+    # Field names mirror the frontend form in index.html
+    ticker: str
+    date: str
+    analysts: list[str] = ["market", "social", "news", "fundamentals"]
+    provider: str = "openai"
+    quick_model: str = "gpt-5.4-mini"
+    deep_model: str = "gpt-5.4-mini"
+    max_debate_rounds: int = 1
+    language: str = "English"
+    checkpoint: bool = False
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return HTMLResponse((_STATIC / "index.html").read_text(encoding="utf-8"))
+
+
+@app.get("/api/models")
+async def get_models():
+    return MODEL_OPTIONS
+
+
+@app.post("/api/analyze")
+async def start_analysis(req: AnalyzeRequest) -> dict:
+    run_id = str(uuid.uuid4())
+    q: Queue = Queue()
+    _runs[run_id] = q
+
+    def _push(event: dict[str, Any]) -> None:
+        q.put(event)
+
+    def run() -> None:
+        try:
+            config = DEFAULT_CONFIG.copy()
+            config["llm_provider"]          = req.provider
+            config["quick_think_llm"]       = req.quick_model
+            config["deep_think_llm"]        = req.deep_model
+            config["max_debate_rounds"]     = req.max_debate_rounds
+            config["max_risk_discuss_rounds"] = req.max_debate_rounds
+            config["output_language"]       = req.language
+            config["checkpoint_enabled"]    = req.checkpoint
+
+            _push({"type": "status", "message": "Initializing…"})
+            stats = ProgressCallbackHandler(_push)
+            ta = TradingAgentsGraph(
+                selected_analysts=req.analysts,
+                debug=False,
+                config=config,
+                callbacks=[stats],
+            )
+            _push({"type": "status", "message": f"Analyzing {req.ticker} on {req.date}…"})
+
+            prev: dict[str, str] = {}
+            for chunk in ta.propagate_stream(req.ticker, req.date):
+                for field, agent_name in _REPORT_FIELDS.items():
+                    val = chunk.get(field) or ""
+                    if val and val != prev.get(field, ""):
+                        _push({"type": "report", "field": field, "agent": agent_name, "content": val})
+                        prev[field] = val
+
+            decision = ta.process_signal(
+                (ta.curr_state or {}).get("final_trade_decision", "")
+            )
+            _push({
+                "type": "complete",
+                "decision": decision,
+                "ticker": req.ticker,
+                "date": req.date,
+                "stats": stats.get_stats(),
+            })
+
+        except Exception as exc:
+            _push({"type": "error", "message": str(exc)})
+        finally:
+            q.put(None)  # sentinel
+
+    threading.Thread(target=run, daemon=True).start()
+    return {"run_id": run_id}
+
+
+@app.get("/api/stream/{run_id}")
+async def stream_job(run_id: str) -> StreamingResponse:
+    q = _runs.get(run_id)
+    if q is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    async def _generate():
+        loop = asyncio.get_event_loop()
+        while True:
+            try:
+                item = await loop.run_in_executor(None, lambda: q.get(timeout=30))
+            except Empty:
+                yield ": keepalive\n\n"
+                continue
+            if item is None:
+                yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                _runs.pop(run_id, None)
+                break
+            yield f"data: {json.dumps(item, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -1,0 +1,614 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TradingAgents</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    body { background: #0f1117; color: #e2e8f0; font-family: 'Inter', system-ui, sans-serif; }
+    .glass { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); backdrop-filter: blur(12px); }
+    .pulse-dot { animation: pulse 1.5s ease-in-out infinite; }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.3} }
+    .spin { animation: spin 1s linear infinite; }
+    @keyframes spin { to{transform:rotate(360deg)} }
+    .slide-in { animation: slideIn 0.3s ease-out; }
+    @keyframes slideIn { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+    .prose-dark h1,.prose-dark h2,.prose-dark h3 { color:#93c5fd; font-weight:600; margin:1rem 0 .5rem; }
+    .prose-dark h1{font-size:1.25rem} .prose-dark h2{font-size:1.1rem} .prose-dark h3{font-size:1rem}
+    .prose-dark p { color:#cbd5e1; margin:.5rem 0; line-height:1.7; }
+    .prose-dark ul,.prose-dark ol { color:#cbd5e1; padding-left:1.5rem; margin:.5rem 0; }
+    .prose-dark li { margin:.25rem 0; }
+    .prose-dark strong { color:#e2e8f0; }
+    .prose-dark code { background:#1e2533; color:#7dd3fc; padding:.1rem .3rem; border-radius:.25rem; font-size:.85em; }
+    .prose-dark pre { background:#1e2533; padding:1rem; border-radius:.5rem; overflow-x:auto; margin:.75rem 0; }
+    .prose-dark blockquote { border-left:3px solid #3b82f6; padding-left:1rem; color:#94a3b8; }
+    .prose-dark hr { border-color:#334155; margin:1rem 0; }
+    .prose-dark table { width:100%; border-collapse:collapse; margin:.75rem 0; }
+    .prose-dark th { background:#1e2533; color:#93c5fd; padding:.5rem .75rem; text-align:left; border:1px solid #334155; }
+    .prose-dark td { padding:.5rem .75rem; border:1px solid #1e2533; color:#cbd5e1; }
+    .prose-dark tr:nth-child(even) td { background:rgba(255,255,255,0.02); }
+    select,input { background:#1a1f2e !important; color:#e2e8f0 !important; border-color:#334155 !important; }
+    select option { background:#1a1f2e; }
+    ::-webkit-scrollbar { width:6px; } ::-webkit-scrollbar-track { background:#0f1117; } ::-webkit-scrollbar-thumb { background:#334155; border-radius:3px; }
+    .tab-btn.active { background:#3b82f6; color:#fff; }
+    .tab-btn { transition:all .2s; }
+    .accordion-content { max-height:0; overflow:hidden; transition:max-height .4s ease; }
+    .accordion-content.open { max-height:9999px; }
+  </style>
+</head>
+<body class="min-h-screen">
+
+<!-- Header -->
+<header class="border-b border-white/10 px-6 py-4 flex items-center gap-3">
+  <div class="w-8 h-8 rounded-lg bg-blue-600 flex items-center justify-center text-sm font-bold">TA</div>
+  <div>
+    <div class="font-semibold text-white">TradingAgents</div>
+    <div class="text-xs text-slate-400">Multi-Agent LLM Financial Analysis</div>
+  </div>
+</header>
+
+<div class="max-w-7xl mx-auto px-4 py-6 flex gap-6">
+
+  <!-- Left sidebar: config form -->
+  <aside class="w-80 flex-shrink-0">
+    <div class="glass rounded-xl p-5 space-y-5 sticky top-6">
+      <h2 class="font-semibold text-white text-sm uppercase tracking-wider">Configuration</h2>
+
+      <!-- Ticker + date -->
+      <div class="space-y-3">
+        <div>
+          <label class="text-xs text-slate-400 block mb-1">Ticker Symbol</label>
+          <input id="ticker" type="text" value="NVDA" placeholder="e.g. NVDA, SPY, AAPL"
+            class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500 transition" />
+        </div>
+        <div>
+          <label class="text-xs text-slate-400 block mb-1">Analysis Date</label>
+          <input id="tradeDate" type="date"
+            class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500 transition" />
+        </div>
+      </div>
+
+      <!-- Analysts -->
+      <div>
+        <label class="text-xs text-slate-400 block mb-2">Analysts</label>
+        <div class="grid grid-cols-2 gap-2" id="analystToggles">
+          <label class="analyst-toggle flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" value="market" checked class="accent-blue-500" /> <span class="text-sm">Market</span>
+          </label>
+          <label class="analyst-toggle flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" value="social" checked class="accent-blue-500" /> <span class="text-sm">Social</span>
+          </label>
+          <label class="analyst-toggle flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" value="news" checked class="accent-blue-500" /> <span class="text-sm">News</span>
+          </label>
+          <label class="analyst-toggle flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" value="fundamentals" checked class="accent-blue-500" /> <span class="text-sm">Fundamentals</span>
+          </label>
+        </div>
+      </div>
+
+      <!-- LLM Provider -->
+      <div>
+        <label class="text-xs text-slate-400 block mb-1">LLM Provider</label>
+        <select id="provider" class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500 transition">
+          <option value="openai">OpenAI</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="google">Google</option>
+          <option value="xai">xAI</option>
+          <option value="deepseek">DeepSeek</option>
+          <option value="qwen">Qwen</option>
+          <option value="glm">GLM</option>
+          <option value="openrouter">OpenRouter</option>
+          <option value="ollama">Ollama</option>
+          <option value="azure">Azure</option>
+        </select>
+      </div>
+
+      <!-- Model selects -->
+      <div class="space-y-3">
+        <div>
+          <label class="text-xs text-slate-400 block mb-1">Quick-Think Model</label>
+          <select id="quickModel" class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500 transition"></select>
+        </div>
+        <div>
+          <label class="text-xs text-slate-400 block mb-1">Deep-Think Model</label>
+          <select id="deepModel" class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500 transition"></select>
+        </div>
+      </div>
+
+      <!-- Advanced -->
+      <details class="group">
+        <summary class="text-xs text-slate-400 cursor-pointer select-none flex items-center gap-1">
+          <span class="group-open:rotate-90 transition-transform inline-block">▶</span> Advanced
+        </summary>
+        <div class="mt-3 space-y-3">
+          <div class="grid grid-cols-2 gap-2">
+            <div>
+              <label class="text-xs text-slate-400 block mb-1">Debate Rounds</label>
+              <input id="debateRounds" type="number" value="1" min="1" max="5"
+                class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500" />
+            </div>
+            <div>
+              <label class="text-xs text-slate-400 block mb-1">Risk Rounds</label>
+              <input id="riskRounds" type="number" value="1" min="1" max="5"
+                class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500" />
+            </div>
+          </div>
+          <div>
+            <label class="text-xs text-slate-400 block mb-1">Output Language</label>
+            <select id="language" class="w-full rounded-lg px-3 py-2 text-sm border focus:outline-none focus:border-blue-500">
+              <option>English</option><option>Chinese</option><option>Spanish</option>
+              <option>French</option><option>German</option><option>Japanese</option>
+            </select>
+          </div>
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input id="checkpoint" type="checkbox" class="accent-blue-500" />
+            <span class="text-sm text-slate-300">Enable Checkpoint Resume</span>
+          </label>
+        </div>
+      </details>
+
+      <button id="runBtn" onclick="startAnalysis()"
+        class="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold py-2.5 rounded-lg text-sm transition">
+        Run Analysis
+      </button>
+    </div>
+  </aside>
+
+  <!-- Main content -->
+  <main class="flex-1 min-w-0 space-y-5">
+
+    <!-- Status bar -->
+    <div id="statusBar" class="text-sm text-slate-400 min-h-[1.25rem] flex items-center gap-2">
+      <span id="statusText"></span>
+      <span id="elapsedTimer" class="hidden font-mono text-slate-500"></span>
+    </div>
+
+    <!-- Pipeline status -->
+    <div class="glass rounded-xl p-5">
+      <h2 class="font-semibold text-white text-sm uppercase tracking-wider mb-4">Pipeline</h2>
+      <div id="pipeline" class="flex flex-wrap gap-3">
+        <!-- Injected by JS -->
+      </div>
+    </div>
+
+    <!-- Activity log (visible while running) -->
+    <div id="activityPanel" class="hidden glass rounded-xl overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-3 border-b border-white/10">
+        <h2 class="font-semibold text-white text-sm uppercase tracking-wider">Live Activity</h2>
+        <span id="activityCount" class="text-xs text-slate-500"></span>
+      </div>
+      <div id="activityLog" class="p-4 h-48 overflow-y-auto space-y-1 font-mono text-xs"></div>
+    </div>
+
+    <!-- Final decision card (hidden until done) -->
+    <div id="decisionCard" class="hidden glass rounded-xl p-6 slide-in">
+      <div class="flex items-start justify-between flex-wrap gap-4">
+        <div>
+          <div class="text-xs text-slate-400 uppercase tracking-wider mb-1">Final Decision</div>
+          <div id="decisionTicker" class="text-3xl font-bold text-white"></div>
+          <div id="decisionDate" class="text-sm text-slate-400 mt-1"></div>
+        </div>
+        <div id="ratingBadge" class="text-2xl font-bold px-6 py-3 rounded-xl"></div>
+      </div>
+      <div id="decisionSummary" class="prose-dark mt-4 text-sm"></div>
+      <div id="runStats" class="hidden mt-3 text-xs text-slate-500 font-mono"></div>
+    </div>
+
+    <!-- Report tabs -->
+    <div id="reportsContainer" class="glass rounded-xl overflow-hidden">
+      <div class="flex gap-1 p-3 border-b border-white/10 overflow-x-auto" id="tabBar">
+        <!-- tabs injected by JS -->
+      </div>
+      <div id="tabContent" class="p-5 min-h-32">
+        <div class="text-slate-500 text-sm text-center py-8">Reports will appear here as agents complete.</div>
+      </div>
+    </div>
+
+  </main>
+</div>
+
+<script>
+const PIPELINE_STAGES = [
+  { key: 'market',       label: 'Market',        group: 'Analysts' },
+  { key: 'social',       label: 'Social',        group: 'Analysts' },
+  { key: 'news',         label: 'News',          group: 'Analysts' },
+  { key: 'fundamentals', label: 'Fundamentals',  group: 'Analysts' },
+  { key: 'bull',         label: 'Bull',          group: 'Research' },
+  { key: 'bear',         label: 'Bear',          group: 'Research' },
+  { key: 'research_mgr', label: 'Res. Manager',  group: 'Research' },
+  { key: 'trader',       label: 'Trader',        group: 'Trading'  },
+  { key: 'aggressive',   label: 'Aggressive',    group: 'Risk'     },
+  { key: 'conservative', label: 'Conservative',  group: 'Risk'     },
+  { key: 'neutral',      label: 'Neutral',       group: 'Risk'     },
+  { key: 'portfolio',    label: 'Portfolio Mgr', group: 'Decision' },
+];
+
+// Backend emits reports for exactly these 7 fields (see webui/app.py FIELD_TO_AGENT)
+const FIELD_TO_STAGE = {
+  market_report:          'market',
+  sentiment_report:       'social',
+  news_report:            'news',
+  fundamentals_report:    'fundamentals',
+  investment_plan:        'research_mgr',
+  trader_investment_plan: 'trader',
+  final_trade_decision:   'portfolio',
+};
+
+const RATING_STYLES = {
+  'Buy':         { bg: 'bg-emerald-500/20', border: 'border-emerald-500', text: 'text-emerald-400' },
+  'Overweight':  { bg: 'bg-green-500/20',   border: 'border-green-400',   text: 'text-green-400' },
+  'Hold':        { bg: 'bg-yellow-500/20',  border: 'border-yellow-400',  text: 'text-yellow-400' },
+  'Underweight': { bg: 'bg-orange-500/20',  border: 'border-orange-400',  text: 'text-orange-400' },
+  'Sell':        { bg: 'bg-red-500/20',     border: 'border-red-500',     text: 'text-red-400' },
+};
+
+let stageStatus  = {};   // key → 'pending'|'running'|'done'
+let stageStart   = {};   // key → Date (when stage went running)
+let reports      = {};   // field → {label, content}
+let activeTab    = null;
+let models       = {};
+let currentSource = null;
+let _timerInterval = null;
+let _startTime   = null;
+let _activityCount = 0;
+
+// ─── Timer helpers ───────────────────────────────────────────────────────────
+
+function fmtElapsed(ms) {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
+}
+
+function startGlobalTimer() {
+  _startTime = Date.now();
+  const el = document.getElementById('elapsedTimer');
+  el.classList.remove('hidden');
+  _timerInterval = setInterval(() => {
+    el.textContent = fmtElapsed(Date.now() - _startTime);
+    // Update running stage pills with their elapsed time
+    Object.entries(stageStart).forEach(([key, t]) => {
+      if (stageStatus[key] === 'running') {
+        const pill = document.getElementById(`stage-${key}`);
+        if (pill) {
+          const stage = PIPELINE_STAGES.find(s => s.key === key);
+          const elapsed = fmtElapsed(Date.now() - t);
+          pill.innerHTML = `${statusIcon('running')} ${stage?.label ?? key} <span class="opacity-60">${elapsed}</span>`;
+        }
+      }
+    });
+  }, 1000);
+}
+
+function stopGlobalTimer() {
+  clearInterval(_timerInterval);
+  _timerInterval = null;
+  document.getElementById('elapsedTimer').classList.add('hidden');
+}
+
+// ─── Activity log ────────────────────────────────────────────────────────────
+
+function appendActivity(html) {
+  const log = document.getElementById('activityLog');
+  const div = document.createElement('div');
+  div.className = 'slide-in';
+  div.innerHTML = html;
+  log.appendChild(div);
+  log.scrollTop = log.scrollHeight;
+  _activityCount++;
+  document.getElementById('activityCount').textContent = `${_activityCount} events`;
+}
+
+function renderProgress(d) {
+  const ts = new Date().toLocaleTimeString([], {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+  const time = `<span class="text-slate-600">${ts}</span>`;
+  if (d.event === 'tool') {
+    const inp = d.input ? ` <span class="text-slate-500">${escHtml(d.input)}</span>` : '';
+    appendActivity(`${time} <span class="text-amber-400">⚙ ${escHtml(d.name)}</span>${inp}`);
+  } else if (d.event === 'tool_done') {
+    const prev = d.preview ? ` <span class="text-slate-600">→ ${escHtml(d.preview)}</span>` : '';
+    appendActivity(`${time} <span class="text-slate-500">  ↩ done${prev}</span>`);
+  } else if (d.event === 'llm') {
+    appendActivity(`${time} <span class="text-blue-400">🤖 ${escHtml(d.name)}</span> <span class="text-slate-500">thinking…</span>`);
+  }
+}
+
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+document.addEventListener('DOMContentLoaded', async () => {
+  document.getElementById('tradeDate').value = new Date().toISOString().slice(0,10);
+  await loadModels();
+  document.getElementById('provider').addEventListener('change', () => updateModelSelects());
+  updateModelSelects();
+  resetPipeline();
+});
+
+async function loadModels() {
+  try {
+    const res = await fetch('/api/models');
+    models = await res.json();
+  } catch(e) { console.warn('Could not load models', e); }
+}
+
+function updateModelSelects() {
+  const provider = document.getElementById('provider').value;
+  const opts = models[provider];
+  if (!opts) return;
+  fillSelect('quickModel', opts.quick || []);
+  fillSelect('deepModel', opts.deep || []);
+}
+
+function fillSelect(id, options) {
+  const sel = document.getElementById(id);
+  sel.innerHTML = '';
+  if (!options || options.length === 0) {
+    const o = document.createElement('option');
+    o.textContent = 'custom'; o.value = 'custom';
+    sel.appendChild(o);
+    return;
+  }
+  options.forEach(([label, value]) => {
+    const o = document.createElement('option');
+    o.textContent = label; o.value = value;
+    sel.appendChild(o);
+  });
+}
+
+// ─── Pipeline UI ─────────────────────────────────────────────────────────────
+
+function resetPipeline() {
+  stageStatus = {};
+  stageStart  = {};
+  PIPELINE_STAGES.forEach(s => { stageStatus[s.key] = 'pending'; });
+  renderPipeline();
+}
+
+function renderPipeline() {
+  const container = document.getElementById('pipeline');
+  const groups = {};
+  PIPELINE_STAGES.forEach(s => {
+    if (!groups[s.group]) groups[s.group] = [];
+    groups[s.group].push(s);
+  });
+  container.innerHTML = '';
+  Object.entries(groups).forEach(([grpName, stages]) => {
+    const grp = document.createElement('div');
+    grp.className = 'flex flex-col gap-1';
+    const lbl = document.createElement('div');
+    lbl.className = 'text-xs text-slate-500 uppercase tracking-wider px-1';
+    lbl.textContent = grpName;
+    grp.appendChild(lbl);
+    const pills = document.createElement('div');
+    pills.className = 'flex gap-1 flex-wrap';
+    stages.forEach(s => {
+      const status = stageStatus[s.key] || 'pending';
+      const pill = document.createElement('div');
+      pill.id = `stage-${s.key}`;
+      pill.className = `px-3 py-1.5 rounded-lg text-xs font-medium flex items-center gap-1.5 transition-all ${statusClass(status)}`;
+      pill.innerHTML = `${statusIcon(status)} ${s.label}`;
+      pills.appendChild(pill);
+    });
+    grp.appendChild(pills);
+    container.appendChild(grp);
+  });
+}
+
+function updateStage(key, status) {
+  stageStatus[key] = status;
+  if (status === 'running' && !stageStart[key]) stageStart[key] = Date.now();
+  const el = document.getElementById(`stage-${key}`);
+  if (!el) return;
+  const stage = PIPELINE_STAGES.find(s => s.key === key);
+  let label = stage ? stage.label : key;
+  if (status === 'done' && stageStart[key]) {
+    label += ` <span class="opacity-50">${fmtElapsed(Date.now() - stageStart[key])}</span>`;
+  }
+  el.className = `px-3 py-1.5 rounded-lg text-xs font-medium flex items-center gap-1.5 transition-all ${statusClass(status)}`;
+  el.innerHTML = `${statusIcon(status)} ${label}`;
+}
+
+function statusClass(s) {
+  return s === 'done'    ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40'
+       : s === 'running' ? 'bg-blue-500/20 text-blue-300 border border-blue-500/40'
+       :                   'bg-white/5 text-slate-500 border border-white/10';
+}
+
+function statusIcon(s) {
+  return s === 'done'    ? '<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>'
+       : s === 'running' ? '<svg class="spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>'
+       :                   '<span class="w-2 h-2 rounded-full bg-current inline-block"></span>';
+}
+
+// ─── Tabs ─────────────────────────────────────────────────────────────────────
+
+function addTab(field, label) {
+  const tabBar = document.getElementById('tabBar');
+  const existing = document.getElementById(`tab-${field}`);
+  if (existing) return;
+
+  const btn = document.createElement('button');
+  btn.id = `tab-${field}`;
+  btn.className = 'tab-btn px-3 py-1.5 rounded-lg text-xs font-medium text-slate-300 hover:bg-white/10 whitespace-nowrap';
+  btn.textContent = label;
+  btn.onclick = () => showTab(field);
+  tabBar.appendChild(btn);
+
+  if (!activeTab) showTab(field);
+}
+
+function showTab(field) {
+  activeTab = field;
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  const btn = document.getElementById(`tab-${field}`);
+  if (btn) btn.classList.add('active');
+
+  const content = document.getElementById('tabContent');
+  const rep = reports[field];
+  if (rep) {
+    content.innerHTML = `<div class="prose-dark text-sm slide-in">${marked.parse(rep.content)}</div>`;
+  }
+}
+
+function updateTabContent(field) {
+  if (activeTab === field) showTab(field);
+}
+
+// ─── Analysis ─────────────────────────────────────────────────────────────────
+
+async function startAnalysis() {
+  const ticker    = document.getElementById('ticker').value.trim().toUpperCase();
+  const tradeDate = document.getElementById('tradeDate').value;
+  if (!ticker || !tradeDate) { alert('Please enter a ticker and date.'); return; }
+
+  const analysts = [...document.querySelectorAll('#analystToggles input:checked')].map(i => i.value);
+  if (!analysts.length) { alert('Select at least one analyst.'); return; }
+
+  // Reset UI
+  reports = {}; activeTab = null; _activityCount = 0;
+  document.getElementById('tabBar').innerHTML = '';
+  document.getElementById('tabContent').innerHTML = '<div class="text-slate-500 text-sm text-center py-8">Waiting for first agent…</div>';
+  document.getElementById('decisionCard').classList.add('hidden');
+  document.getElementById('activityLog').innerHTML = '';
+  document.getElementById('activityCount').textContent = '';
+  document.getElementById('activityPanel').classList.remove('hidden');
+  setStatus('');
+  stopGlobalTimer();
+  resetPipeline();
+
+  const btn = document.getElementById('runBtn');
+  btn.disabled = true; btn.textContent = 'Running…';
+
+  if (currentSource) { currentSource.close(); currentSource = null; }
+
+  // Field names must match AnalysisRequest in webui/app.py
+  const payload = {
+    ticker,
+    date:              tradeDate,
+    analysts,
+    provider:          document.getElementById('provider').value,
+    quick_model:       document.getElementById('quickModel').value,
+    deep_model:        document.getElementById('deepModel').value,
+    max_debate_rounds: parseInt(document.getElementById('debateRounds').value) || 1,
+    language:          document.getElementById('language').value,
+    checkpoint:        document.getElementById('checkpoint').checked,
+  };
+
+  let runId;
+  try {
+    const res  = await fetch('/api/analyze', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload) });
+    const data = await res.json();
+    runId = data.run_id;
+  } catch(e) { alert('Failed to start: ' + e.message); resetBtn(); return; }
+
+  analysts.forEach(a => updateStage(a, 'running'));
+  startGlobalTimer();
+
+  currentSource = new EventSource(`/api/stream/${runId}`);
+
+  // Backend sends generic SSE messages; dispatch on the `type` field
+  currentSource.onmessage = e => {
+    let d; try { d = JSON.parse(e.data); } catch { return; }
+
+    if (d.type === 'progress') {
+      renderProgress(d);
+
+    } else if (d.type === 'status') {
+      setStatus(d.message);
+
+    } else if (d.type === 'report') {
+      setStatus(d.agent + ' completed');
+      reports[d.field] = { label: d.agent, content: d.content };
+      addTab(d.field, d.agent);
+      updateTabContent(d.field);
+
+      const stageKey = FIELD_TO_STAGE[d.field];
+      if (stageKey) {
+        updateStage(stageKey, 'done');
+        // Research Manager completion implicitly means Bull + Bear finished
+        if (stageKey === 'research_mgr') { updateStage('bull','done'); updateStage('bear','done'); }
+        // Portfolio Manager completion means all risk agents finished
+        if (stageKey === 'portfolio')    { ['aggressive','conservative','neutral'].forEach(k => updateStage(k,'done')); }
+      }
+      markNextRunning(stageKey, analysts);
+
+    } else if (d.type === 'complete') {
+      stopGlobalTimer();
+      setStatus('Analysis complete ✓');
+      document.getElementById('activityPanel').classList.add('hidden');
+      showDecisionCard(d.ticker, d.date, d.decision, d.stats);
+      currentSource.close();
+      resetBtn();
+      PIPELINE_STAGES.forEach(s => { if (stageStatus[s.key] !== 'done') updateStage(s.key,'done'); });
+
+    } else if (d.type === 'error') {
+      stopGlobalTimer();
+      setStatus('⚠ ' + d.message);
+      alert('Error: ' + (d.message || 'Unknown error'));
+      currentSource.close(); resetBtn();
+
+    } else if (d.type === 'done') {
+      currentSource.close();
+    }
+  };
+  currentSource.onerror = () => { resetBtn(); };
+}
+
+function markNextRunning(completedKey, selectedAnalysts) {
+  const order = [
+    ...['market','social','news','fundamentals'].filter(a => selectedAnalysts.includes(a)),
+    'bull','bear','research_mgr','trader','aggressive','conservative','neutral','portfolio',
+  ];
+  const idx = order.indexOf(completedKey);
+  if (idx >= 0 && idx + 1 < order.length) {
+    const next = order[idx + 1];
+    if (stageStatus[next] === 'pending') updateStage(next, 'running');
+  }
+}
+
+function showDecisionCard(ticker, date, signal, stats) {
+  const card = document.getElementById('decisionCard');
+  card.classList.remove('hidden');
+  document.getElementById('decisionTicker').textContent = ticker;
+  document.getElementById('decisionDate').textContent   = `Analysis date: ${date}`;
+
+  const badge = document.getElementById('ratingBadge');
+  const style  = RATING_STYLES[signal] || RATING_STYLES['Hold'];
+  badge.className  = `text-2xl font-bold px-6 py-3 rounded-xl border ${style.bg} ${style.border} ${style.text}`;
+  badge.textContent = signal;
+
+  // Summary: first few meaningful lines of the final decision
+  const decision = reports['final_trade_decision']?.content || '';
+  const summary  = decision.split('\n').filter(l => l.trim()).slice(0, 4).join('\n');
+  document.getElementById('decisionSummary').innerHTML = marked.parse(summary);
+
+  // Show run stats if available
+  if (stats) {
+    const fmt = n => n >= 1000 ? (n/1000).toFixed(1)+'k' : String(n||0);
+    document.getElementById('runStats').textContent =
+      `LLM calls: ${stats.llm_calls}  ·  Tool calls: ${stats.tool_calls}  ·  Tokens in: ${fmt(stats.tokens_in)}  ·  Tokens out: ${fmt(stats.tokens_out)}`;
+    document.getElementById('runStats').classList.remove('hidden');
+  }
+
+  // Auto-switch to final decision tab
+  if (reports['final_trade_decision']) showTab('final_trade_decision');
+}
+
+function setStatus(msg) {
+  const el = document.getElementById('statusText');
+  if (el) el.textContent = msg;
+}
+
+function resetBtn() {
+  const btn = document.getElementById('runBtn');
+  btn.disabled = false; btn.textContent = 'Run Analysis';
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
- Add WebUI section to README with usage instructions
- Document tradingagents-web command and python -m webui alternative
- Add features: live progress, configuration, streaming reports, session management
- Document REST API endpoints (GET /, GET /api/models, POST /api/analyze, GET /api/stream)
- Include example programmatic usage with SSE streaming