### PR TITLE
feat(fundamentals): add earnings-context tool for catalyst awareness (#561)

### DIFF
--- a/tests/test_earnings_context.py
+++ b/tests/test_earnings_context.py
@@ -1,0 +1,216 @@
+"""Tests for the earnings-context tool (issue #561).
+
+The tool synthesises four yfinance surfaces (calendar, earnings_estimate,
+revenue_estimate, earnings_history, recommendations_summary) into a single
+markdown string for the Fundamentals Analyst. These tests mock yf.Ticker so
+the suite stays offline and verify:
+
+- All four sections render with realistic synthetic data
+- The surprise-history section is look-ahead-safe (filtered <= curr_date)
+- "Next earnings event" picks the first scheduled date >= curr_date
+- The near-earnings flag flips correctly at the window boundary
+- Each yfinance attribute can fail independently without nuking the report
+- Empty / missing data degrades to "(unavailable)" instead of raising
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from tradingagents.dataflows.y_finance import get_earnings_context
+
+
+def _eps_estimate_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "avg": [2.31, 2.55, 9.10, 10.20],
+            "low": [2.10, 2.30, 8.75, 9.50],
+            "high": [2.50, 2.80, 9.45, 10.90],
+            "numberOfAnalysts": [28, 27, 30, 25],
+            "growth": [0.12, 0.14, 0.10, 0.12],
+        },
+        index=["0q", "+1q", "0y", "+1y"],
+    )
+
+
+def _revenue_estimate_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "avg": [95_200_000_000, 102_500_000_000, 410_000_000_000, 450_000_000_000],
+            "low": [92_000_000_000, 99_000_000_000, 400_000_000_000, 440_000_000_000],
+            "high": [98_500_000_000, 105_000_000_000, 420_000_000_000, 462_000_000_000],
+            "numberOfAnalysts": [28, 27, 30, 25],
+            "growth": [0.08, 0.09, 0.07, 0.10],
+        },
+        index=["0q", "+1q", "0y", "+1y"],
+    )
+
+
+def _earnings_history_df() -> pd.DataFrame:
+    """Five quarters; only four end on/before 2026-01-15 (the look-ahead cutoff)."""
+    return pd.DataFrame(
+        {
+            "epsEstimate": [1.20, 1.30, 1.40, 1.45, 1.60],
+            "epsActual":   [1.25, 1.32, 1.41, 1.52, 1.55],
+            "surprisePercent": [0.0417, 0.0154, 0.0071, 0.0483, -0.0313],
+        },
+        index=pd.to_datetime([
+            "2024-12-31", "2025-03-31", "2025-06-30", "2025-09-30", "2026-03-31",
+        ]),
+    )
+
+
+def _recommendations_summary_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "period": ["0m", "-1m", "-2m", "-3m"],
+            "strongBuy": [12, 11, 10, 9],
+            "buy": [18, 19, 17, 18],
+            "hold": [6, 7, 8, 9],
+            "sell": [1, 1, 2, 2],
+            "strongSell": [0, 0, 1, 1],
+        }
+    )
+
+
+def _build_mock_ticker(**overrides) -> MagicMock:
+    """Build a MagicMock with realistic yfinance attribute defaults; overrides win."""
+    defaults = {
+        "calendar": {"Earnings Date": [pd.Timestamp("2026-01-30")]},
+        "earnings_estimate": _eps_estimate_df(),
+        "revenue_estimate": _revenue_estimate_df(),
+        "earnings_history": _earnings_history_df(),
+        "recommendations_summary": _recommendations_summary_df(),
+        "recommendations": None,
+    }
+    defaults.update(overrides)
+    m = MagicMock()
+    for attr, value in defaults.items():
+        setattr(m, attr, value)
+    return m
+
+
+@pytest.mark.unit
+class TestEarningsContext:
+    def test_full_render_contains_all_sections(self):
+        mock_ticker = _build_mock_ticker()
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+
+        assert "# Earnings Context for AAPL (as of 2026-01-15)" in out
+        assert "## Next Earnings Event" in out
+        assert "## Consensus Estimates (upcoming periods)" in out
+        assert "### EPS" in out
+        assert "### Revenue" in out
+        assert "## Earnings Surprise History" in out
+        assert "## Analyst Recommendations Snapshot" in out
+
+    def test_ticker_uppercased_for_yfinance(self):
+        mock_ticker = _build_mock_ticker()
+        with patch(
+            "tradingagents.dataflows.y_finance.yf.Ticker",
+            return_value=mock_ticker,
+        ) as cls:
+            get_earnings_context("aapl", "2026-01-15")
+        cls.assert_called_once_with("AAPL")
+
+    def test_surprise_history_excludes_dates_after_curr_date(self):
+        """Quarter ending 2026-03-31 is after curr_date 2026-01-15 — must be omitted."""
+        mock_ticker = _build_mock_ticker()
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "2026-03-31" not in out
+        # All four eligible periods are present.
+        for ts in ("2024-12-31", "2025-03-31", "2025-06-30", "2025-09-30"):
+            assert ts in out
+
+    def test_next_earnings_picks_first_date_on_or_after_curr_date(self):
+        """Past dates in the calendar list are skipped; first future date wins."""
+        mock_ticker = _build_mock_ticker(
+            calendar={"Earnings Date": [
+                pd.Timestamp("2025-10-30"),  # past — skip
+                pd.Timestamp("2026-04-25"),  # second future
+                pd.Timestamp("2026-01-30"),  # first future
+            ]},
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "Date: 2026-01-30" in out
+        assert "Date: 2026-04-25" not in out
+
+    def test_near_earnings_flag_yes_inside_window(self):
+        mock_ticker = _build_mock_ticker(
+            calendar={"Earnings Date": [pd.Timestamp("2026-01-20")]},  # 3 business days from Jan 15 (Thu)
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "Near earnings (within 5 trading days): YES" in out
+
+    def test_near_earnings_flag_no_outside_window(self):
+        mock_ticker = _build_mock_ticker(
+            calendar={"Earnings Date": [pd.Timestamp("2026-02-15")]},  # ~22 business days out
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "Near earnings (within 5 trading days): NO" in out
+
+    def test_no_upcoming_earnings_handled(self):
+        mock_ticker = _build_mock_ticker(
+            calendar={"Earnings Date": [pd.Timestamp("2024-01-01")]},  # only a past date
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "No upcoming earnings date scheduled." in out
+
+    def test_empty_calendar_dict_handled(self):
+        mock_ticker = _build_mock_ticker(calendar={})
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "No upcoming earnings date scheduled." in out
+
+    def test_section_failure_is_isolated(self):
+        """If a single yfinance surface raises, only its section degrades."""
+        class _Raiser:
+            def __getattr__(self, name):
+                raise RuntimeError(f"yfinance exploded on {name}")
+
+        m = _build_mock_ticker()
+        # Use a property-like raiser only for earnings_history; other sections must still render.
+        type(m).earnings_history = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=m):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+
+        # Surprise history section degraded
+        assert "## Earnings Surprise History" in out
+        assert "(unavailable)" in out
+        # But the other three sections still rendered
+        assert "Date: 2026-01-30" in out
+        assert "### EPS" in out
+        assert "## Analyst Recommendations Snapshot" in out
+        assert "| 0m |" in out
+
+    def test_recommendations_fallback_to_recommendations_when_summary_empty(self):
+        mock_ticker = _build_mock_ticker(
+            recommendations_summary=pd.DataFrame(),
+            recommendations=_recommendations_summary_df(),
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "## Analyst Recommendations Snapshot" in out
+        assert "| 0m |" in out
+
+    def test_returns_string_always(self):
+        mock_ticker = _build_mock_ticker()
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert isinstance(out, str)
+
+    def test_curr_date_defaults_to_today_when_none(self):
+        mock_ticker = _build_mock_ticker()
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", None)
+        # Header is well-formed and dated; we don't assert the exact date to keep
+        # the test stable across days.
+        assert out.startswith("# Earnings Context for AAPL (as of ")

--- a/tests/test_earnings_context.py
+++ b/tests/test_earnings_context.py
@@ -214,3 +214,44 @@ class TestEarningsContext:
         # Header is well-formed and dated; we don't assert the exact date to keep
         # the test stable across days.
         assert out.startswith("# Earnings Context for AAPL (as of ")
+
+    def test_handles_tz_aware_calendar_dates(self):
+        """yfinance returns tz-aware Earnings Date Timestamps for most US tickers.
+
+        Comparing tz-aware vs tz-naive raises TypeError, so the tool must strip
+        tz info before filtering. Without this fix, the call would crash on
+        real AAPL / NVDA data.
+        """
+        mock_ticker = _build_mock_ticker(
+            calendar={"Earnings Date": [
+                pd.Timestamp("2025-10-30", tz="US/Eastern"),  # past — skip
+                pd.Timestamp("2026-01-30", tz="US/Eastern"),  # first future
+                pd.Timestamp("2026-04-25", tz="US/Eastern"),  # later future
+            ]},
+        )
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        assert "Date: 2026-01-30" in out
+        assert "(unavailable)" not in out.split("## Next Earnings Event")[1].split("##")[0]
+
+    def test_handles_tz_aware_earnings_history_index(self):
+        """yfinance returns tz-aware DatetimeIndex on earnings_history for US tickers."""
+        history = pd.DataFrame(
+            {
+                "epsEstimate": [1.20, 1.30, 1.40, 1.45, 1.60],
+                "epsActual":   [1.25, 1.32, 1.41, 1.52, 1.55],
+                "surprisePercent": [0.0417, 0.0154, 0.0071, 0.0483, -0.0313],
+            },
+            index=pd.DatetimeIndex(
+                ["2024-12-31", "2025-03-31", "2025-06-30", "2025-09-30", "2026-03-31"],
+                tz="US/Eastern",
+            ),
+        )
+        mock_ticker = _build_mock_ticker(earnings_history=history)
+        with patch("tradingagents.dataflows.y_finance.yf.Ticker", return_value=mock_ticker):
+            out = get_earnings_context("AAPL", "2026-01-15", 5)
+        # Look-ahead filter still works through the tz fix.
+        assert "2026-03-31" not in out
+        # And the eligible quarters still render.
+        for ts in ("2024-12-31", "2025-03-31", "2025-06-30", "2025-09-30"):
+            assert ts in out

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -3,6 +3,7 @@ from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_balance_sheet,
     get_cashflow,
+    get_earnings_context,
     get_fundamentals,
     get_income_statement,
     get_insider_transactions,
@@ -21,12 +22,13 @@ def create_fundamentals_analyst(llm):
             get_balance_sheet,
             get_cashflow,
             get_income_statement,
+            get_earnings_context,
         ]
 
         system_message = (
             "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
             + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
-            + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
+            + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements, and `get_earnings_context` for upcoming-earnings catalyst awareness (next earnings date, consensus EPS/revenue, surprise history, analyst ratings)."
             + get_language_instruction(),
         )
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -11,7 +11,8 @@ from tradingagents.agents.utils.fundamental_data_tools import (
     get_fundamentals,
     get_balance_sheet,
     get_cashflow,
-    get_income_statement
+    get_income_statement,
+    get_earnings_context
 )
 from tradingagents.agents.utils.news_data_tools import (
     get_news,

--- a/tradingagents/agents/utils/fundamental_data_tools.py
+++ b/tradingagents/agents/utils/fundamental_data_tools.py
@@ -75,3 +75,25 @@ def get_income_statement(
         str: A formatted report containing income statement data
     """
     return route_to_vendor("get_income_statement", ticker, freq, curr_date)
+
+
+@tool
+def get_earnings_context(
+    ticker: Annotated[str, "ticker symbol"],
+    curr_date: Annotated[str, "current date you are trading at, yyyy-mm-dd"],
+    near_earnings_window: Annotated[int, "trading-day threshold for the 'near earnings' flag"] = 5,
+) -> str:
+    """
+    Retrieve earnings calendar awareness for a given ticker: next earnings
+    date, consensus EPS and revenue estimates, recent surprise history, and
+    sell-side analyst rating distribution. Use this when assessing whether
+    the analysis date falls close to a binary earnings catalyst.
+    Args:
+        ticker (str): Ticker symbol of the company
+        curr_date (str): Current date you are trading at, yyyy-mm-dd
+        near_earnings_window (int): Trading days from earnings to flag (default 5)
+    Returns:
+        str: A Markdown report covering catalyst proximity, consensus
+        estimates, surprise history, and analyst recommendations.
+    """
+    return route_to_vendor("get_earnings_context", ticker, curr_date, near_earnings_window)

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -9,6 +9,7 @@ from .y_finance import (
     get_cashflow as get_yfinance_cashflow,
     get_income_statement as get_yfinance_income_statement,
     get_insider_transactions as get_yfinance_insider_transactions,
+    get_earnings_context as get_yfinance_earnings_context,
 )
 from .yfinance_news import get_news_yfinance, get_global_news_yfinance
 from .alpha_vantage import (
@@ -47,7 +48,8 @@ TOOLS_CATEGORIES = {
             "get_fundamentals",
             "get_balance_sheet",
             "get_cashflow",
-            "get_income_statement"
+            "get_income_statement",
+            "get_earnings_context",
         ]
     },
     "news_data": {
@@ -93,6 +95,9 @@ VENDOR_METHODS = {
     "get_income_statement": {
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
+    },
+    "get_earnings_context": {
+        "yfinance": get_yfinance_earnings_context,
     },
     # news_data
     "get_news": {

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -497,10 +497,10 @@ def get_earnings_context(
     try:
         calendar = yf_retry(lambda: ticker_obj.calendar) or {}
         raw_dates = calendar.get("Earnings Date") or []
-        future = sorted(
-            d for d in (pd.to_datetime(x, errors="coerce") for x in raw_dates)
-            if pd.notna(d) and d >= curr_ts
-        )
+        dates_idx = pd.to_datetime(list(raw_dates), errors="coerce")
+        if getattr(dates_idx, "tz", None) is not None:
+            dates_idx = dates_idx.tz_localize(None)
+        future = sorted(d for d in dates_idx if pd.notna(d) and d >= curr_ts)
         if future:
             next_date = future[0]
             td_until = max(0, len(pd.bdate_range(start=curr_ts, end=next_date)) - 1)
@@ -542,8 +542,11 @@ def get_earnings_context(
         if history is not None and not history.empty:
             hist = history.copy()
             hist.index = pd.to_datetime(hist.index, errors="coerce")
-            hist = hist.dropna(axis=0, subset=hist.columns[:0].union(hist.columns))
-            hist = hist[hist.index <= curr_ts].sort_index(ascending=False).head(4)
+            if getattr(hist.index, "tz", None) is not None:
+                hist.index = hist.index.tz_localize(None)
+            hist = hist[hist.index.notna() & (hist.index <= curr_ts)].sort_index(
+                ascending=False
+            ).head(4)
             if not hist.empty:
                 sections.append("| Quarter Ended | Estimate | Actual | Surprise |")
                 sections.append("|---|---|---|---|")

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -420,3 +420,168 @@ def get_insider_transactions(
         
     except Exception as e:
         return f"Error retrieving insider transactions for {ticker}: {str(e)}"
+
+
+def _fmt_num(value, as_int: bool = False) -> str:
+    """Format a numeric value for the markdown tables; 'n/a' when missing."""
+    if value is None:
+        return "n/a"
+    try:
+        if pd.isna(value):
+            return "n/a"
+    except (TypeError, ValueError):
+        return str(value)
+    try:
+        return f"{int(value)}" if as_int else f"{float(value):,.2f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _fmt_pct(value) -> str:
+    """Format a fractional value (e.g. 0.048) as a signed percentage string."""
+    if value is None:
+        return "n/a"
+    try:
+        if pd.isna(value):
+            return "n/a"
+        return f"{float(value):+.2%}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _render_estimates_table(estimates_df, header_label: str) -> list:
+    """Render a yfinance estimates DataFrame (earnings_estimate / revenue_estimate) as markdown."""
+    lines = [
+        f"### {header_label}",
+        "| Period | Avg | Low | High | # Analysts | YoY Growth |",
+        "|---|---|---|---|---|---|",
+    ]
+    for period, row in estimates_df.iterrows():
+        lines.append(
+            f"| {period} "
+            f"| {_fmt_num(row.get('avg'))} "
+            f"| {_fmt_num(row.get('low'))} "
+            f"| {_fmt_num(row.get('high'))} "
+            f"| {_fmt_num(row.get('numberOfAnalysts'), as_int=True)} "
+            f"| {_fmt_pct(row.get('growth'))} |"
+        )
+    return lines
+
+
+def get_earnings_context(
+    ticker: Annotated[str, "ticker symbol of the company"],
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None,
+    near_earnings_window: Annotated[int, "trading-day threshold for the 'near earnings' flag"] = 5,
+) -> str:
+    """Earnings calendar awareness: next event, consensus, surprises, recommendations.
+
+    Returns one markdown string with four sections so the Fundamentals Analyst
+    can reason about catalyst risk near earnings releases. The surprise history
+    is filtered to fiscal periods ending on or before ``curr_date`` to prevent
+    look-ahead bias; consensus estimates and recommendation counts come from
+    yfinance as a current snapshot (yfinance does not expose historical
+    snapshots of these series).
+    """
+    ticker_upper = ticker.upper()
+    curr_ts = pd.to_datetime(curr_date) if curr_date else pd.Timestamp.today().normalize()
+
+    sections = [f"# Earnings Context for {ticker_upper} (as of {curr_ts.strftime('%Y-%m-%d')})"]
+
+    try:
+        ticker_obj = yf.Ticker(ticker_upper)
+    except Exception as e:
+        return f"Error retrieving earnings context for {ticker}: {e}"
+
+    # --- Next earnings event ---
+    sections.append("\n## Next Earnings Event")
+    try:
+        calendar = yf_retry(lambda: ticker_obj.calendar) or {}
+        raw_dates = calendar.get("Earnings Date") or []
+        future = sorted(
+            d for d in (pd.to_datetime(x, errors="coerce") for x in raw_dates)
+            if pd.notna(d) and d >= curr_ts
+        )
+        if future:
+            next_date = future[0]
+            td_until = max(0, len(pd.bdate_range(start=curr_ts, end=next_date)) - 1)
+            is_near = td_until <= near_earnings_window
+            sections.append(f"- Date: {next_date.strftime('%Y-%m-%d')}")
+            sections.append(f"- Trading days until: {td_until}")
+            sections.append(
+                f"- Near earnings (within {near_earnings_window} trading days): "
+                + ("YES — elevated catalyst risk" if is_near else "NO")
+            )
+        else:
+            sections.append("- No upcoming earnings date scheduled.")
+    except Exception:
+        sections.append("- (unavailable)")
+
+    # --- Consensus estimates (EPS + revenue, upcoming quarters) ---
+    sections.append("\n## Consensus Estimates (upcoming periods)")
+    try:
+        eps_est = yf_retry(lambda: ticker_obj.earnings_estimate)
+        if eps_est is not None and not eps_est.empty:
+            sections.extend(_render_estimates_table(eps_est, "EPS"))
+        else:
+            sections.append("### EPS\n- (unavailable)")
+    except Exception:
+        sections.append("### EPS\n- (unavailable)")
+    try:
+        rev_est = yf_retry(lambda: ticker_obj.revenue_estimate)
+        if rev_est is not None and not rev_est.empty:
+            sections.extend(_render_estimates_table(rev_est, "Revenue"))
+        else:
+            sections.append("### Revenue\n- (unavailable)")
+    except Exception:
+        sections.append("### Revenue\n- (unavailable)")
+
+    # --- Earnings surprise history (look-ahead-safe) ---
+    sections.append(f"\n## Earnings Surprise History (≤ {curr_ts.strftime('%Y-%m-%d')})")
+    try:
+        history = yf_retry(lambda: ticker_obj.earnings_history)
+        if history is not None and not history.empty:
+            hist = history.copy()
+            hist.index = pd.to_datetime(hist.index, errors="coerce")
+            hist = hist.dropna(axis=0, subset=hist.columns[:0].union(hist.columns))
+            hist = hist[hist.index <= curr_ts].sort_index(ascending=False).head(4)
+            if not hist.empty:
+                sections.append("| Quarter Ended | Estimate | Actual | Surprise |")
+                sections.append("|---|---|---|---|")
+                for ts, row in hist.iterrows():
+                    sections.append(
+                        f"| {pd.Timestamp(ts).strftime('%Y-%m-%d')} "
+                        f"| {_fmt_num(row.get('epsEstimate'))} "
+                        f"| {_fmt_num(row.get('epsActual'))} "
+                        f"| {_fmt_pct(row.get('surprisePercent'))} |"
+                    )
+            else:
+                sections.append("- (no reported earnings on or before curr_date)")
+        else:
+            sections.append("- (unavailable)")
+    except Exception:
+        sections.append("- (unavailable)")
+
+    # --- Analyst recommendations snapshot ---
+    sections.append("\n## Analyst Recommendations Snapshot")
+    try:
+        rec = yf_retry(lambda: ticker_obj.recommendations_summary)
+        if rec is None or (hasattr(rec, "empty") and rec.empty):
+            rec = yf_retry(lambda: ticker_obj.recommendations)
+        if rec is not None and not rec.empty:
+            sections.append("| Period | Strong Buy | Buy | Hold | Sell | Strong Sell |")
+            sections.append("|---|---|---|---|---|---|")
+            for _, row in rec.iterrows():
+                sections.append(
+                    f"| {row.get('period', '?')} "
+                    f"| {_fmt_num(row.get('strongBuy'), as_int=True)} "
+                    f"| {_fmt_num(row.get('buy'), as_int=True)} "
+                    f"| {_fmt_num(row.get('hold'), as_int=True)} "
+                    f"| {_fmt_num(row.get('sell'), as_int=True)} "
+                    f"| {_fmt_num(row.get('strongSell'), as_int=True)} |"
+                )
+        else:
+            sections.append("- (unavailable)")
+    except Exception:
+        sections.append("- (unavailable)")
+
+    return "\n".join(sections)

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -34,6 +34,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_balance_sheet,
     get_cashflow,
     get_income_statement,
+    get_earnings_context,
     get_news,
     get_insider_transactions,
     get_global_news
@@ -184,6 +185,7 @@ class TradingAgentsGraph:
                     get_balance_sheet,
                     get_cashflow,
                     get_income_statement,
+                    get_earnings_context,
                 ]
             ),
         }


### PR DESCRIPTION
  Closes #561.                                                                                                                                                                          
                                   
  ## What this adds                      

  A new `get_earnings_context(ticker, curr_date, near_earnings_window=5)` tool bound to the Fundamentals Analyst that surfaces:                                                         
                                                                   
  1. **Next earnings event** with a configurable "near earnings" flag, computed in trading days via `pandas.bdate_range`                                                                
  2. **Consensus estimates** — EPS and revenue, for upcoming quarters and full year
  3. **Earnings surprise history** — last 4 quarters, filtered to fiscal periods on or before `curr_date` (look-ahead-safe)                                                             
  4. **Sell-side analyst rating distribution** — Strong Buy / Buy / Hold / Sell / Strong Sell counts per period                                                                         
                                                                                                                                                                                        
  ## Why                                                                                                                                                                                
                                                                                                                                                                                        
  Per the issue: signals generated within ±5 trading days of earnings carry binary catalyst risk that current analysts can't reason about. Surfacing this lets the Portfolio Manager adjust position-sizing and conservatism near catalysts.
                
  ## Implementation notes                                                                                                                                                               
                
  - **yfinance only**, per the issue's "no new dependencies" constraint. The project's existing `route_to_vendor` fallback handles Alpha-Vantage-configured runs by falling through to  
  yfinance for this method.                                                                                                                                                             
  - **Look-ahead protection** is enforced on the surprise history (rows filtered to fiscal periods ≤ `curr_date`). Consensus estimates and recommendation counts are inherently a
  current snapshot — yfinance does not expose historical snapshots of those series.                                                                                                     
  - **Each yfinance surface fails independently**: if `recommendations_summary` raises but `calendar` succeeds, the report still renders the calendar section. The tool always returns a
   string, never raises.                 
  - **Trading-day approximation**: business days via `pandas.bdate_range`. Ignores market holidays; avoids adding `pandas-market-calendars` as a dependency.                            
   
  ## Files changed                                                                                                                                                                      
                                   
  | File | Change |                      
  |---|---|
  | `tradingagents/dataflows/y_finance.py` | New `get_earnings_context()` + 3 small formatting helpers |
  | `tradingagents/agents/utils/fundamental_data_tools.py` | New `@tool`-decorated wrapper |
  | `tradingagents/dataflows/interface.py` | Register in `TOOLS_CATEGORIES` and `VENDOR_METHODS` |
  | `tradingagents/agents/utils/agent_utils.py` | Re-export |       
  | `tradingagents/graph/trading_graph.py` | Add to fundamentals `ToolNode` |
  | `tradingagents/agents/analysts/fundamentals_analyst.py` | Add to tools list + mention in system prompt |
  | `tests/test_earnings_context.py` | 12 new unit tests, mocked yfinance |
                                                                                                                                                                                        
  ## Test plan  
                                                                                                                                                                                        
  - [x] `uv run pytest tests/test_earnings_context.py -v` — 12/12 pass                                                                                                                  
  - [x] `uv run pytest tests/` — 151/151 pass (1 skipped, network-dependent)                                                                                                            
  - [x] Manual smoke: `@tool` wrapper → `route_to_vendor` → yfinance impl produces valid markdown                                                                                       
  - [ ] Reviewer to verify against a live ticker if desired         
  
Snapshot from Live CLI:

<img width="1657" height="910" alt="image" src="https://github.com/user-attachments/assets/6ebc4b1a-5051-4f34-afe0-511494f8c859" />
