### PR TITLE
fix(analysts): move current_date to top of system prompt

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -27,7 +27,7 @@ def create_fundamentals_analyst(llm):
             "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
             + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
             + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
-            + get_language_instruction(),
+            + get_language_instruction()
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -41,7 +41,7 @@ def create_fundamentals_analyst(llm):
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    " You have access to the following tools: {tool_names}.\n{system_message}\n"
                     "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -34,6 +34,7 @@ def create_fundamentals_analyst(llm):
             [
                 (
                     "system",
+                    "Today's date is {current_date}. Use this date for all analysis and tool calls.\n"
                     "You are a helpful AI assistant, collaborating with other assistants."
                     " Use the provided tools to progress towards answering the question."
                     " If you are unable to fully answer, that's OK; another assistant with different tools"
@@ -41,7 +42,7 @@ def create_fundamentals_analyst(llm):
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
+                    "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -60,7 +60,7 @@ Volume-Based Indicators:
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    " You have access to the following tools: {tool_names}.\n{system_message}\n"
                     "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -53,6 +53,7 @@ Volume-Based Indicators:
             [
                 (
                     "system",
+                    "Today's date is {current_date}. Use this date for all analysis and tool calls.\n"
                     "You are a helpful AI assistant, collaborating with other assistants."
                     " Use the provided tools to progress towards answering the question."
                     " If you are unable to fully answer, that's OK; another assistant with different tools"
@@ -60,7 +61,7 @@ Volume-Based Indicators:
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
+                    "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -28,6 +28,7 @@ def create_news_analyst(llm):
             [
                 (
                     "system",
+                    "Today's date is {current_date}. Use this date for all analysis and tool calls.\n"
                     "You are a helpful AI assistant, collaborating with other assistants."
                     " Use the provided tools to progress towards answering the question."
                     " If you are unable to fully answer, that's OK; another assistant with different tools"
@@ -35,7 +36,7 @@ def create_news_analyst(llm):
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
+                    "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -35,7 +35,7 @@ def create_news_analyst(llm):
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
+                    " You have access to the following tools: {tool_names}.\n{system_message}\n"
                     "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -69,11 +69,12 @@ def create_sentiment_analyst(llm):
             [
                 (
                     "system",
+                    "Today's date is {current_date}. Use this date for all analysis and tool calls.\n"
                     "You are a helpful AI assistant, collaborating with other assistants."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     "\n{system_message}\n"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
+                    "{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]


### PR DESCRIPTION
## Problem

Ollama models (and small LLMs generally) default to their training-cutoff date when generating `start_date`/`end_date` arguments for tool calls (`get_stock_data`, `get_news`, `get_global_news`, etc.).

The date hint was buried at the end of a 500+ word system message:
```
"For your reference, the current date is {current_date}."
```
By the time the model processes this, its training-weight prior for "now" has already taken hold.

## Fix

Move the date instruction to the very first line of every analyst system message and use directive language:
```
"Today's date is {current_date}. Use this date for all analysis and tool calls."
```

This ensures the model reads the correct date before any other instructions, overriding its internal sense of "now" when generating tool call arguments.

## Affected files

- `tradingagents/agents/analysts/market_analyst.py`
- `tradingagents/agents/analysts/fundamentals_analyst.py`
- `tradingagents/agents/analysts/news_analyst.py`
- `tradingagents/agents/analysts/sentiment_analyst.py`