### PR TITLE
feat(llm): add Claude CLI provider for $0 LLM access via Max subscription

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -23,6 +23,7 @@ from rich.rule import Rule
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.progress import ProgressTracker, SECTION_TITLES
 from cli.models import AnalystType
 from cli.utils import *
 from cli.announcements import fetch_announcements, display_announcements
@@ -37,174 +38,113 @@ app = typer.Typer(
 )
 
 
-# Create a deque to store recent messages with a maximum length
 class MessageBuffer:
-    # Fixed teams that always run (not user-selectable)
-    FIXED_AGENTS = {
-        "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
-        "Trading Team": ["Trader"],
-        "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
-        "Portfolio Management": ["Portfolio Manager"],
-    }
+    """CLI-specific Rich TUI wrapper around the shared ProgressTracker.
 
-    # Analyst name mapping
-    ANALYST_MAPPING = {
-        "market": "Market Analyst",
-        "social": "Sentiment Analyst",
-        "news": "News Analyst",
-        "fundamentals": "Fundamentals Analyst",
-    }
+    Delegates thread-safe state storage to ``ProgressTracker`` while
+    keeping Rich-specific formatting (``current_report``, ``final_report``)
+    local.  The module-level ``message_buffer`` singleton exposes the same
+    public API the CLI already uses -- no call-site changes needed.
+    """
 
-    # Report section mapping: section -> (analyst_key for filtering, finalizing_agent)
-    # analyst_key: which analyst selection controls this section (None = always included)
-    # finalizing_agent: which agent must be "completed" for this report to count as done
-    REPORT_SECTIONS = {
-        "market_report": ("market", "Market Analyst"),
-        "sentiment_report": ("social", "Sentiment Analyst"),
-        "news_report": ("news", "News Analyst"),
-        "fundamentals_report": ("fundamentals", "Fundamentals Analyst"),
-        "investment_plan": (None, "Research Manager"),
-        "trader_investment_plan": (None, "Trader"),
-        "final_trade_decision": (None, "Portfolio Manager"),
-    }
+    def __init__(self, max_length: int = 100) -> None:
+        self._tracker = ProgressTracker(max_messages=max_length)
+        # CLI-only state (Rich panel formatting)
+        self.current_report: str | None = None
+        self.final_report: str | None = None
 
-    def __init__(self, max_length=100):
-        self.messages = deque(maxlen=max_length)
-        self.tool_calls = deque(maxlen=max_length)
-        self.current_report = None
-        self.final_report = None  # Store the complete final report
-        self.agent_status = {}
-        self.current_agent = None
-        self.report_sections = {}
-        self.selected_analysts = []
-        self._processed_message_ids = set()
+    # ── Backward-compatible property access ─────────────────────────
+    # CLI is single-threaded so direct access is safe. Desktop uses
+    # tracker.snapshot() instead.
 
-    def init_for_analysis(self, selected_analysts):
-        """Initialize agent status and report sections based on selected analysts.
+    @property
+    def tracker(self) -> ProgressTracker:
+        """Expose the underlying tracker for the desktop app."""
+        return self._tracker
 
-        Args:
-            selected_analysts: List of analyst type strings (e.g., ["market", "news"])
-        """
-        self.selected_analysts = [a.lower() for a in selected_analysts]
+    @property
+    def agent_status(self) -> dict[str, str]:
+        return self._tracker._agent_status
 
-        # Build agent_status dynamically
-        self.agent_status = {}
+    @property
+    def messages(self) -> deque:
+        return self._tracker._messages
 
-        # Add selected analysts
-        for analyst_key in self.selected_analysts:
-            if analyst_key in self.ANALYST_MAPPING:
-                self.agent_status[self.ANALYST_MAPPING[analyst_key]] = "pending"
+    @property
+    def tool_calls(self) -> deque:
+        return self._tracker._tool_calls
 
-        # Add fixed teams
-        for team_agents in self.FIXED_AGENTS.values():
-            for agent in team_agents:
-                self.agent_status[agent] = "pending"
+    @property
+    def current_agent(self) -> str | None:
+        return self._tracker._current_agent
 
-        # Build report_sections dynamically
-        self.report_sections = {}
-        for section, (analyst_key, _) in self.REPORT_SECTIONS.items():
-            if analyst_key is None or analyst_key in self.selected_analysts:
-                self.report_sections[section] = None
+    @property
+    def report_sections(self) -> dict[str, str | None]:
+        return self._tracker._report_sections
 
-        # Reset other state
+    @property
+    def selected_analysts(self) -> list[str]:
+        return self._tracker._selected_analysts
+
+    # ── Delegated write methods ─────────────────────────────────────
+
+    def init_for_analysis(self, selected_analysts: list[str]) -> None:
+        """Reset and configure for a new analysis run."""
+        self._tracker.init_for_analysis(selected_analysts)
         self.current_report = None
         self.final_report = None
-        self.current_agent = None
-        self.messages.clear()
-        self.tool_calls.clear()
-        self._processed_message_ids.clear()
 
-    def get_completed_reports_count(self):
-        """Count reports that are finalized (their finalizing agent is completed).
+    def add_message(self, message_type: str, content: str) -> None:
+        self._tracker.add_message(message_type, content)
 
-        A report is considered complete when:
-        1. The report section has content (not None), AND
-        2. The agent responsible for finalizing that report has status "completed"
+    def add_tool_call(self, tool_name: str, args: object) -> None:
+        self._tracker.add_tool_call(tool_name, args)
 
-        This prevents interim updates (like debate rounds) from counting as completed.
-        """
-        count = 0
-        for section in self.report_sections:
-            if section not in self.REPORT_SECTIONS:
-                continue
-            _, finalizing_agent = self.REPORT_SECTIONS[section]
-            # Report is complete if it has content AND its finalizing agent is done
-            has_content = self.report_sections.get(section) is not None
-            agent_done = self.agent_status.get(finalizing_agent) == "completed"
-            if has_content and agent_done:
-                count += 1
-        return count
+    def update_agent_status(self, agent: str, status: str) -> None:
+        self._tracker.update_agent_status(agent, status)
 
-    def add_message(self, message_type, content):
-        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
-        self.messages.append((timestamp, message_type, content))
+    def update_report_section(self, section_name: str, content: str) -> None:
+        self._tracker.update_report_section(section_name, content)
+        self._update_current_report()
 
-    def add_tool_call(self, tool_name, args):
-        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
-        self.tool_calls.append((timestamp, tool_name, args))
+    def has_seen_message(self, message_id: str) -> bool:
+        """Check and mark a message ID as processed (deduplication)."""
+        return self._tracker.has_seen_message(message_id)
 
-    def update_agent_status(self, agent, status):
-        if agent in self.agent_status:
-            self.agent_status[agent] = status
-            self.current_agent = agent
+    def get_completed_reports_count(self) -> int:
+        return self._tracker.get_completed_reports_count()
 
-    def update_report_section(self, section_name, content):
-        if section_name in self.report_sections:
-            self.report_sections[section_name] = content
-            self._update_current_report()
+    # ── CLI-specific Rich formatting ────────────────────────────────
 
-    def _update_current_report(self):
-        # For the panel display, only show the most recently updated section
+    def _update_current_report(self) -> None:
+        """Update the Rich panel with the most recently written section."""
         latest_section = None
         latest_content = None
 
-        # Find the most recently updated section
         for section, content in self.report_sections.items():
             if content is not None:
                 latest_section = section
                 latest_content = content
-               
-        if latest_section and latest_content:
-            # Format the current section for display
-            section_titles = {
-                "market_report": "Market Analysis",
-                "sentiment_report": "Social Sentiment",
-                "news_report": "News Analysis",
-                "fundamentals_report": "Fundamentals Analysis",
-                "investment_plan": "Research Team Decision",
-                "trader_investment_plan": "Trading Team Plan",
-                "final_trade_decision": "Portfolio Management Decision",
-            }
-            self.current_report = (
-                f"### {section_titles[latest_section]}\n{latest_content}"
-            )
 
-        # Update the final complete report
+        if latest_section and latest_content:
+            title = SECTION_TITLES.get(latest_section, latest_section)
+            self.current_report = f"### {title}\n{latest_content}"
+
         self._update_final_report()
 
-    def _update_final_report(self):
-        report_parts = []
+    def _update_final_report(self) -> None:
+        """Rebuild the full concatenated report for end-of-run display."""
+        report_parts: list[str] = []
 
-        # Analyst Team Reports - use .get() to handle missing sections
+        # Analyst Team Reports
         analyst_sections = ["market_report", "sentiment_report", "news_report", "fundamentals_report"]
         if any(self.report_sections.get(section) for section in analyst_sections):
             report_parts.append("## Analyst Team Reports")
-            if self.report_sections.get("market_report"):
-                report_parts.append(
-                    f"### Market Analysis\n{self.report_sections['market_report']}"
-                )
-            if self.report_sections.get("sentiment_report"):
-                report_parts.append(
-                    f"### Social Sentiment\n{self.report_sections['sentiment_report']}"
-                )
-            if self.report_sections.get("news_report"):
-                report_parts.append(
-                    f"### News Analysis\n{self.report_sections['news_report']}"
-                )
-            if self.report_sections.get("fundamentals_report"):
-                report_parts.append(
-                    f"### Fundamentals Analysis\n{self.report_sections['fundamentals_report']}"
-                )
+            for section_key in analyst_sections:
+                content = self.report_sections.get(section_key)
+                if content:
+                    title = SECTION_TITLES.get(section_key, section_key)
+                    report_parts.append(f"### {title}\n{content}")
 
         # Research Team Reports
         if self.report_sections.get("investment_plan"):
@@ -1131,9 +1071,8 @@ def run_analysis(checkpoint: bool = False):
             for message in chunk.get("messages", []):
                 msg_id = getattr(message, "id", None)
                 if msg_id is not None:
-                    if msg_id in message_buffer._processed_message_ids:
+                    if message_buffer.has_seen_message(msg_id):
                         continue
-                    message_buffer._processed_message_ids.add(msg_id)
 
                 msg_type, content = classify_message_type(message)
                 if content and content.strip():

--- a/cli/main.py
+++ b/cli/main.py
@@ -578,8 +578,30 @@ def get_user_selections():
             )
             raise typer.Exit(1)
         console.print("[green]✓ Claude CLI detected. Using Max subscription (no API key needed).[/green]")
-        selected_shallow_thinker = "default"
-        selected_deep_thinker = "default"
+
+        # Model selection for Claude CLI — Opus only
+        _CLI_MODELS = [
+            ("Claude Opus 4.6", "claude-opus-4-20250514"),
+            ("Claude Opus 4.7 Max", "claude-opus-4-20250715"),
+        ]
+        console.print(
+            create_question_box(
+                "Step 7",
+                "Select Claude model",
+                "Both models use your Max subscription at $0 cost.",
+            )
+        )
+        cli_model_choice = questionary.select(
+            "Select model:",
+            choices=[name for name, _ in _CLI_MODELS],
+            style=custom_style,
+        ).ask()
+        if cli_model_choice is None:
+            raise typer.Exit(0)
+        cli_model_id = next(mid for name, mid in _CLI_MODELS if name == cli_model_choice)
+
+        selected_shallow_thinker = cli_model_id
+        selected_deep_thinker = cli_model_id
         thinking_level = None
         reasoning_effort = None
         anthropic_effort = None

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import datetime
+import shutil
 import typer
 import questionary
 from pathlib import Path
@@ -567,50 +568,66 @@ def get_user_selections():
     if selected_llm_provider == "ollama":
         confirm_ollama_endpoint(backend_url)
 
-    # Confirm the provider's API key is present; prompt the user to paste
-    # one and persist it to .env if it's missing, so the analysis run
-    # doesn't fail later at the first API call.
-    ensure_api_key(selected_llm_provider)
+    # Claude CLI uses the existing 'claude auth login' session — no API key
+    # and no model selection needed (uses the user's CLI session default).
+    if selected_llm_provider == "claude_cli":
+        if shutil.which("claude") is None:
+            console.print(
+                "[red]Error: 'claude' CLI not found on PATH.[/red]\n"
+                "[yellow]Install Claude Code and run 'claude auth login' first.[/yellow]"
+            )
+            raise typer.Exit(1)
+        console.print("[green]✓ Claude CLI detected. Using Max subscription (no API key needed).[/green]")
+        selected_shallow_thinker = "default"
+        selected_deep_thinker = "default"
+        thinking_level = None
+        reasoning_effort = None
+        anthropic_effort = None
+    else:
+        # Confirm the provider's API key is present; prompt the user to paste
+        # one and persist it to .env if it's missing, so the analysis run
+        # doesn't fail later at the first API call.
+        ensure_api_key(selected_llm_provider)
 
-    # Step 7: Thinking agents
-    console.print(
-        create_question_box(
-            "Step 7: Thinking Agents", "Select your thinking agents for analysis"
-        )
-    )
-    selected_shallow_thinker = select_shallow_thinking_agent(selected_llm_provider)
-    selected_deep_thinker = select_deep_thinking_agent(selected_llm_provider)
-
-    # Step 8: Provider-specific thinking configuration
-    thinking_level = None
-    reasoning_effort = None
-    anthropic_effort = None
-
-    provider_lower = selected_llm_provider.lower()
-    if provider_lower == "google":
+        # Step 7: Thinking agents
         console.print(
             create_question_box(
-                "Step 8: Thinking Mode",
-                "Configure Gemini thinking mode"
+                "Step 7: Thinking Agents", "Select your thinking agents for analysis"
             )
         )
-        thinking_level = ask_gemini_thinking_config()
-    elif provider_lower == "openai":
-        console.print(
-            create_question_box(
-                "Step 8: Reasoning Effort",
-                "Configure OpenAI reasoning effort level"
+        selected_shallow_thinker = select_shallow_thinking_agent(selected_llm_provider)
+        selected_deep_thinker = select_deep_thinking_agent(selected_llm_provider)
+
+        # Step 8: Provider-specific thinking configuration
+        thinking_level = None
+        reasoning_effort = None
+        anthropic_effort = None
+
+        provider_lower = selected_llm_provider.lower()
+        if provider_lower == "google":
+            console.print(
+                create_question_box(
+                    "Step 8: Thinking Mode",
+                    "Configure Gemini thinking mode"
+                )
             )
-        )
-        reasoning_effort = ask_openai_reasoning_effort()
-    elif provider_lower == "anthropic":
-        console.print(
-            create_question_box(
-                "Step 8: Effort Level",
-                "Configure Claude effort level"
+            thinking_level = ask_gemini_thinking_config()
+        elif provider_lower == "openai":
+            console.print(
+                create_question_box(
+                    "Step 8: Reasoning Effort",
+                    "Configure OpenAI reasoning effort level"
+                )
             )
-        )
-        anthropic_effort = ask_anthropic_effort()
+            reasoning_effort = ask_openai_reasoning_effort()
+        elif provider_lower == "anthropic":
+            console.print(
+                create_question_box(
+                    "Step 8: Effort Level",
+                    "Configure Claude effort level"
+                )
+            )
+            anthropic_effort = ask_anthropic_effort()
 
     return {
         "ticker": selected_ticker,

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -251,6 +251,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", ollama_url),
+        ("Claude CLI (Max subscription, $0 cost)", "claude_cli", None),
     ]
 
     choice = questionary.select(

--- a/desktop/__main__.py
+++ b/desktop/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point: ``python -m desktop``."""
+
+from desktop.app import run_app
+
+run_app()

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -26,7 +26,10 @@ logger = logging.getLogger(__name__)
 
 _ASSETS = Path(__file__).parent / "assets"
 db = HistoryDB()
-runner = PipelineRunner()
+
+# Read watchdog timeout from user settings (defaults to 900s if not set)
+_watchdog_timeout = int(db.get_setting("watchdog_timeout", "900") or "900")
+runner = PipelineRunner(watchdog_timeout=_watchdog_timeout)
 
 # Mark any analyses stuck in "running" from a previous crashed session.
 for _stale in db.list_analyses(status="running"):

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -28,7 +28,7 @@ _ASSETS = Path(__file__).parent / "assets"
 db = HistoryDB()
 
 # Read watchdog timeout from user settings (defaults to 900s if not set)
-_watchdog_timeout = int(db.get_setting("watchdog_timeout", "900") or "900")
+_watchdog_timeout = int(db.get_setting("watchdog_timeout", "1200") or "1200")
 runner = PipelineRunner(watchdog_timeout=_watchdog_timeout)
 
 # Mark any analyses stuck in "running" from a previous crashed session.

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -285,13 +285,17 @@ runner.on_finished = on_pipeline_finished
 
 
 def create_header(drawer_ref: ui.left_drawer) -> ui.label:
-    """Top header bar with app title.
+    """Top header bar with app title and theme toggle.
 
     Takes the page-local drawer reference to avoid the global (WR-03 fix).
     Returns the running badge label so the page can update it from its
     own timer instead of using bind_visibility_from (BUG-03 fix).
     """
-    with ui.header().classes("bg-dark text-white items-center justify-between"):
+    # Read persisted theme preference (default: dark)
+    is_dark = db.get_setting("theme", "dark") != "light"
+    dark_mode = ui.dark_mode(is_dark)
+
+    with ui.header().classes("items-center justify-between ta-header"):
         ui.button(icon="menu", on_click=lambda: drawer_ref.toggle()).props("flat color=white")
         ui.label("TradingAgents").classes("text-h6 q-ml-sm")
         ui.space()
@@ -302,7 +306,22 @@ def create_header(drawer_ref: ui.left_drawer) -> ui.label:
             "running-badge text-caption bg-green-8 text-white q-px-sm q-py-xs rounded-borders"
         )
         running_label.set_visibility(runner.is_running)
+
+        # Theme toggle button
+        theme_btn = ui.button(
+            icon="dark_mode" if is_dark else "light_mode",
+            on_click=lambda: _toggle_theme(dark_mode, theme_btn),
+        ).props("flat round color=white size=sm").tooltip("Toggle dark/light mode")
+
         return running_label
+
+
+def _toggle_theme(dark_mode: ui.dark_mode, btn: ui.button) -> None:
+    """Toggle between dark and light mode, persisting the preference."""
+    new_dark = not dark_mode.value
+    dark_mode.set_value(new_dark)
+    btn.props(f'icon={"dark_mode" if new_dark else "light_mode"}')
+    db.set_setting("theme", "dark" if new_dark else "light")
 
 
 def create_drawer() -> ui.left_drawer:
@@ -476,7 +495,7 @@ def run_app(*, host: str = "127.0.0.1", port: int = 8080, reload: bool = False) 
         host=host,
         port=port,
         reload=reload,
-        dark=True,
+        dark=None,  # Per-page via ui.dark_mode() in create_header()
         native=False,  # Use browser window; set True for native window later
         favicon=None,
     )

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -4,17 +4,23 @@ Provides the shared layout (header + left drawer + page slot) and
 wires up page routing.  Each page module registers itself via
 ``@ui.page``.
 
+Also hosts the **app-level completion handler** that persists reports
+and logs regardless of which page the user is on (CR-02 fix).
+
 Run with:  ``python -m desktop``
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from nicegui import app, ui
 
 from desktop.state.database import HistoryDB
-from desktop.state.runner import PipelineRunner
+from desktop.state.runner import EventKind, PipelineRunner, RunnerEvent
+
+logger = logging.getLogger(__name__)
 
 # ── Shared singletons (one per process) ─────────────────────────────────
 
@@ -22,14 +28,93 @@ _ASSETS = Path(__file__).parent / "assets"
 db = HistoryDB()
 runner = PipelineRunner()
 
+# Mark any analyses stuck in "running" from a previous crashed session.
+for _stale in db.list_analyses(status="running"):
+    db.mark_interrupted(_stale.id)
+
+
+# ── App-level persistence (CR-02) ─────────────────────────────────────
+#
+# These functions run from the pipeline thread's finally block via
+# runner callbacks, so completion data is ALWAYS persisted — even if
+# the user closed their tab or navigated to a different page.
+
+
+def persist_reports(runner_ref: PipelineRunner) -> None:
+    """Save ProgressTracker report sections as .md files on disk.
+
+    Creates ``~/.tradingagents/results/<id>/`` with one file per
+    report section.  Sets ``result_dir`` on the database row.
+    """
+    aid = runner_ref.analysis_id
+    if not aid:
+        return
+    snap = runner_ref.tracker.snapshot()
+    sections = {k: v for k, v in snap.report_sections.items() if v}
+    if not sections:
+        logger.warning("No report sections to persist for analysis #%d", aid)
+        return
+
+    result_dir = Path.home() / ".tradingagents" / "results" / str(aid)
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    for key, content in sections.items():
+        (result_dir / f"{key}.md").write_text(content, encoding="utf-8")
+
+    db.update_result_dir(aid, str(result_dir))
+    logger.info("Persisted %d report sections to %s", len(sections), result_dir)
+
+
+def flush_logs(runner_ref: PipelineRunner) -> None:
+    """Persist all log entries from the tracker to the database."""
+    aid = runner_ref.analysis_id
+    if not aid:
+        return
+    snap = runner_ref.tracker.snapshot()
+    count = db.flush_logs(aid, snap.messages, snap.tool_calls)
+    if count:
+        logger.info("Flushed %d log entries for analysis #%d", count, aid)
+
+
+def on_pipeline_finished(event: RunnerEvent) -> None:
+    """App-level handler — runs on the pipeline thread regardless of UI state.
+
+    Persists reports, logs, and updates the analysis status in the DB.
+    This guarantees no data loss even if the user navigated away or
+    closed the browser tab.
+    """
+    aid = runner.analysis_id
+    if not aid:
+        return
+
+    try:
+        if event.kind == EventKind.COMPLETED:
+            db.mark_completed(aid)
+        elif event.kind == EventKind.FAILED:
+            db.mark_failed(aid, str(event.data) if event.data else "Unknown error")
+        elif event.kind == EventKind.CANCELLED:
+            db.mark_interrupted(aid)
+
+        persist_reports(runner)
+        flush_logs(runner)
+    except Exception:
+        logger.exception("Failed to persist results for analysis #%d", aid)
+
+
+# Register the callback on the runner so it fires from the pipeline thread.
+runner.on_finished = on_pipeline_finished
+
 
 # ── Layout ──────────────────────────────────────────────────────────────
 
 
-def create_header() -> None:
-    """Top header bar with app title."""
+def create_header(drawer_ref: ui.left_drawer) -> None:
+    """Top header bar with app title.
+
+    Takes the page-local drawer reference to avoid the global (WR-03 fix).
+    """
     with ui.header().classes("bg-dark text-white items-center justify-between"):
-        ui.button(icon="menu", on_click=lambda: drawer.toggle()).props("flat color=white")
+        ui.button(icon="menu", on_click=lambda: drawer_ref.toggle()).props("flat color=white")
         ui.label("TradingAgents").classes("text-h6 q-ml-sm")
         ui.space()
         # Running badge — visible only when pipeline is active
@@ -41,8 +126,8 @@ def create_header() -> None:
 
 def create_drawer() -> ui.left_drawer:
     """Left navigation drawer with page links."""
-    drawer = ui.left_drawer(value=True, bordered=True).classes("bg-dark")
-    with drawer:
+    d = ui.left_drawer(value=True, bordered=True).classes("bg-dark")
+    with d:
         ui.label("Navigation").classes("text-subtitle1 text-white q-pa-md")
         ui.separator().classes("bg-grey-8")
 
@@ -57,7 +142,7 @@ def create_drawer() -> ui.left_drawer:
             "text-caption text-grey-6 q-pa-md"
         )
 
-    return drawer
+    return d
 
 
 def _nav_item(label: str, target: str, icon: str) -> None:
@@ -70,9 +155,6 @@ def _nav_item(label: str, target: str, icon: str) -> None:
 
 
 # ── Page scaffolding ────────────────────────────────────────────────────
-
-# Module-level drawer reference so create_header can toggle it.
-drawer: ui.left_drawer
 
 
 @ui.page("/")
@@ -99,6 +181,14 @@ def page_logs() -> None:
     render_logs_page(runner=runner)
 
 
+@ui.page("/analysis/{analysis_id}")
+def page_detail(analysis_id: int) -> None:
+    """Detail page — view a completed analysis."""
+    _page_wrapper()
+    from desktop.pages.detail import render_detail_page
+    render_detail_page(db=db, analysis_id=analysis_id)
+
+
 @ui.page("/settings")
 def page_settings() -> None:
     """Settings page — user preferences."""
@@ -109,10 +199,9 @@ def page_settings() -> None:
 
 def _page_wrapper() -> None:
     """Common layout wrapper applied to every page."""
-    global drawer
     ui.add_css(_ASSETS / "style.css")
-    create_header()
-    drawer = create_drawer()
+    d = create_drawer()
+    create_header(d)
 
 
 # ── App entry ───────────────────────────────────────────────────────────
@@ -133,7 +222,12 @@ def run_app(*, host: str = "127.0.0.1", port: int = 8080, reload: bool = False) 
 
 
 def _cleanup() -> None:
-    """Graceful shutdown — mark any running analysis as interrupted."""
+    """Graceful shutdown — mark any running analysis as interrupted.
+
+    HI-03: Join the pipeline thread so ``on_finished`` has time to
+    persist reports and logs before the process exits.
+    """
     if runner.is_running and runner.analysis_id is not None:
         db.mark_interrupted(runner.analysis_id)
         runner.cancel()
+        runner.join(timeout=5.0)

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -1,0 +1,139 @@
+"""NiceGUI application scaffold with left-drawer navigation.
+
+Provides the shared layout (header + left drawer + page slot) and
+wires up page routing.  Each page module registers itself via
+``@ui.page``.
+
+Run with:  ``python -m desktop``
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nicegui import app, ui
+
+from desktop.state.database import HistoryDB
+from desktop.state.runner import PipelineRunner
+
+# ── Shared singletons (one per process) ─────────────────────────────────
+
+_ASSETS = Path(__file__).parent / "assets"
+db = HistoryDB()
+runner = PipelineRunner()
+
+
+# ── Layout ──────────────────────────────────────────────────────────────
+
+
+def create_header() -> None:
+    """Top header bar with app title."""
+    with ui.header().classes("bg-dark text-white items-center justify-between"):
+        ui.button(icon="menu", on_click=lambda: drawer.toggle()).props("flat color=white")
+        ui.label("TradingAgents").classes("text-h6 q-ml-sm")
+        ui.space()
+        # Running badge — visible only when pipeline is active
+        running_label = ui.label("Analysis Running").classes(
+            "running-badge text-caption bg-green-8 text-white q-px-sm q-py-xs rounded-borders"
+        )
+        running_label.bind_visibility_from(runner, "is_running")
+
+
+def create_drawer() -> ui.left_drawer:
+    """Left navigation drawer with page links."""
+    drawer = ui.left_drawer(value=True, bordered=True).classes("bg-dark")
+    with drawer:
+        ui.label("Navigation").classes("text-subtitle1 text-white q-pa-md")
+        ui.separator().classes("bg-grey-8")
+
+        with ui.column().classes("q-pa-sm gap-none"):
+            _nav_item("New Analysis", "/", "analytics")
+            _nav_item("History", "/history", "history")
+            _nav_item("Logs", "/logs", "article")
+            _nav_item("Settings", "/settings", "settings")
+
+        ui.separator().classes("bg-grey-8 q-mt-auto")
+        ui.label("TradingAgents Desktop").classes(
+            "text-caption text-grey-6 q-pa-md"
+        )
+
+    return drawer
+
+
+def _nav_item(label: str, target: str, icon: str) -> None:
+    """Single navigation item in the drawer."""
+    with ui.item(on_click=lambda: ui.navigate.to(target)).classes("text-white"):
+        with ui.item_section().props("avatar"):
+            ui.icon(icon).classes("text-grey-4")
+        with ui.item_section():
+            ui.label(label)
+
+
+# ── Page scaffolding ────────────────────────────────────────────────────
+
+# Module-level drawer reference so create_header can toggle it.
+drawer: ui.left_drawer
+
+
+@ui.page("/")
+def page_analysis() -> None:
+    """Analysis page — form + live progress."""
+    _page_wrapper()
+    from desktop.pages.analysis import render_analysis_page
+    render_analysis_page(runner=runner, db=db)
+
+
+@ui.page("/history")
+def page_history() -> None:
+    """History page — past analyses table."""
+    _page_wrapper()
+    from desktop.pages.history import render_history_page
+    render_history_page(db=db)
+
+
+@ui.page("/logs")
+def page_logs() -> None:
+    """Logs page — debug log viewer."""
+    _page_wrapper()
+    from desktop.pages.logs import render_logs_page
+    render_logs_page(runner=runner)
+
+
+@ui.page("/settings")
+def page_settings() -> None:
+    """Settings page — user preferences."""
+    _page_wrapper()
+    from desktop.pages.settings import render_settings_page
+    render_settings_page(db=db)
+
+
+def _page_wrapper() -> None:
+    """Common layout wrapper applied to every page."""
+    global drawer
+    ui.add_css(_ASSETS / "style.css")
+    create_header()
+    drawer = create_drawer()
+
+
+# ── App entry ───────────────────────────────────────────────────────────
+
+
+def run_app(*, host: str = "127.0.0.1", port: int = 8080, reload: bool = False) -> None:
+    """Start the NiceGUI desktop app."""
+    app.on_shutdown(lambda: _cleanup())
+    ui.run(
+        title="TradingAgents",
+        host=host,
+        port=port,
+        reload=reload,
+        dark=True,
+        native=False,  # Use browser window; set True for native window later
+        favicon=None,
+    )
+
+
+def _cleanup() -> None:
+    """Graceful shutdown — mark any running analysis as interrupted."""
+    if runner.is_running and runner.analysis_id is not None:
+        db.mark_interrupted(runner.analysis_id)
+        runner.cancel()

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -173,7 +173,7 @@ def page_history() -> None:
     """History page — past analyses table."""
     _page_wrapper()
     from desktop.pages.history import render_history_page
-    render_history_page(db=db)
+    render_history_page(db=db, runner=runner)
 
 
 @ui.page("/logs")

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from nicegui import app, ui
 
@@ -27,9 +28,84 @@ logger = logging.getLogger(__name__)
 _ASSETS = Path(__file__).parent / "assets"
 db = HistoryDB()
 
+# LEAK-02: Module-level reference so shutdown can join it.
+# Set by analysis.py when a batch starts.
+active_batch_runner: Any = None  # BatchRunner | None — avoid circular import
+
 # Read watchdog timeout from user settings (defaults to 900s if not set)
 _watchdog_timeout = int(db.get_setting("watchdog_timeout", "1200") or "1200")
 runner = PipelineRunner(watchdog_timeout=_watchdog_timeout)
+
+# ── v3 Feedback Loop services (lazy-started on first page load) ──────
+from desktop.services.price_service import PriceService
+from desktop.services.alert_engine import AlertEngine
+from desktop.services.outcome_tracker import OutcomeTracker
+from desktop.services.scheduler import Scheduler
+
+price_service = PriceService(ttl_seconds=300)
+alert_engine = AlertEngine(db=db, price_service=price_service)
+outcome_tracker = OutcomeTracker(db=db, price_service=price_service)
+
+
+def _scheduled_analysis_callback(
+    tickers: list[str], schedule_id: int,
+) -> None:
+    """Callback invoked by the Scheduler when a schedule fires.
+
+    Reads default config from settings and dispatches via BatchRunner
+    (for multi-ticker) or PipelineRunner (for single ticker).
+    """
+    from desktop.state.batch import BatchRunner
+
+    # Build config from saved settings (same defaults as analysis page)
+    provider = db.get_setting("default_provider", "openai") or "openai"
+    depth = int(db.get_setting("research_depth", "1") or "1")
+    language = db.get_setting("output_language", "English") or "English"
+    analysts_str = db.get_setting(
+        "default_analysts", "market,social,news,fundamentals"
+    ) or "market,social,news,fundamentals"
+    selected_analysts = [a.strip() for a in analysts_str.split(",") if a.strip()]
+
+    config: dict[str, Any] = {
+        "llm_provider": provider,
+        "max_debate_rounds": depth,
+        "max_risk_discuss_rounds": depth,
+        "output_language": language,
+    }
+
+    today = __import__("datetime").date.today().isoformat()
+
+    if len(tickers) == 1:
+        # Single ticker — use PipelineRunner directly
+        analysis_id = db.insert_analysis(
+            ticker=tickers[0],
+            date=today,
+            provider=provider,
+            model=config.get("deep_think_llm", "default"),
+            config=config,
+            selected_analysts=selected_analysts,
+        )
+        runner.start(
+            config=config,
+            ticker=tickers[0],
+            date=today,
+            selected_analysts=selected_analysts,
+            analysis_id=analysis_id,
+        )
+    else:
+        # Multi-ticker — use BatchRunner
+        batch = BatchRunner(runner=runner, db=db)
+        batch.start(
+            tickers=tickers,
+            config=config,
+            date=today,
+            selected_analysts=selected_analysts,
+        )
+
+
+scheduler = Scheduler(
+    db=db, runner=runner, run_analysis=_scheduled_analysis_callback,
+)
 
 # Mark any analyses stuck in "running" from a previous crashed session.
 for _stale in db.list_analyses(status="running"):
@@ -43,40 +119,126 @@ for _stale in db.list_analyses(status="running"):
 # the user closed their tab or navigated to a different page.
 
 
-def persist_reports(runner_ref: PipelineRunner) -> None:
+def persist_reports(analysis_id: int, tracker: Any) -> None:
     """Save ProgressTracker report sections as .md files on disk.
 
     Creates ``~/.tradingagents/results/<id>/`` with one file per
     report section.  Sets ``result_dir`` on the database row.
+
+    CR-01 fix: accepts ``analysis_id`` directly (captured from event
+    payload) instead of reading ``runner.analysis_id`` which is
+    mutable and may already point to the next ticker in batch mode.
     """
-    aid = runner_ref.analysis_id
-    if not aid:
-        return
-    snap = runner_ref.tracker.snapshot()
+    snap = tracker.snapshot()
     sections = {k: v for k, v in snap.report_sections.items() if v}
     if not sections:
-        logger.warning("No report sections to persist for analysis #%d", aid)
+        logger.warning("No report sections to persist for analysis #%d", analysis_id)
         return
 
-    result_dir = Path.home() / ".tradingagents" / "results" / str(aid)
+    result_dir = Path.home() / ".tradingagents" / "results" / str(analysis_id)
     result_dir.mkdir(parents=True, exist_ok=True)
 
     for key, content in sections.items():
         (result_dir / f"{key}.md").write_text(content, encoding="utf-8")
 
-    db.update_result_dir(aid, str(result_dir))
+    db.update_result_dir(analysis_id, str(result_dir))
     logger.info("Persisted %d report sections to %s", len(sections), result_dir)
 
+    # ── Approach C: Extract structured recommendation at write time ─────
+    # The markdown format is known (just generated), so extraction is
+    # highly reliable here. This populates the recommendations table
+    # that the Dashboard, Scorecard, and Alerts features read from.
+    _extract_recommendation_at_write(analysis_id, result_dir)
 
-def flush_logs(runner_ref: PipelineRunner) -> None:
-    """Persist all log entries from the tracker to the database."""
-    aid = runner_ref.analysis_id
-    if not aid:
+
+def _extract_recommendation_at_write(analysis_id: int, result_dir: Path) -> None:
+    """Extract structured recommendation data from the just-written report.
+
+    Called by persist_reports() right after markdown files are saved.
+    Failures are logged but never propagated — the analysis is already
+    persisted, so a failed extraction just means the dashboard won't
+    show this recommendation until migration backfills it.
+    """
+    decision_path = result_dir / "final_trade_decision.md"
+    if not decision_path.exists():
+        logger.debug("No final_trade_decision.md for analysis #%d, skipping extraction", analysis_id)
         return
-    snap = runner_ref.tracker.snapshot()
-    count = db.flush_logs(aid, snap.messages, snap.tool_calls)
+
+    try:
+        from desktop.services.recommendation_extractor import extract_from_file
+
+        # Get the ticker from the analysis row
+        analysis = db.get_analysis(analysis_id)
+        ticker = analysis.ticker if analysis else None
+
+        rec = extract_from_file(decision_path, ticker=ticker, analysis_id=analysis_id)
+
+        # Insert into recommendations table
+        rec_id = db.insert_recommendation(
+            analysis_id=analysis_id,
+            ticker=rec.ticker or ticker or "UNKNOWN",
+            verdict=rec.verdict,
+            confidence=rec.confidence,
+            price_at_analysis=rec.price_at_analysis,
+            stop_loss=rec.stop_loss,
+            entry_trigger=rec.entry_trigger,
+            profit_target=rec.profit_target,
+            review_date=rec.review_date,
+            notes=rec.notes,
+        )
+
+        # Deactivate older recommendations for the same ticker
+        effective_ticker = rec.ticker or ticker or "UNKNOWN"
+        deactivated = db.deactivate_older_for_ticker(effective_ticker, keep_id=rec_id)
+        if deactivated:
+            logger.info(
+                "Deactivated %d older recommendation(s) for %s",
+                deactivated,
+                effective_ticker,
+            )
+
+        logger.info(
+            "Extracted recommendation #%d for %s: %s (stop=%s, entry=%s, target=%s)",
+            rec_id,
+            effective_ticker,
+            rec.verdict,
+            rec.stop_loss,
+            rec.entry_trigger,
+            rec.profit_target,
+        )
+
+        # Auto-create alerts for the new recommendation's price levels
+        try:
+            rec_row = db.get_recommendation(rec_id)
+            if rec_row is not None:
+                alert_count = alert_engine.create_alerts_for_recommendation(rec_row)
+                if alert_count:
+                    logger.info(
+                        "Created %d alert(s) for %s recommendation #%d",
+                        alert_count,
+                        effective_ticker,
+                        rec_id,
+                    )
+        except Exception:
+            logger.exception("Failed to create alerts for recommendation #%d", rec_id)
+    except Exception:
+        logger.exception(
+            "Failed to extract recommendation for analysis #%d — "
+            "dashboard will backfill via migration",
+            analysis_id,
+        )
+
+
+def flush_logs(analysis_id: int, tracker: Any) -> None:
+    """Persist all log entries from the tracker to the database.
+
+    CR-01 fix: accepts ``analysis_id`` directly (captured from event
+    payload) instead of reading ``runner.analysis_id``.
+    """
+    snap = tracker.snapshot()
+    count = db.flush_logs(analysis_id, snap.messages, snap.tool_calls)
     if count:
-        logger.info("Flushed %d log entries for analysis #%d", count, aid)
+        logger.info("Flushed %d log entries for analysis #%d", count, analysis_id)
 
 
 def on_pipeline_finished(event: RunnerEvent) -> None:
@@ -86,20 +248,31 @@ def on_pipeline_finished(event: RunnerEvent) -> None:
     This guarantees no data loss even if the user navigated away or
     closed the browser tab.
     """
-    aid = runner.analysis_id
+    # WR-05 + RACE-03: Read analysis_id ONLY from event payload (set at
+    # capture time). Do NOT fall back to runner.analysis_id — in batch mode
+    # the runner may already have a new ID for the next ticker.
+    aid = None
+    if isinstance(event.data, dict):
+        aid = event.data.get("analysis_id")
     if not aid:
+        logger.warning("on_pipeline_finished: event missing analysis_id, skipping persistence")
         return
 
     try:
         if event.kind == EventKind.COMPLETED:
             db.mark_completed(aid)
         elif event.kind == EventKind.FAILED:
-            db.mark_failed(aid, str(event.data) if event.data else "Unknown error")
+            error_text = "Unknown error"
+            if isinstance(event.data, dict):
+                error_text = event.data.get("error", error_text)
+            elif isinstance(event.data, str):
+                error_text = event.data
+            db.mark_failed(aid, error_text)
         elif event.kind == EventKind.CANCELLED:
             db.mark_interrupted(aid)
 
-        persist_reports(runner)
-        flush_logs(runner)
+        persist_reports(aid, runner.tracker)
+        flush_logs(aid, runner.tracker)
     except Exception:
         logger.exception("Failed to persist results for analysis #%d", aid)
 
@@ -111,20 +284,25 @@ runner.on_finished = on_pipeline_finished
 # ── Layout ──────────────────────────────────────────────────────────────
 
 
-def create_header(drawer_ref: ui.left_drawer) -> None:
+def create_header(drawer_ref: ui.left_drawer) -> ui.label:
     """Top header bar with app title.
 
     Takes the page-local drawer reference to avoid the global (WR-03 fix).
+    Returns the running badge label so the page can update it from its
+    own timer instead of using bind_visibility_from (BUG-03 fix).
     """
     with ui.header().classes("bg-dark text-white items-center justify-between"):
         ui.button(icon="menu", on_click=lambda: drawer_ref.toggle()).props("flat color=white")
         ui.label("TradingAgents").classes("text-h6 q-ml-sm")
         ui.space()
-        # Running badge — visible only when pipeline is active
+        # BUG-03: Don't use bind_visibility_from on process-level singleton.
+        # It causes N lock acquisitions per 100ms per connected tab.
+        # Instead, page timers update this label's visibility explicitly.
         running_label = ui.label("Analysis Running").classes(
             "running-badge text-caption bg-green-8 text-white q-px-sm q-py-xs rounded-borders"
         )
-        running_label.bind_visibility_from(runner, "is_running")
+        running_label.set_visibility(runner.is_running)
+        return running_label
 
 
 def create_drawer() -> ui.left_drawer:
@@ -136,7 +314,12 @@ def create_drawer() -> ui.left_drawer:
 
         with ui.column().classes("q-pa-sm gap-none"):
             _nav_item("New Analysis", "/", "analytics")
+            _nav_item("Dashboard", "/dashboard", "dashboard")
             _nav_item("History", "/history", "history")
+            _nav_item("Scorecard", "/scorecard", "leaderboard")
+            _nav_item("Alerts", "/alerts", "notifications")
+            _nav_item("Schedules", "/schedules", "schedule")
+            _nav_item("Portfolio", "/portfolio", "account_balance_wallet")
             _nav_item("Logs", "/logs", "article")
             _nav_item("Settings", "/settings", "settings")
 
@@ -163,48 +346,117 @@ def _nav_item(label: str, target: str, icon: str) -> None:
 @ui.page("/")
 def page_analysis() -> None:
     """Analysis page — form + live progress."""
-    _page_wrapper()
+    badge = _page_wrapper()
     from desktop.pages.analysis import render_analysis_page
-    render_analysis_page(runner=runner, db=db)
+    render_analysis_page(runner=runner, db=db, running_badge=badge)
 
 
 @ui.page("/history")
 def page_history() -> None:
     """History page — past analyses table."""
-    _page_wrapper()
+    badge = _page_wrapper()
     from desktop.pages.history import render_history_page
     render_history_page(db=db, runner=runner)
+    _badge_timer(badge)
 
 
 @ui.page("/logs")
 def page_logs() -> None:
     """Logs page — debug log viewer."""
-    _page_wrapper()
+    badge = _page_wrapper()
     from desktop.pages.logs import render_logs_page
     render_logs_page(runner=runner)
+    _badge_timer(badge)
 
 
 @ui.page("/analysis/{analysis_id}")
 def page_detail(analysis_id: int) -> None:
     """Detail page — view a completed analysis."""
-    _page_wrapper()
+    badge = _page_wrapper()
     from desktop.pages.detail import render_detail_page
     render_detail_page(db=db, analysis_id=analysis_id)
+    _badge_timer(badge)
+
+
+@ui.page("/compare/{id_a}/{id_b}")
+def page_compare(id_a: int, id_b: int) -> None:
+    """Compare page — side-by-side analysis comparison."""
+    badge = _page_wrapper()
+    from desktop.pages.compare import render_compare_page
+    render_compare_page(db=db, id_a=id_a, id_b=id_b)
+    _badge_timer(badge)
 
 
 @ui.page("/settings")
 def page_settings() -> None:
     """Settings page — user preferences."""
-    _page_wrapper()
+    badge = _page_wrapper()
     from desktop.pages.settings import render_settings_page
     render_settings_page(db=db)
+    _badge_timer(badge)
 
 
-def _page_wrapper() -> None:
-    """Common layout wrapper applied to every page."""
+@ui.page("/dashboard")
+def page_dashboard() -> None:
+    """Dashboard — active recommendations with live prices."""
+    badge = _page_wrapper()
+    from desktop.pages.dashboard import render_dashboard_page
+    render_dashboard_page(db=db)
+    _badge_timer(badge)
+
+
+@ui.page("/scorecard")
+def page_scorecard() -> None:
+    """Scorecard — recommendation accuracy metrics."""
+    badge = _page_wrapper()
+    from desktop.pages.scorecard import render_scorecard_page
+    render_scorecard_page(db=db)
+    _badge_timer(badge)
+
+
+@ui.page("/alerts")
+def page_alerts() -> None:
+    """Alerts — price level monitoring."""
+    badge = _page_wrapper()
+    from desktop.pages.alerts import render_alerts_page
+    render_alerts_page(db=db, alert_engine=alert_engine)
+    _badge_timer(badge)
+
+
+@ui.page("/schedules")
+def page_schedules() -> None:
+    """Schedules — recurring pre-market analysis."""
+    badge = _page_wrapper()
+    from desktop.pages.schedules import render_schedules_page
+    render_schedules_page(db=db, scheduler=scheduler)
+    _badge_timer(badge)
+
+
+@ui.page("/portfolio")
+def page_portfolio() -> None:
+    """Portfolio — position tracking + recommendation overlay."""
+    badge = _page_wrapper()
+    from desktop.pages.portfolio import render_portfolio_page
+    render_portfolio_page(db=db)
+    _badge_timer(badge)
+
+
+def _badge_timer(badge: ui.label) -> None:
+    """BUG-03: Lightweight timer to update the running badge on non-analysis pages."""
+    def _update() -> None:
+        badge.set_visibility(runner.is_running)
+    ui.timer(2.0, _update)
+
+
+def _page_wrapper() -> ui.label:
+    """Common layout wrapper applied to every page.
+
+    Returns the header running-badge label so pages can update its
+    visibility from their own polling timer (BUG-03 fix).
+    """
     ui.add_css(_ASSETS / "style.css")
     d = create_drawer()
-    create_header(d)
+    return create_header(d)
 
 
 # ── App entry ───────────────────────────────────────────────────────────
@@ -212,6 +464,12 @@ def _page_wrapper() -> None:
 
 def run_app(*, host: str = "127.0.0.1", port: int = 8080, reload: bool = False) -> None:
     """Start the NiceGUI desktop app."""
+    # Start v3 background services
+    alert_engine.start()
+    outcome_tracker.start()
+    scheduler.start()
+    logger.info("v3 background services started (alert engine + outcome tracker + scheduler)")
+
     app.on_shutdown(lambda: _cleanup())
     ui.run(
         title="TradingAgents",
@@ -229,7 +487,25 @@ def _cleanup() -> None:
 
     HI-03: Join the pipeline thread so ``on_finished`` has time to
     persist reports and logs before the process exits.
+    LEAK-02: Also join any active batch runner thread.
     """
+    # Cancel and join batch runner first (it calls runner.start internally)
+    if active_batch_runner is not None:
+        try:
+            active_batch_runner.cancel()
+            active_batch_runner.join(timeout=5.0)
+        except Exception:
+            logger.exception("Failed to join batch runner on shutdown")
+
+    # Stop v3 background services
+    try:
+        scheduler.stop()
+        alert_engine.stop()
+        outcome_tracker.stop()
+        logger.info("v3 background services stopped")
+    except Exception:
+        logger.exception("Failed to stop v3 background services")
+
     if runner.is_running and runner.analysis_id is not None:
         db.mark_interrupted(runner.analysis_id)
         runner.cancel()

--- a/desktop/app.py
+++ b/desktop/app.py
@@ -401,7 +401,7 @@ def page_dashboard() -> None:
     """Dashboard — active recommendations with live prices."""
     badge = _page_wrapper()
     from desktop.pages.dashboard import render_dashboard_page
-    render_dashboard_page(db=db)
+    render_dashboard_page(db=db, price_service=price_service)
     _badge_timer(badge)
 
 
@@ -437,7 +437,7 @@ def page_portfolio() -> None:
     """Portfolio — position tracking + recommendation overlay."""
     badge = _page_wrapper()
     from desktop.pages.portfolio import render_portfolio_page
-    render_portfolio_page(db=db)
+    render_portfolio_page(db=db, price_service=price_service)
     _badge_timer(badge)
 
 

--- a/desktop/assets/style.css
+++ b/desktop/assets/style.css
@@ -1,5 +1,7 @@
 /* TradingAgents Desktop — custom styles */
 
+/* ── Theme variables ─────────────────────────────────────────────── */
+
 :root {
     --ta-green: #2e7d32;
     --ta-green-light: #4caf50;
@@ -9,9 +11,60 @@
     --ta-grey: #616161;
 }
 
-/* Left drawer */
-.q-drawer {
+/* Dark mode (default) */
+body.body--dark {
+    --ta-bg-surface: #1a1a2e;
+    --ta-bg-card: #1e1e2e;
+    --ta-text-primary: #e0e0e0;
+    --ta-text-secondary: #bdbdbd;
+    --ta-text-muted: #757575;
+    --ta-border: #444;
+    --ta-code-bg: rgba(255, 255, 255, 0.08);
+    --ta-pre-bg: rgba(0, 0, 0, 0.3);
+    --ta-table-header-bg: #2a2a3e;
+    --ta-table-stripe: rgba(255, 255, 255, 0.03);
+}
+
+/* Light mode */
+body.body--light {
+    --ta-bg-surface: #f5f5f5;
+    --ta-bg-card: #ffffff;
+    --ta-text-primary: #212121;
+    --ta-text-secondary: #424242;
+    --ta-text-muted: #757575;
+    --ta-border: #e0e0e0;
+    --ta-code-bg: rgba(0, 0, 0, 0.06);
+    --ta-pre-bg: rgba(0, 0, 0, 0.04);
+    --ta-table-header-bg: #e8eaf6;
+    --ta-table-stripe: rgba(0, 0, 0, 0.02);
+}
+
+/* ── Header ──────────────────────────────────────────────────────── */
+
+.ta-header {
     background-color: #1a1a2e !important;
+    color: white !important;
+}
+
+/* Left drawer */
+body.body--dark .q-drawer {
+    background-color: #1a1a2e !important;
+}
+body.body--light .q-drawer {
+    background-color: #ffffff !important;
+    border-right: 1px solid #e0e0e0;
+}
+body.body--light .q-drawer .text-white {
+    color: #212121 !important;
+}
+body.body--light .q-drawer .text-grey-4 {
+    color: #616161 !important;
+}
+body.body--light .q-drawer .text-grey-6 {
+    color: #9e9e9e !important;
+}
+body.body--light .q-drawer .bg-grey-8 {
+    background-color: #e0e0e0 !important;
 }
 
 .q-item__label {
@@ -62,7 +115,7 @@
 .report-content h2,
 .report-content h3,
 .report-content h4 {
-    color: #e0e0e0;
+    color: var(--ta-text-primary);
     margin-top: 1em;
     margin-bottom: 0.5em;
 }
@@ -72,7 +125,7 @@
 .report-content h3 { font-size: 1.05rem; }
 
 .report-content strong {
-    color: #ffffff;
+    color: var(--ta-text-primary);
     font-weight: 600;
 }
 
@@ -85,19 +138,19 @@
 
 .report-content th,
 .report-content td {
-    border: 1px solid #444;
+    border: 1px solid var(--ta-border);
     padding: 6px 10px;
     text-align: left;
 }
 
 .report-content th {
-    background-color: #2a2a3e;
-    color: #e0e0e0;
+    background-color: var(--ta-table-header-bg);
+    color: var(--ta-text-primary);
     font-weight: 600;
 }
 
 .report-content tr:nth-child(even) {
-    background-color: rgba(255, 255, 255, 0.03);
+    background-color: var(--ta-table-stripe);
 }
 
 .report-content ul,
@@ -111,14 +164,14 @@
 }
 
 .report-content code {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: var(--ta-code-bg);
     padding: 2px 5px;
     border-radius: 3px;
     font-size: 0.85em;
 }
 
 .report-content pre {
-    background-color: rgba(0, 0, 0, 0.3);
+    background-color: var(--ta-pre-bg);
     padding: 12px;
     border-radius: 4px;
     overflow-x: auto;
@@ -131,16 +184,32 @@
 }
 
 .report-content blockquote {
-    border-left: 3px solid #4caf50;
+    border-left: 3px solid var(--ta-green-light);
     padding-left: 12px;
     margin: 0.75em 0;
-    color: #bdbdbd;
+    color: var(--ta-text-secondary);
 }
 
 .report-content hr {
     border: none;
-    border-top: 1px solid #444;
+    border-top: 1px solid var(--ta-border);
     margin: 1em 0;
+}
+
+/* ── Light mode overrides for page content ───────────────────────── */
+
+body.body--light .bg-dark {
+    background-color: var(--ta-bg-card) !important;
+}
+body.body--light .text-white {
+    color: var(--ta-text-primary) !important;
+}
+body.body--light .text-grey-4,
+body.body--light .text-grey-5 {
+    color: var(--ta-text-muted) !important;
+}
+body.body--light .text-grey-6 {
+    color: #9e9e9e !important;
 }
 
 /* Progress bar */

--- a/desktop/assets/style.css
+++ b/desktop/assets/style.css
@@ -50,6 +50,99 @@
     padding: 12px 16px;
 }
 
+/* Markdown report content */
+.report-content {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.report-content h1,
+.report-content h2,
+.report-content h3,
+.report-content h4 {
+    color: #e0e0e0;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+.report-content h1 { font-size: 1.4rem; }
+.report-content h2 { font-size: 1.2rem; }
+.report-content h3 { font-size: 1.05rem; }
+
+.report-content strong {
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.report-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.75em 0;
+    font-size: 0.85rem;
+}
+
+.report-content th,
+.report-content td {
+    border: 1px solid #444;
+    padding: 6px 10px;
+    text-align: left;
+}
+
+.report-content th {
+    background-color: #2a2a3e;
+    color: #e0e0e0;
+    font-weight: 600;
+}
+
+.report-content tr:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
+.report-content ul,
+.report-content ol {
+    padding-left: 1.5em;
+    margin: 0.5em 0;
+}
+
+.report-content li {
+    margin-bottom: 0.25em;
+}
+
+.report-content code {
+    background-color: rgba(255, 255, 255, 0.08);
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 0.85em;
+}
+
+.report-content pre {
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 0.75em 0;
+}
+
+.report-content pre code {
+    background: none;
+    padding: 0;
+}
+
+.report-content blockquote {
+    border-left: 3px solid #4caf50;
+    padding-left: 12px;
+    margin: 0.75em 0;
+    color: #bdbdbd;
+}
+
+.report-content hr {
+    border: none;
+    border-top: 1px solid #444;
+    margin: 1em 0;
+}
+
 /* Progress bar */
 .ta-progress .q-linear-progress__track {
     opacity: 0.15;

--- a/desktop/assets/style.css
+++ b/desktop/assets/style.css
@@ -1,0 +1,65 @@
+/* TradingAgents Desktop — custom styles */
+
+:root {
+    --ta-green: #2e7d32;
+    --ta-green-light: #4caf50;
+    --ta-blue: #1565c0;
+    --ta-red: #c62828;
+    --ta-orange: #e65100;
+    --ta-grey: #616161;
+}
+
+/* Left drawer */
+.q-drawer {
+    background-color: #1a1a2e !important;
+}
+
+.q-item__label {
+    font-weight: 500;
+}
+
+/* Agent status cards */
+.agent-card {
+    border-left: 4px solid var(--ta-grey);
+    transition: border-color 0.3s ease;
+}
+.agent-card.pending {
+    border-left-color: var(--ta-grey);
+}
+.agent-card.in_progress {
+    border-left-color: var(--ta-blue);
+}
+.agent-card.completed {
+    border-left-color: var(--ta-green);
+}
+.agent-card.error {
+    border-left-color: var(--ta-red);
+}
+
+/* Log panel */
+.log-panel {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* Report sections */
+.report-section .q-expansion-item__content {
+    padding: 12px 16px;
+}
+
+/* Progress bar */
+.ta-progress .q-linear-progress__track {
+    opacity: 0.15;
+}
+
+/* Running badge pulse */
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+.running-badge {
+    animation: pulse 2s ease-in-out infinite;
+}

--- a/desktop/components/agent_card.py
+++ b/desktop/components/agent_card.py
@@ -38,18 +38,20 @@ class AgentStatusPanel:
     def __init__(self) -> None:
         self._container: ui.column | None = None
         self._cards: dict[str, _AgentCard] = {}
-        self._team_badges: dict[str, ui.label] = {}
+        self._team_expansions: dict[str, ui.expansion] = {}
+        self._team_names: dict[str, str] = {}  # expansion -> base name
 
     def build(self) -> None:
         """Render the initial layout (call once during page setup)."""
         self._container = ui.column().classes("w-full gap-sm")
         with self._container:
             for team_name, agents in _TEAM_ORDER:
-                with ui.expansion(team_name, icon="groups").classes(
+                expansion = ui.expansion(team_name, icon="groups").classes(
                     "w-full bg-dark"
-                ).props("dense default-opened header-class='text-subtitle2 text-white'"):
-                    badge = ui.label("").classes("text-caption text-grey-5")
-                    self._team_badges[team_name] = badge
+                ).props("dense default-opened header-class='text-subtitle2 text-white'")
+                self._team_expansions[team_name] = expansion
+                self._team_names[team_name] = team_name
+                with expansion:
                     for agent_name in agents:
                         card = _AgentCard(agent_name)
                         card.build()
@@ -65,14 +67,33 @@ class AgentStatusPanel:
             else:
                 card.hide()
 
-        # Update team badges
+        # Update team expansion headers with visible status
         for team_name, agents in _TEAM_ORDER:
+            expansion = self._team_expansions.get(team_name)
+            if not expansion:
+                continue
             active = [a for a in agents if a in snap.agent_status]
             if not active:
-                self._team_badges[team_name].set_text("")
+                # WR-05: use .props() instead of internal _props dict
+                expansion.props(f'label="{team_name}"')
                 continue
+
             done = sum(1 for a in active if snap.agent_status.get(a) == "completed")
-            self._team_badges[team_name].set_text(f"{done}/{len(active)} done")
+            in_prog = sum(1 for a in active if snap.agent_status.get(a) == "in_progress")
+            total = len(active)
+
+            if done == total:
+                label = f"{team_name}  ✔ Complete"
+            elif in_prog > 0:
+                label = f"{team_name}  ▶ {done}/{total}"
+            elif done > 0:
+                label = f"{team_name}  {done}/{total}"
+            else:
+                label = team_name
+            # WR-05: use .props() instead of internal _props dict
+            # Escape quotes in label for safe prop assignment
+            safe_label = label.replace('"', '\\"')
+            expansion.props(f'label="{safe_label}"')
 
 
 class _AgentCard:
@@ -95,9 +116,9 @@ class _AgentCard:
     def update(self, status: str) -> None:
         icon_name, color = _STATUS_ICONS.get(status, ("help", "grey"))
         if self._icon:
-            self._icon._props["name"] = icon_name
+            # WR-05: use .props() instead of internal _props dict
+            self._icon.props(f'name="{icon_name}"')
             self._icon.classes(replace=f"text-{color}")
-            self._icon.update()
         if self._status_label:
             self._status_label.set_text(status.replace("_", " "))
             self._status_label.classes(replace=f"text-caption text-{color}")

--- a/desktop/components/agent_card.py
+++ b/desktop/components/agent_card.py
@@ -1,0 +1,116 @@
+"""Agent status cards grouped by team.
+
+Renders a vertical list of team sections, each containing agent cards
+with status indicators (pending / in_progress / completed / error).
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from tradingagents.progress import FIXED_AGENTS, ProgressSnapshot
+
+# Display order: Analyst Team first, then pipeline order
+_TEAM_ORDER = [
+    ("Analyst Team", [
+        "Market Analyst", "Sentiment Analyst", "News Analyst", "Fundamentals Analyst",
+    ]),
+    ("Research Team", FIXED_AGENTS["Research Team"]),
+    ("Trading Team", FIXED_AGENTS["Trading Team"]),
+    ("Risk Management", FIXED_AGENTS["Risk Management"]),
+    ("Portfolio Management", FIXED_AGENTS["Portfolio Management"]),
+]
+
+_STATUS_ICONS: dict[str, tuple[str, str]] = {
+    "pending": ("hourglass_empty", "grey"),
+    "in_progress": ("sync", "blue"),
+    "completed": ("check_circle", "green"),
+    "error": ("error", "red"),
+}
+
+
+class AgentStatusPanel:
+    """Reactive panel showing all agent statuses grouped by team.
+
+    Call ``update(snapshot)`` from the UI timer to refresh.
+    """
+
+    def __init__(self) -> None:
+        self._container: ui.column | None = None
+        self._cards: dict[str, _AgentCard] = {}
+        self._team_badges: dict[str, ui.label] = {}
+
+    def build(self) -> None:
+        """Render the initial layout (call once during page setup)."""
+        self._container = ui.column().classes("w-full gap-sm")
+        with self._container:
+            for team_name, agents in _TEAM_ORDER:
+                with ui.expansion(team_name, icon="groups").classes(
+                    "w-full bg-dark"
+                ).props("dense default-opened header-class='text-subtitle2 text-white'"):
+                    badge = ui.label("").classes("text-caption text-grey-5")
+                    self._team_badges[team_name] = badge
+                    for agent_name in agents:
+                        card = _AgentCard(agent_name)
+                        card.build()
+                        self._cards[agent_name] = card
+
+    def update(self, snap: ProgressSnapshot) -> None:
+        """Refresh all cards from a snapshot."""
+        for agent_name, card in self._cards.items():
+            status = snap.agent_status.get(agent_name)
+            if status is not None:
+                card.update(status)
+                card.show()
+            else:
+                card.hide()
+
+        # Update team badges
+        for team_name, agents in _TEAM_ORDER:
+            active = [a for a in agents if a in snap.agent_status]
+            if not active:
+                self._team_badges[team_name].set_text("")
+                continue
+            done = sum(1 for a in active if snap.agent_status.get(a) == "completed")
+            self._team_badges[team_name].set_text(f"{done}/{len(active)} done")
+
+
+class _AgentCard:
+    """Single agent status card with icon + name + status label."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._row: ui.row | None = None
+        self._icon: ui.icon | None = None
+        self._status_label: ui.label | None = None
+
+    def build(self) -> None:
+        self._row = ui.row().classes("agent-card pending items-center q-pa-xs q-ml-md w-full")
+        with self._row:
+            self._icon = ui.icon("hourglass_empty").classes("text-grey")
+            ui.label(self.name).classes("text-body2 q-ml-xs")
+            ui.space()
+            self._status_label = ui.label("pending").classes("text-caption text-grey")
+
+    def update(self, status: str) -> None:
+        icon_name, color = _STATUS_ICONS.get(status, ("help", "grey"))
+        if self._icon:
+            self._icon._props["name"] = icon_name
+            self._icon.classes(replace=f"text-{color}")
+            self._icon.update()
+        if self._status_label:
+            self._status_label.set_text(status.replace("_", " "))
+            self._status_label.classes(replace=f"text-caption text-{color}")
+        if self._row:
+            # Update border class
+            for s in ("pending", "in_progress", "completed", "error"):
+                self._row.classes(remove=s)
+            self._row.classes(add=status)
+
+    def show(self) -> None:
+        if self._row:
+            self._row.set_visibility(True)
+
+    def hide(self) -> None:
+        if self._row:
+            self._row.set_visibility(False)

--- a/desktop/components/batch_progress.py
+++ b/desktop/components/batch_progress.py
@@ -1,0 +1,74 @@
+"""Batch progress strip for multi-ticker analysis runs.
+
+Shows which ticker is currently being analyzed, how many are done,
+and provides a cancel-all button.
+
+See also: PLAN-features-v2.md, Feature 3.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+
+class BatchProgressPanel:
+    """Batch-level progress indicator above the per-ticker dashboard.
+
+    Call ``update()`` from the UI timer with the current batch state.
+    """
+
+    def __init__(self) -> None:
+        self._progress: ui.linear_progress | None = None
+        self._label: ui.label | None = None
+        self._ticker_chips: ui.row | None = None
+
+    def build(self, tickers: list[str]) -> None:
+        """Render the batch progress strip."""
+        with ui.card().classes("w-full ta-batch-progress"):
+            with ui.row().classes("items-center w-full"):
+                ui.icon("playlist_play").classes("text-purple text-h6")
+                ui.label("Batch Analysis").classes("text-subtitle1")
+                ui.space()
+                self._label = ui.label(
+                    f"0 / {len(tickers)} tickers"
+                ).classes("text-caption text-grey")
+
+            self._progress = ui.linear_progress(
+                value=0, show_value=False,
+            ).classes("q-mt-sm").props("color=purple size=8px rounded")
+
+            # Ticker chips — show status of each ticker
+            self._ticker_chips = ui.row().classes("gap-xs q-mt-sm flex-wrap")
+            with self._ticker_chips:
+                for ticker in tickers:
+                    # WR-05: Removed unused data-ticker attribute that had
+                    # no JS consumer and posed a defense-in-depth gap if
+                    # called without prior ticker validation.
+                    ui.label(ticker).classes(
+                        "text-caption text-white bg-grey-8 q-px-sm q-py-xs rounded-borders"
+                    )
+
+    def update(
+        self,
+        *,
+        current_index: int,
+        total: int,
+        current_ticker: str,
+        completed_tickers: list[str],
+        failed_tickers: list[str],
+    ) -> None:
+        """Refresh the batch progress strip."""
+        fraction = current_index / max(total, 1)
+        if self._progress:
+            self._progress.set_value(fraction)
+        if self._label:
+            self._label.set_text(
+                f"{current_index} / {total} tickers — now: {current_ticker}"
+            )
+
+    def mark_complete(self, completed: int, total: int) -> None:
+        """Final state — all done."""
+        if self._progress:
+            self._progress.set_value(1.0)
+        if self._label:
+            self._label.set_text(f"{completed} / {total} tickers complete")

--- a/desktop/components/log_panel.py
+++ b/desktop/components/log_panel.py
@@ -8,19 +8,10 @@ from __future__ import annotations
 
 from nicegui import ui
 
+from desktop.utils.reports import TYPE_COLORS
 from tradingagents.progress import ProgressSnapshot
 
 _MAX_VISIBLE = 20
-
-_TYPE_COLORS: dict[str, str] = {
-    "System": "text-blue-4",
-    "Agent": "text-green-4",
-    "User": "text-yellow-4",
-    "Data": "text-purple-4",
-    "Tool": "text-orange-4",
-    "Control": "text-grey-5",
-    "Error": "text-red-4",
-}
 
 
 class LogPanel:
@@ -70,10 +61,10 @@ class LogPanel:
             visible = all_entries[:_MAX_VISIBLE]
 
             for ts, entry_type, content in visible:
-                color = _TYPE_COLORS.get(entry_type, "text-grey")
+                color = TYPE_COLORS.get(entry_type, "grey")
                 with ui.row().classes("items-baseline gap-xs q-py-none"):
                     ui.label(ts).classes("text-caption text-grey-6")
-                    ui.label(f"[{entry_type}]").classes(f"text-caption {color}")
+                    ui.label(f"[{entry_type}]").classes(f"text-caption text-{color}")
                     ui.label(content).classes("text-caption text-white")
 
 

--- a/desktop/components/log_panel.py
+++ b/desktop/components/log_panel.py
@@ -1,0 +1,84 @@
+"""Scrolling message log panel.
+
+Displays recent messages and tool calls from the ProgressTracker
+with auto-scroll and a capped visible window.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from tradingagents.progress import ProgressSnapshot
+
+_MAX_VISIBLE = 20
+
+_TYPE_COLORS: dict[str, str] = {
+    "System": "text-blue-4",
+    "Agent": "text-green-4",
+    "User": "text-yellow-4",
+    "Data": "text-purple-4",
+    "Tool": "text-orange-4",
+    "Control": "text-grey-5",
+    "Error": "text-red-4",
+}
+
+
+class LogPanel:
+    """Scrollable log panel showing recent messages.
+
+    Call ``update(snapshot)`` from the UI timer.
+    """
+
+    def __init__(self) -> None:
+        self._container: ui.column | None = None
+        self._last_count = 0
+
+    def build(self) -> None:
+        """Render the log panel layout."""
+        with ui.card().classes("w-full"):
+            with ui.row().classes("items-center"):
+                ui.icon("terminal").classes("text-grey-5")
+                ui.label("Live Log").classes("text-subtitle2")
+            self._container = ui.column().classes("log-panel w-full q-mt-xs gap-none")
+
+    def update(self, snap: ProgressSnapshot) -> None:
+        """Refresh the log from a snapshot."""
+        total = len(snap.messages) + len(snap.tool_calls)
+        if total == self._last_count:
+            return  # No new messages
+        self._last_count = total
+
+        if self._container is None:
+            return
+
+        self._container.clear()
+        with self._container:
+            # Merge messages and tool calls, sort by timestamp
+            all_entries: list[tuple[str, str, str]] = []
+
+            for ts, msg_type, content in snap.messages:
+                all_entries.append((ts, msg_type, _truncate(str(content), 120)))
+
+            for ts, tool_name, args in snap.tool_calls:
+                args_str = str(args)
+                if len(args_str) > 60:
+                    args_str = args_str[:57] + "..."
+                all_entries.append((ts, "Tool", f"{tool_name}: {args_str}"))
+
+            # Sort newest first, take last N
+            all_entries.sort(key=lambda x: x[0], reverse=True)
+            visible = all_entries[:_MAX_VISIBLE]
+
+            for ts, entry_type, content in visible:
+                color = _TYPE_COLORS.get(entry_type, "text-grey")
+                with ui.row().classes("items-baseline gap-xs q-py-none"):
+                    ui.label(ts).classes("text-caption text-grey-6")
+                    ui.label(f"[{entry_type}]").classes(f"text-caption {color}")
+                    ui.label(content).classes("text-caption text-white")
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate text with ellipsis."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."

--- a/desktop/components/price_chart.py
+++ b/desktop/components/price_chart.py
@@ -1,0 +1,210 @@
+"""Interactive candlestick + volume chart for analysis reports.
+
+Uses plotly via NiceGUI's ``ui.plotly()`` for zero-JS charting.
+Fetches OHLCV data from yfinance at render time — the ticker and
+date are already known from ``AnalysisRow`` or the running config.
+
+See also: PLAN-features-v2.md, Feature 1.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from nicegui import ui
+
+logger = logging.getLogger(__name__)
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+_LOOKBACK_DAYS = 90  # calendar days → ~60 trading days
+_CHART_HEIGHT = 340
+_SMA_PERIOD = 20
+
+
+# ── Data fetching ─────────────────────────────────────────────────────────
+
+
+def _fetch_ohlcv(
+    ticker: str,
+    end_date: str,
+    lookback_days: int = _LOOKBACK_DAYS,
+) -> Any | None:
+    """Fetch OHLCV DataFrame via yfinance, returning None on failure."""
+    try:
+        import yfinance as yf
+
+        end = datetime.date.fromisoformat(end_date)
+        start = end - datetime.timedelta(days=lookback_days)
+        df = yf.Ticker(ticker).history(
+            start=start.isoformat(),
+            end=(end + datetime.timedelta(days=1)).isoformat(),
+        )
+        if df.empty:
+            logger.warning("No price data for %s (%s → %s)", ticker, start, end)
+            return None
+        return df
+    except Exception:
+        logger.exception("Failed to fetch price data for %s", ticker)
+        return None
+
+
+# ── Chart figure builder ──────────────────────────────────────────────────
+
+
+def _build_figure(
+    df: Any,
+    ticker: str,
+    analysis_date: str,
+) -> go.Figure:
+    """Build a dark-themed candlestick + volume plotly figure."""
+    fig = make_subplots(
+        rows=2,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.03,
+        row_heights=[0.7, 0.3],
+    )
+
+    # Candlestick
+    fig.add_trace(
+        go.Candlestick(
+            x=df.index,
+            open=df["Open"],
+            high=df["High"],
+            low=df["Low"],
+            close=df["Close"],
+            name="Price",
+            increasing_line_color="#26a69a",
+            decreasing_line_color="#ef5350",
+        ),
+        row=1,
+        col=1,
+    )
+
+    # 20-day SMA overlay
+    if len(df) >= _SMA_PERIOD:
+        sma = df["Close"].rolling(window=_SMA_PERIOD).mean()
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=sma,
+                name=f"SMA {_SMA_PERIOD}",
+                line={"color": "#ffa726", "width": 1.5},
+            ),
+            row=1,
+            col=1,
+        )
+
+    # Volume bars
+    colors = [
+        "#26a69a" if c >= o else "#ef5350"
+        for o, c in zip(df["Open"], df["Close"], strict=False)
+    ]
+    fig.add_trace(
+        go.Bar(
+            x=df.index,
+            y=df["Volume"],
+            name="Volume",
+            marker_color=colors,
+            opacity=0.5,
+        ),
+        row=2,
+        col=1,
+    )
+
+    # Vertical line at analysis date (shape + annotation for plotly 6.x compat)
+    try:
+        analysis_dt = datetime.date.fromisoformat(analysis_date)
+        dt_val = datetime.datetime(analysis_dt.year, analysis_dt.month, analysis_dt.day)
+        fig.add_shape(
+            type="line",
+            x0=dt_val, x1=dt_val,
+            y0=0, y1=1,
+            yref="paper",
+            line={"color": "#7e57c2", "dash": "dash", "width": 1},
+        )
+        fig.add_annotation(
+            x=dt_val, y=1, yref="paper",
+            text="Analysis",
+            showarrow=False,
+            font={"color": "#7e57c2", "size": 11},
+            yshift=10,
+        )
+    except ValueError:
+        pass
+
+    # Dark theme layout
+    fig.update_layout(
+        template="plotly_dark",
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(30,30,30,0.8)",
+        height=_CHART_HEIGHT,
+        margin={"l": 50, "r": 20, "t": 30, "b": 20},
+        showlegend=False,
+        xaxis_rangeslider_visible=False,
+        title={
+            "text": f"{ticker} Price Action",
+            "font": {"size": 14, "color": "#bbb"},
+            "x": 0.01,
+            "xanchor": "left",
+        },
+    )
+    fig.update_xaxes(gridcolor="rgba(255,255,255,0.05)")
+    fig.update_yaxes(gridcolor="rgba(255,255,255,0.05)")
+    fig.update_yaxes(title_text="Price", row=1, col=1)
+    fig.update_yaxes(title_text="Vol", row=2, col=1)
+
+    return fig
+
+
+# ── Public component ──────────────────────────────────────────────────────
+
+
+class PriceChart:
+    """Reusable price chart component.
+
+    Usage::
+
+        chart = PriceChart(ticker="AAPL", analysis_date="2025-05-14")
+        chart.build()          # renders immediately (fetches data inline)
+    """
+
+    def __init__(self, ticker: str, analysis_date: str) -> None:
+        self._ticker = ticker.upper().strip()
+        self._date = analysis_date
+
+    def build(self) -> None:
+        """Render a spinner, then fetch data off the event loop and show chart.
+
+        PERF-01: Uses NiceGUI's run.io_bound to avoid blocking the ASGI
+        event loop during yfinance HTTP requests (1-5s per chart).
+        """
+        # Placeholder while data loads
+        container = ui.column().classes("w-full")
+        with container:
+            spinner = ui.row().classes("w-full justify-center q-pa-sm")
+            with spinner:
+                ui.spinner("dots", size="lg", color="grey")
+                ui.label("Loading chart...").classes("text-caption text-grey q-ml-sm")
+
+        async def _load_chart() -> None:
+            from nicegui import run
+            df = await run.io_bound(_fetch_ohlcv, self._ticker, self._date)
+            container.clear()
+            with container:
+                if df is None:
+                    with ui.card().classes("w-full ta-chart-fallback"):
+                        ui.label(
+                            f"Price chart unavailable for {self._ticker}"
+                        ).classes("text-caption text-grey")
+                    return
+                fig = _build_figure(df, self._ticker, self._date)
+                ui.plotly(fig).classes("w-full")
+
+        ui.timer(0.01, _load_chart, once=True)

--- a/desktop/components/progress_bar.py
+++ b/desktop/components/progress_bar.py
@@ -1,0 +1,85 @@
+"""Progress indicator for the analysis pipeline.
+
+Shows completed reports / total reports with elapsed time and
+a heartbeat indicator (last activity).
+"""
+
+from __future__ import annotations
+
+import time
+
+from nicegui import ui
+
+from tradingagents.progress import ProgressSnapshot
+
+
+class ProgressPanel:
+    """Reactive progress bar + stats strip.
+
+    Call ``update(snapshot)`` from the UI timer.
+    """
+
+    def __init__(self) -> None:
+        self._progress: ui.linear_progress | None = None
+        self._label: ui.label | None = None
+        self._elapsed: ui.label | None = None
+        self._heartbeat: ui.label | None = None
+        self._start_time: float | None = None
+
+    def build(self) -> None:
+        """Render the progress bar layout."""
+        with ui.card().classes("w-full ta-progress"):
+            with ui.row().classes("items-center w-full"):
+                ui.icon("assessment").classes("text-green text-h6")
+                ui.label("Analysis Progress").classes("text-subtitle1")
+                ui.space()
+                self._elapsed = ui.label("00:00").classes("text-caption text-grey")
+
+            self._progress = ui.linear_progress(value=0, show_value=False).classes(
+                "q-mt-sm"
+            ).props("color=green size=8px rounded")
+
+            with ui.row().classes("items-center q-mt-xs"):
+                self._label = ui.label("0 / 0 reports").classes("text-caption")
+                ui.space()
+                self._heartbeat = ui.label("").classes("text-caption text-grey")
+
+    def start(self) -> None:
+        """Mark the start time for elapsed display."""
+        self._start_time = time.time()
+
+    def update(self, snap: ProgressSnapshot, *, total_reports: int) -> None:
+        """Refresh from a progress snapshot."""
+        # Report progress
+        completed = sum(
+            1 for section, content in snap.report_sections.items()
+            if content is not None
+        )
+        fraction = completed / max(total_reports, 1)
+
+        if self._progress:
+            self._progress.set_value(fraction)
+        if self._label:
+            self._label.set_text(f"{completed} / {total_reports} reports")
+
+        # Elapsed time
+        if self._elapsed and self._start_time:
+            elapsed = time.time() - self._start_time
+            mins, secs = divmod(int(elapsed), 60)
+            self._elapsed.set_text(f"{mins:02d}:{secs:02d}")
+
+        # Heartbeat
+        if self._heartbeat and snap.last_activity:
+            from datetime import datetime
+            delta = datetime.now() - snap.last_activity
+            secs_ago = int(delta.total_seconds())
+            if secs_ago < 5:
+                self._heartbeat.set_text("Active now")
+                self._heartbeat.classes(replace="text-caption text-green")
+            elif secs_ago < 60:
+                self._heartbeat.set_text(f"Last activity {secs_ago}s ago")
+                self._heartbeat.classes(replace="text-caption text-grey")
+            else:
+                mins_ago = secs_ago // 60
+                self._heartbeat.set_text(f"No activity for {mins_ago}m")
+                self._heartbeat.classes(replace="text-caption text-red")

--- a/desktop/components/progress_bar.py
+++ b/desktop/components/progress_bar.py
@@ -10,7 +10,7 @@ import time
 
 from nicegui import ui
 
-from tradingagents.progress import ProgressSnapshot
+from tradingagents.progress import REPORT_SECTIONS, ProgressSnapshot
 
 
 class ProgressPanel:
@@ -50,11 +50,21 @@ class ProgressPanel:
 
     def update(self, snap: ProgressSnapshot, *, total_reports: int) -> None:
         """Refresh from a progress snapshot."""
-        # Report progress
-        completed = sum(
-            1 for section, content in snap.report_sections.items()
-            if content is not None
-        )
+        # Report progress — count a section as complete only when
+        # both content exists AND the finalizing agent is done.
+        # Prevents inflated counts from intermediate data (e.g. risk
+        # debate histories written before the Portfolio Manager runs).
+        completed = 0
+        for section, content in snap.report_sections.items():
+            if content is None:
+                continue
+            meta = REPORT_SECTIONS.get(section)
+            if meta is None:
+                completed += 1  # unknown section with content — count it
+                continue
+            _, finalizing_agent = meta
+            if snap.agent_status.get(finalizing_agent) == "completed":
+                completed += 1
         fraction = completed / max(total_reports, 1)
 
         if self._progress:

--- a/desktop/components/report_section.py
+++ b/desktop/components/report_section.py
@@ -11,17 +11,8 @@ from __future__ import annotations
 
 from nicegui import ui
 
+from desktop.utils.reports import MD_EXTRAS
 from tradingagents.progress import SECTION_TITLES, ProgressSnapshot
-
-# markdown2 extras enabled for report rendering
-_MD_EXTRAS: list[str] = [
-    "tables",
-    "fenced-code-blocks",
-    "strike",
-    "task_list",
-    "cuddled-lists",
-    "header-ids",
-]
 
 
 class ReportSectionsPanel:
@@ -71,7 +62,7 @@ class _ReportSection:
         )
         with self._expansion:
             self._content_area = ui.markdown(
-                "", extras=_MD_EXTRAS,
+                "", extras=MD_EXTRAS,
             ).classes("report-content text-white w-full")
 
     def update(self, content: str | None) -> None:

--- a/desktop/components/report_section.py
+++ b/desktop/components/report_section.py
@@ -2,6 +2,9 @@
 
 Each report section (Market, News, etc.) is rendered as a Quasar
 expansion item that opens when its content first arrives.
+
+Uses ``ui.markdown()`` (backed by markdown2) so reports render
+tables, bold, headers, lists, and fenced code blocks properly.
 """
 
 from __future__ import annotations
@@ -9,6 +12,16 @@ from __future__ import annotations
 from nicegui import ui
 
 from tradingagents.progress import SECTION_TITLES, ProgressSnapshot
+
+# markdown2 extras enabled for report rendering
+_MD_EXTRAS: list[str] = [
+    "tables",
+    "fenced-code-blocks",
+    "strike",
+    "task_list",
+    "cuddled-lists",
+    "header-ids",
+]
 
 
 class ReportSectionsPanel:
@@ -45,7 +58,7 @@ class _ReportSection:
         self.key = key
         self.title = title
         self._expansion: ui.expansion | None = None
-        self._content_area: ui.html | None = None
+        self._content_area: ui.markdown | None = None
         self._has_opened = False
         self._last_content: str | None = None
 
@@ -57,7 +70,9 @@ class _ReportSection:
             "dense header-class='text-subtitle2 text-grey-4'"
         )
         with self._expansion:
-            self._content_area = ui.html("").classes("text-body2 text-white")
+            self._content_area = ui.markdown(
+                "", extras=_MD_EXTRAS,
+            ).classes("report-content text-white w-full")
 
     def update(self, content: str | None) -> None:
         if content is None:
@@ -67,20 +82,9 @@ class _ReportSection:
 
         self._last_content = content
         if self._content_area:
-            # Render markdown as HTML via NiceGUI's markdown
-            self._content_area.content = f"<pre style='white-space:pre-wrap;font-family:inherit'>{_escape_html(content)}</pre>"
+            self._content_area.set_content(content)
 
         # Auto-open on first content
         if not self._has_opened and self._expansion:
             self._expansion.open()
             self._has_opened = True
-
-
-def _escape_html(text: str) -> str:
-    """Basic HTML escaping."""
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-    )

--- a/desktop/components/report_section.py
+++ b/desktop/components/report_section.py
@@ -1,0 +1,86 @@
+"""Expandable report section component.
+
+Each report section (Market, News, etc.) is rendered as a Quasar
+expansion item that opens when its content first arrives.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from tradingagents.progress import SECTION_TITLES, ProgressSnapshot
+
+
+class ReportSectionsPanel:
+    """Accordion of report sections that fill in as the pipeline runs.
+
+    Call ``update(snapshot)`` from the UI timer.
+    """
+
+    def __init__(self) -> None:
+        self._sections: dict[str, _ReportSection] = {}
+        self._container: ui.column | None = None
+
+    def build(self, section_keys: list[str]) -> None:
+        """Render empty expansion items for each expected section."""
+        self._container = ui.column().classes("w-full gap-xs")
+        with self._container:
+            for key in section_keys:
+                title = SECTION_TITLES.get(key, key)
+                section = _ReportSection(key, title)
+                section.build()
+                self._sections[key] = section
+
+    def update(self, snap: ProgressSnapshot) -> None:
+        """Refresh content from a snapshot."""
+        for key, section in self._sections.items():
+            content = snap.report_sections.get(key)
+            section.update(content)
+
+
+class _ReportSection:
+    """Single expandable report section."""
+
+    def __init__(self, key: str, title: str) -> None:
+        self.key = key
+        self.title = title
+        self._expansion: ui.expansion | None = None
+        self._content_area: ui.html | None = None
+        self._has_opened = False
+        self._last_content: str | None = None
+
+    def build(self) -> None:
+        self._expansion = ui.expansion(
+            f"{self.title}",
+            icon="description",
+        ).classes("w-full report-section bg-dark").props(
+            "dense header-class='text-subtitle2 text-grey-4'"
+        )
+        with self._expansion:
+            self._content_area = ui.html("").classes("text-body2 text-white")
+
+    def update(self, content: str | None) -> None:
+        if content is None:
+            return
+        if content == self._last_content:
+            return
+
+        self._last_content = content
+        if self._content_area:
+            # Render markdown as HTML via NiceGUI's markdown
+            self._content_area.content = f"<pre style='white-space:pre-wrap;font-family:inherit'>{_escape_html(content)}</pre>"
+
+        # Auto-open on first content
+        if not self._has_opened and self._expansion:
+            self._expansion.open()
+            self._has_opened = True
+
+
+def _escape_html(text: str) -> str:
+    """Basic HTML escaping."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/desktop/pages/alerts.py
+++ b/desktop/pages/alerts.py
@@ -1,0 +1,367 @@
+"""Alerts page -- active price alerts and fired alert history.
+
+Displays the alert engine status, unseen notifications, the active
+alerts table, and a full history of fired alerts.  Auto-refreshes
+every 10 seconds to pick up newly fired alerts.
+
+See also: PLAN-desktop.md, Phase 3 -- Price Alerts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nicegui import ui
+
+from desktop.services.alert_engine import AlertEngine
+from desktop.state.database import AlertHistoryRow, AlertRow, HistoryDB
+
+logger = logging.getLogger(__name__)
+
+
+def render_alerts_page(*, db: HistoryDB, alert_engine: AlertEngine) -> None:
+    """Render the alerts page content."""
+    page = _AlertsPage(db=db, alert_engine=alert_engine)
+    page.build()
+
+
+class _AlertsPage:
+    """Internal page controller for the alerts view."""
+
+    def __init__(self, *, db: HistoryDB, alert_engine: AlertEngine) -> None:
+        self._db = db
+        self._engine = alert_engine
+
+        # UI refs for auto-refresh updates
+        self._status_icon: ui.icon | None = None
+        self._status_label: ui.label | None = None
+        self._unseen_container: ui.column | None = None
+        self._active_table: ui.table | None = None
+        self._history_table: ui.table | None = None
+        self._empty_state: ui.column | None = None
+
+    def build(self) -> None:
+        """Render the full page layout."""
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            self._build_header()
+            self._build_unseen_section()
+            self._build_active_table()
+            self._build_history_table()
+            self._build_empty_state()
+
+            # Initial data load
+            self._refresh()
+
+            # Auto-refresh every 10 seconds
+            ui.timer(10.0, self._refresh)
+
+    # ------------------------------------------------------------------
+    # Header + engine status
+    # ------------------------------------------------------------------
+
+    def _build_header(self) -> None:
+        """Page title with engine health indicator."""
+        with ui.row().classes("items-center w-full"):
+            ui.label("Price Alerts").classes("text-h5 text-white")
+
+            ui.space()
+
+            # Engine status indicator
+            with ui.row().classes("items-center gap-xs"):
+                self._status_icon = ui.icon("circle").classes("text-caption")
+                self._status_label = ui.label("").classes(
+                    "text-caption text-grey-4"
+                )
+
+            self._update_engine_status()
+
+    def _update_engine_status(self) -> None:
+        """Refresh the engine status indicator."""
+        if self._status_icon is None or self._status_label is None:
+            return
+
+        if not self._engine.is_running:
+            self._status_icon.classes(replace="text-caption text-grey-6")
+            self._status_label.set_text("Engine stopped")
+        elif self._engine.is_degraded:
+            backoff = self._engine.backoff_seconds
+            minutes = backoff // 60
+            self._status_icon.classes(replace="text-caption text-yellow-6")
+            self._status_label.set_text(
+                f"Degraded -- retry in {minutes}m"
+            )
+        else:
+            self._status_icon.classes(replace="text-caption text-green-6")
+            last = self._engine.last_poll_at
+            suffix = f" -- last poll {last}" if last else ""
+            self._status_label.set_text(f"Healthy{suffix}")
+
+    # ------------------------------------------------------------------
+    # Unseen alerts section
+    # ------------------------------------------------------------------
+
+    def _build_unseen_section(self) -> None:
+        """Container for unseen alert notifications."""
+        self._unseen_container = ui.column().classes("w-full gap-sm")
+
+    def _populate_unseen(self, unseen: list[AlertHistoryRow]) -> None:
+        """Rebuild the unseen alerts cards."""
+        if self._unseen_container is None:
+            return
+
+        self._unseen_container.clear()
+
+        if not unseen:
+            return
+
+        with self._unseen_container:
+            with ui.row().classes("items-center w-full"):
+                ui.label(
+                    f"{len(unseen)} unseen alert(s)"
+                ).classes("text-subtitle1 text-yellow-4")
+                ui.space()
+                ui.button(
+                    "Mark all seen",
+                    icon="done_all",
+                    on_click=lambda: self._mark_all_seen(unseen),
+                ).props("flat dense color=yellow")
+
+            for entry in unseen:
+                with ui.card().classes(
+                    "w-full bg-yellow-10 q-pa-sm"
+                ).style("border-left: 4px solid #f9a825"):
+                    with ui.row().classes("items-center w-full"):
+                        ui.icon("notifications_active").classes(
+                            "text-yellow-4"
+                        )
+                        ui.label(entry.message).classes(
+                            "text-body2 text-white q-ml-sm"
+                        )
+                        ui.space()
+                        ui.label(f"${entry.price:.2f}").classes(
+                            "text-body2 text-white"
+                        )
+                        ui.label(entry.fired_at).classes(
+                            "text-caption text-grey-5 q-ml-sm"
+                        )
+
+    def _mark_all_seen(self, unseen: list[AlertHistoryRow]) -> None:
+        """Mark all unseen alerts as seen and refresh."""
+        ids = [entry.id for entry in unseen]
+        if ids:
+            try:
+                self._db.mark_alerts_seen(ids)
+                ui.notify(
+                    f"Marked {len(ids)} alert(s) as seen", type="positive"
+                )
+            except Exception:
+                logger.exception("Failed to mark alerts as seen")
+                ui.notify("Failed to mark alerts as seen", type="negative")
+                return
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    # Active alerts table
+    # ------------------------------------------------------------------
+
+    def _build_active_table(self) -> None:
+        """Table of active (untriggered) alerts."""
+        ui.label("Active Alerts").classes("text-h6 text-white q-mt-md")
+
+        columns = [
+            {
+                "name": "ticker",
+                "label": "Ticker",
+                "field": "ticker",
+                "sortable": True,
+            },
+            {
+                "name": "alert_type",
+                "label": "Type",
+                "field": "alert_type",
+                "sortable": True,
+            },
+            {
+                "name": "target_price",
+                "label": "Target Price",
+                "field": "target_price",
+                "sortable": True,
+            },
+            {
+                "name": "direction",
+                "label": "Direction",
+                "field": "direction",
+                "sortable": True,
+            },
+            {
+                "name": "created_at",
+                "label": "Created",
+                "field": "created_at",
+                "sortable": True,
+            },
+        ]
+
+        self._active_table = ui.table(
+            columns=columns,
+            rows=[],
+            row_key="id",
+            pagination={"rowsPerPage": 15},
+        ).classes("w-full").props("flat bordered dense")
+
+    def _populate_active_table(self, alerts: list[AlertRow]) -> None:
+        """Refresh active alerts table rows."""
+        if self._active_table is None:
+            return
+
+        rows = [
+            {
+                "id": a.id,
+                "ticker": a.ticker,
+                "alert_type": _format_alert_type(a.alert_type),
+                "target_price": f"${a.target_price:.2f}",
+                "direction": a.direction.capitalize(),
+                "created_at": a.created_at,
+            }
+            for a in alerts
+        ]
+
+        self._active_table.rows = rows
+        self._active_table.update()
+
+    # ------------------------------------------------------------------
+    # Alert history table
+    # ------------------------------------------------------------------
+
+    def _build_history_table(self) -> None:
+        """Table of all fired alerts (full history)."""
+        ui.label("Alert History").classes("text-h6 text-white q-mt-md")
+
+        columns = [
+            {
+                "name": "fired_at",
+                "label": "Fired At",
+                "field": "fired_at",
+                "sortable": True,
+            },
+            {
+                "name": "message",
+                "label": "Message",
+                "field": "message",
+            },
+            {
+                "name": "price",
+                "label": "Price",
+                "field": "price",
+                "sortable": True,
+            },
+            {
+                "name": "seen",
+                "label": "Seen",
+                "field": "seen",
+                "sortable": True,
+            },
+        ]
+
+        self._history_table = ui.table(
+            columns=columns,
+            rows=[],
+            row_key="id",
+            pagination={"rowsPerPage": 15},
+        ).classes("w-full").props("flat bordered dense")
+
+    def _populate_history_table(
+        self, history: list[AlertHistoryRow]
+    ) -> None:
+        """Refresh alert history table rows."""
+        if self._history_table is None:
+            return
+
+        rows = [
+            {
+                "id": h.id,
+                "fired_at": h.fired_at,
+                "message": h.message,
+                "price": f"${h.price:.2f}",
+                "seen": "Yes" if h.seen else "No",
+            }
+            for h in history
+        ]
+
+        self._history_table.rows = rows
+        self._history_table.update()
+
+    # ------------------------------------------------------------------
+    # Empty state
+    # ------------------------------------------------------------------
+
+    def _build_empty_state(self) -> None:
+        """Placeholder shown when no alerts exist."""
+        self._empty_state = ui.column().classes(
+            "w-full items-center q-pa-xl"
+        )
+
+    def _update_empty_state(
+        self,
+        *,
+        has_active: bool,
+        has_history: bool,
+    ) -> None:
+        """Show or hide the empty state message."""
+        if self._empty_state is None:
+            return
+
+        self._empty_state.clear()
+
+        if has_active or has_history:
+            self._empty_state.set_visibility(False)
+            return
+
+        self._empty_state.set_visibility(True)
+        with self._empty_state:
+            ui.icon("notifications_none").classes(
+                "text-grey-6 text-h2 q-mb-md"
+            )
+            ui.label("No alerts yet").classes("text-h6 text-grey-5")
+            ui.label(
+                "Alerts are created automatically when you run analyses "
+                "with price levels."
+            ).classes("text-body2 text-grey-6 text-center")
+
+    # ------------------------------------------------------------------
+    # Refresh
+    # ------------------------------------------------------------------
+
+    def _refresh(self) -> None:
+        """Reload all data from the database and update every section."""
+        try:
+            unseen = self._db.list_unseen_alert_history()
+            active = self._db.list_active_alerts()
+            history = self._db.list_all_alert_history()
+        except Exception:
+            logger.exception("Failed to load alert data")
+            return
+
+        self._update_engine_status()
+        self._populate_unseen(unseen)
+        self._populate_active_table(active)
+        self._populate_history_table(history)
+        self._update_empty_state(
+            has_active=len(active) > 0,
+            has_history=len(history) > 0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_alert_type(alert_type: str) -> str:
+    """Human-readable label for an alert type."""
+    labels = {
+        "stop_loss": "Stop Loss",
+        "entry_trigger": "Entry Trigger",
+        "profit_target": "Profit Target",
+        "custom": "Custom",
+    }
+    return labels.get(alert_type, alert_type.replace("_", " ").title())

--- a/desktop/pages/analysis.py
+++ b/desktop/pages/analysis.py
@@ -396,7 +396,9 @@ class _AnalysisPage:
             with self._page_root:
                 self._build_progress_view()
                 self._start_polling()
-        ui.notify(f"Analysis started for {ticker}", type="positive")
+                # Must be inside `with` block — the slot context from
+                # _page_root.clear() is gone outside it.
+                ui.notify(f"Analysis started for {ticker}", type="positive")
 
     # ── Progress view (running state) ───────────────────────────────
 

--- a/desktop/pages/analysis.py
+++ b/desktop/pages/analysis.py
@@ -1,0 +1,334 @@
+"""Analysis page — two-state form + live progress dashboard.
+
+**Pre-run state:** Configuration form (ticker, provider, analysts, date).
+**Running state:** Form collapses to summary; progress dashboard expands.
+
+See also: PLAN-desktop.md, F1 + F2.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+from nicegui import ui
+
+from desktop.components.agent_card import AgentStatusPanel
+from desktop.components.log_panel import LogPanel
+from desktop.components.progress_bar import ProgressPanel
+from desktop.components.report_section import ReportSectionsPanel
+from desktop.state.database import HistoryDB
+from desktop.state.runner import EventKind, PipelineRunner
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.progress import REPORT_SECTIONS
+
+# Provider options for the dropdown (display, key, url)
+_PROVIDERS: list[tuple[str, str, str | None]] = [
+    ("Claude CLI (Max, $0)", "claude_cli", None),
+    ("OpenAI", "openai", "https://api.openai.com/v1"),
+    ("Google", "google", None),
+    ("Anthropic", "anthropic", "https://api.anthropic.com/"),
+    ("xAI", "xai", "https://api.x.ai/v1"),
+    ("DeepSeek", "deepseek", "https://api.deepseek.com"),
+    ("Ollama", "ollama", "http://localhost:11434"),
+    ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
+]
+
+_ANALYSTS = [
+    ("Market Analyst", "market"),
+    ("Sentiment Analyst", "social"),
+    ("News Analyst", "news"),
+    ("Fundamentals Analyst", "fundamentals"),
+]
+
+
+def render_analysis_page(*, runner: PipelineRunner, db: HistoryDB) -> None:
+    """Render the analysis page content."""
+    page = _AnalysisPage(runner=runner, db=db)
+    page.build()
+
+
+class _AnalysisPage:
+    """Internal page controller managing form and progress states."""
+
+    def __init__(self, *, runner: PipelineRunner, db: HistoryDB) -> None:
+        self._runner = runner
+        self._db = db
+
+        # Form state
+        self._ticker = "SPY"
+        self._date = datetime.date.today().isoformat()
+        self._provider_key = "claude_cli"
+        self._backend_url: str | None = None
+        self._selected_analysts: list[str] = ["market", "social", "news", "fundamentals"]
+        self._research_depth = 1
+
+        # UI refs
+        self._form_container: ui.column | None = None
+        self._progress_container: ui.column | None = None
+        self._summary_strip: ui.row | None = None
+        self._agent_panel: AgentStatusPanel | None = None
+        self._progress_panel: ProgressPanel | None = None
+        self._log_panel: LogPanel | None = None
+        self._report_panel: ReportSectionsPanel | None = None
+        self._timer: ui.timer | None = None
+
+    def build(self) -> None:
+        """Render the full page layout."""
+        # If already running, show progress state
+        if self._runner.is_running:
+            self._build_progress_view()
+            self._start_polling()
+            return
+
+        self._build_form()
+
+    # ── Form (pre-run state) ────────────────────────────────────────
+
+    def _build_form(self) -> None:
+        """Render the configuration form."""
+        self._form_container = ui.column().classes("w-full max-w-2xl mx-auto q-pa-md gap-md")
+        with self._form_container:
+            ui.label("New Analysis").classes("text-h5 text-white")
+            ui.label(
+                "Configure and run a trading analysis. The pipeline takes 5-15 minutes."
+            ).classes("text-body2 text-grey-5")
+
+            with ui.card().classes("w-full"):
+                # Ticker
+                ticker_input = ui.input(
+                    "Ticker Symbol",
+                    value=self._ticker,
+                    placeholder="e.g. SPY, AAPL, 0700.HK",
+                ).classes("w-full").props("outlined dense")
+                ticker_input.on("update:model-value", lambda e: setattr(self, "_ticker", e.args))
+
+                # Date
+                date_input = ui.input(
+                    "Analysis Date",
+                    value=self._date,
+                ).classes("w-full q-mt-sm").props("outlined dense")
+                with date_input:
+                    with ui.menu() as menu:
+                        ui.date(
+                            value=self._date,
+                            on_change=lambda e: (
+                                setattr(self, "_date", e.value),
+                                date_input.set_value(e.value),
+                                menu.close(),
+                            ),
+                        ).props("today-btn")
+                    with date_input.add_slot("append"):
+                        ui.icon("event").on("click", menu.open).classes("cursor-pointer")
+
+                # Provider
+                provider_options = {display: key for display, key, _ in _PROVIDERS}
+                provider_select = ui.select(
+                    label="LLM Provider",
+                    options=list(provider_options.keys()),
+                    value="Claude CLI (Max, $0)",
+                ).classes("w-full q-mt-sm").props("outlined dense")
+                provider_select.on(
+                    "update:model-value",
+                    lambda e: self._on_provider_change(e.args, provider_options),
+                )
+
+                # Analysts (checkboxes)
+                ui.label("Analyst Team").classes("text-subtitle2 q-mt-md")
+                with ui.row().classes("gap-md"):
+                    for display, key in _ANALYSTS:
+                        ui.checkbox(
+                            display,
+                            value=True,
+                            on_change=lambda e, k=key: self._toggle_analyst(k, e.value),
+                        )
+
+                # Research depth
+                ui.label("Research Depth").classes("text-subtitle2 q-mt-md")
+                ui.slider(
+                    min=1, max=3, step=1, value=1,
+                    on_change=lambda e: setattr(self, "_research_depth", int(e.value)),
+                ).classes("w-full").props("label-always markers snap")
+
+            # Run button
+            ui.button(
+                "Run Analysis",
+                icon="play_arrow",
+                on_click=self._on_run,
+            ).classes("w-full q-mt-md").props("color=green size=lg")
+
+    def _on_provider_change(self, display_name: str, mapping: dict[str, str]) -> None:
+        self._provider_key = mapping.get(display_name, "claude_cli")
+        self._backend_url = next(
+            (url for d, _, url in _PROVIDERS if d == display_name), None
+        )
+
+    def _toggle_analyst(self, key: str, checked: bool) -> None:
+        if checked and key not in self._selected_analysts:
+            self._selected_analysts.append(key)
+        elif not checked and key in self._selected_analysts:
+            self._selected_analysts.remove(key)
+
+    async def _on_run(self) -> None:
+        """Validate and start the analysis pipeline."""
+        ticker = self._ticker.strip().upper()
+        if not ticker:
+            ui.notify("Please enter a ticker symbol", type="warning")
+            return
+        if not self._selected_analysts:
+            ui.notify("Select at least one analyst", type="warning")
+            return
+
+        config: dict[str, Any] = {
+            "llm_provider": self._provider_key,
+            "backend_url": self._backend_url,
+            "max_debate_rounds": self._research_depth,
+            "max_risk_discuss_rounds": self._research_depth,
+        }
+
+        # For Claude CLI, set models
+        if self._provider_key == "claude_cli":
+            config["quick_think_llm"] = "claude-opus-4-20250514"
+            config["deep_think_llm"] = "claude-opus-4-20250514"
+
+        # Insert into database
+        analysis_id = self._db.insert_analysis(
+            ticker=ticker,
+            date=self._date,
+            provider=self._provider_key,
+            model=config.get("deep_think_llm", "default"),
+            config=config,
+            selected_analysts=self._selected_analysts,
+        )
+        self._runner.analysis_id = analysis_id
+
+        # Start the pipeline
+        try:
+            self._runner.start(
+                config=config,
+                ticker=ticker,
+                date=self._date,
+                selected_analysts=list(self._selected_analysts),
+            )
+        except RuntimeError as e:
+            ui.notify(str(e), type="negative")
+            return
+
+        # Switch to progress view
+        if self._form_container:
+            self._form_container.clear()
+            self._form_container.delete()
+
+        self._build_progress_view()
+        self._start_polling()
+        ui.notify(f"Analysis started for {ticker}", type="positive")
+
+    # ── Progress view (running state) ───────────────────────────────
+
+    def _build_progress_view(self) -> None:
+        """Render the live progress dashboard."""
+        self._progress_container = ui.column().classes("w-full q-pa-md gap-md")
+        with self._progress_container:
+            # Summary strip
+            self._summary_strip = ui.row().classes(
+                "items-center w-full bg-dark q-pa-sm rounded-borders"
+            )
+            with self._summary_strip:
+                ui.icon("analytics").classes("text-green text-h5")
+                ui.label(f"{self._ticker}").classes("text-h6 text-white q-ml-sm")
+                ui.label(f"{self._date}").classes("text-caption text-grey q-ml-sm")
+                ui.label(f"{self._provider_key}").classes("text-caption text-grey q-ml-sm")
+                ui.space()
+                ui.button(
+                    "Cancel",
+                    icon="stop",
+                    on_click=self._on_cancel,
+                ).props("color=red flat dense")
+
+            # Two-column layout
+            with ui.row().classes("w-full gap-md"):
+                # Left column: agent status + progress bar
+                with ui.column().classes("w-1/3 gap-md"):
+                    self._progress_panel = ProgressPanel()
+                    self._progress_panel.build()
+                    self._progress_panel.start()
+
+                    self._agent_panel = AgentStatusPanel()
+                    self._agent_panel.build()
+
+                # Right column: reports + log
+                with ui.column().classes("w-2/3 gap-md"):
+                    # Report sections
+                    snap = self._runner.tracker.snapshot()
+                    section_keys = list(snap.report_sections.keys())
+                    self._report_panel = ReportSectionsPanel()
+                    self._report_panel.build(section_keys)
+
+                    # Log panel
+                    self._log_panel = LogPanel()
+                    self._log_panel.build()
+
+    def _start_polling(self) -> None:
+        """Start the UI timer that polls runner events and updates components."""
+        self._timer = ui.timer(0.25, self._poll)
+
+    def _poll(self) -> None:
+        """Called every 250ms by the UI timer."""
+        # Drain events from the runner queue
+        for event in self._runner.drain_events():
+            if event.kind == EventKind.COMPLETED:
+                self._on_completed(event.data)
+            elif event.kind == EventKind.FAILED:
+                self._on_failed(event.data)
+            elif event.kind == EventKind.CANCELLED:
+                self._on_cancelled()
+            elif event.kind == EventKind.WATCHDOG:
+                ui.notify(
+                    f"Pipeline stalled: {event.data}. Consider restarting.",
+                    type="warning",
+                    timeout=10000,
+                )
+
+        # Update UI components from tracker snapshot
+        snap = self._runner.tracker.snapshot()
+        total = self._runner.tracker.get_total_reports_count()
+
+        if self._agent_panel:
+            self._agent_panel.update(snap)
+        if self._progress_panel:
+            self._progress_panel.update(snap, total_reports=total)
+        if self._log_panel:
+            self._log_panel.update(snap)
+        if self._report_panel:
+            self._report_panel.update(snap)
+
+    def _on_cancel(self) -> None:
+        self._runner.cancel()
+        ui.notify("Cancelling analysis...", type="info")
+
+    def _on_completed(self, data: dict[str, Any]) -> None:
+        """Pipeline finished successfully."""
+        if self._timer:
+            self._timer.deactivate()
+        if self._runner.analysis_id:
+            self._db.mark_completed(self._runner.analysis_id)
+        ui.notify("Analysis completed!", type="positive", timeout=10000)
+        # Final UI update
+        self._poll()
+
+    def _on_failed(self, error_text: str) -> None:
+        """Pipeline failed with an error."""
+        if self._timer:
+            self._timer.deactivate()
+        if self._runner.analysis_id:
+            self._db.mark_failed(self._runner.analysis_id, error_text)
+        ui.notify(f"Analysis failed: {error_text}", type="negative", timeout=15000)
+
+    def _on_cancelled(self) -> None:
+        """Pipeline was cancelled."""
+        if self._timer:
+            self._timer.deactivate()
+        if self._runner.analysis_id:
+            self._db.mark_interrupted(self._runner.analysis_id)
+        ui.notify("Analysis cancelled", type="warning")

--- a/desktop/pages/analysis.py
+++ b/desktop/pages/analysis.py
@@ -10,20 +10,23 @@ from __future__ import annotations
 
 import datetime
 import logging
-from pathlib import Path
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 from nicegui import ui
 
+import desktop.app as _app_module  # LEAK-02: register batch runner
 from desktop.components.agent_card import AgentStatusPanel
+from desktop.components.batch_progress import BatchProgressPanel
 from desktop.components.log_panel import LogPanel
+from desktop.components.price_chart import PriceChart
 from desktop.components.progress_bar import ProgressPanel
 from desktop.components.report_section import ReportSectionsPanel
+from desktop.state.batch import BatchRunner
 from desktop.state.database import HistoryDB
 from desktop.state.runner import EventKind, PipelineRunner
-from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.llm_clients.model_catalog import MODEL_OPTIONS
 from tradingagents.progress import REPORT_SECTIONS
 
@@ -46,15 +49,18 @@ _ANALYSTS = [
     ("Fundamentals Analyst", "fundamentals"),
 ]
 
-# Claude CLI models (not in the shared model catalog)
+# Claude CLI models (not in the shared model catalog).
+# IDs must match the Anthropic versioned format (claude-opus-4-6, not
+# date-pinned snapshots like claude-opus-4-20250514 which is Opus 4 base).
 _CLAUDE_CLI_MODELS: dict[str, list[tuple[str, str]]] = {
     "quick": [
-        ("Claude Opus 4.6", "claude-opus-4-20250514"),
-        ("Claude Opus 4.7 Max", "claude-opus-4-20250715"),
+        ("Claude Opus 4.7 — Latest frontier", "claude-opus-4-7"),
+        ("Claude Opus 4.6 — Frontier intelligence", "claude-opus-4-6"),
+        ("Claude Sonnet 4.6 — Fast + smart balance", "claude-sonnet-4-6"),
     ],
     "deep": [
-        ("Claude Opus 4.6", "claude-opus-4-20250514"),
-        ("Claude Opus 4.7 Max", "claude-opus-4-20250715"),
+        ("Claude Opus 4.7 — Latest frontier", "claude-opus-4-7"),
+        ("Claude Opus 4.6 — Frontier intelligence", "claude-opus-4-6"),
     ],
 }
 
@@ -74,6 +80,10 @@ _LANGUAGES: list[tuple[str, str]] = [
 ]
 
 
+# WR-02: Ticker symbol validation (letters, digits, dots, dashes, carets)
+_TICKER_RE = re.compile(r"^[A-Z0-9.\-^]{1,20}$")
+
+
 def _get_models_for_provider(
     provider_key: str, mode: str,
 ) -> list[tuple[str, str]]:
@@ -84,16 +94,23 @@ def _get_models_for_provider(
     return [(name, mid) for name, mid in models if mid != "custom"]
 
 
-def render_analysis_page(*, runner: PipelineRunner, db: HistoryDB) -> None:
+def render_analysis_page(
+    *,
+    runner: PipelineRunner,
+    db: HistoryDB,
+    running_badge: Any = None,
+) -> None:
     """Render the analysis page content."""
-    page = _AnalysisPage(runner=runner, db=db)
+    page = _AnalysisPage(runner=runner, db=db, running_badge=running_badge)
     page.build()
 
 
 class _AnalysisPage:
     """Internal page controller managing form and progress states."""
 
-    def __init__(self, *, runner: PipelineRunner, db: HistoryDB) -> None:
+    def __init__(
+        self, *, runner: PipelineRunner, db: HistoryDB, running_badge: Any = None,
+    ) -> None:
         self._runner = runner
         self._db = db
 
@@ -119,8 +136,8 @@ class _AnalysisPage:
             "market", "social", "news", "fundamentals"
         ]
         self._research_depth = saved_depth
-        self._quick_model_id: str | None = "claude-opus-4-20250514"
-        self._deep_model_id: str | None = "claude-opus-4-20250514"
+        self._quick_model_id: str | None = "claude-opus-4-7"
+        self._deep_model_id: str | None = "claude-opus-4-7"
         self._language: str = "English"
 
         # UI refs — form inputs (read .value directly to avoid stale state)
@@ -137,6 +154,17 @@ class _AnalysisPage:
         self._log_panel: LogPanel | None = None
         self._report_panel: ReportSectionsPanel | None = None
         self._timer: ui.timer | None = None
+
+        # Run button ref for RACE-01 (disable on click)
+        self._run_btn: ui.button | None = None
+        # Header running badge for BUG-03 (manual visibility update)
+        self._running_badge: ui.label | None = running_badge
+
+        # Batch mode state
+        self._batch_mode: bool = False
+        self._batch_runner: BatchRunner | None = None
+        self._batch_panel: BatchProgressPanel | None = None
+        self._watchlist_select: ui.select | None = None
 
     def build(self) -> None:
         """Render the full page layout."""
@@ -159,12 +187,30 @@ class _AnalysisPage:
             ).classes("text-body2 text-grey-5")
 
             with ui.card().classes("w-full"):
+                # Batch mode toggle
+                with ui.row().classes("items-center gap-sm q-mb-sm"):
+                    ui.switch(
+                        "Batch Mode (multiple tickers)",
+                        value=False,
+                        on_change=lambda e: self._toggle_batch_mode(e.value),
+                    ).props("color=purple dense")
+
                 # Ticker — read .value directly in _on_run to avoid stale state
                 self._ticker_input = ui.input(
                     "Ticker Symbol",
                     value="SPY",
                     placeholder="e.g. SPY, AAPL, 0700.HK",
                 ).classes("w-full").props("outlined dense")
+
+                # Watchlist selector (only visible in batch mode)
+                watchlists = self._db.list_watchlists()
+                wl_options = {name: ", ".join(tickers) for name, tickers in watchlists.items()}
+                self._watchlist_select = ui.select(
+                    label="Load Watchlist",
+                    options=list(wl_options.keys()) if wl_options else ["No saved watchlists"],
+                    on_change=lambda e: self._load_watchlist(e.value),
+                ).classes("w-full q-mt-xs").props("outlined dense clearable")
+                self._watchlist_select.set_visibility(False)
 
                 # Date
                 self._date_input = ui.input(
@@ -259,8 +305,8 @@ class _AnalysisPage:
                     on_change=lambda e: setattr(self, "_research_depth", int(e.value)),
                 ).classes("w-full").props("label-always markers snap")
 
-            # Run button
-            ui.button(
+            # Run button — save ref for RACE-01 (disable on click)
+            self._run_btn = ui.button(
                 "Run Analysis",
                 icon="play_arrow",
                 on_click=self._on_run,
@@ -323,20 +369,32 @@ class _AnalysisPage:
         elif not checked and key in self._selected_analysts:
             self._selected_analysts.remove(key)
 
-    async def _on_run(self) -> None:
-        """Validate and start the analysis pipeline."""
-        # Read current values directly from UI elements (not stale callbacks)
-        ticker = (self._ticker_input.value or "").strip().upper() if self._ticker_input else ""
-        date = (self._date_input.value or "") if self._date_input else ""
+    def _toggle_batch_mode(self, enabled: bool) -> None:
+        """Switch between single-ticker and batch mode."""
+        self._batch_mode = enabled
+        if self._ticker_input:
+            if enabled:
+                self._ticker_input.props("label='Tickers (comma-separated)'")
+                self._ticker_input.props(
+                    "placeholder='e.g. SPY, AAPL, MSFT, NVDA, TSLA'"
+                )
+            else:
+                self._ticker_input.props("label='Ticker Symbol'")
+                self._ticker_input.props("placeholder='e.g. SPY, AAPL, 0700.HK'")
+        if self._watchlist_select:
+            self._watchlist_select.set_visibility(enabled)
 
-        if not ticker:
-            ui.notify("Please enter a ticker symbol", type="warning")
+    def _load_watchlist(self, name: str | None) -> None:
+        """Populate the ticker input from a saved watchlist."""
+        if not name or not self._ticker_input:
             return
-        if not self._selected_analysts:
-            ui.notify("Select at least one analyst", type="warning")
-            return
+        watchlists = self._db.list_watchlists()
+        tickers = watchlists.get(name, [])
+        if tickers:
+            self._ticker_input.set_value(", ".join(tickers))
 
-        # Resolve language (custom → read text input)
+    def _build_config(self) -> dict[str, Any]:
+        """Build config dict from current form state."""
         language = self._language
         if language == "custom" and self._custom_language_input:
             language = (self._custom_language_input.value or "").strip()
@@ -350,12 +408,102 @@ class _AnalysisPage:
             "max_risk_discuss_rounds": self._research_depth,
             "output_language": language,
         }
-
-        # Set user-selected models (all providers, not just claude_cli)
         if self._quick_model_id:
             config["quick_think_llm"] = self._quick_model_id
         if self._deep_model_id:
             config["deep_think_llm"] = self._deep_model_id
+        return config
+
+    async def _on_run(self) -> None:
+        """Validate and start the analysis pipeline (single or batch)."""
+        # RACE-01: Disable button immediately to prevent double-submission
+        if self._run_btn:
+            self._run_btn.disable()
+
+        raw_ticker = (self._ticker_input.value or "").strip().upper() if self._ticker_input else ""
+        date = (self._date_input.value or "") if self._date_input else ""
+
+        if not raw_ticker:
+            ui.notify("Please enter a ticker symbol", type="warning")
+            if self._run_btn:
+                self._run_btn.enable()
+            return
+        if not self._selected_analysts:
+            ui.notify("Select at least one analyst", type="warning")
+            if self._run_btn:
+                self._run_btn.enable()
+            return
+
+        # WR-03: Validate date format
+        try:
+            datetime.date.fromisoformat(date)
+        except ValueError:
+            ui.notify("Invalid date format. Use YYYY-MM-DD.", type="warning")
+            if self._run_btn:
+                self._run_btn.enable()
+            return
+
+        config = self._build_config()
+
+        # Batch mode: parse comma-separated tickers
+        if self._batch_mode:
+            tickers = [t.strip() for t in raw_ticker.split(",") if t.strip()]
+            if len(tickers) < 2:
+                ui.notify("Batch mode needs at least 2 tickers", type="warning")
+                if self._run_btn:
+                    self._run_btn.enable()
+                return
+            if len(tickers) > 20:
+                ui.notify("Maximum 20 tickers per batch", type="warning")
+                if self._run_btn:
+                    self._run_btn.enable()
+                return
+            # WR-02: Validate each ticker
+            invalid = [t for t in tickers if not _TICKER_RE.match(t)]
+            if invalid:
+                ui.notify(f"Invalid ticker(s): {', '.join(invalid)}", type="warning")
+                if self._run_btn:
+                    self._run_btn.enable()
+                return
+
+            self._batch_runner = BatchRunner(runner=self._runner, db=self._db)
+            # LEAK-02: Register on app module so shutdown can join it
+            _app_module.active_batch_runner = self._batch_runner
+            try:
+                self._batch_runner.start(
+                    tickers=tickers,
+                    config=config,
+                    date=date,
+                    selected_analysts=list(self._selected_analysts),
+                )
+            except RuntimeError as e:
+                ui.notify(str(e), type="negative")
+                if self._run_btn:
+                    self._run_btn.enable()
+                return
+
+            self._run_ticker = tickers[0]
+            self._run_date = date
+
+            if self._page_root:
+                self._page_root.clear()
+                with self._page_root:
+                    self._build_batch_progress_view(tickers)
+                    self._start_batch_polling()
+                    ui.notify(
+                        f"Batch started: {len(tickers)} tickers", type="positive",
+                    )
+            return
+
+        # Single ticker mode (original flow)
+        ticker = raw_ticker
+
+        # WR-02: Validate ticker format
+        if not _TICKER_RE.match(ticker):
+            ui.notify(f"Invalid ticker format: {ticker}", type="warning")
+            if self._run_btn:
+                self._run_btn.enable()
+            return
 
         # WR-06: Insert into database with error handling
         try:
@@ -370,6 +518,8 @@ class _AnalysisPage:
         except Exception as e:
             logger.exception("Failed to create analysis record")
             ui.notify(f"Database error: {e}", type="negative")
+            if self._run_btn:
+                self._run_btn.enable()
             return
 
         # Store ticker/date for the progress view summary strip
@@ -387,7 +537,11 @@ class _AnalysisPage:
                 analysis_id=analysis_id,
             )
         except RuntimeError as e:
+            # RACE-01: Mark the orphaned DB row as interrupted
+            self._db.mark_interrupted(analysis_id)
             ui.notify(str(e), type="negative")
+            if self._run_btn:
+                self._run_btn.enable()
             return
 
         # Swap form → progress view inside the persistent root container
@@ -396,8 +550,6 @@ class _AnalysisPage:
             with self._page_root:
                 self._build_progress_view()
                 self._start_polling()
-                # Must be inside `with` block — the slot context from
-                # _page_root.clear() is gone outside it.
                 ui.notify(f"Analysis started for {ticker}", type="positive")
 
     # ── Progress view (running state) ───────────────────────────────
@@ -437,6 +589,10 @@ class _AnalysisPage:
                     on_click=self._on_cancel,
                 ).props("color=red flat dense")
 
+            # Price chart (renders once, not polled)
+            if ticker and ticker != "???":
+                PriceChart(ticker=ticker, analysis_date=date or "").build()
+
             # Two-column layout
             with ui.row().classes("w-full gap-md"):
                 # Left column: agent status + progress bar
@@ -471,7 +627,12 @@ class _AnalysisPage:
             if event.kind == EventKind.COMPLETED:
                 self._on_completed(event.data)
             elif event.kind == EventKind.FAILED:
-                self._on_failed(event.data)
+                # WR-05: event.data is now a dict with analysis_id + error
+                if isinstance(event.data, dict):
+                    error_text = event.data.get("error", "Unknown error")
+                else:
+                    error_text = str(event.data) if event.data else "Unknown error"
+                self._on_failed(error_text)
             elif event.kind == EventKind.CANCELLED:
                 self._on_cancelled()
             elif event.kind == EventKind.WATCHDOG:
@@ -493,6 +654,10 @@ class _AnalysisPage:
             self._log_panel.update(snap)
         if self._report_panel:
             self._report_panel.update(snap)
+
+        # BUG-03: Update header badge from page timer instead of bind_visibility
+        if self._running_badge:
+            self._running_badge.set_visibility(self._runner.is_running)
 
     def _on_cancel(self) -> None:
         self._runner.cancel()
@@ -531,5 +696,136 @@ class _AnalysisPage:
             if self._page_root and self._agent_panel:
                 self._poll()
         except Exception:
-            # WR-01: log instead of silently swallowing — aids debugging
-            logger.debug("Final poll skipped (page likely navigated away)", exc_info=True)
+            # WR-07: log at WARNING (was DEBUG) — aids debugging
+            logger.warning("Final poll skipped (page likely navigated away)", exc_info=True)
+
+    # ── Batch progress view ────────────────────────────────────────────
+
+    def _build_batch_progress_view(self, tickers: list[str]) -> None:
+        """Render the batch-level progress + per-ticker dashboard."""
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Batch header
+            with ui.row().classes(
+                "items-center w-full bg-dark q-pa-sm rounded-borders"
+            ):
+                ui.icon("playlist_play").classes("text-purple text-h5")
+                ui.label("Batch Analysis").classes("text-h6 text-white q-ml-sm")
+                ui.label(f"{len(tickers)} tickers").classes(
+                    "text-caption text-grey q-ml-sm"
+                )
+                ui.space()
+                ui.button(
+                    "Cancel All", icon="stop",
+                    on_click=self._on_batch_cancel,
+                ).props("color=red flat dense")
+
+            # Batch-level progress strip
+            self._batch_panel = BatchProgressPanel()
+            self._batch_panel.build(tickers)
+
+            # Per-ticker progress (reuses existing components)
+            self._progress_panel = ProgressPanel()
+            self._progress_panel.build()
+            self._progress_panel.start()
+
+            self._agent_panel = AgentStatusPanel()
+            self._agent_panel.build()
+
+            self._log_panel = LogPanel()
+            self._log_panel.build()
+
+            # Save watchlist prompt
+            with ui.row().classes("items-center gap-sm q-mt-sm"):
+                wl_name_input = ui.input(
+                    "Save as watchlist", placeholder="e.g. Tech Stocks",
+                ).props("outlined dense").classes("w-48")
+
+                async def save_wl() -> None:
+                    name = (wl_name_input.value or "").strip()
+                    if not name:
+                        ui.notify("Enter a watchlist name", type="warning")
+                        return
+                    # WR-04: Catch ValueError from save_watchlist validation
+                    # (rejects empty, >100 chars, or names with : \n etc.)
+                    try:
+                        self._db.save_watchlist(name, tickers)
+                        ui.notify(f"Watchlist '{name}' saved!", type="positive")
+                    except ValueError as e:
+                        ui.notify(str(e), type="warning")
+
+                ui.button("Save", icon="bookmark", on_click=save_wl).props(
+                    "flat dense color=purple"
+                )
+
+    def _start_batch_polling(self) -> None:
+        """Start the UI timer for batch mode."""
+        self._timer = ui.timer(0.5, self._batch_poll)
+
+    def _batch_poll(self) -> None:
+        """Called every 500ms during batch runs.
+
+        LEAK-01: Wrapped in try/except so navigating away doesn't cause
+        exceptions from updating destroyed page elements.
+        """
+        if not self._batch_runner:
+            return
+
+        try:
+            state = self._batch_runner.snapshot()
+
+            # Update batch-level progress
+            if self._batch_panel:
+                if state.is_done:
+                    self._batch_panel.mark_complete(
+                        len(state.completed_tickers), len(state.tickers),
+                    )
+                else:
+                    self._batch_panel.update(
+                        current_index=len(state.completed_tickers),
+                        total=len(state.tickers),
+                        current_ticker=state.current_ticker,
+                        completed_tickers=state.completed_tickers,
+                        failed_tickers=state.failed_tickers,
+                    )
+
+            # Update per-ticker progress (same as single mode)
+            snap = self._runner.tracker.snapshot()
+            total = self._runner.tracker.get_total_reports_count()
+
+            if self._agent_panel:
+                self._agent_panel.update(snap)
+            if self._progress_panel:
+                self._progress_panel.update(snap, total_reports=total)
+            if self._log_panel:
+                self._log_panel.update(snap)
+
+            # BUG-03: Update header badge
+            if self._running_badge:
+                self._running_badge.set_visibility(self._runner.is_running)
+        except Exception:
+            # LEAK-01: Page likely navigated away; deactivate timer
+            logger.warning("Batch poll skipped (page likely navigated away)", exc_info=True)
+            if self._timer:
+                self._timer.deactivate()
+            return
+
+        # Batch done?
+        if state.is_done:
+            # WR-03: Clear stale batch runner reference so shutdown
+            # doesn't try to join an already-finished runner and GC
+            # can reclaim the BatchRunner + its internal queue.
+            _app_module.active_batch_runner = None
+            if self._timer:
+                self._timer.deactivate()
+            ok = len(state.completed_tickers)
+            fail = len(state.failed_tickers)
+            msg = f"Batch complete: {ok} succeeded"
+            if fail:
+                msg += f", {fail} failed"
+            ui.notify(msg, type="positive" if not fail else "warning", timeout=10000)
+
+    def _on_batch_cancel(self) -> None:
+        """Cancel the entire batch run."""
+        if self._batch_runner:
+            self._batch_runner.cancel()
+        ui.notify("Cancelling batch...", type="info")

--- a/desktop/pages/analysis.py
+++ b/desktop/pages/analysis.py
@@ -9,8 +9,11 @@ See also: PLAN-desktop.md, F1 + F2.
 from __future__ import annotations
 
 import datetime
+import logging
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from nicegui import ui
 
@@ -21,6 +24,7 @@ from desktop.components.report_section import ReportSectionsPanel
 from desktop.state.database import HistoryDB
 from desktop.state.runner import EventKind, PipelineRunner
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.llm_clients.model_catalog import MODEL_OPTIONS
 from tradingagents.progress import REPORT_SECTIONS
 
 # Provider options for the dropdown (display, key, url)
@@ -42,6 +46,43 @@ _ANALYSTS = [
     ("Fundamentals Analyst", "fundamentals"),
 ]
 
+# Claude CLI models (not in the shared model catalog)
+_CLAUDE_CLI_MODELS: dict[str, list[tuple[str, str]]] = {
+    "quick": [
+        ("Claude Opus 4.6", "claude-opus-4-20250514"),
+        ("Claude Opus 4.7 Max", "claude-opus-4-20250715"),
+    ],
+    "deep": [
+        ("Claude Opus 4.6", "claude-opus-4-20250514"),
+        ("Claude Opus 4.7 Max", "claude-opus-4-20250715"),
+    ],
+}
+
+_LANGUAGES: list[tuple[str, str]] = [
+    ("English", "English"),
+    ("中文 (Chinese)", "Chinese"),
+    ("日本語 (Japanese)", "Japanese"),
+    ("한국어 (Korean)", "Korean"),
+    ("हिंदी (Hindi)", "Hindi"),
+    ("Español (Spanish)", "Spanish"),
+    ("Português (Portuguese)", "Portuguese"),
+    ("Français (French)", "French"),
+    ("Deutsch (German)", "German"),
+    ("العربية (Arabic)", "Arabic"),
+    ("Русский (Russian)", "Russian"),
+    ("Custom", "custom"),
+]
+
+
+def _get_models_for_provider(
+    provider_key: str, mode: str,
+) -> list[tuple[str, str]]:
+    """Return model options for a provider and mode (no 'custom' entries)."""
+    if provider_key == "claude_cli":
+        return _CLAUDE_CLI_MODELS.get(mode, [])
+    models = MODEL_OPTIONS.get(provider_key, {}).get(mode, [])
+    return [(name, mid) for name, mid in models if mid != "custom"]
+
 
 def render_analysis_page(*, runner: PipelineRunner, db: HistoryDB) -> None:
     """Render the analysis page content."""
@@ -56,17 +97,40 @@ class _AnalysisPage:
         self._runner = runner
         self._db = db
 
-        # Form state
-        self._ticker = "SPY"
-        self._date = datetime.date.today().isoformat()
-        self._provider_key = "claude_cli"
-        self._backend_url: str | None = None
-        self._selected_analysts: list[str] = ["market", "social", "news", "fundamentals"]
-        self._research_depth = 1
+        # WR-04: Read saved defaults from settings DB so the form
+        # reflects what the user configured on the Settings page.
+        saved = db.get_all_settings()
 
-        # UI refs
-        self._form_container: ui.column | None = None
-        self._progress_container: ui.column | None = None
+        saved_provider = saved.get("default_provider", "claude_cli")
+        saved_analysts_csv = saved.get(
+            "default_analysts", "market,social,news,fundamentals"
+        )
+        saved_analysts = [
+            a.strip() for a in saved_analysts_csv.split(",") if a.strip()
+        ]
+        saved_depth = int(saved.get("research_depth", "1"))
+
+        # Form state — seeded from saved settings
+        self._provider_key = saved_provider
+        self._backend_url: str | None = next(
+            (url for _, key, url in _PROVIDERS if key == saved_provider), None
+        )
+        self._selected_analysts: list[str] = saved_analysts or [
+            "market", "social", "news", "fundamentals"
+        ]
+        self._research_depth = saved_depth
+        self._quick_model_id: str | None = "claude-opus-4-20250514"
+        self._deep_model_id: str | None = "claude-opus-4-20250514"
+        self._language: str = "English"
+
+        # UI refs — form inputs (read .value directly to avoid stale state)
+        self._ticker_input: ui.input | None = None
+        self._date_input: ui.input | None = None
+        self._quick_model_select: ui.select | None = None
+        self._deep_model_select: ui.select | None = None
+        self._language_select: ui.select | None = None
+        self._custom_language_input: ui.input | None = None
+        self._page_root: ui.column | None = None
         self._summary_strip: ui.row | None = None
         self._agent_panel: AgentStatusPanel | None = None
         self._progress_panel: ProgressPanel | None = None
@@ -76,78 +140,122 @@ class _AnalysisPage:
 
     def build(self) -> None:
         """Render the full page layout."""
-        # If already running, show progress state
-        if self._runner.is_running:
-            self._build_progress_view()
-            self._start_polling()
-            return
-
-        self._build_form()
+        self._page_root = ui.column().classes("w-full")
+        with self._page_root:
+            if self._runner.is_running:
+                self._build_progress_view()
+                self._start_polling()
+            else:
+                self._build_form()
 
     # ── Form (pre-run state) ────────────────────────────────────────
 
     def _build_form(self) -> None:
         """Render the configuration form."""
-        self._form_container = ui.column().classes("w-full max-w-2xl mx-auto q-pa-md gap-md")
-        with self._form_container:
+        with ui.column().classes("w-full max-w-2xl mx-auto q-pa-md gap-md"):
             ui.label("New Analysis").classes("text-h5 text-white")
             ui.label(
                 "Configure and run a trading analysis. The pipeline takes 5-15 minutes."
             ).classes("text-body2 text-grey-5")
 
             with ui.card().classes("w-full"):
-                # Ticker
-                ticker_input = ui.input(
+                # Ticker — read .value directly in _on_run to avoid stale state
+                self._ticker_input = ui.input(
                     "Ticker Symbol",
-                    value=self._ticker,
+                    value="SPY",
                     placeholder="e.g. SPY, AAPL, 0700.HK",
                 ).classes("w-full").props("outlined dense")
-                ticker_input.on("update:model-value", lambda e: setattr(self, "_ticker", e.args))
 
                 # Date
-                date_input = ui.input(
+                self._date_input = ui.input(
                     "Analysis Date",
-                    value=self._date,
+                    value=datetime.date.today().isoformat(),
                 ).classes("w-full q-mt-sm").props("outlined dense")
-                with date_input:
+                with self._date_input:
                     with ui.menu() as menu:
                         ui.date(
-                            value=self._date,
+                            value=datetime.date.today().isoformat(),
                             on_change=lambda e: (
-                                setattr(self, "_date", e.value),
-                                date_input.set_value(e.value),
+                                self._date_input.set_value(e.value),
                                 menu.close(),
                             ),
                         ).props("today-btn")
-                    with date_input.add_slot("append"):
+                    with self._date_input.add_slot("append"):
                         ui.icon("event").on("click", menu.open).classes("cursor-pointer")
 
-                # Provider
+                # Provider — WR-04: initial value from saved settings
                 provider_options = {display: key for display, key, _ in _PROVIDERS}
-                provider_select = ui.select(
+                provider_display = next(
+                    (d for d, k in provider_options.items() if k == self._provider_key),
+                    "Claude CLI (Max, $0)",
+                )
+                ui.select(
                     label="LLM Provider",
                     options=list(provider_options.keys()),
-                    value="Claude CLI (Max, $0)",
+                    value=provider_display,
+                    on_change=lambda e: self._on_provider_change(e.value, provider_options),
                 ).classes("w-full q-mt-sm").props("outlined dense")
-                provider_select.on(
-                    "update:model-value",
-                    lambda e: self._on_provider_change(e.args, provider_options),
+
+                # Language selector
+                lang_options = {display: key for display, key in _LANGUAGES}
+                self._language_select = ui.select(
+                    label="Output Language",
+                    options=list(lang_options.keys()),
+                    value="English",
+                    on_change=lambda e: self._on_language_change(
+                        e.value, lang_options,
+                    ),
+                ).classes("w-full q-mt-sm").props("outlined dense")
+
+                self._custom_language_input = ui.input(
+                    "Custom Language",
+                    placeholder="e.g. Turkish, Vietnamese, …",
+                ).classes("w-full q-mt-xs").props("outlined dense")
+                self._custom_language_input.set_visibility(False)
+
+                # Model selectors (quick + deep think)
+                ui.label("Model Configuration").classes(
+                    "text-subtitle2 q-mt-md"
                 )
 
-                # Analysts (checkboxes)
+                quick_models = _get_models_for_provider(
+                    self._provider_key, "quick",
+                )
+                quick_opts = {d: m for d, m in quick_models}
+                self._quick_model_select = ui.select(
+                    label="Quick Think Model",
+                    options=list(quick_opts.keys()),
+                    value=next(iter(quick_opts), None),
+                    on_change=lambda e: self._on_quick_model_change(e.value),
+                ).classes("w-full q-mt-xs").props("outlined dense")
+                self._quick_model_select.set_visibility(bool(quick_opts))
+
+                deep_models = _get_models_for_provider(
+                    self._provider_key, "deep",
+                )
+                deep_opts = {d: m for d, m in deep_models}
+                self._deep_model_select = ui.select(
+                    label="Deep Think Model",
+                    options=list(deep_opts.keys()),
+                    value=next(iter(deep_opts), None),
+                    on_change=lambda e: self._on_deep_model_change(e.value),
+                ).classes("w-full q-mt-xs").props("outlined dense")
+                self._deep_model_select.set_visibility(bool(deep_opts))
+
+                # Analysts (checkboxes) — WR-04: pre-checked from saved settings
                 ui.label("Analyst Team").classes("text-subtitle2 q-mt-md")
                 with ui.row().classes("gap-md"):
                     for display, key in _ANALYSTS:
                         ui.checkbox(
                             display,
-                            value=True,
+                            value=key in self._selected_analysts,
                             on_change=lambda e, k=key: self._toggle_analyst(k, e.value),
                         )
 
-                # Research depth
+                # Research depth — WR-04: initial value from saved settings
                 ui.label("Research Depth").classes("text-subtitle2 q-mt-md")
                 ui.slider(
-                    min=1, max=3, step=1, value=1,
+                    min=1, max=3, step=1, value=self._research_depth,
                     on_change=lambda e: setattr(self, "_research_depth", int(e.value)),
                 ).classes("w-full").props("label-always markers snap")
 
@@ -163,6 +271,51 @@ class _AnalysisPage:
         self._backend_url = next(
             (url for d, _, url in _PROVIDERS if d == display_name), None
         )
+        # Refresh both model selectors from catalog
+        self._refresh_model_select(self._quick_model_select, "quick", "_quick_model_id")
+        self._refresh_model_select(self._deep_model_select, "deep", "_deep_model_id")
+
+    def _refresh_model_select(
+        self, select: ui.select | None, mode: str, attr: str,
+    ) -> None:
+        """Repopulate a model dropdown after the provider changed."""
+        if select is None:
+            return
+        models = _get_models_for_provider(self._provider_key, mode)
+        options = {display: mid for display, mid in models}
+        select.options = list(options.keys())
+        if options:
+            first = next(iter(options))
+            select.set_value(first)
+            setattr(self, attr, options[first])
+        else:
+            select.set_value(None)
+            setattr(self, attr, None)
+        select.set_visibility(bool(options))
+        select.update()
+
+    def _on_quick_model_change(self, display_name: str | None) -> None:
+        models = _get_models_for_provider(self._provider_key, "quick")
+        model_map = {d: m for d, m in models}
+        self._quick_model_id = model_map.get(display_name or "") if display_name else None
+
+    def _on_deep_model_change(self, display_name: str | None) -> None:
+        models = _get_models_for_provider(self._provider_key, "deep")
+        model_map = {d: m for d, m in models}
+        self._deep_model_id = model_map.get(display_name or "") if display_name else None
+
+    def _on_language_change(
+        self, display_name: str, mapping: dict[str, str],
+    ) -> None:
+        value = mapping.get(display_name, "English")
+        if value == "custom":
+            self._language = "custom"
+            if self._custom_language_input:
+                self._custom_language_input.set_visibility(True)
+        else:
+            self._language = value
+            if self._custom_language_input:
+                self._custom_language_input.set_visibility(False)
 
     def _toggle_analyst(self, key: str, checked: bool) -> None:
         if checked and key not in self._selected_analysts:
@@ -172,7 +325,10 @@ class _AnalysisPage:
 
     async def _on_run(self) -> None:
         """Validate and start the analysis pipeline."""
-        ticker = self._ticker.strip().upper()
+        # Read current values directly from UI elements (not stale callbacks)
+        ticker = (self._ticker_input.value or "").strip().upper() if self._ticker_input else ""
+        date = (self._date_input.value or "") if self._date_input else ""
+
         if not ticker:
             ui.notify("Please enter a ticker symbol", type="warning")
             return
@@ -180,65 +336,98 @@ class _AnalysisPage:
             ui.notify("Select at least one analyst", type="warning")
             return
 
+        # Resolve language (custom → read text input)
+        language = self._language
+        if language == "custom" and self._custom_language_input:
+            language = (self._custom_language_input.value or "").strip()
+        if not language or language == "custom":
+            language = "English"
+
         config: dict[str, Any] = {
             "llm_provider": self._provider_key,
             "backend_url": self._backend_url,
             "max_debate_rounds": self._research_depth,
             "max_risk_discuss_rounds": self._research_depth,
+            "output_language": language,
         }
 
-        # For Claude CLI, set models
-        if self._provider_key == "claude_cli":
-            config["quick_think_llm"] = "claude-opus-4-20250514"
-            config["deep_think_llm"] = "claude-opus-4-20250514"
+        # Set user-selected models (all providers, not just claude_cli)
+        if self._quick_model_id:
+            config["quick_think_llm"] = self._quick_model_id
+        if self._deep_model_id:
+            config["deep_think_llm"] = self._deep_model_id
 
-        # Insert into database
-        analysis_id = self._db.insert_analysis(
-            ticker=ticker,
-            date=self._date,
-            provider=self._provider_key,
-            model=config.get("deep_think_llm", "default"),
-            config=config,
-            selected_analysts=self._selected_analysts,
-        )
-        self._runner.analysis_id = analysis_id
+        # WR-06: Insert into database with error handling
+        try:
+            analysis_id = self._db.insert_analysis(
+                ticker=ticker,
+                date=date,
+                provider=self._provider_key,
+                model=config.get("deep_think_llm", "default"),
+                config=config,
+                selected_analysts=self._selected_analysts,
+            )
+        except Exception as e:
+            logger.exception("Failed to create analysis record")
+            ui.notify(f"Database error: {e}", type="negative")
+            return
 
-        # Start the pipeline
+        # Store ticker/date for the progress view summary strip
+        self._run_ticker = ticker
+        self._run_date = date
+
+        # Start the pipeline — pass analysis_id so it's set under the lock
+        # before the thread spawns (HI-01 race fix)
         try:
             self._runner.start(
                 config=config,
                 ticker=ticker,
-                date=self._date,
+                date=date,
                 selected_analysts=list(self._selected_analysts),
+                analysis_id=analysis_id,
             )
         except RuntimeError as e:
             ui.notify(str(e), type="negative")
             return
 
-        # Switch to progress view
-        if self._form_container:
-            self._form_container.clear()
-            self._form_container.delete()
-
-        self._build_progress_view()
-        self._start_polling()
+        # Swap form → progress view inside the persistent root container
+        if self._page_root:
+            self._page_root.clear()
+            with self._page_root:
+                self._build_progress_view()
+                self._start_polling()
         ui.notify(f"Analysis started for {ticker}", type="positive")
 
     # ── Progress view (running state) ───────────────────────────────
 
     def _build_progress_view(self) -> None:
-        """Render the live progress dashboard."""
-        self._progress_container = ui.column().classes("w-full q-pa-md gap-md")
-        with self._progress_container:
+        """Render the live progress dashboard.
+
+        WR-01: On browser refresh, ``_run_ticker`` isn't set because
+        ``_on_run`` never ran in this page instance.  Fall back to the
+        database row so the user sees the real ticker, not "???".
+        """
+        ticker = getattr(self, "_run_ticker", None)
+        date = getattr(self, "_run_date", None)
+
+        if not ticker and self._runner.analysis_id:
+            row = self._db.get_analysis(self._runner.analysis_id)
+            if row:
+                ticker = row.ticker
+                date = row.date
+
+        ticker = ticker or "???"
+        date = date or ""
+
+        with ui.column().classes("w-full q-pa-md gap-md"):
             # Summary strip
-            self._summary_strip = ui.row().classes(
+            with ui.row().classes(
                 "items-center w-full bg-dark q-pa-sm rounded-borders"
-            )
-            with self._summary_strip:
+            ):
                 ui.icon("analytics").classes("text-green text-h5")
-                ui.label(f"{self._ticker}").classes("text-h6 text-white q-ml-sm")
-                ui.label(f"{self._date}").classes("text-caption text-grey q-ml-sm")
-                ui.label(f"{self._provider_key}").classes("text-caption text-grey q-ml-sm")
+                ui.label(ticker).classes("text-h6 text-white q-ml-sm")
+                ui.label(date).classes("text-caption text-grey q-ml-sm")
+                ui.label(self._provider_key).classes("text-caption text-grey q-ml-sm")
                 ui.space()
                 ui.button(
                     "Cancel",
@@ -308,27 +497,37 @@ class _AnalysisPage:
         ui.notify("Cancelling analysis...", type="info")
 
     def _on_completed(self, data: dict[str, Any]) -> None:
-        """Pipeline finished successfully."""
+        """Pipeline finished — UI-side handler.
+
+        Persistence (DB status, reports, logs) is handled by the
+        app-level ``on_pipeline_finished`` callback in app.py, which
+        runs on the pipeline thread regardless of UI state.  This
+        handler only manages UI updates and notifications.
+        """
         if self._timer:
             self._timer.deactivate()
-        if self._runner.analysis_id:
-            self._db.mark_completed(self._runner.analysis_id)
         ui.notify("Analysis completed!", type="positive", timeout=10000)
-        # Final UI update
-        self._poll()
+        self._safe_final_poll()
 
     def _on_failed(self, error_text: str) -> None:
-        """Pipeline failed with an error."""
+        """Pipeline failed — UI notification only."""
         if self._timer:
             self._timer.deactivate()
-        if self._runner.analysis_id:
-            self._db.mark_failed(self._runner.analysis_id, error_text)
         ui.notify(f"Analysis failed: {error_text}", type="negative", timeout=15000)
+        self._safe_final_poll()
 
     def _on_cancelled(self) -> None:
-        """Pipeline was cancelled."""
+        """Pipeline cancelled — UI notification only."""
         if self._timer:
             self._timer.deactivate()
-        if self._runner.analysis_id:
-            self._db.mark_interrupted(self._runner.analysis_id)
         ui.notify("Analysis cancelled", type="warning")
+        self._safe_final_poll()
+
+    def _safe_final_poll(self) -> None:
+        """WR-04: Best-effort final UI update, safe if page navigated away."""
+        try:
+            if self._page_root and self._agent_panel:
+                self._poll()
+        except Exception:
+            # WR-01: log instead of silently swallowing — aids debugging
+            logger.debug("Final poll skipped (page likely navigated away)", exc_info=True)

--- a/desktop/pages/compare.py
+++ b/desktop/pages/compare.py
@@ -1,0 +1,230 @@
+"""Compare page — side-by-side view of two analyses.
+
+Renders two analyses in parallel columns with price charts, report
+sections, and a summary diff strip at the top.
+
+Entry point: ``/compare?a={id1}&b={id2}`` from the History page.
+
+See also: PLAN-features-v2.md, Feature 2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nicegui import ui
+
+from desktop.components.price_chart import PriceChart
+from desktop.state.database import AnalysisRow, HistoryDB
+from desktop.utils.paths import validated_result_dir
+from desktop.utils.reports import (
+    MD_EXTRAS,
+    discover_report_files,
+    status_chip,
+)
+
+
+def render_compare_page(*, db: HistoryDB, id_a: int, id_b: int) -> None:
+    """Render the comparison page for two analyses."""
+    page = _ComparePage(db=db, id_a=id_a, id_b=id_b)
+    page.build()
+
+
+class _ComparePage:
+    def __init__(self, *, db: HistoryDB, id_a: int, id_b: int) -> None:
+        self._db = db
+        self._id_a = id_a
+        self._id_b = id_b
+
+    def build(self) -> None:
+        a = self._db.get_analysis(self._id_a)
+        b = self._db.get_analysis(self._id_b)
+
+        if a is None or b is None:
+            with ui.column().classes("w-full q-pa-md"):
+                missing = []
+                if a is None:
+                    missing.append(str(self._id_a))
+                if b is None:
+                    missing.append(str(self._id_b))
+                ui.label(
+                    f"Analysis not found: {', '.join(missing)}"
+                ).classes("text-h5 text-red")
+                ui.button(
+                    "Back to History", icon="arrow_back",
+                    on_click=lambda: ui.navigate.to("/history"),
+                )
+            return
+
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Back button + title
+            with ui.row().classes("items-center gap-md"):
+                ui.button(
+                    icon="arrow_back",
+                    on_click=lambda: ui.navigate.to("/history"),
+                ).props("flat dense")
+                ui.label("Compare Analyses").classes("text-h5 text-white")
+
+            # Diff summary strip
+            self._build_diff_strip(a, b)
+
+            # Two-column layout
+            with ui.grid(columns=2).classes("w-full gap-md"):
+                # Column A
+                with ui.column().classes("gap-md"):
+                    self._build_analysis_column(a, label="A")
+
+                # Column B
+                with ui.column().classes("gap-md"):
+                    self._build_analysis_column(b, label="B")
+
+    def _build_diff_strip(self, a: AnalysisRow, b: AnalysisRow) -> None:
+        """Summary card highlighting key differences."""
+        with ui.card().classes("w-full"):
+            with ui.row().classes("items-center gap-lg"):
+                ui.icon("compare_arrows").classes("text-purple text-h5")
+                ui.label("Comparison Summary").classes("text-subtitle1")
+
+            with ui.grid(columns=3).classes("w-full q-mt-sm"):
+                # Column headers
+                ui.label("").classes("text-caption text-grey")
+                ui.label(f"Analysis A (#{a.id})").classes(
+                    "text-caption text-blue-4 text-bold"
+                )
+                ui.label(f"Analysis B (#{b.id})").classes(
+                    "text-caption text-orange-4 text-bold"
+                )
+
+                # Ticker
+                ui.label("Ticker").classes("text-caption text-grey")
+                _diff_cell(a.ticker, b.ticker, a.ticker)
+                _diff_cell(b.ticker, a.ticker, b.ticker)
+
+                # Date
+                ui.label("Date").classes("text-caption text-grey")
+                _diff_cell(a.date, b.date, a.date)
+                _diff_cell(b.date, a.date, b.date)
+
+                # Provider
+                ui.label("Provider").classes("text-caption text-grey")
+                ui.label(a.provider).classes("text-caption")
+                ui.label(b.provider).classes("text-caption")
+
+                # Status
+                ui.label("Status").classes("text-caption text-grey")
+                status_chip(a.status)
+                status_chip(b.status)
+
+            # Decision comparison (if both have result files)
+            decision_a = _read_decision(a)
+            decision_b = _read_decision(b)
+            if decision_a or decision_b:
+                ui.separator().classes("q-my-sm")
+                with ui.row().classes("gap-lg"):
+                    with ui.column().classes("w-1/2"):
+                        ui.label("Decision A").classes(
+                            "text-caption text-blue-4"
+                        )
+                        ui.label(decision_a or "N/A").classes(
+                            "text-body2 text-white"
+                        )
+                    with ui.column().classes("w-1/2"):
+                        ui.label("Decision B").classes(
+                            "text-caption text-orange-4"
+                        )
+                        ui.label(decision_b or "N/A").classes(
+                            "text-body2 text-white"
+                        )
+
+    def _build_analysis_column(
+        self, analysis: AnalysisRow, *, label: str,
+    ) -> None:
+        """Render one analysis column with header, chart, and reports."""
+        color = "blue" if label == "A" else "orange"
+
+        # Header strip
+        with ui.card().classes(f"w-full border-{color}"):
+            with ui.row().classes("items-center"):
+                ui.label(label).classes(
+                    f"text-h6 text-{color} text-bold q-mr-sm"
+                )
+                ui.label(analysis.ticker).classes("text-h6 text-white")
+                ui.label(analysis.date).classes("text-caption text-grey q-ml-sm")
+                status_chip(analysis.status)
+
+        # Price chart
+        PriceChart(
+            ticker=analysis.ticker, analysis_date=analysis.date,
+        ).build()
+
+        # Report sections from disk
+        if not analysis.result_dir or not Path(analysis.result_dir).is_dir():
+            ui.label("No report files on disk.").classes(
+                "text-body2 text-grey-5"
+            )
+            return
+
+        # SEC-01: Use is_relative_to instead of fragile startswith
+        root = validated_result_dir(analysis.result_dir)
+        if root is None:
+            ui.label("Invalid result directory.").classes("text-body2 text-red")
+            return
+
+        sections = discover_report_files(root)
+
+        for title, md_path in sections:
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                content = f"*Error reading report: {exc}*"
+            with ui.expansion(
+                title, icon="description",
+            ).classes("w-full bg-dark").props(
+                "dense header-class='text-subtitle2 text-grey-4'"
+            ):
+                ui.markdown(content, extras=MD_EXTRAS).classes(
+                    "report-content text-white q-pa-sm"
+                )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _read_decision(analysis: AnalysisRow) -> str | None:
+    """Try to extract the first line of the final trade decision.
+
+    BUG-02 fix: validates result_dir before reading files.
+    """
+    if not analysis.result_dir:
+        return None
+
+    # BUG-02: Validate path before reading (was missing here)
+    root = validated_result_dir(analysis.result_dir)
+    if root is None:
+        return None
+
+    candidates = [
+        root / "5_portfolio" / "decision.md",
+        root / "final_trade_decision.md",
+        root / "reports" / "final_trade_decision.md",
+    ]
+    for path in candidates:
+        if path.is_file():
+            try:
+                text = path.read_text(encoding="utf-8").strip()
+                # Return first non-empty, non-header line
+                for line in text.splitlines():
+                    stripped = line.strip()
+                    if stripped and not stripped.startswith("#"):
+                        return stripped[:200]
+            except (OSError, UnicodeDecodeError):
+                pass
+    return None
+
+
+def _diff_cell(value: str, other: str, display: str) -> None:
+    """Render a cell that highlights when values differ."""
+    if value != other:
+        ui.label(display).classes("text-caption text-yellow text-bold")
+    else:
+        ui.label(display).classes("text-caption")

--- a/desktop/pages/dashboard.py
+++ b/desktop/pages/dashboard.py
@@ -1,0 +1,452 @@
+"""Active Recommendations Dashboard — live prices, status, and portfolio heat.
+
+Displays all active recommendations with current market prices fetched
+via ``PriceService``, color-coded verdicts, stop/target breach indicators,
+and an auto-refresh timer.
+
+See also: PLAN-desktop.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from nicegui import ui
+
+from desktop.services.price_service import PriceResult, PriceService
+from desktop.state.database import HistoryDB, RecommendationRow
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Verdict → color mapping (Quasar classes)
+# ---------------------------------------------------------------------------
+
+_VERDICT_COLORS: dict[str, str] = {
+    "BUY": "bg-green text-white",
+    "OVERWEIGHT": "bg-green text-white",
+    "HOLD": "bg-orange text-white",
+    "SELL": "bg-red text-white",
+    "UNDERWEIGHT": "bg-red text-white",
+}
+_VERDICT_DEFAULT = "bg-grey text-white"
+
+_BULLISH_VERDICTS = frozenset({"BUY", "OVERWEIGHT"})
+_BEARISH_VERDICTS = frozenset({"SELL", "UNDERWEIGHT"})
+
+_AUTO_REFRESH_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def render_dashboard_page(*, db: HistoryDB) -> None:
+    """Render the active recommendations dashboard."""
+    page = _DashboardPage(db=db)
+    page.build()
+
+
+# ---------------------------------------------------------------------------
+# Internal page controller
+# ---------------------------------------------------------------------------
+
+
+class _DashboardPage:
+    """Builds and manages the Active Recommendations Dashboard."""
+
+    def __init__(self, *, db: HistoryDB) -> None:
+        self._db = db
+        self._price_svc = PriceService()
+
+        # UI refs
+        self._table: ui.table | None = None
+        self._last_updated_label: ui.label | None = None
+        self._loading_spinner: ui.spinner | None = None
+        self._timer: ui.timer | None = None
+
+        # Stat card labels
+        self._total_label: ui.label | None = None
+        self._buy_label: ui.label | None = None
+        self._hold_label: ui.label | None = None
+        self._sell_label: ui.label | None = None
+
+        # Footer labels
+        self._heat_label: ui.label | None = None
+        self._dist_label: ui.label | None = None
+
+    # ── Build ──────────────────────────────────────────────────────────
+
+    def build(self) -> None:
+        """Render the full dashboard layout."""
+        recs = self._db.list_active_recommendations()
+
+        if not recs:
+            self._build_empty_state()
+            return
+
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            self._build_header()
+            self._build_summary_stats(recs)
+            self._build_table()
+            self._build_footer()
+
+        # Initial data load
+        self._refresh_data()
+
+        # Auto-refresh timer
+        self._timer = ui.timer(_AUTO_REFRESH_SECONDS, self._refresh_data)
+
+    # ── Empty state ────────────────────────────────────────────────────
+
+    def _build_empty_state(self) -> None:
+        """Show a friendly empty state when no active recommendations exist."""
+        with ui.column().classes(
+            "w-full items-center justify-center q-pa-xl gap-md"
+        ).style("min-height: 60vh"):
+            ui.icon("analytics").classes("text-grey-6").style("font-size: 72px")
+            ui.label("No recommendations yet").classes(
+                "text-h5 text-grey-4"
+            )
+            ui.label(
+                "Run your first analysis to see recommendations here"
+            ).classes("text-body1 text-grey-6")
+            ui.button(
+                "Go to Analysis",
+                icon="arrow_forward",
+                on_click=lambda: ui.navigate.to("/"),
+            ).props("color=green size=lg")
+
+    # ── Header ─────────────────────────────────────────────────────────
+
+    def _build_header(self) -> None:
+        with ui.row().classes("items-center w-full"):
+            ui.label("Active Recommendations").classes("text-h5 text-white")
+            ui.space()
+            self._loading_spinner = ui.spinner("dots", size="sm")
+            self._loading_spinner.set_visibility(False)
+            ui.button(
+                "Refresh",
+                icon="refresh",
+                on_click=self._on_manual_refresh,
+            ).props("flat dense")
+            self._last_updated_label = ui.label("").classes(
+                "text-caption text-grey-5"
+            )
+
+    # ── Summary stat cards ─────────────────────────────────────────────
+
+    def _build_summary_stats(self, recs: list[RecommendationRow]) -> None:
+        with ui.row().classes("w-full gap-md flex-wrap"):
+            self._total_label = self._stat_card(
+                "Total Active", str(len(recs)), "list_alt", "text-blue"
+            )
+            buy_count = sum(
+                1 for r in recs if r.verdict in _BULLISH_VERDICTS
+            )
+            self._buy_label = self._stat_card(
+                "BUY / Overweight", str(buy_count), "trending_up", "text-green"
+            )
+            hold_count = sum(1 for r in recs if r.verdict == "HOLD")
+            self._hold_label = self._stat_card(
+                "HOLD", str(hold_count), "pause_circle", "text-orange"
+            )
+            sell_count = sum(
+                1 for r in recs if r.verdict in _BEARISH_VERDICTS
+            )
+            self._sell_label = self._stat_card(
+                "SELL / Underweight", str(sell_count), "trending_down", "text-red"
+            )
+
+    @staticmethod
+    def _stat_card(
+        title: str, value: str, icon_name: str, icon_color: str,
+    ) -> ui.label:
+        """Build a single summary-stat card and return the value label."""
+        with ui.card().classes("bg-dark-page q-pa-md min-w-[140px]"):
+            with ui.row().classes("items-center gap-sm"):
+                ui.icon(icon_name).classes(f"{icon_color} text-h6")
+                ui.label(title).classes("text-caption text-grey-5")
+            value_label = ui.label(value).classes("text-h4 text-white q-mt-xs")
+        return value_label
+
+    # ── Main table ─────────────────────────────────────────────────────
+
+    def _build_table(self) -> None:
+        columns = [
+            {"name": "ticker", "label": "Ticker", "field": "ticker", "sortable": True},
+            {"name": "verdict", "label": "Verdict", "field": "verdict", "sortable": True},
+            {"name": "entry_price", "label": "Entry Price", "field": "entry_price", "sortable": True},
+            {"name": "current_price", "label": "Current Price", "field": "current_price", "sortable": True},
+            {"name": "delta_pct", "label": "Delta %", "field": "delta_pct", "sortable": True},
+            {"name": "stop_loss", "label": "Stop Loss", "field": "stop_loss"},
+            {"name": "target", "label": "Target", "field": "target"},
+            {"name": "status", "label": "Status", "field": "status"},
+            {"name": "actions", "label": "", "field": "actions"},
+        ]
+
+        self._table = ui.table(
+            columns=columns,
+            rows=[],
+            row_key="id",
+            pagination={"rowsPerPage": 20},
+        ).classes("w-full").props("flat bordered dense")
+
+        # Ticker column — bold
+        self._table.add_slot(
+            "body-cell-ticker",
+            """
+            <q-td :props="props">
+                <span class="text-bold text-white">{{ props.row.ticker }}</span>
+            </q-td>
+            """,
+        )
+
+        # Verdict column — color-coded badge
+        self._table.add_slot(
+            "body-cell-verdict",
+            """
+            <q-td :props="props">
+                <q-badge :class="props.row.verdict_class" :label="props.row.verdict" />
+            </q-td>
+            """,
+        )
+
+        # Delta % column — green/red coloring
+        self._table.add_slot(
+            "body-cell-delta_pct",
+            """
+            <q-td :props="props">
+                <span :class="props.row.delta_color">{{ props.row.delta_pct }}</span>
+            </q-td>
+            """,
+        )
+
+        # Status column — icons
+        self._table.add_slot(
+            "body-cell-status",
+            """
+            <q-td :props="props">
+                <span>{{ props.row.status }}</span>
+            </q-td>
+            """,
+        )
+
+        # Actions column — View button
+        self._table.add_slot(
+            "body-cell-actions",
+            """
+            <q-td :props="props">
+                <q-btn flat dense color="green" icon="visibility" label="View"
+                       @click="$parent.$emit('view', props.row)" />
+            </q-td>
+            """,
+        )
+
+        def _on_view(e) -> None:
+            try:
+                aid = int(e.args["analysis_id"])
+            except (KeyError, TypeError, ValueError):
+                ui.notify("Invalid analysis ID", type="warning")
+                return
+            ui.navigate.to(f"/analysis/{aid}")
+
+        self._table.on("view", _on_view)
+
+    # ── Footer ─────────────────────────────────────────────────────────
+
+    def _build_footer(self) -> None:
+        with ui.row().classes("items-center w-full q-mt-sm gap-lg"):
+            ui.icon("local_fire_department").classes("text-orange text-h6")
+            self._heat_label = ui.label("Portfolio Heat: --").classes(
+                "text-body2 text-grey-4"
+            )
+            ui.space()
+            self._dist_label = ui.label("").classes(
+                "text-caption text-grey-5"
+            )
+
+    # ── Refresh logic ──────────────────────────────────────────────────
+
+    def _on_manual_refresh(self) -> None:
+        """Invalidate cache then refresh."""
+        self._price_svc.invalidate()
+        self._refresh_data()
+
+    def _refresh_data(self) -> None:
+        """Fetch active recs + live prices, then update all UI components."""
+        if self._loading_spinner:
+            self._loading_spinner.set_visibility(True)
+
+        try:
+            recs = self._db.list_active_recommendations()
+            if not recs:
+                self._update_table([])
+                self._update_stats([])
+                self._update_footer([])
+                return
+
+            tickers = list({r.ticker for r in recs})
+            prices = self._price_svc.get_prices(tickers)
+
+            rows = self._build_rows(recs, prices)
+            self._update_table(rows)
+            self._update_stats(recs)
+            self._update_footer(recs)
+
+            now_str = datetime.now().strftime("%H:%M:%S")
+            if self._last_updated_label:
+                self._last_updated_label.set_text(f"Last updated: {now_str}")
+
+        except Exception:
+            logger.exception("Dashboard refresh failed")
+            ui.notify("Failed to refresh dashboard", type="negative")
+        finally:
+            if self._loading_spinner:
+                self._loading_spinner.set_visibility(False)
+
+    # ── Row building ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _build_rows(
+        recs: list[RecommendationRow],
+        prices: dict[str, PriceResult],
+    ) -> list[dict]:
+        """Convert recommendation rows + price data into table row dicts."""
+        rows: list[dict] = []
+
+        for rec in recs:
+            price_data = prices.get(rec.ticker)
+            current_price = price_data.price if price_data else None
+            entry_price = rec.price_at_analysis
+
+            # Delta % calculation
+            delta_pct_val: float | None = None
+            if current_price is not None and entry_price and entry_price != 0:
+                delta_pct_val = ((current_price - entry_price) / entry_price) * 100
+
+            # Format delta display
+            if delta_pct_val is not None:
+                sign = "+" if delta_pct_val >= 0 else ""
+                delta_display = f"{sign}{delta_pct_val:.1f}%"
+            else:
+                delta_display = "--"
+
+            # Delta color logic (invert for SELL verdicts)
+            is_bearish = rec.verdict in _BEARISH_VERDICTS
+            if delta_pct_val is not None:
+                positive_is_good = not is_bearish
+                if (delta_pct_val >= 0) == positive_is_good:
+                    delta_color = "text-green"
+                else:
+                    delta_color = "text-red"
+            else:
+                delta_color = "text-grey"
+
+            # Status indicators
+            status_parts: list[str] = []
+            if (
+                rec.stop_loss is not None
+                and current_price is not None
+                and not is_bearish
+                and current_price <= rec.stop_loss
+            ):
+                status_parts.append("⚠️ Stop")
+            if (
+                rec.profit_target is not None
+                and current_price is not None
+                and not is_bearish
+                and current_price >= rec.profit_target
+            ):
+                status_parts.append("\U0001f3af Target")
+            if (
+                rec.stop_loss is not None
+                and current_price is not None
+                and is_bearish
+                and current_price >= rec.stop_loss
+            ):
+                status_parts.append("⚠️ Stop")
+            if (
+                rec.profit_target is not None
+                and current_price is not None
+                and is_bearish
+                and current_price <= rec.profit_target
+            ):
+                status_parts.append("\U0001f3af Target")
+            if price_data and price_data.is_stale:
+                status_parts.append("\U0001f4ca Stale")
+            if price_data and price_data.error and current_price is None:
+                status_parts.append("❌ Error")
+
+            verdict_class = _VERDICT_COLORS.get(rec.verdict, _VERDICT_DEFAULT)
+
+            rows.append(
+                {
+                    "id": rec.id,
+                    "analysis_id": rec.analysis_id,
+                    "ticker": rec.ticker,
+                    "verdict": rec.verdict,
+                    "verdict_class": verdict_class,
+                    "entry_price": f"${entry_price:.2f}" if entry_price else "--",
+                    "current_price": f"${current_price:.2f}" if current_price else "--",
+                    "delta_pct": delta_display,
+                    "delta_color": delta_color,
+                    "stop_loss": f"${rec.stop_loss:.2f}" if rec.stop_loss else "--",
+                    "target": f"${rec.profit_target:.2f}" if rec.profit_target else "--",
+                    "status": " ".join(status_parts) if status_parts else "--",
+                }
+            )
+
+        return rows
+
+    # ── UI update helpers ──────────────────────────────────────────────
+
+    def _update_table(self, rows: list[dict]) -> None:
+        if self._table:
+            self._table.rows = rows
+            self._table.update()
+
+    def _update_stats(self, recs: list[RecommendationRow]) -> None:
+        total = len(recs)
+        buy_count = sum(1 for r in recs if r.verdict in _BULLISH_VERDICTS)
+        hold_count = sum(1 for r in recs if r.verdict == "HOLD")
+        sell_count = sum(1 for r in recs if r.verdict in _BEARISH_VERDICTS)
+
+        if self._total_label:
+            self._total_label.set_text(str(total))
+        if self._buy_label:
+            self._buy_label.set_text(str(buy_count))
+        if self._hold_label:
+            self._hold_label.set_text(str(hold_count))
+        if self._sell_label:
+            self._sell_label.set_text(str(sell_count))
+
+    def _update_footer(self, recs: list[RecommendationRow]) -> None:
+        if not recs:
+            if self._heat_label:
+                self._heat_label.set_text("Portfolio Heat: --")
+            if self._dist_label:
+                self._dist_label.set_text("")
+            return
+
+        # Average confidence (portfolio heat)
+        confidences = [r.confidence for r in recs if r.confidence is not None]
+        avg_conf = sum(confidences) / len(confidences) if confidences else 0
+        if self._heat_label:
+            self._heat_label.set_text(f"Portfolio Heat: {avg_conf:.0f}% avg confidence")
+
+        # Verdict distribution summary
+        buy_count = sum(1 for r in recs if r.verdict in _BULLISH_VERDICTS)
+        hold_count = sum(1 for r in recs if r.verdict == "HOLD")
+        sell_count = sum(1 for r in recs if r.verdict in _BEARISH_VERDICTS)
+        parts = []
+        if buy_count:
+            parts.append(f"{buy_count} BUY")
+        if hold_count:
+            parts.append(f"{hold_count} HOLD")
+        if sell_count:
+            parts.append(f"{sell_count} SELL")
+        if self._dist_label:
+            self._dist_label.set_text(" | ".join(parts))

--- a/desktop/pages/dashboard.py
+++ b/desktop/pages/dashboard.py
@@ -14,6 +14,8 @@ from datetime import datetime
 
 from nicegui import ui
 
+from typing import Any
+
 from desktop.services.price_service import PriceResult, PriceService
 from desktop.state.database import HistoryDB, RecommendationRow
 
@@ -43,9 +45,9 @@ _AUTO_REFRESH_SECONDS = 60
 # ---------------------------------------------------------------------------
 
 
-def render_dashboard_page(*, db: HistoryDB) -> None:
+def render_dashboard_page(*, db: HistoryDB, price_service: Any = None) -> None:
     """Render the active recommendations dashboard."""
-    page = _DashboardPage(db=db)
+    page = _DashboardPage(db=db, price_service=price_service)
     page.build()
 
 
@@ -57,9 +59,9 @@ def render_dashboard_page(*, db: HistoryDB) -> None:
 class _DashboardPage:
     """Builds and manages the Active Recommendations Dashboard."""
 
-    def __init__(self, *, db: HistoryDB) -> None:
+    def __init__(self, *, db: HistoryDB, price_service: Any = None) -> None:
         self._db = db
-        self._price_svc = PriceService()
+        self._price_svc = price_service if price_service is not None else PriceService()
 
         # UI refs
         self._table: ui.table | None = None

--- a/desktop/pages/detail.py
+++ b/desktop/pages/detail.py
@@ -12,17 +12,15 @@ from pathlib import Path
 
 from nicegui import ui
 
+from desktop.components.price_chart import PriceChart
 from desktop.state.database import HistoryDB
-
-# markdown2 extras — shared with report_section.py for consistency
-_MD_EXTRAS: list[str] = [
-    "tables",
-    "fenced-code-blocks",
-    "strike",
-    "task_list",
-    "cuddled-lists",
-    "header-ids",
-]
+from desktop.utils.paths import validated_result_dir
+from desktop.utils.reports import (
+    MD_EXTRAS,
+    TYPE_COLORS,
+    discover_report_files,
+    status_chip,
+)
 
 
 def render_detail_page(*, db: HistoryDB, analysis_id: int) -> None:
@@ -56,7 +54,15 @@ class _DetailPage:
 
                 ui.space()
 
-                _status_badge(analysis.status)
+                status_chip(analysis.status)
+
+                # PDF export button
+                if analysis.result_dir and Path(analysis.result_dir).is_dir():
+                    _aid = analysis  # capture for closure
+                    ui.button(
+                        "Export PDF", icon="picture_as_pdf",
+                        on_click=lambda a=_aid: self._export_pdf(a),
+                    ).props("flat dense color=blue")
 
                 ui.button("Back", icon="arrow_back",
                           on_click=lambda: ui.navigate.to("/history")).props(
@@ -68,6 +74,11 @@ class _DetailPage:
                 ui.label(f"Started: {analysis.started_at}")
                 if analysis.completed_at:
                     ui.label(f"Completed: {analysis.completed_at}")
+
+            # Price chart
+            PriceChart(
+                ticker=analysis.ticker, analysis_date=analysis.date,
+            ).build()
 
             # Error text (if failed)
             if analysis.error_text:
@@ -81,22 +92,19 @@ class _DetailPage:
                 ui.label("No report files found on disk.").classes(
                     "text-body2 text-grey-5 q-pa-md"
                 )
-                # Still show logs even without report files
                 self._build_logs_section()
                 return
 
-            # CR-01: Validate result_dir is under the expected base to
-            # prevent path traversal via stored/imported paths.
-            root = Path(result_dir).resolve()
-            expected_base = (Path.home() / ".tradingagents" / "results").resolve()
-            if not str(root).startswith(str(expected_base)):
+            # SEC-01: Use is_relative_to instead of fragile startswith
+            root = validated_result_dir(result_dir)
+            if root is None:
                 ui.label("Invalid result directory.").classes(
                     "text-body2 text-red q-pa-md"
                 )
                 self._build_logs_section()
                 return
 
-            sections = _discover_report_files(root)
+            sections = discover_report_files(root)
 
             if not sections:
                 ui.label("No report files found on disk.").classes(
@@ -108,7 +116,6 @@ class _DetailPage:
             ui.label("Reports").classes("text-h6 text-white q-mt-md")
 
             # Complete report link if present
-            # WR-03: wrap file reads with error handling
             complete = root / "complete_report.md"
             if complete.exists():
                 try:
@@ -122,7 +129,7 @@ class _DetailPage:
                 ):
                     ui.markdown(
                         complete_text,
-                        extras=_MD_EXTRAS,
+                        extras=MD_EXTRAS,
                     ).classes("report-content text-white q-pa-sm")
 
             # Individual sections
@@ -136,12 +143,37 @@ class _DetailPage:
                 ).classes("w-full bg-dark").props(
                     "dense header-class='text-subtitle2 text-grey-4'"
                 ):
-                    ui.markdown(content, extras=_MD_EXTRAS).classes(
+                    ui.markdown(content, extras=MD_EXTRAS).classes(
                         "report-content text-white q-pa-sm"
                     )
 
-            # ── Persisted logs ─────────────────────────────────────
+            # Persisted logs
             self._build_logs_section()
+
+    def _export_pdf(self, analysis: object) -> None:
+        """Export this analysis as PDF."""
+        try:
+            from desktop.services.pdf_export import PDFExporter
+
+            exporter = PDFExporter()
+            pdf_path = exporter.export_analysis(
+                result_dir=Path(analysis.result_dir),
+                ticker=analysis.ticker,
+                verdict="",  # will be read from the report
+                date=analysis.date,
+            )
+            ui.notify(f"PDF exported: {pdf_path.name}", type="positive")
+            # Open the file
+            import subprocess
+            subprocess.Popen(["open", str(pdf_path)])
+        except ImportError:
+            ui.notify(
+                "weasyprint not installed. Run: pip install weasyprint",
+                type="warning",
+                close_button=True,
+            )
+        except Exception as exc:
+            ui.notify(f"Export failed: {exc}", type="negative")
 
     def _build_logs_section(self) -> None:
         """Render persisted log entries from the database."""
@@ -166,7 +198,7 @@ class _DetailPage:
                     )
                     return
                 for entry in entries:
-                    color = _TYPE_COLORS.get(entry.entry_type, "grey")
+                    color = TYPE_COLORS.get(entry.entry_type, "grey")
                     with ui.row().classes("items-baseline gap-xs q-py-none"):
                         ui.label(entry.timestamp).classes("text-caption text-grey-6")
                         ui.label(f"[{entry.entry_type}]").classes(
@@ -191,7 +223,7 @@ class _DetailPage:
                 text = "\n".join(
                     f"{e.timestamp} [{e.entry_type}] {e.content}" for e in entries
                 )
-                # CR-01: use json.dumps for safe JS string escaping
+                # SECURITY: json.dumps is required here to prevent JS injection
                 escaped = _json.dumps(text)
                 await ui.run_javascript(
                     f"navigator.clipboard.writeText({escaped})", respond=False
@@ -208,104 +240,3 @@ class _DetailPage:
             ).style("max-height: 500px; overflow-y: auto")
 
         refresh_logs()
-
-
-# ── Report file discovery ──────────────────────────────────────────────
-
-# New format: numbered subdirectories with short names
-_PHASE_TITLES: dict[str, str] = {
-    "1_analysts": "Analysts",
-    "2_research": "Research Team",
-    "3_trading": "Trading Team",
-    "4_risk": "Risk Management",
-    "5_portfolio": "Portfolio Management",
-}
-
-_FILE_TITLES: dict[str, str] = {
-    # New format (short names in subdirs)
-    "fundamentals": "Fundamentals Analysis",
-    "market": "Market Analysis",
-    "news": "News Analysis",
-    "sentiment": "Social Sentiment",
-    "bull": "Bull Researcher",
-    "bear": "Bear Researcher",
-    "manager": "Research Manager Decision",
-    "trader": "Trading Team Plan",
-    "aggressive": "Aggressive Risk Analyst",
-    "neutral": "Neutral Risk Analyst",
-    "conservative": "Conservative Risk Analyst",
-    "decision": "Portfolio Management Decision",
-    # Old format (flat reports/ directory)
-    "market_report": "Market Analysis",
-    "sentiment_report": "Social Sentiment",
-    "news_report": "News Analysis",
-    "fundamentals_report": "Fundamentals Analysis",
-    "investment_plan": "Research Team Decision",
-    "trader_investment_plan": "Trading Team Plan",
-    "final_trade_decision": "Portfolio Management Decision",
-}
-
-
-def _discover_report_files(root: Path) -> list[tuple[str, Path]]:
-    """Find all report markdown files in either directory layout.
-
-    Returns a list of ``(display_title, path)`` tuples in a logical
-    order (analysts → research → trading → risk → portfolio).
-    """
-    sections: list[tuple[str, Path]] = []
-
-    # New format: numbered subdirectories (1_analysts/, 2_research/, ...)
-    phase_dirs = sorted(
-        (d for d in root.iterdir() if d.is_dir() and d.name[0].isdigit()),
-        key=lambda d: d.name,
-    )
-    if phase_dirs:
-        for phase_dir in phase_dirs:
-            phase_label = _PHASE_TITLES.get(phase_dir.name, phase_dir.name)
-            for md in sorted(phase_dir.glob("*.md")):
-                stem = md.stem
-                title = _FILE_TITLES.get(stem, f"{phase_label} — {stem.replace('_', ' ').title()}")
-                sections.append((f"{phase_label} / {title}", md))
-        return sections
-
-    # Old format: flat reports/ subdirectory
-    reports_dir = root / "reports"
-    if reports_dir.is_dir():
-        for md in sorted(reports_dir.glob("*.md")):
-            title = _FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
-            sections.append((title, md))
-        return sections
-
-    # Fallback: any .md files directly in root (excluding complete_report)
-    for md in sorted(root.glob("*.md")):
-        if md.name == "complete_report.md":
-            continue
-        title = _FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
-        sections.append((title, md))
-
-    return sections
-
-
-_TYPE_COLORS: dict[str, str] = {
-    "System": "blue-4",
-    "Agent": "green-4",
-    "User": "yellow-4",
-    "Data": "purple-4",
-    "Tool": "orange-4",
-    "Control": "grey-5",
-    "Error": "red-4",
-}
-
-
-def _status_badge(status: str) -> None:
-    """Render a colored status badge."""
-    colors = {
-        "completed": "green",
-        "running": "blue",
-        "failed": "red",
-        "interrupted": "orange",
-    }
-    color = colors.get(status, "grey")
-    ui.label(status.capitalize()).classes(
-        f"text-caption text-white bg-{color} q-px-sm q-py-xs rounded-borders"
-    )

--- a/desktop/pages/detail.py
+++ b/desktop/pages/detail.py
@@ -152,20 +152,28 @@ class _DetailPage:
 
     def _export_pdf(self, analysis: object) -> None:
         """Export this analysis as PDF."""
+        from desktop.utils.paths import validated_result_dir
+
         try:
             from desktop.services.pdf_export import PDFExporter
 
+            # SEC: Validate result_dir before using it
+            root = validated_result_dir(analysis.result_dir)
+            if root is None:
+                ui.notify("Invalid result directory", type="negative")
+                return
+
             exporter = PDFExporter()
             pdf_path = exporter.export_analysis(
-                result_dir=Path(analysis.result_dir),
+                result_dir=root,
                 ticker=analysis.ticker,
                 verdict="",  # will be read from the report
                 date=analysis.date,
             )
             ui.notify(f"PDF exported: {pdf_path.name}", type="positive")
-            # Open the file
+            # Open the file using the validated path
             import subprocess
-            subprocess.Popen(["open", str(pdf_path)])
+            subprocess.Popen(["open", str(pdf_path)])  # noqa: S603
         except ImportError:
             ui.notify(
                 "weasyprint not installed. Run: pip install weasyprint",

--- a/desktop/pages/detail.py
+++ b/desktop/pages/detail.py
@@ -1,0 +1,311 @@
+"""Detail page — view a completed analysis and its report sections.
+
+Reads markdown files from the analysis ``result_dir`` and renders them
+in expandable sections identical to the live progress view.
+
+See also: PLAN-desktop.md, F3 extension.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nicegui import ui
+
+from desktop.state.database import HistoryDB
+
+# markdown2 extras — shared with report_section.py for consistency
+_MD_EXTRAS: list[str] = [
+    "tables",
+    "fenced-code-blocks",
+    "strike",
+    "task_list",
+    "cuddled-lists",
+    "header-ids",
+]
+
+
+def render_detail_page(*, db: HistoryDB, analysis_id: int) -> None:
+    """Render the detail page for a single completed analysis."""
+    page = _DetailPage(db=db, analysis_id=analysis_id)
+    page.build()
+
+
+class _DetailPage:
+    def __init__(self, *, db: HistoryDB, analysis_id: int) -> None:
+        self._db = db
+        self._analysis_id = analysis_id
+
+    def build(self) -> None:
+        analysis = self._db.get_analysis(self._analysis_id)
+        if analysis is None:
+            with ui.column().classes("w-full q-pa-md"):
+                ui.label("Analysis not found").classes("text-h5 text-red")
+                ui.button("Back to History", icon="arrow_back",
+                          on_click=lambda: ui.navigate.to("/history"))
+            return
+
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Header strip
+            with ui.row().classes("items-center w-full bg-dark q-pa-sm rounded-borders"):
+                ui.icon("analytics").classes("text-green text-h5")
+                ui.label(analysis.ticker).classes("text-h6 text-white q-ml-sm")
+                ui.label(analysis.date).classes("text-caption text-grey q-ml-sm")
+                ui.label(analysis.provider).classes("text-caption text-grey q-ml-sm")
+                ui.label(analysis.model).classes("text-caption text-grey q-ml-sm")
+
+                ui.space()
+
+                _status_badge(analysis.status)
+
+                ui.button("Back", icon="arrow_back",
+                          on_click=lambda: ui.navigate.to("/history")).props(
+                    "flat dense"
+                )
+
+            # Timing info
+            with ui.row().classes("gap-md text-caption text-grey-5"):
+                ui.label(f"Started: {analysis.started_at}")
+                if analysis.completed_at:
+                    ui.label(f"Completed: {analysis.completed_at}")
+
+            # Error text (if failed)
+            if analysis.error_text:
+                ui.label(f"Error: {analysis.error_text}").classes(
+                    "text-body2 text-red q-pa-sm bg-dark rounded-borders"
+                )
+
+            # Report sections
+            result_dir = analysis.result_dir
+            if not result_dir or not Path(result_dir).is_dir():
+                ui.label("No report files found on disk.").classes(
+                    "text-body2 text-grey-5 q-pa-md"
+                )
+                # Still show logs even without report files
+                self._build_logs_section()
+                return
+
+            # CR-01: Validate result_dir is under the expected base to
+            # prevent path traversal via stored/imported paths.
+            root = Path(result_dir).resolve()
+            expected_base = (Path.home() / ".tradingagents" / "results").resolve()
+            if not str(root).startswith(str(expected_base)):
+                ui.label("Invalid result directory.").classes(
+                    "text-body2 text-red q-pa-md"
+                )
+                self._build_logs_section()
+                return
+
+            sections = _discover_report_files(root)
+
+            if not sections:
+                ui.label("No report files found on disk.").classes(
+                    "text-body2 text-grey-5 q-pa-md"
+                )
+                self._build_logs_section()
+                return
+
+            ui.label("Reports").classes("text-h6 text-white q-mt-md")
+
+            # Complete report link if present
+            # WR-03: wrap file reads with error handling
+            complete = root / "complete_report.md"
+            if complete.exists():
+                try:
+                    complete_text = complete.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError) as exc:
+                    complete_text = f"*Error reading report: {exc}*"
+                with ui.expansion(
+                    "Complete Report", icon="summarize",
+                ).classes("w-full bg-dark").props(
+                    "dense header-class='text-subtitle1 text-green-4'"
+                ):
+                    ui.markdown(
+                        complete_text,
+                        extras=_MD_EXTRAS,
+                    ).classes("report-content text-white q-pa-sm")
+
+            # Individual sections
+            for title, md_path in sections:
+                try:
+                    content = md_path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError) as exc:
+                    content = f"*Error reading report: {exc}*"
+                with ui.expansion(
+                    title, icon="description",
+                ).classes("w-full bg-dark").props(
+                    "dense header-class='text-subtitle2 text-grey-4'"
+                ):
+                    ui.markdown(content, extras=_MD_EXTRAS).classes(
+                        "report-content text-white q-pa-sm"
+                    )
+
+            # ── Persisted logs ─────────────────────────────────────
+            self._build_logs_section()
+
+    def _build_logs_section(self) -> None:
+        """Render persisted log entries from the database."""
+        log_count = self._db.count_log_entries(self._analysis_id)
+        if log_count == 0:
+            return
+
+        ui.label(f"Logs ({log_count})").classes("text-h6 text-white q-mt-lg")
+
+        # Filter selector
+        filter_type = {"value": "All"}
+
+        def refresh_logs(entry_type: str = "All") -> None:
+            filter_type["value"] = entry_type
+            et = entry_type if entry_type != "All" else None
+            entries = self._db.get_log_entries(self._analysis_id, entry_type=et)
+            log_area.clear()
+            with log_area:
+                if not entries:
+                    ui.label("No entries match this filter.").classes(
+                        "text-grey-5 q-pa-md"
+                    )
+                    return
+                for entry in entries:
+                    color = _TYPE_COLORS.get(entry.entry_type, "grey")
+                    with ui.row().classes("items-baseline gap-xs q-py-none"):
+                        ui.label(entry.timestamp).classes("text-caption text-grey-6")
+                        ui.label(f"[{entry.entry_type}]").classes(
+                            f"text-caption text-{color}"
+                        )
+                        ui.label(entry.content).classes(
+                            "text-caption text-white"
+                        ).style("word-break: break-all")
+
+        with ui.row().classes("items-center gap-md"):
+            ui.select(
+                label="Filter by type",
+                options=["All", "System", "Agent", "Tool", "Data", "Error"],
+                value="All",
+                on_change=lambda e: refresh_logs(e.value),
+            ).props("outlined dense").classes("w-40")
+
+            async def copy_all() -> None:
+                import json as _json
+
+                entries = self._db.get_log_entries(self._analysis_id)
+                text = "\n".join(
+                    f"{e.timestamp} [{e.entry_type}] {e.content}" for e in entries
+                )
+                # CR-01: use json.dumps for safe JS string escaping
+                escaped = _json.dumps(text)
+                await ui.run_javascript(
+                    f"navigator.clipboard.writeText({escaped})", respond=False
+                )
+                ui.notify("Logs copied!", type="positive")
+
+            ui.button("Copy All", icon="content_copy", on_click=copy_all).props(
+                "flat dense"
+            )
+
+        with ui.card().classes("w-full"):
+            log_area = ui.column().classes(
+                "w-full gap-none"
+            ).style("max-height: 500px; overflow-y: auto")
+
+        refresh_logs()
+
+
+# ── Report file discovery ──────────────────────────────────────────────
+
+# New format: numbered subdirectories with short names
+_PHASE_TITLES: dict[str, str] = {
+    "1_analysts": "Analysts",
+    "2_research": "Research Team",
+    "3_trading": "Trading Team",
+    "4_risk": "Risk Management",
+    "5_portfolio": "Portfolio Management",
+}
+
+_FILE_TITLES: dict[str, str] = {
+    # New format (short names in subdirs)
+    "fundamentals": "Fundamentals Analysis",
+    "market": "Market Analysis",
+    "news": "News Analysis",
+    "sentiment": "Social Sentiment",
+    "bull": "Bull Researcher",
+    "bear": "Bear Researcher",
+    "manager": "Research Manager Decision",
+    "trader": "Trading Team Plan",
+    "aggressive": "Aggressive Risk Analyst",
+    "neutral": "Neutral Risk Analyst",
+    "conservative": "Conservative Risk Analyst",
+    "decision": "Portfolio Management Decision",
+    # Old format (flat reports/ directory)
+    "market_report": "Market Analysis",
+    "sentiment_report": "Social Sentiment",
+    "news_report": "News Analysis",
+    "fundamentals_report": "Fundamentals Analysis",
+    "investment_plan": "Research Team Decision",
+    "trader_investment_plan": "Trading Team Plan",
+    "final_trade_decision": "Portfolio Management Decision",
+}
+
+
+def _discover_report_files(root: Path) -> list[tuple[str, Path]]:
+    """Find all report markdown files in either directory layout.
+
+    Returns a list of ``(display_title, path)`` tuples in a logical
+    order (analysts → research → trading → risk → portfolio).
+    """
+    sections: list[tuple[str, Path]] = []
+
+    # New format: numbered subdirectories (1_analysts/, 2_research/, ...)
+    phase_dirs = sorted(
+        (d for d in root.iterdir() if d.is_dir() and d.name[0].isdigit()),
+        key=lambda d: d.name,
+    )
+    if phase_dirs:
+        for phase_dir in phase_dirs:
+            phase_label = _PHASE_TITLES.get(phase_dir.name, phase_dir.name)
+            for md in sorted(phase_dir.glob("*.md")):
+                stem = md.stem
+                title = _FILE_TITLES.get(stem, f"{phase_label} — {stem.replace('_', ' ').title()}")
+                sections.append((f"{phase_label} / {title}", md))
+        return sections
+
+    # Old format: flat reports/ subdirectory
+    reports_dir = root / "reports"
+    if reports_dir.is_dir():
+        for md in sorted(reports_dir.glob("*.md")):
+            title = _FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
+            sections.append((title, md))
+        return sections
+
+    # Fallback: any .md files directly in root (excluding complete_report)
+    for md in sorted(root.glob("*.md")):
+        if md.name == "complete_report.md":
+            continue
+        title = _FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
+        sections.append((title, md))
+
+    return sections
+
+
+_TYPE_COLORS: dict[str, str] = {
+    "System": "blue-4",
+    "Agent": "green-4",
+    "User": "yellow-4",
+    "Data": "purple-4",
+    "Tool": "orange-4",
+    "Control": "grey-5",
+    "Error": "red-4",
+}
+
+
+def _status_badge(status: str) -> None:
+    """Render a colored status badge."""
+    colors = {
+        "completed": "green",
+        "running": "blue",
+        "failed": "red",
+        "interrupted": "orange",
+    }
+    color = colors.get(status, "grey")
+    ui.label(status.capitalize()).classes(
+        f"text-caption text-white bg-{color} q-px-sm q-py-xs rounded-borders"
+    )

--- a/desktop/pages/history.py
+++ b/desktop/pages/history.py
@@ -45,6 +45,7 @@ class _HistoryPage:
                 {"name": "status", "label": "Status", "field": "status", "sortable": True},
                 {"name": "started_at", "label": "Started", "field": "started_at", "sortable": True},
                 {"name": "completed_at", "label": "Completed", "field": "completed_at"},
+                {"name": "actions", "label": "", "field": "actions"},
             ]
             self._table = ui.table(
                 columns=columns,
@@ -52,6 +53,27 @@ class _HistoryPage:
                 row_key="id",
                 pagination={"rowsPerPage": 15},
             ).classes("w-full").props("flat bordered dense")
+
+            # Add "View" button column via slot
+            self._table.add_slot(
+                "body-cell-actions",
+                """
+                <q-td :props="props">
+                    <q-btn flat dense color="green" icon="visibility" label="View"
+                           @click="$parent.$emit('view', props.row)" />
+                </q-td>
+                """,
+            )
+            def _on_view(e) -> None:
+                # CR-02: validate client-controlled ID before navigation
+                try:
+                    aid = int(e.args["id"])
+                except (KeyError, TypeError, ValueError):
+                    ui.notify("Invalid analysis ID", type="warning")
+                    return
+                ui.navigate.to(f"/analysis/{aid}")
+
+            self._table.on("view", _on_view)
 
             self._refresh()
 

--- a/desktop/pages/history.py
+++ b/desktop/pages/history.py
@@ -1,0 +1,80 @@
+"""History page — past analyses table with search and filtering.
+
+See also: PLAN-desktop.md, F3.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from desktop.state.database import HistoryDB
+
+
+def render_history_page(*, db: HistoryDB) -> None:
+    """Render the history page content."""
+    page = _HistoryPage(db=db)
+    page.build()
+
+
+class _HistoryPage:
+    def __init__(self, *, db: HistoryDB) -> None:
+        self._db = db
+        self._search = ""
+        self._table: ui.table | None = None
+
+    def build(self) -> None:
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            ui.label("Analysis History").classes("text-h5 text-white")
+
+            # Search bar
+            with ui.row().classes("items-center gap-sm"):
+                ui.input(
+                    "Search ticker...",
+                    on_change=lambda e: self._refresh(e.value),
+                ).props("outlined dense clearable").classes("w-64")
+                ui.button("Refresh", icon="refresh", on_click=lambda: self._refresh()).props(
+                    "flat dense"
+                )
+
+            # Table
+            columns = [
+                {"name": "id", "label": "ID", "field": "id", "sortable": True},
+                {"name": "ticker", "label": "Ticker", "field": "ticker", "sortable": True},
+                {"name": "date", "label": "Date", "field": "date", "sortable": True},
+                {"name": "provider", "label": "Provider", "field": "provider"},
+                {"name": "status", "label": "Status", "field": "status", "sortable": True},
+                {"name": "started_at", "label": "Started", "field": "started_at", "sortable": True},
+                {"name": "completed_at", "label": "Completed", "field": "completed_at"},
+            ]
+            self._table = ui.table(
+                columns=columns,
+                rows=[],
+                row_key="id",
+                pagination={"rowsPerPage": 15},
+            ).classes("w-full").props("flat bordered dense")
+
+            self._refresh()
+
+    def _refresh(self, search: str | None = None) -> None:
+        if search is not None:
+            self._search = search.strip()
+
+        ticker_filter = self._search.upper() if self._search else None
+        analyses = self._db.list_analyses(ticker=ticker_filter, limit=100)
+
+        rows = [
+            {
+                "id": a.id,
+                "ticker": a.ticker,
+                "date": a.date,
+                "provider": a.provider,
+                "status": a.status,
+                "started_at": a.started_at,
+                "completed_at": a.completed_at or "",
+            }
+            for a in analyses
+        ]
+
+        if self._table:
+            self._table.rows = rows
+            self._table.update()

--- a/desktop/pages/history.py
+++ b/desktop/pages/history.py
@@ -1,24 +1,32 @@
 """History page — past analyses table with search and filtering.
 
+Includes a **Resume** button for interrupted/failed analyses that have
+LangGraph checkpoints on disk (same ticker+date → auto-resume from
+the last successful node).
+
 See also: PLAN-desktop.md, F3.
 """
 
 from __future__ import annotations
 
+import json
+
 from nicegui import ui
 
 from desktop.state.database import HistoryDB
+from desktop.state.runner import PipelineRunner
 
 
-def render_history_page(*, db: HistoryDB) -> None:
+def render_history_page(*, db: HistoryDB, runner: PipelineRunner | None = None) -> None:
     """Render the history page content."""
-    page = _HistoryPage(db=db)
+    page = _HistoryPage(db=db, runner=runner)
     page.build()
 
 
 class _HistoryPage:
-    def __init__(self, *, db: HistoryDB) -> None:
+    def __init__(self, *, db: HistoryDB, runner: PipelineRunner | None = None) -> None:
         self._db = db
+        self._runner = runner
         self._search = ""
         self._table: ui.table | None = None
 
@@ -54,16 +62,20 @@ class _HistoryPage:
                 pagination={"rowsPerPage": 15},
             ).classes("w-full").props("flat bordered dense")
 
-            # Add "View" button column via slot
+            # Add "View" + "Resume" buttons via slot
             self._table.add_slot(
                 "body-cell-actions",
                 """
                 <q-td :props="props">
                     <q-btn flat dense color="green" icon="visibility" label="View"
                            @click="$parent.$emit('view', props.row)" />
+                    <q-btn v-if="props.row.status === 'interrupted' || props.row.status === 'failed'"
+                           flat dense color="orange" icon="replay" label="Resume"
+                           @click="$parent.$emit('resume', props.row)" />
                 </q-td>
                 """,
             )
+
             def _on_view(e) -> None:
                 # CR-02: validate client-controlled ID before navigation
                 try:
@@ -73,9 +85,82 @@ class _HistoryPage:
                     return
                 ui.navigate.to(f"/analysis/{aid}")
 
+            def _on_resume(e) -> None:
+                try:
+                    aid = int(e.args["id"])
+                except (KeyError, TypeError, ValueError):
+                    ui.notify("Invalid analysis ID", type="warning")
+                    return
+                self._resume_analysis(aid)
+
             self._table.on("view", _on_view)
+            self._table.on("resume", _on_resume)
 
             self._refresh()
+
+    def _resume_analysis(self, analysis_id: int) -> None:
+        """Resume an interrupted/failed analysis using its saved checkpoint.
+
+        Reads ticker, date, config, and selected_analysts from the DB row,
+        creates a new DB entry (so each attempt is tracked), and starts the
+        pipeline.  LangGraph finds the checkpoint via the deterministic
+        thread_id = SHA256(ticker:date) and resumes from the last saved node.
+        """
+        if self._runner is None:
+            ui.notify("Runner not available", type="negative")
+            return
+
+        if self._runner.is_running:
+            ui.notify("Another analysis is already running", type="warning")
+            return
+
+        row = self._db.get_analysis(analysis_id)
+        if row is None:
+            ui.notify("Analysis not found", type="negative")
+            return
+
+        if row.status not in ("interrupted", "failed"):
+            ui.notify(f"Cannot resume — status is '{row.status}'", type="warning")
+            return
+
+        # Reconstruct config from the saved JSON
+        try:
+            config: dict = json.loads(row.config_json) if row.config_json else {}
+        except json.JSONDecodeError:
+            config = {}
+
+        selected_analysts = [
+            a.strip() for a in (row.selected_analysts or "").split(",") if a.strip()
+        ] or ["market", "social", "news", "fundamentals"]
+
+        # Create a new DB row for this resume attempt
+        new_id = self._db.insert_analysis(
+            ticker=row.ticker,
+            date=row.date,
+            provider=row.provider,
+            model=row.model,
+            config=config,
+            selected_analysts=selected_analysts,
+        )
+
+        try:
+            self._runner.start(
+                config=config,
+                ticker=row.ticker,
+                date=row.date,
+                selected_analysts=selected_analysts,
+                analysis_id=new_id,
+            )
+        except RuntimeError as e:
+            ui.notify(str(e), type="negative")
+            return
+
+        ui.notify(
+            f"Resuming {row.ticker} from checkpoint — continuing where it left off",
+            type="positive",
+            timeout=8000,
+        )
+        ui.navigate.to("/")
 
     def _refresh(self, search: str | None = None) -> None:
         if search is not None:

--- a/desktop/pages/history.py
+++ b/desktop/pages/history.py
@@ -29,12 +29,14 @@ class _HistoryPage:
         self._runner = runner
         self._search = ""
         self._table: ui.table | None = None
+        self._selected: list[dict] = []
+        self._compare_btn: ui.button | None = None
 
     def build(self) -> None:
         with ui.column().classes("w-full q-pa-md gap-md"):
             ui.label("Analysis History").classes("text-h5 text-white")
 
-            # Search bar
+            # Search bar + Compare button
             with ui.row().classes("items-center gap-sm"):
                 ui.input(
                     "Search ticker...",
@@ -43,6 +45,12 @@ class _HistoryPage:
                 ui.button("Refresh", icon="refresh", on_click=lambda: self._refresh()).props(
                     "flat dense"
                 )
+                ui.space()
+                self._compare_btn = ui.button(
+                    "Compare", icon="compare_arrows",
+                    on_click=self._on_compare,
+                ).props("flat dense color=purple")
+                self._compare_btn.set_visibility(False)
 
             # Table
             columns = [
@@ -60,6 +68,8 @@ class _HistoryPage:
                 rows=[],
                 row_key="id",
                 pagination={"rowsPerPage": 15},
+                selection="multiple",
+                on_select=lambda e: self._on_selection_change(e.selection),
             ).classes("w-full").props("flat bordered dense")
 
             # Add "View" + "Resume" buttons via slot
@@ -97,6 +107,26 @@ class _HistoryPage:
             self._table.on("resume", _on_resume)
 
             self._refresh()
+
+    def _on_selection_change(self, selection: list[dict]) -> None:
+        """Update compare button visibility based on selection count."""
+        self._selected = selection
+        count = len(selection)
+        if self._compare_btn:
+            self._compare_btn.set_visibility(count == 2)
+            if count == 2:
+                self._compare_btn.set_text(
+                    f"Compare #{selection[0]['id']} vs #{selection[1]['id']}"
+                )
+
+    def _on_compare(self) -> None:
+        """Navigate to the comparison page with the two selected analyses."""
+        if len(self._selected) != 2:
+            ui.notify("Select exactly 2 analyses to compare", type="warning")
+            return
+        id_a = self._selected[0]["id"]
+        id_b = self._selected[1]["id"]
+        ui.navigate.to(f"/compare/{id_a}/{id_b}")
 
     def _resume_analysis(self, analysis_id: int) -> None:
         """Resume an interrupted/failed analysis using its saved checkpoint.
@@ -152,6 +182,8 @@ class _HistoryPage:
                 analysis_id=new_id,
             )
         except RuntimeError as e:
+            # CR-02: Clean up orphaned "running" row on start failure
+            self._db.mark_interrupted(new_id)
             ui.notify(str(e), type="negative")
             return
 

--- a/desktop/pages/logs.py
+++ b/desktop/pages/logs.py
@@ -1,0 +1,134 @@
+"""Debug logs page — full pipeline log viewer with filtering.
+
+See also: PLAN-desktop.md, F7.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from desktop.state.runner import PipelineRunner
+from tradingagents.progress import ProgressSnapshot
+
+_TYPE_COLORS: dict[str, str] = {
+    "System": "blue-4",
+    "Agent": "green-4",
+    "User": "yellow-4",
+    "Data": "purple-4",
+    "Tool": "orange-4",
+    "Control": "grey-5",
+    "Error": "red-4",
+}
+
+
+def render_logs_page(*, runner: PipelineRunner) -> None:
+    """Render the logs page content."""
+    page = _LogsPage(runner=runner)
+    page.build()
+
+
+class _LogsPage:
+    def __init__(self, *, runner: PipelineRunner) -> None:
+        self._runner = runner
+        self._log_area: ui.column | None = None
+        self._filter_type: str = "All"
+        self._last_count = 0
+        self._timer: ui.timer | None = None
+
+    def build(self) -> None:
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            ui.label("Debug Logs").classes("text-h5 text-white")
+            ui.label(
+                "Full pipeline log for troubleshooting. Copy and share with your AI assistant."
+            ).classes("text-body2 text-grey-5")
+
+            # Controls
+            with ui.row().classes("items-center gap-md"):
+                ui.select(
+                    label="Filter by type",
+                    options=["All", "System", "Agent", "Tool", "Data", "Error"],
+                    value="All",
+                    on_change=lambda e: self._set_filter(e.value),
+                ).props("outlined dense").classes("w-40")
+
+                ui.button(
+                    "Copy All",
+                    icon="content_copy",
+                    on_click=self._copy_logs,
+                ).props("flat dense")
+
+            # Log area
+            with ui.card().classes("w-full"):
+                self._log_area = ui.column().classes(
+                    "log-panel w-full gap-none"
+                ).style("max-height: 600px; overflow-y: auto")
+
+            # Start polling if runner is active
+            self._timer = ui.timer(0.5, self._poll)
+            self._poll()  # Initial render
+
+    def _set_filter(self, filter_type: str) -> None:
+        self._filter_type = filter_type
+        self._last_count = -1  # Force refresh
+        self._poll()
+
+    def _poll(self) -> None:
+        snap = self._runner.tracker.snapshot()
+        total = len(snap.messages) + len(snap.tool_calls)
+        if total == self._last_count:
+            return
+        self._last_count = total
+        self._render_logs(snap)
+
+    def _render_logs(self, snap: ProgressSnapshot) -> None:
+        if self._log_area is None:
+            return
+
+        self._log_area.clear()
+
+        # Merge all entries
+        entries: list[tuple[str, str, str]] = []
+        for ts, msg_type, content in snap.messages:
+            entries.append((ts, msg_type, str(content)))
+        for ts, tool_name, args in snap.tool_calls:
+            args_str = str(args)
+            if len(args_str) > 100:
+                args_str = args_str[:97] + "..."
+            entries.append((ts, "Tool", f"{tool_name}: {args_str}"))
+
+        # Sort chronologically
+        entries.sort(key=lambda x: x[0])
+
+        # Filter
+        if self._filter_type != "All":
+            entries = [e for e in entries if e[1] == self._filter_type]
+
+        with self._log_area:
+            if not entries:
+                ui.label("No log entries yet.").classes("text-grey-5 q-pa-md")
+                return
+
+            for ts, entry_type, content in entries:
+                color = _TYPE_COLORS.get(entry_type, "grey")
+                with ui.row().classes("items-baseline gap-xs q-py-none"):
+                    ui.label(ts).classes("text-caption text-grey-6")
+                    ui.label(f"[{entry_type}]").classes(f"text-caption text-{color}")
+                    ui.label(content).classes("text-caption text-white").style(
+                        "word-break: break-all"
+                    )
+
+    async def _copy_logs(self) -> None:
+        """Copy all log entries to clipboard."""
+        snap = self._runner.tracker.snapshot()
+        lines: list[str] = []
+        for ts, msg_type, content in snap.messages:
+            lines.append(f"{ts} [{msg_type}] {content}")
+        for ts, tool_name, args in snap.tool_calls:
+            lines.append(f"{ts} [Tool] {tool_name}: {args}")
+        lines.sort()
+
+        text = "\n".join(lines)
+        await ui.run_javascript(
+            f"navigator.clipboard.writeText({text!r})", respond=False
+        )
+        ui.notify("Logs copied to clipboard!", type="positive")

--- a/desktop/pages/logs.py
+++ b/desktop/pages/logs.py
@@ -10,17 +10,8 @@ import json
 from nicegui import ui
 
 from desktop.state.runner import PipelineRunner
+from desktop.utils.reports import TYPE_COLORS
 from tradingagents.progress import ProgressSnapshot
-
-_TYPE_COLORS: dict[str, str] = {
-    "System": "blue-4",
-    "Agent": "green-4",
-    "User": "yellow-4",
-    "Data": "purple-4",
-    "Tool": "orange-4",
-    "Control": "grey-5",
-    "Error": "red-4",
-}
 
 _MAX_VISIBLE = 200  # Cap visible entries to prevent DOM overload
 
@@ -120,7 +111,7 @@ class _LogsPage:
                 return
 
             for ts, entry_type, content in entries:
-                color = _TYPE_COLORS.get(entry_type, "grey")
+                color = TYPE_COLORS.get(entry_type, "grey")
                 with ui.row().classes("items-baseline gap-xs q-py-none"):
                     ui.label(ts).classes("text-caption text-grey-6")
                     ui.label(f"[{entry_type}]").classes(f"text-caption text-{color}")

--- a/desktop/pages/logs.py
+++ b/desktop/pages/logs.py
@@ -5,6 +5,8 @@ See also: PLAN-desktop.md, F7.
 
 from __future__ import annotations
 
+import json
+
 from nicegui import ui
 
 from desktop.state.runner import PipelineRunner
@@ -19,6 +21,8 @@ _TYPE_COLORS: dict[str, str] = {
     "Control": "grey-5",
     "Error": "red-4",
 }
+
+_MAX_VISIBLE = 200  # Cap visible entries to prevent DOM overload
 
 
 def render_logs_page(*, runner: PipelineRunner) -> None:
@@ -63,7 +67,7 @@ class _LogsPage:
                     "log-panel w-full gap-none"
                 ).style("max-height: 600px; overflow-y: auto")
 
-            # Start polling if runner is active
+            # Polling timer — auto-deactivates when runner stops
             self._timer = ui.timer(0.5, self._poll)
             self._poll()  # Initial render
 
@@ -76,6 +80,9 @@ class _LogsPage:
         snap = self._runner.tracker.snapshot()
         total = len(snap.messages) + len(snap.tool_calls)
         if total == self._last_count:
+            # Deactivate timer when runner is no longer active
+            if not self._runner.is_running and self._timer:
+                self._timer.deactivate()
             return
         self._last_count = total
         self._render_logs(snap)
@@ -103,6 +110,10 @@ class _LogsPage:
         if self._filter_type != "All":
             entries = [e for e in entries if e[1] == self._filter_type]
 
+        # Cap visible entries to prevent DOM overload
+        if len(entries) > _MAX_VISIBLE:
+            entries = entries[-_MAX_VISIBLE:]
+
         with self._log_area:
             if not entries:
                 ui.label("No log entries yet.").classes("text-grey-5 q-pa-md")
@@ -128,7 +139,9 @@ class _LogsPage:
         lines.sort()
 
         text = "\n".join(lines)
+        # CR-01: use json.dumps for safe JS string escaping
+        escaped = json.dumps(text)
         await ui.run_javascript(
-            f"navigator.clipboard.writeText({text!r})", respond=False
+            f"navigator.clipboard.writeText({escaped})", respond=False
         )
         ui.notify("Logs copied to clipboard!", type="positive")

--- a/desktop/pages/portfolio.py
+++ b/desktop/pages/portfolio.py
@@ -1,0 +1,491 @@
+"""Portfolio Tracker page -- view holdings and alignment with recommendations.
+
+Displays current positions alongside system recommendations, highlighting
+alignment (holding what the system says to hold) and misalignment
+(holding what it says to sell, or not holding what it says to buy).
+
+See also: PLAN-desktop.md, Phase 4.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from desktop.services.price_service import PriceResult, PriceService
+from desktop.state.database import (
+    HistoryDB,
+    PositionRow,
+    RecommendationRow,
+)
+
+# ── Alignment helpers ────────────────────────────────────────────────────
+
+_ALIGNED = "aligned"
+_MISALIGNED = "misaligned"
+_NEUTRAL = "neutral"
+
+
+def _alignment_status(
+    *, holding: bool, verdict: str | None,
+) -> str:
+    """Determine alignment between a position and the system verdict.
+
+    Returns 'aligned', 'misaligned', or 'neutral'.
+    """
+    if verdict is None:
+        return _NEUTRAL
+    v = verdict.upper()
+    if holding and v in ("HOLD", "BUY", "OVERWEIGHT"):
+        return _ALIGNED
+    if holding and v in ("SELL", "UNDERWEIGHT"):
+        return _MISALIGNED
+    if not holding and v in ("BUY", "OVERWEIGHT"):
+        return _MISALIGNED
+    return _NEUTRAL
+
+
+def _alignment_icon(status: str) -> tuple[str, str]:
+    """Return (icon_name, css_color_class) for an alignment status."""
+    if status == _ALIGNED:
+        return "check_circle", "text-green"
+    if status == _MISALIGNED:
+        return "warning", "text-orange"
+    return "remove_circle_outline", "text-grey"
+
+
+def _pnl_color(value: float) -> str:
+    """CSS class for profit/loss coloring."""
+    if value > 0:
+        return "text-green"
+    if value < 0:
+        return "text-red"
+    return "text-grey"
+
+
+# ── Public entry point ───────────────────────────────────────────────────
+
+
+def render_portfolio_page(*, db: HistoryDB) -> None:
+    """Render the Portfolio Tracker page."""
+    page = _PortfolioPage(db=db)
+    page.build()
+
+
+# ── Page implementation ──────────────────────────────────────────────────
+
+
+class _PortfolioPage:
+    def __init__(self, *, db: HistoryDB) -> None:
+        self._db = db
+        self._price_service = PriceService()
+        self._content_area: ui.column | None = None
+
+    def build(self) -> None:
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Header
+            with ui.row().classes("items-center w-full"):
+                ui.icon("work").classes("text-green text-h5")
+                ui.label("Portfolio").classes("text-h5 text-white q-ml-sm")
+                ui.space()
+                ui.button(
+                    "Add Position", icon="add",
+                    on_click=self._open_add_dialog,
+                ).props("color=green")
+                ui.button(
+                    "Refresh", icon="refresh",
+                    on_click=self._refresh,
+                ).props("flat dense")
+
+            # Content area (rebuilt on refresh)
+            self._content_area = ui.column().classes("w-full gap-md")
+
+            self._refresh()
+
+    # ── Refresh / rebuild ─────────────────────────────────────────────
+
+    def _refresh(self) -> None:
+        """Reload positions and recommendations, then rebuild the table."""
+        if self._content_area is None:
+            return
+
+        positions = self._db.list_positions()
+        recs = self._db.list_active_recommendations()
+        rec_by_ticker: dict[str, RecommendationRow] = {
+            r.ticker: r for r in recs
+        }
+
+        # Fetch current prices for all held tickers.
+        tickers = [p.ticker for p in positions]
+        prices: dict[str, PriceResult] = (
+            self._price_service.get_prices(tickers) if tickers else {}
+        )
+
+        self._content_area.clear()
+        with self._content_area:
+            if not positions:
+                self._build_empty_state()
+                return
+
+            self._build_summary(positions, prices, rec_by_ticker)
+            self._build_table(positions, prices, rec_by_ticker)
+
+    # ── Empty state ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _build_empty_state() -> None:
+        with ui.card().classes("w-full q-pa-lg"):
+            with ui.column().classes("items-center gap-md"):
+                ui.icon("account_balance_wallet").classes(
+                    "text-grey-6 text-h2"
+                )
+                ui.label(
+                    "No positions yet. Add your holdings to see how they "
+                    "align with the system's recommendations."
+                ).classes("text-body1 text-grey-5 text-center")
+
+    # ── Summary row ───────────────────────────────────────────────────
+
+    def _build_summary(
+        self,
+        positions: list[PositionRow],
+        prices: dict[str, PriceResult],
+        rec_by_ticker: dict[str, RecommendationRow],
+    ) -> None:
+        total_value = 0.0
+        total_cost = 0.0
+        aligned_count = 0
+        total_count = len(positions)
+
+        for pos in positions:
+            pr = prices.get(pos.ticker)
+            current = pr.price if pr and pr.price else pos.avg_price
+            total_value += current * pos.quantity
+            total_cost += pos.avg_price * pos.quantity
+
+            rec = rec_by_ticker.get(pos.ticker)
+            verdict = rec.verdict if rec else None
+            if _alignment_status(holding=True, verdict=verdict) == _ALIGNED:
+                aligned_count += 1
+
+        total_pnl = total_value - total_cost
+        total_pnl_pct = (
+            ((total_value - total_cost) / total_cost * 100) if total_cost else 0.0
+        )
+        alignment_score = (
+            (aligned_count / total_count * 100) if total_count else 0.0
+        )
+
+        with ui.row().classes("w-full gap-md"):
+            # Total value card
+            with ui.card().classes("q-pa-md"):
+                ui.label("Portfolio Value").classes("text-caption text-grey-5")
+                ui.label(f"${total_value:,.2f}").classes("text-h6 text-white")
+
+            # Total P&L card
+            with ui.card().classes("q-pa-md"):
+                ui.label("Total P&L").classes("text-caption text-grey-5")
+                pnl_cls = _pnl_color(total_pnl)
+                ui.label(
+                    f"${total_pnl:+,.2f} ({total_pnl_pct:+.1f}%)"
+                ).classes(f"text-h6 {pnl_cls}")
+
+            # Alignment card
+            with ui.card().classes("q-pa-md"):
+                ui.label("System Alignment").classes("text-caption text-grey-5")
+                align_cls = "text-green" if alignment_score >= 70 else "text-orange"
+                ui.label(
+                    f"{alignment_score:.0f}% ({aligned_count}/{total_count})"
+                ).classes(f"text-h6 {align_cls}")
+
+    # ── Positions table ───────────────────────────────────────────────
+
+    def _build_table(
+        self,
+        positions: list[PositionRow],
+        prices: dict[str, PriceResult],
+        rec_by_ticker: dict[str, RecommendationRow],
+    ) -> None:
+        with ui.card().classes("w-full"):
+            ui.label("Positions").classes("text-subtitle1 text-white q-mb-sm")
+
+            columns = [
+                {"name": "ticker", "label": "Ticker", "field": "ticker", "sortable": True},
+                {"name": "shares", "label": "Shares", "field": "shares", "sortable": True},
+                {"name": "avg_price", "label": "Avg Price", "field": "avg_price", "sortable": True},
+                {"name": "current", "label": "Current Price", "field": "current", "sortable": True},
+                {"name": "pnl_dollar", "label": "P&L ($)", "field": "pnl_dollar", "sortable": True},
+                {"name": "pnl_pct", "label": "P&L (%)", "field": "pnl_pct", "sortable": True},
+                {"name": "verdict", "label": "System Verdict", "field": "verdict"},
+                {"name": "alignment", "label": "Alignment", "field": "alignment"},
+                {"name": "actions", "label": "", "field": "actions"},
+            ]
+
+            rows = []
+            for pos in positions:
+                pr = prices.get(pos.ticker)
+                current = pr.price if pr and pr.price else None
+                pnl_dollar = (
+                    (current - pos.avg_price) * pos.quantity
+                    if current else 0.0
+                )
+                pnl_pct = (
+                    ((current - pos.avg_price) / pos.avg_price * 100)
+                    if current and pos.avg_price else 0.0
+                )
+
+                rec = rec_by_ticker.get(pos.ticker)
+                verdict = rec.verdict if rec else "N/A"
+                align = _alignment_status(
+                    holding=True, verdict=rec.verdict if rec else None,
+                )
+
+                rows.append({
+                    "ticker": pos.ticker,
+                    "shares": pos.quantity,
+                    "avg_price": f"${pos.avg_price:.2f}",
+                    "current": f"${current:.2f}" if current else "N/A",
+                    "pnl_dollar": f"${pnl_dollar:+,.2f}",
+                    "pnl_pct": f"{pnl_pct:+.1f}%",
+                    "verdict": verdict,
+                    "alignment": align,
+                })
+
+            table = ui.table(
+                columns=columns,
+                rows=rows,
+                row_key="ticker",
+                pagination={"rowsPerPage": 25},
+            ).classes("w-full").props("flat bordered dense")
+
+            # Custom cell renderers via slots
+
+            # P&L dollar coloring
+            table.add_slot(
+                "body-cell-pnl_dollar",
+                """
+                <q-td :props="props">
+                    <span :class="parseFloat(props.value) >= 0 ? 'text-green' : 'text-red'">
+                        {{ props.value }}
+                    </span>
+                </q-td>
+                """,
+            )
+
+            # P&L percent coloring
+            table.add_slot(
+                "body-cell-pnl_pct",
+                """
+                <q-td :props="props">
+                    <span :class="parseFloat(props.value) >= 0 ? 'text-green' : 'text-red'">
+                        {{ props.value }}
+                    </span>
+                </q-td>
+                """,
+            )
+
+            # Alignment icon
+            table.add_slot(
+                "body-cell-alignment",
+                """
+                <q-td :props="props">
+                    <q-icon v-if="props.value === 'aligned'"
+                            name="check_circle" color="green" size="sm" />
+                    <q-icon v-else-if="props.value === 'misaligned'"
+                            name="warning" color="orange" size="sm" />
+                    <q-icon v-else name="remove_circle_outline" color="grey" size="sm" />
+                    <span class="q-ml-xs text-caption">{{ props.value }}</span>
+                </q-td>
+                """,
+            )
+
+            # Action buttons
+            table.add_slot(
+                "body-cell-actions",
+                """
+                <q-td :props="props">
+                    <q-btn flat dense color="blue" icon="edit"
+                           @click="$parent.$emit('edit', props.row)" />
+                    <q-btn flat dense color="red" icon="delete"
+                           @click="$parent.$emit('delete', props.row)" />
+                </q-td>
+                """,
+            )
+
+            table.on("edit", lambda e: self._open_edit_dialog(e.args))
+            table.on("delete", lambda e: self._confirm_delete(e.args))
+
+    # ── Add position dialog ───────────────────────────────────────────
+
+    def _open_add_dialog(self) -> None:
+        """Open a dialog to add a new portfolio position."""
+        form_data: dict = {
+            "ticker": "",
+            "quantity": "",
+            "avg_price": "",
+            "date_opened": "",
+            "notes": "",
+        }
+
+        with ui.dialog() as dialog, ui.card().classes("w-96"):
+            ui.label("Add Position").classes("text-h6 text-white q-mb-md")
+
+            ticker_input = ui.input(
+                "Ticker (e.g., AAPL)",
+                on_change=lambda e: form_data.update(ticker=e.value),
+            ).props("outlined dense")
+
+            qty_input = ui.number(
+                "Quantity (shares)",
+                on_change=lambda e: form_data.update(quantity=e.value),
+            ).props("outlined dense")
+
+            price_input = ui.number(
+                "Average Price ($)",
+                on_change=lambda e: form_data.update(avg_price=e.value),
+            ).props("outlined dense")
+
+            ui.input(
+                "Date Opened (optional, YYYY-MM-DD)",
+                on_change=lambda e: form_data.update(date_opened=e.value),
+            ).props("outlined dense")
+
+            ui.textarea(
+                "Notes (optional)",
+                on_change=lambda e: form_data.update(notes=e.value),
+            ).props("outlined dense").classes("w-full")
+
+            with ui.row().classes("w-full justify-end gap-sm q-mt-md"):
+                ui.button("Cancel", on_click=dialog.close).props("flat")
+                ui.button(
+                    "Add",
+                    on_click=lambda: self._save_position(form_data, dialog),
+                ).props("color=green")
+
+        dialog.open()
+
+    def _save_position(self, data: dict, dialog: ui.dialog) -> None:
+        """Validate and save a new position."""
+        ticker = (data.get("ticker") or "").strip().upper()
+        if not ticker or not ticker.isalpha():
+            ui.notify("Ticker must be uppercase letters only", type="warning")
+            return
+
+        try:
+            quantity = float(data.get("quantity") or 0)
+        except (TypeError, ValueError):
+            ui.notify("Quantity must be a positive number", type="warning")
+            return
+        if quantity <= 0:
+            ui.notify("Quantity must be greater than 0", type="warning")
+            return
+
+        try:
+            avg_price = float(data.get("avg_price") or 0)
+        except (TypeError, ValueError):
+            ui.notify("Price must be a positive number", type="warning")
+            return
+        if avg_price <= 0:
+            ui.notify("Price must be greater than 0", type="warning")
+            return
+
+        date_opened = (data.get("date_opened") or "").strip() or None
+        notes = (data.get("notes") or "").strip() or None
+
+        self._db.upsert_position(
+            ticker=ticker,
+            quantity=quantity,
+            avg_price=avg_price,
+            date_opened=date_opened,
+            notes=notes,
+        )
+
+        ui.notify(f"Added {ticker}", type="positive")
+        dialog.close()
+        self._refresh()
+
+    # ── Edit position dialog ──────────────────────────────────────────
+
+    def _open_edit_dialog(self, row: dict) -> None:
+        """Open a dialog to edit an existing position."""
+        ticker = row.get("ticker", "")
+        positions = self._db.list_positions()
+        existing = next((p for p in positions if p.ticker == ticker), None)
+        if existing is None:
+            ui.notify(f"Position {ticker} not found", type="warning")
+            return
+
+        form_data: dict = {
+            "ticker": existing.ticker,
+            "quantity": existing.quantity,
+            "avg_price": existing.avg_price,
+            "date_opened": existing.date_opened or "",
+            "notes": existing.notes or "",
+        }
+
+        with ui.dialog() as dialog, ui.card().classes("w-96"):
+            ui.label(f"Edit {ticker}").classes("text-h6 text-white q-mb-md")
+
+            ui.input("Ticker").props("outlined dense readonly").bind_value(
+                form_data, "ticker"
+            )
+
+            ui.number(
+                "Quantity",
+                value=existing.quantity,
+                on_change=lambda e: form_data.update(quantity=e.value),
+            ).props("outlined dense")
+
+            ui.number(
+                "Average Price ($)",
+                value=existing.avg_price,
+                on_change=lambda e: form_data.update(avg_price=e.value),
+            ).props("outlined dense")
+
+            ui.input(
+                "Date Opened",
+                value=existing.date_opened or "",
+                on_change=lambda e: form_data.update(date_opened=e.value),
+            ).props("outlined dense")
+
+            ui.textarea(
+                "Notes",
+                value=existing.notes or "",
+                on_change=lambda e: form_data.update(notes=e.value),
+            ).props("outlined dense").classes("w-full")
+
+            with ui.row().classes("w-full justify-end gap-sm q-mt-md"):
+                ui.button("Cancel", on_click=dialog.close).props("flat")
+                ui.button(
+                    "Save",
+                    on_click=lambda: self._save_position(form_data, dialog),
+                ).props("color=green")
+
+        dialog.open()
+
+    # ── Delete confirmation ───────────────────────────────────────────
+
+    def _confirm_delete(self, row: dict) -> None:
+        """Show a confirmation dialog before deleting a position."""
+        ticker = row.get("ticker", "")
+
+        with ui.dialog() as dialog, ui.card().classes("w-80"):
+            ui.label(f"Delete {ticker}?").classes("text-h6 text-white")
+            ui.label(
+                f"Remove {ticker} from your portfolio? This cannot be undone."
+            ).classes("text-body2 text-grey-4 q-my-md")
+
+            with ui.row().classes("w-full justify-end gap-sm"):
+                ui.button("Cancel", on_click=dialog.close).props("flat")
+                ui.button(
+                    "Delete",
+                    on_click=lambda: self._do_delete(ticker, dialog),
+                ).props("color=red")
+
+        dialog.open()
+
+    def _do_delete(self, ticker: str, dialog: ui.dialog) -> None:
+        """Execute the position deletion."""
+        self._db.delete_position(ticker)
+        ui.notify(f"Deleted {ticker}", type="positive")
+        dialog.close()
+        self._refresh()

--- a/desktop/pages/portfolio.py
+++ b/desktop/pages/portfolio.py
@@ -9,6 +9,8 @@ See also: PLAN-desktop.md, Phase 4.
 
 from __future__ import annotations
 
+from typing import Any
+
 from nicegui import ui
 
 from desktop.services.price_service import PriceResult, PriceService
@@ -65,9 +67,9 @@ def _pnl_color(value: float) -> str:
 # ── Public entry point ───────────────────────────────────────────────────
 
 
-def render_portfolio_page(*, db: HistoryDB) -> None:
+def render_portfolio_page(*, db: HistoryDB, price_service: Any = None) -> None:
     """Render the Portfolio Tracker page."""
-    page = _PortfolioPage(db=db)
+    page = _PortfolioPage(db=db, price_service=price_service)
     page.build()
 
 
@@ -75,9 +77,9 @@ def render_portfolio_page(*, db: HistoryDB) -> None:
 
 
 class _PortfolioPage:
-    def __init__(self, *, db: HistoryDB) -> None:
+    def __init__(self, *, db: HistoryDB, price_service: Any = None) -> None:
         self._db = db
-        self._price_service = PriceService()
+        self._price_service = price_service if price_service is not None else PriceService()
         self._content_area: ui.column | None = None
 
     def build(self) -> None:

--- a/desktop/pages/schedules.py
+++ b/desktop/pages/schedules.py
@@ -197,7 +197,7 @@ class _SchedulesPage:
 
         if self._scheduler:
             try:
-                self._scheduler._run_scheduled(schedule_id, tickers)
+                self._scheduler.run_now(schedule_id, tickers)
                 ui.notify(
                     f"Dispatched {len(tickers)} ticker(s): {', '.join(tickers)}",
                     type="positive",

--- a/desktop/pages/schedules.py
+++ b/desktop/pages/schedules.py
@@ -1,0 +1,404 @@
+"""Schedules page — manage recurring pre-market analysis schedules.
+
+Create, enable/disable, and delete scheduled analysis runs.  Each
+schedule has a watchlist (comma-separated tickers), a cron-like time
+expression, and a timezone.
+
+The scheduler fires in the background; this page just manages the
+DB rows and tells the ``Scheduler`` service to arm/disarm timers.
+
+See also: PLAN-features-v3.md, Feature 4.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nicegui import ui
+
+from desktop.services.scheduler import CronExpr
+from desktop.state.database import HistoryDB, ScheduleRow
+
+
+def render_schedules_page(
+    *,
+    db: HistoryDB,
+    scheduler: Any,  # Scheduler — avoid circular import
+) -> None:
+    """Render the schedules management page."""
+    page = _SchedulesPage(db=db, scheduler=scheduler)
+    page.build()
+
+
+class _SchedulesPage:
+    def __init__(self, *, db: HistoryDB, scheduler: Any) -> None:
+        self._db = db
+        self._scheduler = scheduler
+
+    def build(self) -> None:
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Header
+            with ui.row().classes("items-center w-full"):
+                ui.icon("schedule").classes("text-blue text-h5")
+                ui.label("Scheduled Analysis").classes("text-h5 text-white")
+                ui.space()
+
+                # Scheduler status
+                if self._scheduler and self._scheduler.is_running:
+                    ui.badge("Scheduler Active", color="green").props("outline")
+                else:
+                    ui.badge("Scheduler Inactive", color="grey").props("outline")
+
+                ui.button(
+                    "New Schedule", icon="add",
+                    on_click=self._show_create_dialog,
+                ).props("color=blue")
+
+            # Help text
+            ui.label(
+                "Automate your analysis runs. Schedules fire at the configured "
+                "time and queue tickers through the analysis pipeline."
+            ).classes("text-body2 text-grey-5")
+
+            # Schedules list
+            self._schedules_container = ui.column().classes("w-full gap-md")
+            self._refresh_list()
+
+    def _refresh_list(self) -> None:
+        """Reload schedules from DB and rebuild the list."""
+        self._schedules_container.clear()
+        schedules = self._db.list_schedules()
+
+        with self._schedules_container:
+            if not schedules:
+                self._build_empty_state()
+                return
+
+            for sched in schedules:
+                self._build_schedule_card(sched)
+
+    def _build_empty_state(self) -> None:
+        """Render empty state when no schedules exist."""
+        with ui.card().classes("w-full bg-dark"):
+            with ui.column().classes("items-center q-pa-xl gap-md"):
+                ui.icon("schedule").classes("text-grey-6 text-h3")
+                ui.label("No Schedules Yet").classes("text-h6 text-grey-4")
+                ui.label(
+                    "Create a schedule to automatically run analysis at "
+                    "specific times. Great for pre-market prep."
+                ).classes("text-body2 text-grey-5 text-center")
+                ui.button(
+                    "Create First Schedule", icon="add",
+                    on_click=self._show_create_dialog,
+                ).props("color=blue")
+
+    def _build_schedule_card(self, sched: ScheduleRow) -> None:
+        """Render a single schedule card with controls."""
+        is_enabled = bool(sched.is_enabled)
+
+        # Parse cron for display
+        try:
+            parsed = CronExpr.parse(sched.cron_expr)
+            time_label = parsed.human_label()
+        except ValueError:
+            time_label = sched.cron_expr
+
+        tickers = [t.strip() for t in sched.watchlist.split(",") if t.strip()]
+
+        with ui.card().classes("w-full bg-dark"):
+            with ui.row().classes("items-center w-full q-pa-sm"):
+                # Enable/disable toggle
+                ui.switch(
+                    value=is_enabled,
+                    on_change=lambda e, sid=sched.id, cron=sched.cron_expr,
+                    tz=sched.timezone: self._toggle_schedule(
+                        sid, e.value, cron, tz
+                    ),
+                ).props("color=green")
+
+                # Schedule info
+                with ui.column().classes("gap-none"):
+                    ui.label(sched.name).classes(
+                        f"text-subtitle1 {'text-white' if is_enabled else 'text-grey-6'}"
+                    )
+                    with ui.row().classes("items-center gap-sm"):
+                        ui.icon("access_time", size="xs").classes("text-blue-4")
+                        ui.label(time_label).classes("text-caption text-grey-4")
+                        ui.label(f"({sched.timezone})").classes("text-caption text-grey-6")
+
+                ui.space()
+
+                # Tickers
+                with ui.row().classes("gap-xs"):
+                    for ticker in tickers[:5]:  # show up to 5
+                        ui.badge(ticker, color="blue-grey").props("outline")
+                    if len(tickers) > 5:
+                        ui.badge(f"+{len(tickers) - 5}", color="grey").props("outline")
+
+                ui.space()
+
+                # Last / next run info
+                with ui.column().classes("gap-none items-end"):
+                    if sched.last_run:
+                        ui.label(f"Last: {sched.last_run}").classes(
+                            "text-caption text-grey-6"
+                        )
+                    if sched.next_run and is_enabled:
+                        ui.label(f"Next: {sched.next_run}").classes(
+                            "text-caption text-green-4"
+                        )
+
+                # Actions
+                with ui.row().classes("gap-xs"):
+                    ui.button(
+                        icon="play_arrow",
+                        on_click=lambda sid=sched.id: self._run_now(sid),
+                    ).props("flat dense round color=green").tooltip("Run Now")
+                    ui.button(
+                        icon="history",
+                        on_click=lambda sid=sched.id, name=sched.name: (
+                            self._show_run_history(sid, name)
+                        ),
+                    ).props("flat dense round color=blue").tooltip("Run History")
+                    ui.button(
+                        icon="delete",
+                        on_click=lambda sid=sched.id, name=sched.name: (
+                            self._confirm_delete(sid, name)
+                        ),
+                    ).props("flat dense round color=red").tooltip("Delete")
+
+    def _toggle_schedule(
+        self, schedule_id: int, enabled: bool, cron_expr: str, timezone: str,
+    ) -> None:
+        """Enable or disable a schedule."""
+        self._db.update_schedule_enabled(schedule_id, enabled)
+        if self._scheduler:
+            if enabled:
+                self._scheduler.add_schedule(schedule_id, cron_expr, timezone)
+            else:
+                self._scheduler.remove_schedule(schedule_id)
+        status = "enabled" if enabled else "disabled"
+        ui.notify(f"Schedule {status}", type="positive")
+        self._refresh_list()
+
+    def _run_now(self, schedule_id: int) -> None:
+        """Manually trigger a schedule immediately."""
+        schedules = self._db.list_schedules()
+        sched = next((s for s in schedules if s.id == schedule_id), None)
+        if sched is None:
+            ui.notify("Schedule not found", type="negative")
+            return
+
+        tickers = [t.strip().upper() for t in sched.watchlist.split(",") if t.strip()]
+        if not tickers:
+            ui.notify("Watchlist is empty", type="warning")
+            return
+
+        if self._scheduler:
+            try:
+                self._scheduler._run_scheduled(schedule_id, tickers)
+                ui.notify(
+                    f"Dispatched {len(tickers)} ticker(s): {', '.join(tickers)}",
+                    type="positive",
+                )
+            except Exception as exc:
+                ui.notify(f"Failed to dispatch: {exc}", type="negative")
+        else:
+            ui.notify("Scheduler not available", type="warning")
+
+    def _show_create_dialog(self) -> None:
+        """Show the dialog to create a new schedule."""
+        with ui.dialog() as dialog, ui.card().classes("w-96 bg-dark"):
+            ui.label("New Schedule").classes("text-h6 text-white")
+            ui.separator().classes("bg-grey-8")
+
+            name_input = ui.input(
+                label="Name",
+                placeholder="e.g., Pre-Market Scan",
+            ).classes("w-full")
+
+            watchlist_input = ui.input(
+                label="Watchlist (comma-separated tickers)",
+                placeholder="e.g., AAPL, MSFT, NVDA, TSLA",
+            ).classes("w-full")
+
+            with ui.row().classes("w-full gap-md"):
+                hour_input = ui.number(
+                    label="Hour (0-23)", value=8, min=0, max=23,
+                    format="%.0f",
+                ).classes("w-20")
+                minute_input = ui.number(
+                    label="Minute (0-59)", value=30, min=0, max=59,
+                    format="%.0f",
+                ).classes("w-20")
+
+            days_select = ui.select(
+                label="Days",
+                options=[
+                    "MON-FRI",
+                    "Every day",
+                    "MON,WED,FRI",
+                    "TUE,THU",
+                    "SAT,SUN",
+                ],
+                value="MON-FRI",
+            ).classes("w-full")
+
+            tz_select = ui.select(
+                label="Timezone",
+                options=[
+                    "America/New_York",
+                    "America/Chicago",
+                    "America/Denver",
+                    "America/Los_Angeles",
+                    "UTC",
+                    "Europe/London",
+                    "Europe/Moscow",
+                    "Asia/Tokyo",
+                    "Asia/Shanghai",
+                ],
+                value="America/New_York",
+            ).classes("w-full")
+
+            with ui.row().classes("w-full justify-end gap-sm q-mt-md"):
+                ui.button("Cancel", on_click=dialog.close).props("flat")
+                ui.button(
+                    "Create", icon="add",
+                    on_click=lambda: self._create_schedule(
+                        dialog=dialog,
+                        name=name_input.value or "",
+                        watchlist=watchlist_input.value or "",
+                        hour=int(hour_input.value or 8),
+                        minute=int(minute_input.value or 0),
+                        days=days_select.value or "MON-FRI",
+                        timezone=tz_select.value or "America/New_York",
+                    ),
+                ).props("color=blue")
+
+        dialog.open()
+
+    def _create_schedule(
+        self,
+        *,
+        dialog: Any,
+        name: str,
+        watchlist: str,
+        hour: int,
+        minute: int,
+        days: str,
+        timezone: str,
+    ) -> None:
+        """Validate and create a new schedule."""
+        name = name.strip()
+        if not name:
+            ui.notify("Please enter a schedule name", type="warning")
+            return
+
+        tickers = [t.strip().upper() for t in watchlist.split(",") if t.strip()]
+        if not tickers:
+            ui.notify("Please enter at least one ticker", type="warning")
+            return
+
+        # Build cron expression
+        days_token = "*" if days == "Every day" else days
+        cron_expr = f"{hour:02d}:{minute:02d} {days_token}"
+
+        # Validate
+        try:
+            CronExpr.parse(cron_expr)
+        except ValueError as exc:
+            ui.notify(f"Invalid schedule: {exc}", type="negative")
+            return
+
+        # Insert into DB
+        try:
+            schedule_id = self._db.insert_schedule(
+                name=name,
+                watchlist=", ".join(tickers),
+                cron_expr=cron_expr,
+                timezone=timezone,
+            )
+        except Exception as exc:
+            ui.notify(f"Failed to create schedule: {exc}", type="negative")
+            return
+
+        # Arm the timer
+        if self._scheduler:
+            self._scheduler.add_schedule(schedule_id, cron_expr, timezone)
+
+        dialog.close()
+        ui.notify(f"Schedule '{name}' created", type="positive")
+        self._refresh_list()
+
+    def _confirm_delete(self, schedule_id: int, name: str) -> None:
+        """Show confirmation dialog before deleting a schedule."""
+        with ui.dialog() as dialog, ui.card().classes("bg-dark"):
+            ui.label(f"Delete '{name}'?").classes("text-h6 text-white")
+            ui.label(
+                "This will permanently remove the schedule and all its run history."
+            ).classes("text-body2 text-grey-4")
+
+            with ui.row().classes("w-full justify-end gap-sm q-mt-md"):
+                ui.button("Cancel", on_click=dialog.close).props("flat")
+                ui.button(
+                    "Delete", icon="delete",
+                    on_click=lambda: self._delete_schedule(dialog, schedule_id),
+                ).props("color=red")
+
+        dialog.open()
+
+    def _delete_schedule(self, dialog: Any, schedule_id: int) -> None:
+        """Delete a schedule from DB and disarm its timer."""
+        if self._scheduler:
+            self._scheduler.remove_schedule(schedule_id)
+        self._db.delete_schedule(schedule_id)
+        dialog.close()
+        ui.notify("Schedule deleted", type="positive")
+        self._refresh_list()
+
+    def _show_run_history(self, schedule_id: int, name: str) -> None:
+        """Show recent runs for a schedule in a dialog."""
+        runs = self._db.list_schedule_runs(schedule_id, limit=20)
+
+        with ui.dialog() as dialog, ui.card().classes("w-128 bg-dark"):
+            ui.label(f"Run History — {name}").classes("text-h6 text-white")
+            ui.separator().classes("bg-grey-8")
+
+            if not runs:
+                ui.label("No runs yet.").classes("text-body2 text-grey-5 q-pa-md")
+            else:
+                with ui.column().classes(
+                    "w-full gap-sm"
+                ).style("max-height: 400px; overflow-y: auto"):
+                    for run in runs:
+                        _color = {
+                            "completed": "green",
+                            "running": "blue",
+                            "failed": "red",
+                            "skipped_conflict": "orange",
+                        }.get(run.status, "grey")
+
+                        with ui.row().classes("items-center w-full gap-sm"):
+                            ui.badge(
+                                run.status, color=_color,
+                            ).props("outline")
+                            ui.label(run.started_at).classes("text-caption text-grey-4")
+                            if run.completed_at:
+                                ui.label(f"→ {run.completed_at}").classes(
+                                    "text-caption text-grey-6"
+                                )
+
+                            # Tickers
+                            try:
+                                tickers = json.loads(run.tickers_json)
+                            except (json.JSONDecodeError, TypeError):
+                                tickers = []
+                            ui.label(", ".join(tickers)).classes(
+                                "text-caption text-white"
+                            )
+
+            with ui.row().classes("w-full justify-end q-mt-md"):
+                ui.button("Close", on_click=dialog.close).props("flat")
+
+        dialog.open()

--- a/desktop/pages/scorecard.py
+++ b/desktop/pages/scorecard.py
@@ -1,0 +1,362 @@
+"""Recommendation Accuracy Scorecard — system performance dashboard.
+
+Shows historical accuracy metrics: win rate, average return, best/worst
+calls, and per-verdict breakdowns.  All data comes from stored
+recommendation outcomes (no live price lookups).
+
+See also: PLAN-desktop.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nicegui import ui
+
+from desktop.state.database import (
+    HistoryDB,
+    RecommendationOutcomeRow,
+    RecommendationRow,
+)
+
+
+def render_scorecard_page(*, db: HistoryDB) -> None:
+    """Render the scorecard page content."""
+    page = _ScorecardPage(db=db)
+    page.build()
+
+
+# ── Internal data structures ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _RecommendationWithOutcome:
+    """A recommendation paired with its latest outcome row."""
+
+    rec: RecommendationRow
+    outcome: RecommendationOutcomeRow | None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+_SELL_VERDICTS = frozenset({"SELL", "UNDERWEIGHT"})
+
+
+def _effective_return(rec: RecommendationRow, outcome: RecommendationOutcomeRow) -> float:
+    """Return the effective return, inverting sign for SELL/UNDERWEIGHT."""
+    if rec.verdict in _SELL_VERDICTS:
+        return -outcome.return_pct
+    return outcome.return_pct
+
+
+def _color_for_value(value: float) -> str:
+    """Return a Quasar color name for a numeric value."""
+    if value > 0:
+        return "green"
+    if value < 0:
+        return "red"
+    return "orange"
+
+
+def _fmt_pct(value: float) -> str:
+    """Format a percentage with sign and 1 decimal place."""
+    sign = "+" if value > 0 else ""
+    return f"{sign}{value:.1f}%"
+
+
+# ── Page class ────────────────────────────────────────────────────────
+
+
+class _ScorecardPage:
+    def __init__(self, *, db: HistoryDB) -> None:
+        self._db = db
+
+    def build(self) -> None:
+        # Gather all data up-front
+        all_recs = self._load_all_recommendations()
+        outcomes_30d = self._db.list_all_outcomes(min_days=30)
+
+        # Build lookup: recommendation_id -> RecommendationRow
+        rec_by_id: dict[int, RecommendationRow] = {r.id: r for r in all_recs}
+
+        # Pair each recommendation with its latest outcome
+        paired = self._pair_recs_with_latest_outcomes(all_recs)
+
+        # Filter 30d outcomes to only those with a matching recommendation
+        valid_30d = [o for o in outcomes_30d if o.recommendation_id in rec_by_id]
+
+        with ui.column().classes("w-full q-pa-md gap-md"):
+            # Header
+            with ui.row().classes("items-center gap-sm"):
+                ui.label("System Performance Scorecard").classes(
+                    "text-h5 text-white"
+                )
+                with ui.icon("info").classes("text-grey-5 cursor-pointer"):
+                    ui.tooltip(
+                        "Metrics are computed from stored outcome checkpoints "
+                        "(1d, 7d, 30d, 90d). Win rate uses the 30-day checkpoint. "
+                        "For SELL verdicts, a price decrease counts as a win."
+                    )
+
+            # Empty state
+            if not valid_30d:
+                self._build_empty_state()
+                return
+
+            # Compute aggregate metrics from 30d outcomes
+            self._build_top_stats(valid_30d, rec_by_id)
+            self._build_verdict_breakdown(valid_30d, rec_by_id)
+            self._build_best_worst_table(valid_30d, rec_by_id)
+            self._build_all_recommendations_table(paired)
+
+    # ── Data loading ──────────────────────────────────────────────────
+
+    def _load_all_recommendations(self) -> list[RecommendationRow]:
+        """Load all recommendations (active and inactive) from the DB."""
+        conn = self._db._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM recommendations ORDER BY id DESC"
+            ).fetchall()
+            return [HistoryDB._row_to_recommendation(r) for r in rows]
+        finally:
+            conn.close()
+
+    def _pair_recs_with_latest_outcomes(
+        self, recs: list[RecommendationRow],
+    ) -> list[_RecommendationWithOutcome]:
+        """Pair each recommendation with its most recent outcome."""
+        paired: list[_RecommendationWithOutcome] = []
+        for rec in recs:
+            outcomes = self._db.get_outcomes(rec.id)
+            latest = outcomes[-1] if outcomes else None
+            paired.append(_RecommendationWithOutcome(rec=rec, outcome=latest))
+        return paired
+
+    # ── Empty state ───────────────────────────────────────────────────
+
+    def _build_empty_state(self) -> None:
+        with ui.column().classes("w-full items-center q-pa-xl gap-md"):
+            ui.label("No outcome data yet").classes("text-h5 text-grey-5")
+            ui.label(
+                "Outcomes are recorded automatically at 1d, 7d, 30d, and 90d "
+                "checkpoints. Run some analyses and check back later!"
+            ).classes("text-body1 text-grey-6 text-center").style(
+                "max-width: 500px"
+            )
+
+    # ── Top stats row ─────────────────────────────────────────────────
+
+    def _build_top_stats(
+        self,
+        outcomes: list[RecommendationOutcomeRow],
+        rec_by_id: dict[int, RecommendationRow],
+    ) -> None:
+        effective_returns = []
+        stop_hits = 0
+        target_hits = 0
+
+        for o in outcomes:
+            rec = rec_by_id.get(o.recommendation_id)
+            if rec is None:
+                continue
+            effective_returns.append(_effective_return(rec, o))
+            if o.stop_hit:
+                stop_hits += 1
+            if o.target_hit:
+                target_hits += 1
+
+        total = len(effective_returns)
+        wins = sum(1 for r in effective_returns if r > 0)
+        win_rate = (wins / total * 100) if total else 0.0
+        avg_return = (sum(effective_returns) / total) if total else 0.0
+        stop_rate = (stop_hits / total * 100) if total else 0.0
+        target_rate = (target_hits / total * 100) if total else 0.0
+
+        with ui.row().classes("w-full gap-md"):
+            self._metric_card(
+                label="Win Rate (30d)",
+                value=f"{win_rate:.0f}%",
+                subtitle=f"{wins} / {total}",
+                color=_color_for_value(win_rate - 50),
+            )
+            self._metric_card(
+                label="Avg Return (30d)",
+                value=_fmt_pct(avg_return),
+                subtitle=f"{total} outcomes",
+                color=_color_for_value(avg_return),
+            )
+            self._metric_card(
+                label="Stop-Loss Hit Rate",
+                value=f"{stop_rate:.0f}%",
+                subtitle=f"{stop_hits} / {total}",
+                color=_color_for_value(-stop_rate),  # lower = better
+            )
+            self._metric_card(
+                label="Target Hit Rate",
+                value=f"{target_rate:.0f}%",
+                subtitle=f"{target_hits} / {total}",
+                color=_color_for_value(target_rate),
+            )
+
+    # ── Verdict breakdown ─────────────────────────────────────────────
+
+    def _build_verdict_breakdown(
+        self,
+        outcomes: list[RecommendationOutcomeRow],
+        rec_by_id: dict[int, RecommendationRow],
+    ) -> None:
+        ui.label("By Verdict").classes("text-h6 text-white q-mt-md")
+
+        buckets: dict[str, list[float]] = {"BUY": [], "HOLD": [], "SELL": []}
+
+        for o in outcomes:
+            rec = rec_by_id.get(o.recommendation_id)
+            if rec is None:
+                continue
+            eff = _effective_return(rec, o)
+            verdict = rec.verdict
+            if verdict in ("BUY", "OVERWEIGHT"):
+                buckets["BUY"].append(eff)
+            elif verdict in _SELL_VERDICTS:
+                buckets["SELL"].append(eff)
+            else:
+                buckets["HOLD"].append(eff)
+
+        with ui.row().classes("w-full gap-md"):
+            for verdict, returns in buckets.items():
+                count = len(returns)
+                avg = (sum(returns) / count) if count else 0.0
+                note = (
+                    "(price drop = win)"
+                    if verdict == "SELL" and count > 0
+                    else ""
+                )
+                self._metric_card(
+                    label=f"{verdict} Calls",
+                    value=_fmt_pct(avg) if count else "N/A",
+                    subtitle=f"{count} calls{' ' + note if note else ''}",
+                    color=_color_for_value(avg) if count else "grey",
+                )
+
+    # ── Best / Worst table ────────────────────────────────────────────
+
+    def _build_best_worst_table(
+        self,
+        outcomes: list[RecommendationOutcomeRow],
+        rec_by_id: dict[int, RecommendationRow],
+    ) -> None:
+        scored: list[tuple[float, RecommendationOutcomeRow, RecommendationRow]] = []
+        for o in outcomes:
+            rec = rec_by_id.get(o.recommendation_id)
+            if rec is None:
+                continue
+            scored.append((_effective_return(rec, o), o, rec))
+
+        if not scored:
+            return
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        best = scored[:3]
+        worst = scored[-3:]
+        worst.reverse()
+
+        ui.label("Best & Worst Calls (30d)").classes("text-h6 text-white q-mt-md")
+
+        columns = [
+            {"name": "rank", "label": "", "field": "rank"},
+            {"name": "ticker", "label": "Ticker", "field": "ticker", "sortable": True},
+            {"name": "verdict", "label": "Verdict", "field": "verdict"},
+            {"name": "return_pct", "label": "Return", "field": "return_pct", "sortable": True},
+            {"name": "days", "label": "Days", "field": "days"},
+        ]
+
+        rows: list[dict] = []
+        for eff, o, rec in best:
+            rows.append({
+                "rank": "Best",
+                "ticker": rec.ticker,
+                "verdict": rec.verdict,
+                "return_pct": _fmt_pct(eff),
+                "days": o.days_elapsed,
+            })
+        for eff, o, rec in worst:
+            rows.append({
+                "rank": "Worst",
+                "ticker": rec.ticker,
+                "verdict": rec.verdict,
+                "return_pct": _fmt_pct(eff),
+                "days": o.days_elapsed,
+            })
+
+        ui.table(
+            columns=columns,
+            rows=rows,
+            row_key="ticker",
+        ).classes("w-full").props("flat bordered dense")
+
+    # ── All recommendations table ─────────────────────────────────────
+
+    def _build_all_recommendations_table(
+        self, paired: list[_RecommendationWithOutcome],
+    ) -> None:
+        ui.label("All Recommendations").classes("text-h6 text-white q-mt-md")
+
+        columns = [
+            {"name": "ticker", "label": "Ticker", "field": "ticker", "sortable": True},
+            {"name": "verdict", "label": "Verdict", "field": "verdict", "sortable": True},
+            {"name": "entry_price", "label": "Entry Price", "field": "entry_price", "sortable": True},
+            {"name": "outcome", "label": "Outcome", "field": "outcome", "sortable": True},
+            {"name": "days", "label": "Days", "field": "days", "sortable": True},
+            {"name": "stop_hit", "label": "Stop Hit", "field": "stop_hit"},
+            {"name": "target_hit", "label": "Target Hit", "field": "target_hit"},
+        ]
+
+        rows: list[dict] = []
+        for item in paired:
+            rec = item.rec
+            o = item.outcome
+            if o is not None:
+                eff = _effective_return(rec, o)
+                outcome_str = _fmt_pct(eff)
+                days = o.days_elapsed
+                stop = "Yes" if o.stop_hit else "No"
+                target = "Yes" if o.target_hit else "No"
+            else:
+                outcome_str = "Pending"
+                days = ""
+                stop = "-"
+                target = "-"
+
+            rows.append({
+                "ticker": rec.ticker,
+                "verdict": rec.verdict,
+                "entry_price": f"${rec.price_at_analysis:.2f}" if rec.price_at_analysis else "-",
+                "outcome": outcome_str,
+                "days": days,
+                "stop_hit": stop,
+                "target_hit": target,
+            })
+
+        ui.table(
+            columns=columns,
+            rows=rows,
+            row_key="ticker",
+            pagination={"rowsPerPage": 15},
+        ).classes("w-full").props("flat bordered dense")
+
+    # ── Shared metric card component ──────────────────────────────────
+
+    @staticmethod
+    def _metric_card(
+        *,
+        label: str,
+        value: str,
+        subtitle: str,
+        color: str,
+    ) -> None:
+        """Render a single metric card with a big number and label."""
+        with ui.card().classes("q-pa-md flex-1 min-w-[180px]"):
+            ui.label(label).classes("text-caption text-grey-5")
+            ui.label(value).classes(f"text-h4 text-{color} q-my-xs")
+            ui.label(subtitle).classes("text-caption text-grey-6")

--- a/desktop/pages/scorecard.py
+++ b/desktop/pages/scorecard.py
@@ -113,14 +113,7 @@ class _ScorecardPage:
 
     def _load_all_recommendations(self) -> list[RecommendationRow]:
         """Load all recommendations (active and inactive) from the DB."""
-        conn = self._db._connect()
-        try:
-            rows = conn.execute(
-                "SELECT * FROM recommendations ORDER BY id DESC"
-            ).fetchall()
-            return [HistoryDB._row_to_recommendation(r) for r in rows]
-        finally:
-            conn.close()
+        return self._db.list_all_recommendations()
 
     def _pair_recs_with_latest_outcomes(
         self, recs: list[RecommendationRow],

--- a/desktop/pages/settings.py
+++ b/desktop/pages/settings.py
@@ -13,7 +13,7 @@ _DEFAULT_SETTINGS = {
     "default_provider": "claude_cli",
     "default_analysts": "market,social,news,fundamentals",
     "research_depth": "1",
-    "watchdog_timeout": "900",
+    "watchdog_timeout": "1200",
 }
 
 

--- a/desktop/pages/settings.py
+++ b/desktop/pages/settings.py
@@ -13,7 +13,7 @@ _DEFAULT_SETTINGS = {
     "default_provider": "claude_cli",
     "default_analysts": "market,social,news,fundamentals",
     "research_depth": "1",
-    "watchdog_timeout": "300",
+    "watchdog_timeout": "900",
 }
 
 

--- a/desktop/pages/settings.py
+++ b/desktop/pages/settings.py
@@ -42,7 +42,7 @@ class _SettingsPage:
                     label="Default Provider",
                     options=[
                         "claude_cli", "openai", "google", "anthropic",
-                        "deepseek", "ollama", "openrouter",
+                        "xai", "deepseek", "ollama", "openrouter",
                     ],
                     value=settings.get("default_provider", "claude_cli"),
                 ).classes("w-full").props("outlined dense")
@@ -66,7 +66,7 @@ class _SettingsPage:
                 # Watchdog timeout
                 watchdog_input = ui.number(
                     "Watchdog Timeout (seconds)",
-                    value=int(settings.get("watchdog_timeout", "300")),
+                    value=int(settings.get("watchdog_timeout", "1200")),
                     min=60, max=1800, step=30,
                 ).classes("w-full q-mt-md").props("outlined dense")
 
@@ -78,7 +78,7 @@ class _SettingsPage:
                 self._db.set_setting("default_analysts", ",".join(selected))
 
                 self._db.set_setting("research_depth", str(int(depth_slider.value)))
-                self._db.set_setting("watchdog_timeout", str(int(watchdog_input.value or 300)))
+                self._db.set_setting("watchdog_timeout", str(int(watchdog_input.value or 1200)))
 
                 ui.notify("Settings saved!", type="positive")
 

--- a/desktop/pages/settings.py
+++ b/desktop/pages/settings.py
@@ -1,0 +1,87 @@
+"""Settings page — user preferences stored in SQLite.
+
+See also: PLAN-desktop.md, F5.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from desktop.state.database import HistoryDB
+
+_DEFAULT_SETTINGS = {
+    "default_provider": "claude_cli",
+    "default_analysts": "market,social,news,fundamentals",
+    "research_depth": "1",
+    "watchdog_timeout": "300",
+}
+
+
+def render_settings_page(*, db: HistoryDB) -> None:
+    """Render the settings page content."""
+    page = _SettingsPage(db=db)
+    page.build()
+
+
+class _SettingsPage:
+    def __init__(self, *, db: HistoryDB) -> None:
+        self._db = db
+
+    def build(self) -> None:
+        settings = {**_DEFAULT_SETTINGS, **self._db.get_all_settings()}
+
+        with ui.column().classes("w-full max-w-xl mx-auto q-pa-md gap-md"):
+            ui.label("Settings").classes("text-h5 text-white")
+            ui.label("Default values for new analyses.").classes(
+                "text-body2 text-grey-5"
+            )
+
+            with ui.card().classes("w-full"):
+                # Default provider
+                provider_input = ui.select(
+                    label="Default Provider",
+                    options=[
+                        "claude_cli", "openai", "google", "anthropic",
+                        "deepseek", "ollama", "openrouter",
+                    ],
+                    value=settings.get("default_provider", "claude_cli"),
+                ).classes("w-full").props("outlined dense")
+
+                # Default analysts
+                ui.label("Default Analysts").classes("text-subtitle2 q-mt-md")
+                current_analysts = settings.get("default_analysts", "").split(",")
+                analyst_checks: dict[str, ui.checkbox] = {}
+                with ui.row().classes("gap-md"):
+                    for key in ["market", "social", "news", "fundamentals"]:
+                        cb = ui.checkbox(key.capitalize(), value=key in current_analysts)
+                        analyst_checks[key] = cb
+
+                # Research depth
+                depth_slider = ui.slider(
+                    min=1, max=3, step=1,
+                    value=int(settings.get("research_depth", "1")),
+                ).classes("w-full q-mt-md").props("label-always markers snap")
+                ui.label("Research Depth").classes("text-subtitle2")
+
+                # Watchdog timeout
+                watchdog_input = ui.number(
+                    "Watchdog Timeout (seconds)",
+                    value=int(settings.get("watchdog_timeout", "300")),
+                    min=60, max=1800, step=30,
+                ).classes("w-full q-mt-md").props("outlined dense")
+
+            # Save button
+            async def save() -> None:
+                self._db.set_setting("default_provider", provider_input.value or "claude_cli")
+
+                selected = [k for k, cb in analyst_checks.items() if cb.value]
+                self._db.set_setting("default_analysts", ",".join(selected))
+
+                self._db.set_setting("research_depth", str(int(depth_slider.value)))
+                self._db.set_setting("watchdog_timeout", str(int(watchdog_input.value or 300)))
+
+                ui.notify("Settings saved!", type="positive")
+
+            ui.button("Save Settings", icon="save", on_click=save).classes(
+                "w-full q-mt-md"
+            ).props("color=green")

--- a/desktop/services/__init__.py
+++ b/desktop/services/__init__.py
@@ -1,0 +1,13 @@
+"""Shared services for the TradingAgents Desktop feedback loop.
+
+Services are stateless singletons (created once, used by all pages).
+Each service owns one concern:
+
+- ``recommendation_extractor`` — extract structured data from markdown
+- ``price_service`` — per-ticker yfinance with TTL cache
+- ``alert_engine`` — background polling + desktop notifications
+- ``outcome_tracker`` — automated recommendation accuracy tracking
+- ``scheduler`` — cron-style timer scheduler for pre-market automation
+- ``pdf_export`` — markdown → HTML → PDF pipeline
+- ``email_service`` — SMTP send with attachment
+"""

--- a/desktop/services/alert_engine.py
+++ b/desktop/services/alert_engine.py
@@ -1,0 +1,338 @@
+"""Background polling engine that checks recommendation price levels.
+
+Loads active alerts from the DB, fetches current prices via PriceService,
+and fires callbacks when a target price is breached.  Uses
+``threading.Timer`` for non-blocking scheduling — each poll schedules the
+next one, so no thread is blocked between polls.
+
+Polling frequency adapts to US market hours:
+- Every 5 min during market hours (9:30-16:00 ET, weekdays)
+- Every 30 min outside market hours
+
+Crash recovery: exponential backoff (5m -> 10m -> 20m, capped at 60m)
+with automatic reset on success.
+
+Thread-safe start/stop.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import zoneinfo
+from collections.abc import Callable
+from datetime import datetime
+from typing import Final
+
+from desktop.services.price_service import PriceService
+from desktop.state.database import (
+    AlertHistoryRow,
+    AlertRow,
+    HistoryDB,
+    RecommendationRow,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MARKET_POLL_SECONDS: Final[int] = 300  # 5 min
+_OFF_HOURS_POLL_SECONDS: Final[int] = 1800  # 30 min
+_INITIAL_BACKOFF_SECONDS: Final[int] = 300  # 5 min
+_MAX_BACKOFF_SECONDS: Final[int] = 3600  # 60 min
+_ET_ZONE: Final[zoneinfo.ZoneInfo] = zoneinfo.ZoneInfo("America/New_York")
+
+# Alert type -> direction mapping for auto-creation from recommendations
+_ALERT_SPECS: Final[list[tuple[str, str, str]]] = [
+    # (attr on RecommendationRow, alert_type, direction)
+    ("stop_loss", "stop_loss", "below"),
+    ("entry_trigger", "entry_trigger", "below"),
+    ("profit_target", "profit_target", "above"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_market_hours() -> bool:
+    """Return True if the US stock market is currently open."""
+    et = datetime.now(_ET_ZONE)
+    if et.weekday() >= 5:  # Saturday=5, Sunday=6
+        return False
+    minutes = et.hour * 60 + et.minute
+    return 9 * 60 + 30 <= minutes <= 16 * 60
+
+
+def _poll_interval() -> int:
+    """Return the appropriate poll interval in seconds."""
+    return _MARKET_POLL_SECONDS if _is_market_hours() else _OFF_HOURS_POLL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class AlertEngine:
+    """Background polling engine for price alerts.
+
+    Parameters
+    ----------
+    db:
+        Database instance for reading/writing alerts.
+    price_service:
+        Price fetcher for current ticker prices.
+    """
+
+    def __init__(self, db: HistoryDB, price_service: PriceService) -> None:
+        self._db = db
+        self._price_service = price_service
+
+        self._lock = threading.Lock()
+        self._timer: threading.Timer | None = None
+        self._running = False
+        self._degraded = False
+        self._backoff = 0
+        self._consecutive_failures = 0
+        self._last_poll_at: str | None = None
+        self._callbacks: list[Callable[[AlertHistoryRow], None]] = []
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the polling loop in background."""
+        with self._lock:
+            if self._running:
+                logger.warning("AlertEngine.start() called but already running")
+                return
+            self._running = True
+            self._degraded = False
+            self._backoff = 0
+            self._consecutive_failures = 0
+
+        logger.info("AlertEngine started")
+        self._schedule_next(delay=0)
+
+    def stop(self) -> None:
+        """Stop the polling loop."""
+        with self._lock:
+            self._running = False
+            timer = self._timer
+            self._timer = None
+
+        if timer is not None:
+            timer.cancel()
+
+        logger.info("AlertEngine stopped")
+
+    @property
+    def is_running(self) -> bool:
+        with self._lock:
+            return self._running
+
+    @property
+    def is_degraded(self) -> bool:
+        """True if in exponential backoff after a failure."""
+        with self._lock:
+            return self._degraded
+
+    @property
+    def backoff_seconds(self) -> int:
+        """Current backoff interval (0 if healthy)."""
+        with self._lock:
+            return self._backoff
+
+    @property
+    def last_poll_at(self) -> str | None:
+        """ISO timestamp of last successful poll."""
+        with self._lock:
+            return self._last_poll_at
+
+    @property
+    def unseen_count(self) -> int:
+        """Number of unseen alert history entries."""
+        try:
+            return self._db.count_unseen_alert_history()
+        except Exception:
+            logger.exception("Failed to count unseen alerts")
+            return 0
+
+    def on_alert(self, callback: Callable[[AlertHistoryRow], None]) -> None:
+        """Register a callback for when an alert fires."""
+        with self._lock:
+            self._callbacks.append(callback)
+
+    def create_alerts_for_recommendation(self, rec: RecommendationRow) -> int:
+        """Auto-create alerts from a recommendation's price levels.
+
+        Creates up to 3 alerts (stop_loss, entry_trigger, profit_target)
+        if the recommendation has those price levels set.  Skips any
+        alert type that already exists for the same recommendation.
+
+        Returns the count of alerts created.
+        """
+        existing = self._db.list_alerts_for_recommendation(rec.id)
+        existing_types = {a.alert_type for a in existing}
+
+        created = 0
+        for attr, alert_type, direction in _ALERT_SPECS:
+            if alert_type in existing_types:
+                continue
+            price = getattr(rec, attr, None)
+            if price is None:
+                continue
+
+            try:
+                self._db.insert_alert(
+                    recommendation_id=rec.id,
+                    ticker=rec.ticker,
+                    alert_type=alert_type,
+                    target_price=price,
+                    direction=direction,
+                )
+                created += 1
+                logger.info(
+                    "Created %s alert for %s at $%.2f (%s)",
+                    alert_type, rec.ticker, price, direction,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to create %s alert for recommendation #%d",
+                    alert_type, rec.id,
+                )
+
+        return created
+
+    # ------------------------------------------------------------------
+    # Internal scheduling
+    # ------------------------------------------------------------------
+
+    def _schedule_next(self, delay: int | None = None) -> None:
+        """Schedule the next poll after *delay* seconds.
+
+        If *delay* is None, uses the adaptive interval (market hours
+        aware) or the current backoff value.
+        """
+        with self._lock:
+            if not self._running:
+                return
+
+            if delay is None:
+                delay = self._backoff if self._degraded else _poll_interval()
+
+            self._timer = threading.Timer(float(max(delay, 0)), self._poll_cycle)
+            self._timer.daemon = True
+            self._timer.name = "alert-engine-poll"
+            self._timer.start()
+
+    def _poll_cycle(self) -> None:
+        """Execute one poll cycle, then schedule the next."""
+        with self._lock:
+            if not self._running:
+                return
+
+        try:
+            self._execute_poll()
+
+            # Success: reset backoff state
+            with self._lock:
+                self._degraded = False
+                self._backoff = 0
+                self._consecutive_failures = 0
+                self._last_poll_at = datetime.now(_ET_ZONE).isoformat(
+                    timespec="seconds"
+                )
+
+        except Exception:
+            logger.exception("Alert poll cycle failed")
+            with self._lock:
+                self._consecutive_failures += 1
+                self._degraded = True
+                # Exponential backoff: 5m -> 10m -> 20m -> 40m -> 60m (cap)
+                self._backoff = min(
+                    _INITIAL_BACKOFF_SECONDS * (2 ** (self._consecutive_failures - 1)),
+                    _MAX_BACKOFF_SECONDS,
+                )
+                logger.warning(
+                    "Alert engine degraded: %d consecutive failures, "
+                    "next retry in %ds",
+                    self._consecutive_failures,
+                    self._backoff,
+                )
+
+        # Schedule next regardless of success/failure
+        self._schedule_next()
+
+    def _execute_poll(self) -> None:
+        """Fetch prices and check all active alerts."""
+        active_alerts = self._db.list_active_alerts()
+        if not active_alerts:
+            return
+
+        # Group alerts by ticker to batch-fetch prices
+        tickers = list({a.ticker for a in active_alerts})
+        prices = self._price_service.get_prices(tickers)
+
+        for alert in active_alerts:
+            price_result = prices.get(alert.ticker)
+            if price_result is None or price_result.price is None:
+                continue
+            if price_result.error is not None and not price_result.is_stale:
+                continue
+
+            current_price = price_result.price
+            if self._is_triggered(alert, current_price):
+                self._fire_alert(alert, current_price)
+
+    @staticmethod
+    def _is_triggered(alert: AlertRow, current_price: float) -> bool:
+        """Check whether the current price breaches the alert threshold."""
+        if alert.direction == "above":
+            return current_price >= alert.target_price
+        if alert.direction == "below":
+            return current_price <= alert.target_price
+        return False
+
+    def _fire_alert(self, alert: AlertRow, price: float) -> None:
+        """Trigger an alert: update DB, record history, invoke callbacks."""
+        message = (
+            f"{alert.ticker} {alert.alert_type.replace('_', ' ')} alert: "
+            f"price ${price:.2f} hit {alert.direction} "
+            f"target ${alert.target_price:.2f}"
+        )
+
+        try:
+            self._db.trigger_alert(alert.id, price)
+            history_id = self._db.insert_alert_history(
+                alert_id=alert.id, price=price, message=message,
+            )
+            logger.info("Alert #%d fired: %s", alert.id, message)
+        except Exception:
+            logger.exception("Failed to persist alert #%d trigger", alert.id)
+            return
+
+        # Build the history row for callbacks
+        history_row = AlertHistoryRow(
+            id=history_id,
+            alert_id=alert.id,
+            fired_at=datetime.now(_ET_ZONE).isoformat(timespec="seconds"),
+            price=price,
+            message=message,
+            seen=0,
+        )
+
+        # Invoke registered callbacks (best-effort)
+        with self._lock:
+            callbacks = list(self._callbacks)
+
+        for cb in callbacks:
+            try:
+                cb(history_row)
+            except Exception:
+                logger.exception("Alert callback failed for alert #%d", alert.id)

--- a/desktop/services/outcome_tracker.py
+++ b/desktop/services/outcome_tracker.py
@@ -1,0 +1,203 @@
+"""Background task that records recommendation outcomes at checkpoints.
+
+Checks active recommendations at 1d, 7d, 30d, and 90d intervals,
+fetching current prices and recording return percentages plus
+stop-loss / profit-target hit status.
+
+Runs on app start and every 4 hours via ``threading.Timer``.
+Thread-safe start/stop.
+
+See also: PLAN-desktop.md, Phase 4.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from datetime import datetime, timezone
+
+from desktop.services.price_service import PriceService
+from desktop.state.database import HistoryDB, RecommendationRow
+
+logger = logging.getLogger(__name__)
+
+# Checkpoints in days — outcomes are recorded once per checkpoint.
+_CHECKPOINTS: tuple[int, ...] = (1, 7, 30, 90)
+
+# Interval between background checks (4 hours in seconds).
+_CHECK_INTERVAL: int = 4 * 60 * 60
+
+
+def _days_since(created_at: str) -> float:
+    """Return fractional days elapsed since *created_at* (ISO format)."""
+    created = datetime.fromisoformat(created_at)
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    now = datetime.now(tz=timezone.utc)
+    return (now - created).total_seconds() / 86_400
+
+
+def _check_stop_hit(
+    price: float, rec: RecommendationRow,
+) -> bool:
+    """Return True if the current price breached the stop-loss level."""
+    if rec.stop_loss is None:
+        return False
+    return price <= rec.stop_loss
+
+
+def _check_target_hit(
+    price: float, rec: RecommendationRow,
+) -> bool:
+    """Return True if the current price reached the profit target."""
+    if rec.profit_target is None:
+        return False
+    return price >= rec.profit_target
+
+
+def _compute_return_pct(
+    price_at_analysis: float | None, price_now: float,
+) -> float:
+    """Percentage return from analysis price to current price."""
+    if price_at_analysis is None or price_at_analysis == 0.0:
+        return 0.0
+    return round(((price_now - price_at_analysis) / price_at_analysis) * 100, 4)
+
+
+class OutcomeTracker:
+    """Background service that records recommendation outcomes.
+
+    Parameters
+    ----------
+    db : HistoryDB
+        Database handle for reading recommendations and writing outcomes.
+    price_service : PriceService
+        Cached price fetcher for current quotes.
+    """
+
+    def __init__(self, db: HistoryDB, price_service: PriceService) -> None:
+        self._db = db
+        self._price_service = price_service
+        self._timer: threading.Timer | None = None
+        self._lock = threading.Lock()
+        self._running = False
+
+    # ── Public API ─────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start the background check loop (idempotent)."""
+        with self._lock:
+            if self._running:
+                return
+            self._running = True
+        logger.info("OutcomeTracker started")
+        self._schedule_next(initial=True)
+
+    def stop(self) -> None:
+        """Stop the background check loop and cancel pending timer."""
+        with self._lock:
+            self._running = False
+            timer = self._timer
+            self._timer = None
+        if timer is not None:
+            timer.cancel()
+        logger.info("OutcomeTracker stopped")
+
+    def run_check(self) -> int:
+        """Run a single outcome check cycle.
+
+        Returns the number of new outcome rows recorded.
+        """
+        recs = self._db.list_active_recommendations()
+        if not recs:
+            return 0
+
+        # Batch-fetch prices for all unique tickers.
+        tickers = list({r.ticker for r in recs})
+        prices = self._price_service.get_prices(tickers)
+
+        recorded = 0
+        for rec in recs:
+            price_result = prices.get(rec.ticker)
+            if price_result is None or price_result.price is None:
+                logger.debug("No price available for %s, skipping", rec.ticker)
+                continue
+
+            days_elapsed = _days_since(rec.created_at)
+            current_price = price_result.price
+
+            for checkpoint in _CHECKPOINTS:
+                if days_elapsed < checkpoint:
+                    break  # Sorted ascending — no later checkpoints apply.
+
+                recorded += self._record_if_missing(
+                    rec=rec,
+                    checkpoint=checkpoint,
+                    current_price=current_price,
+                )
+
+        if recorded:
+            logger.info("Recorded %d new outcome(s)", recorded)
+        return recorded
+
+    # ── Private helpers ────────────────────────────────────────────────
+
+    def _record_if_missing(
+        self,
+        *,
+        rec: RecommendationRow,
+        checkpoint: int,
+        current_price: float,
+    ) -> int:
+        """Insert an outcome row if one does not already exist.
+
+        Returns 1 on success, 0 if already exists or on error.
+        """
+        try:
+            self._db.insert_outcome(
+                recommendation_id=rec.id,
+                days_elapsed=checkpoint,
+                price_at_check=current_price,
+                return_pct=_compute_return_pct(rec.price_at_analysis, current_price),
+                stop_hit=_check_stop_hit(current_price, rec),
+                target_hit=_check_target_hit(current_price, rec),
+            )
+            return 1
+        except sqlite3.IntegrityError:
+            # UNIQUE(recommendation_id, days_elapsed) — already recorded.
+            return 0
+        except Exception:
+            logger.exception(
+                "Failed to record outcome for rec #%d at %dd",
+                rec.id, checkpoint,
+            )
+            return 0
+
+    def _schedule_next(self, *, initial: bool = False) -> None:
+        """Schedule the next check cycle via a daemon timer."""
+        with self._lock:
+            if not self._running:
+                return
+
+        # Run the check immediately on first call.
+        if initial:
+            try:
+                self.run_check()
+            except Exception:
+                logger.exception("OutcomeTracker initial check failed")
+
+        with self._lock:
+            if not self._running:
+                return
+            self._timer = threading.Timer(_CHECK_INTERVAL, self._on_timer)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def _on_timer(self) -> None:
+        """Timer callback — run check then reschedule."""
+        try:
+            self.run_check()
+        except Exception:
+            logger.exception("OutcomeTracker periodic check failed")
+        self._schedule_next()

--- a/desktop/services/pdf_export.py
+++ b/desktop/services/pdf_export.py
@@ -9,6 +9,7 @@ See also: PLAN-desktop.md, Phase 4.
 
 from __future__ import annotations
 
+import html as html_mod
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -137,8 +138,8 @@ def _md_to_html(text: str) -> str:
     """Convert Markdown text to HTML, with fallback to plain <pre>."""
     if _MD_AVAILABLE and markdown2 is not None:
         return markdown2.markdown(text, extras=_MD_EXTRAS)
-    # Minimal fallback: wrap in <pre> to preserve formatting.
-    return f"<pre>{text}</pre>"
+    # Minimal fallback: escape and wrap in <pre> to preserve formatting.
+    return f"<pre>{html_mod.escape(text)}</pre>"
 
 
 def _now_stamp() -> str:
@@ -183,13 +184,16 @@ class PDFExporter:
 
         parts: list[str] = []
 
-        # Header
+        # Header — escape user-controlled values to prevent XSS
         badge_cls = _verdict_class(verdict)
+        esc_ticker = html_mod.escape(ticker)
+        esc_date = html_mod.escape(date)
+        esc_verdict = html_mod.escape(verdict.upper())
         parts.append(
             f'<div class="header">'
-            f"<h1>TradingAgents &mdash; {ticker}</h1>"
-            f'<div class="meta">Analysis Date: {date} &nbsp;|&nbsp; '
-            f'<span class="{badge_cls} verdict-badge">{verdict.upper()}</span>'
+            f"<h1>TradingAgents &mdash; {esc_ticker}</h1>"
+            f'<div class="meta">Analysis Date: {esc_date} &nbsp;|&nbsp; '
+            f'<span class="{badge_cls} verdict-badge">{esc_verdict}</span>'
             f"</div></div>"
         )
 
@@ -204,7 +208,7 @@ class PDFExporter:
             except (OSError, UnicodeDecodeError) as exc:
                 raw = f"*Error reading {md_path.name}: {exc}*"
 
-            section_title = md_path.stem.replace("_", " ").title()
+            section_title = html_mod.escape(md_path.stem.replace("_", " ").title())
             html_body = _md_to_html(raw)
             parts.append(
                 f'<div class="section">'

--- a/desktop/services/pdf_export.py
+++ b/desktop/services/pdf_export.py
@@ -1,0 +1,301 @@
+"""PDF export service: markdown -> HTML -> PDF.
+
+Uses ``markdown2`` for Markdown conversion and ``weasyprint`` for
+HTML-to-PDF rendering.  Falls back with a clear ``ImportError`` if
+weasyprint is not installed (it has native dependencies).
+
+See also: PLAN-desktop.md, Phase 4.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ── Lazy imports (fail gracefully) ────────────────────────────────────────
+
+try:
+    import markdown2  # type: ignore[import-untyped]
+
+    _MD_AVAILABLE = True
+except ImportError:
+    markdown2 = None  # type: ignore[assignment]
+    _MD_AVAILABLE = False
+
+_MD_EXTRAS = ["tables", "fenced-code-blocks", "strike", "task_list"]
+
+# ── Dark-themed HTML template ─────────────────────────────────────────────
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  @page {{ size: A4; margin: 1.5cm; }}
+  body {{
+    background: #1a1a2e;
+    color: #e0e0e0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 11pt;
+    line-height: 1.5;
+  }}
+  .header {{
+    border-bottom: 2px solid #16213e;
+    padding-bottom: 12px;
+    margin-bottom: 20px;
+  }}
+  .header h1 {{
+    color: #4ecca3;
+    margin: 0 0 4px 0;
+    font-size: 18pt;
+  }}
+  .meta {{ color: #8892b0; font-size: 9pt; }}
+  .verdict-badge {{
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 10pt;
+    color: #fff;
+  }}
+  .verdict-buy {{ background: #2e7d32; }}
+  .verdict-sell {{ background: #c62828; }}
+  .verdict-hold {{ background: #f57f17; }}
+  .verdict-default {{ background: #455a64; }}
+  .section {{
+    background: #16213e;
+    border-radius: 6px;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+  }}
+  .section h2 {{
+    color: #4ecca3;
+    font-size: 13pt;
+    margin: 0 0 8px 0;
+    border-bottom: 1px solid #1a1a2e;
+    padding-bottom: 6px;
+  }}
+  table {{
+    width: 100%;
+    border-collapse: collapse;
+    margin: 8px 0;
+  }}
+  th, td {{
+    border: 1px solid #2a2a4a;
+    padding: 6px 10px;
+    text-align: left;
+    font-size: 9pt;
+  }}
+  th {{ background: #0f3460; color: #4ecca3; }}
+  code {{
+    background: #0f3460;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 9pt;
+  }}
+  pre {{
+    background: #0f3460;
+    padding: 10px;
+    border-radius: 4px;
+    overflow-x: auto;
+    font-size: 9pt;
+  }}
+  .footer {{
+    border-top: 1px solid #16213e;
+    padding-top: 8px;
+    margin-top: 24px;
+    text-align: center;
+    color: #555;
+    font-size: 8pt;
+  }}
+</style>
+</head>
+<body>
+{content}
+</body>
+</html>
+"""
+
+
+def _verdict_class(verdict: str) -> str:
+    """Map a verdict string to a CSS class name."""
+    v = verdict.upper()
+    if v in ("BUY", "OVERWEIGHT"):
+        return "verdict-buy"
+    if v in ("SELL", "UNDERWEIGHT"):
+        return "verdict-sell"
+    if v == "HOLD":
+        return "verdict-hold"
+    return "verdict-default"
+
+
+def _md_to_html(text: str) -> str:
+    """Convert Markdown text to HTML, with fallback to plain <pre>."""
+    if _MD_AVAILABLE and markdown2 is not None:
+        return markdown2.markdown(text, extras=_MD_EXTRAS)
+    # Minimal fallback: wrap in <pre> to preserve formatting.
+    return f"<pre>{text}</pre>"
+
+
+def _now_stamp() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _require_weasyprint():  # noqa: ANN202
+    """Import weasyprint or raise a helpful error."""
+    try:
+        import weasyprint  # type: ignore[import-untyped]
+
+        return weasyprint
+    except ImportError as exc:
+        raise ImportError(
+            "weasyprint is required for PDF export but is not installed. "
+            "Install with: pip install weasyprint  "
+            "(Note: weasyprint requires system libraries — see "
+            "https://doc.courtbouillon.org/weasyprint/stable/first_steps.html)"
+        ) from exc
+
+
+# ── Public service ────────────────────────────────────────────────────────
+
+
+class PDFExporter:
+    """Export analyses and summaries to dark-themed PDF files."""
+
+    def export_analysis(
+        self,
+        *,
+        result_dir: Path,
+        ticker: str,
+        verdict: str,
+        date: str,
+    ) -> Path:
+        """Export a single analysis to PDF.
+
+        Reads all ``.md`` files in *result_dir* and renders them as
+        styled sections. Returns the path to the generated PDF.
+        """
+        weasyprint = _require_weasyprint()
+
+        parts: list[str] = []
+
+        # Header
+        badge_cls = _verdict_class(verdict)
+        parts.append(
+            f'<div class="header">'
+            f"<h1>TradingAgents &mdash; {ticker}</h1>"
+            f'<div class="meta">Analysis Date: {date} &nbsp;|&nbsp; '
+            f'<span class="{badge_cls} verdict-badge">{verdict.upper()}</span>'
+            f"</div></div>"
+        )
+
+        # Report sections
+        md_files = sorted(result_dir.glob("**/*.md"))
+        if not md_files:
+            parts.append('<div class="section"><p>No report files found.</p></div>')
+
+        for md_path in md_files:
+            try:
+                raw = md_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                raw = f"*Error reading {md_path.name}: {exc}*"
+
+            section_title = md_path.stem.replace("_", " ").title()
+            html_body = _md_to_html(raw)
+            parts.append(
+                f'<div class="section">'
+                f"<h2>{section_title}</h2>"
+                f"{html_body}</div>"
+            )
+
+        # Footer
+        parts.append(
+            f'<div class="footer">'
+            f"Generated by TradingAgents Desktop &mdash; {_now_stamp()}"
+            f"</div>"
+        )
+
+        full_html = _HTML_TEMPLATE.format(content="\n".join(parts))
+
+        out_path = result_dir / f"{ticker}_{date}_report.pdf"
+        weasyprint.HTML(string=full_html).write_pdf(str(out_path))
+        logger.info("Exported analysis PDF: %s", out_path)
+        return out_path
+
+    def export_summary(
+        self,
+        *,
+        recommendations: list,  # list[RecommendationRow]
+        prices: dict,  # dict[str, PriceResult]
+    ) -> Path:
+        """Export all active recommendations as a summary PDF.
+
+        Returns the path to the generated file (in a temp-like location
+        under ``~/.tradingagents/exports/``).
+        """
+        weasyprint = _require_weasyprint()
+
+        parts: list[str] = []
+
+        # Header
+        parts.append(
+            '<div class="header">'
+            "<h1>TradingAgents &mdash; Portfolio Summary</h1>"
+            f'<div class="meta">Generated: {_now_stamp()}</div>'
+            "</div>"
+        )
+
+        # Summary table
+        rows_html: list[str] = []
+        for rec in recommendations:
+            pr = prices.get(rec.ticker)
+            current = pr.price if pr and pr.price else None
+            change = ""
+            if current is not None and rec.price_at_analysis:
+                pct = ((current - rec.price_at_analysis) / rec.price_at_analysis) * 100
+                color = "#4ecca3" if pct >= 0 else "#ef5350"
+                change = f'<span style="color:{color}">{pct:+.2f}%</span>'
+
+            badge_cls = _verdict_class(rec.verdict)
+            rows_html.append(
+                f"<tr>"
+                f"<td><strong>{rec.ticker}</strong></td>"
+                f'<td><span class="{badge_cls} verdict-badge">{rec.verdict}</span></td>'
+                f"<td>{rec.confidence or 'N/A'}%</td>"
+                f"<td>${rec.price_at_analysis or 0:.2f}</td>"
+                f"<td>${current or 0:.2f}</td>"
+                f"<td>{change}</td>"
+                f"</tr>"
+            )
+
+        table = (
+            '<div class="section"><h2>Active Recommendations</h2>'
+            "<table><tr>"
+            "<th>Ticker</th><th>Verdict</th><th>Confidence</th>"
+            "<th>Entry Price</th><th>Current</th><th>Return</th>"
+            "</tr>"
+            + "\n".join(rows_html)
+            + "</table></div>"
+        )
+        parts.append(table)
+
+        # Footer
+        parts.append(
+            f'<div class="footer">'
+            f"Generated by TradingAgents Desktop &mdash; {_now_stamp()}"
+            f"</div>"
+        )
+
+        full_html = _HTML_TEMPLATE.format(content="\n".join(parts))
+
+        export_dir = Path.home() / ".tradingagents" / "exports"
+        export_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+        out_path = export_dir / f"summary_{stamp}.pdf"
+        weasyprint.HTML(string=full_html).write_pdf(str(out_path))
+        logger.info("Exported summary PDF: %s", out_path)
+        return out_path

--- a/desktop/services/price_service.py
+++ b/desktop/services/price_service.py
@@ -1,0 +1,328 @@
+"""Per-ticker yfinance price fetcher with TTL cache.
+
+Fetches one ticker at a time so a single invalid symbol never poisons
+the results for others.  A 5-minute TTL cache avoids hammering yfinance
+on repeated page loads, and stale data is returned (with ``is_stale=True``)
+when a refresh fails so the UI can display a warning badge rather than
+nothing at all.
+
+Thread-safe: the alert engine may call from a background thread while the
+NiceGUI UI calls from the main thread.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defensive yfinance import
+# ---------------------------------------------------------------------------
+
+try:
+    import yfinance as yf  # type: ignore[import-untyped]
+
+    _YF_AVAILABLE: Final[bool] = True
+except ImportError:
+    yf = None  # type: ignore[assignment]
+    _YF_AVAILABLE = False
+    logger.warning(
+        "yfinance is not installed — PriceService will return error results. "
+        "Install with: pip install yfinance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PriceResult:
+    """Immutable snapshot of a single ticker's price data."""
+
+    ticker: str
+    price: float | None
+    previous_close: float | None
+    change_pct: float | None
+    is_stale: bool
+    fetched_at: str | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class _CachedPrice:
+    """Internal cache entry — never exposed to callers."""
+
+    result: PriceResult
+    fetched_at_dt: datetime
+
+
+@dataclass(frozen=True)
+class _CachedHistorical:
+    """Internal cache entry for historical OHLCV data."""
+
+    data: list[dict]
+    fetched_at_dt: datetime
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TTL: Final[int] = 300  # 5 minutes
+_HISTORICAL_TTL: Final[int] = 3600  # 1 hour
+_MAX_WORKERS: Final[int] = 5
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _iso_now() -> str:
+    return _now().isoformat()
+
+
+def _compute_change_pct(
+    price: float | None, previous_close: float | None
+) -> float | None:
+    if price is None or previous_close is None or previous_close == 0.0:
+        return None
+    return round(((price - previous_close) / previous_close) * 100, 4)
+
+
+def _unavailable_result(ticker: str, error: str) -> PriceResult:
+    """Build a PriceResult for when yfinance is missing or a fetch fails."""
+    return PriceResult(
+        ticker=ticker,
+        price=None,
+        previous_close=None,
+        change_pct=None,
+        is_stale=False,
+        fetched_at=None,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class PriceService:
+    """Thread-safe, TTL-cached, per-ticker price fetcher.
+
+    Parameters
+    ----------
+    ttl_seconds:
+        How many seconds a cached price is considered fresh (default 300).
+    """
+
+    def __init__(self, ttl_seconds: int = _DEFAULT_TTL) -> None:
+        self._ttl_seconds: Final[int] = ttl_seconds
+        self._cache: dict[str, _CachedPrice] = {}
+        self._historical_cache: dict[str, _CachedHistorical] = {}
+        self._lock = threading.Lock()
+        self._historical_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_price(self, ticker: str) -> PriceResult:
+        """Fetch the current price for *ticker*.
+
+        Returns a cached value when within the TTL window.  If the live
+        fetch fails but a previous value exists, returns it with
+        ``is_stale=True``.
+        """
+        ticker = ticker.upper().strip()
+
+        if not _YF_AVAILABLE:
+            return _unavailable_result(ticker, "yfinance is not installed")
+
+        with self._lock:
+            cached = self._cache.get(ticker)
+            if cached is not None:
+                age = (_now() - cached.fetched_at_dt).total_seconds()
+                if age < self._ttl_seconds:
+                    return cached.result
+
+        # Outside the lock: network I/O can be slow.
+        result = self._fetch_single(ticker, stale_fallback=cached)
+
+        with self._lock:
+            if result.error is None:
+                self._cache[ticker] = _CachedPrice(
+                    result=result, fetched_at_dt=_now()
+                )
+
+        return result
+
+    def get_prices(self, tickers: list[str]) -> dict[str, PriceResult]:
+        """Fetch prices for multiple tickers with per-ticker isolation.
+
+        Uses a thread pool (up to 5 workers) so the total wall-clock time
+        is dominated by the single slowest fetch, not the sum.
+        """
+        if not tickers:
+            return {}
+
+        results: dict[str, PriceResult] = {}
+
+        with ThreadPoolExecutor(max_workers=_MAX_WORKERS) as pool:
+            futures = {
+                pool.submit(self.get_price, t): t for t in tickers
+            }
+            for future in as_completed(futures):
+                t = futures[future]
+                try:
+                    results[t.upper().strip()] = future.result()
+                except Exception:
+                    # Should never happen — get_price catches internally.
+                    logger.exception("Unexpected error fetching %s", t)
+                    results[t.upper().strip()] = _unavailable_result(
+                        t.upper().strip(), "unexpected executor error"
+                    )
+
+        return results
+
+    def invalidate(self, ticker: str | None = None) -> None:
+        """Clear the price cache for *ticker*, or all tickers if ``None``."""
+        with self._lock:
+            if ticker is None:
+                self._cache.clear()
+            else:
+                self._cache.pop(ticker.upper().strip(), None)
+
+        with self._historical_lock:
+            if ticker is None:
+                self._historical_cache.clear()
+            else:
+                self._historical_cache.pop(ticker.upper().strip(), None)
+
+    def get_historical(
+        self, ticker: str, period: str = "3mo"
+    ) -> list[dict] | None:
+        """Return historical OHLCV rows for *ticker*.
+
+        Cached separately with a 1-hour TTL.  Returns ``None`` on error.
+        """
+        ticker = ticker.upper().strip()
+
+        if not _YF_AVAILABLE:
+            logger.warning("yfinance unavailable — cannot fetch history for %s", ticker)
+            return None
+
+        cache_key = f"{ticker}:{period}"
+
+        with self._historical_lock:
+            cached = self._historical_cache.get(cache_key)
+            if cached is not None:
+                age = (_now() - cached.fetched_at_dt).total_seconds()
+                if age < _HISTORICAL_TTL:
+                    return cached.data
+
+        data = self._fetch_historical(ticker, period)
+
+        if data is not None:
+            with self._historical_lock:
+                self._historical_cache[cache_key] = _CachedHistorical(
+                    data=data, fetched_at_dt=_now()
+                )
+
+        return data
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_single(
+        self,
+        ticker: str,
+        *,
+        stale_fallback: _CachedPrice | None,
+    ) -> PriceResult:
+        """Hit yfinance for a single ticker.
+
+        On failure, return the stale fallback (if available) with
+        ``is_stale=True``, or an error result.
+        """
+        try:
+            info = yf.Ticker(ticker).fast_info
+            price: float | None = getattr(info, "last_price", None)
+            previous_close: float | None = getattr(
+                info, "previous_close", None
+            )
+
+            if price is None:
+                raise ValueError(f"No price data returned for {ticker}")
+
+            return PriceResult(
+                ticker=ticker,
+                price=round(price, 4),
+                previous_close=(
+                    round(previous_close, 4) if previous_close is not None else None
+                ),
+                change_pct=_compute_change_pct(price, previous_close),
+                is_stale=False,
+                fetched_at=_iso_now(),
+                error=None,
+            )
+
+        except Exception as exc:
+            logger.error("Failed to fetch price for %s: %s", ticker, exc)
+
+            if stale_fallback is not None:
+                stale = stale_fallback.result
+                return PriceResult(
+                    ticker=stale.ticker,
+                    price=stale.price,
+                    previous_close=stale.previous_close,
+                    change_pct=stale.change_pct,
+                    is_stale=True,
+                    fetched_at=stale.fetched_at,
+                    error=str(exc),
+                )
+
+            return _unavailable_result(ticker, str(exc))
+
+    @staticmethod
+    def _fetch_historical(ticker: str, period: str) -> list[dict] | None:
+        """Download historical OHLCV data and return as a list of dicts."""
+        try:
+            df = yf.Ticker(ticker).history(period=period)
+
+            if df is None or df.empty:
+                logger.warning("No historical data for %s (period=%s)", ticker, period)
+                return None
+
+            rows: list[dict] = []
+            for date, row in df.iterrows():
+                rows.append(
+                    {
+                        "date": str(date.date()) if hasattr(date, "date") else str(date),
+                        "open": round(float(row["Open"]), 4),
+                        "high": round(float(row["High"]), 4),
+                        "low": round(float(row["Low"]), 4),
+                        "close": round(float(row["Close"]), 4),
+                        "volume": int(row["Volume"]),
+                    }
+                )
+
+            return rows
+
+        except Exception as exc:
+            logger.error(
+                "Failed to fetch historical data for %s (period=%s): %s",
+                ticker,
+                period,
+                exc,
+            )
+            return None

--- a/desktop/services/recommendation_extractor.py
+++ b/desktop/services/recommendation_extractor.py
@@ -190,8 +190,9 @@ _TICKER_BODY_RE = re.compile(
     re.MULTILINE,
 )
 # Also: **Инструмент:** CRWD (CrowdStrike)
+# Allow colon and bold markers in any order between keyword and ticker
 _TICKER_INSTRUMENT_RE = re.compile(
-    r"\*{0,2}инструмент\*{0,2}[\s:]+\*{0,2}([A-Z]{1,5})\b",
+    r"\*{0,2}инструмент[:\s*]+([A-Z]{1,5})\b",
     re.IGNORECASE,
 )
 

--- a/desktop/services/recommendation_extractor.py
+++ b/desktop/services/recommendation_extractor.py
@@ -1,0 +1,649 @@
+"""Extract structured recommendation data from final_trade_decision.md files.
+
+This is the core of "Approach C: Extract-at-Write" -- called at persist time
+(right after the report is written, format is fresh and known) and during
+one-time migration of historical reports (can fail gracefully).
+
+Reports are written in Russian by the AI trading agent system.  The extractor
+handles both Russian *and* English keywords so it survives format drift.
+
+Typical header patterns found in production reports
+----------------------------------------------------
+- ``# Вердикт Портфельного Менеджера: NFLX``
+- ``# ФИНАЛЬНОЕ РЕШЕНИЕ ПОРТФЕЛЬНОГО МЕНЕДЖЕРА: CRWD``
+- ``## ИТОГОВОЕ РЕШЕНИЕ ПОРТФЕЛЬНОГО УПРАВЛЯЮЩЕГО``
+- ``# Решение Портфельного Управляющего: SPY``
+
+Verdict patterns (always in bold)::
+
+    ## Итоговый рейтинг: **HOLD**
+    ## ⚖️ ВЕРДИКТ: **Hold**
+    ### Рейтинг: **SELL**
+    ## Рейтинг: Underweight          (no bold, still valid)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+_VALID_VERDICTS = frozenset({
+    "BUY",
+    "HOLD",
+    "SELL",
+    "UNDERWEIGHT",
+    "OVERWEIGHT",
+    "UNKNOWN",
+})
+
+_NOTES_MAX_LEN = 200
+
+# ── Data transfer object ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExtractedRecommendation:
+    """Immutable container for structured recommendation data.
+
+    Every field except *ticker* and *verdict* is optional -- the extractor
+    returns ``None`` for anything it cannot confidently parse.
+    """
+
+    ticker: str
+    verdict: str  # BUY | HOLD | SELL | UNDERWEIGHT | OVERWEIGHT | UNKNOWN
+    confidence: int | None = None  # 1-10 if mentioned
+    price_at_analysis: float | None = None  # current price at analysis time
+    stop_loss: float | None = None  # dollar amount
+    entry_trigger: float | None = None  # dollar amount
+    profit_target: float | None = None  # dollar amount
+    review_date: str | None = None  # when to re-evaluate
+    notes: str | None = None  # key catalyst / first 200 chars of conclusion
+    analysis_id: int | None = None  # FK back to analyses table
+
+
+# ── Price regex ──────────────────────────────────────────────────────────
+# Matches $77, $89.17, $89,17 (Russian decimal), $1,283, $2,850.50 etc.
+_PRICE_RE = re.compile(r"\$\s?([\d]+(?:[.,]\d{1,3})*)")
+
+
+def _parse_price_str(raw: str) -> float | None:
+    """Parse a price string handling both English and Russian decimal formats.
+
+    Rules for comma disambiguation:
+    - Comma followed by exactly 2 digits at end of string: Russian decimal
+      ($89,17 -> 89.17, $94,70 -> 94.70)
+    - Comma followed by 3 digits: thousands separator
+      ($1,283 -> 1283.0)
+    - Dot followed by 1-2 digits: English decimal ($89.17 -> 89.17)
+    """
+    if not raw:
+        return None
+
+    # Check for Russian decimal: single comma + exactly 2 trailing digits
+    russian_decimal = re.match(r"^(\d+),(\d{2})$", raw)
+    if russian_decimal:
+        try:
+            return float(f"{russian_decimal.group(1)}.{russian_decimal.group(2)}")
+        except ValueError:
+            return None
+
+    # Standard format: strip thousands commas, keep dot as decimal
+    cleaned = raw.replace(",", "")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _first_price(text: str) -> float | None:
+    """Return the first dollar-denominated price found in *text*, or None."""
+    m = _PRICE_RE.search(text)
+    if m is None:
+        return None
+    return _parse_price_str(m.group(1))
+
+
+def _all_prices(text: str) -> list[float]:
+    """Return every dollar-denominated price found in *text*."""
+    results: list[float] = []
+    for m in _PRICE_RE.finditer(text):
+        val = _parse_price_str(m.group(1))
+        if val is not None:
+            results.append(val)
+    return results
+
+
+# ── Verdict extraction ───────────────────────────────────────────────────
+# Ordered so the longest alternatives come first in the alternation.
+_VERDICT_KEYWORDS = re.compile(
+    r"\b(UNDERWEIGHT|OVERWEIGHT|HOLD|SELL|BUY)\b",
+    re.IGNORECASE,
+)
+
+# Bold variant: **HOLD**, **Sell**, etc.
+_VERDICT_BOLD_RE = re.compile(
+    r"\*\*\s*(UNDERWEIGHT|OVERWEIGHT|HOLD|SELL|BUY)\s*\*\*",
+    re.IGNORECASE,
+)
+
+# Russian + English verdict header lines (case-insensitive).
+# Matches:  ## Итоговый рейтинг: **HOLD**
+#           ## ВЕРДИКТ: **Hold**
+#           ### Рейтинг: **SELL**
+#           ## Рейтинг: Underweight
+_VERDICT_LINE_RE = re.compile(
+    r"^#{1,4}\s*[^\n]*?"
+    r"(?:рейтинг|вердикт|verdict|rating|решение|decision)"
+    r"[:\s]*\**\s*"
+    r"(UNDERWEIGHT|OVERWEIGHT|HOLD|SELL|BUY)"
+    r"\s*\**",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extract_verdict(text: str) -> str:
+    """Extract the recommendation verdict from the markdown text.
+
+    Strategy: prefer a verdict that appears in a header line (most reliable),
+    then fall back to the first bold verdict, then any verdict keyword in
+    the first 30 lines.
+    """
+    # 1. Header-line verdict (highest confidence)
+    m = _VERDICT_LINE_RE.search(text)
+    if m is not None:
+        return m.group(1).upper()
+
+    # 2. Bold verdict in the first ~40 lines (covers most real reports)
+    first_chunk = "\n".join(text.splitlines()[:40])
+    m = _VERDICT_BOLD_RE.search(first_chunk)
+    if m is not None:
+        return m.group(1).upper()
+
+    # 3. Any bare keyword in the first ~15 lines
+    header_chunk = "\n".join(text.splitlines()[:15])
+    m = _VERDICT_KEYWORDS.search(header_chunk)
+    if m is not None:
+        return m.group(1).upper()
+
+    return "UNKNOWN"
+
+
+# ── Ticker extraction ────────────────────────────────────────────────────
+# Looks for the ticker in the first H1/H2 header:
+#   # Вердикт Портфельного Менеджера: NFLX
+#   # ФИНАЛЬНОЕ РЕШЕНИЕ ПОРТФЕЛЬНОГО МЕНЕДЖЕРА: CRWD
+_TICKER_HEADER_RE = re.compile(
+    r"^#{1,3}\s*[^\n]*?:\s*([A-Z]{1,5})\b",
+    re.MULTILINE,
+)
+# Fallback: look for ticker mentioned in context like "позиции в FIG",
+# "позиции** в FIG", "Инструмент: CRWD", or "акции NFLX".
+# Allows optional markdown bold markers (**) between words.
+_TICKER_BODY_RE = re.compile(
+    r"(?:позици\w+)\*{0,2}\s+(?:в\s+)?([A-Z]{1,5})\b",
+    re.MULTILINE,
+)
+# Also: **Инструмент:** CRWD (CrowdStrike)
+_TICKER_INSTRUMENT_RE = re.compile(
+    r"\*{0,2}инструмент\*{0,2}[\s:]+\*{0,2}([A-Z]{1,5})\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_ticker(text: str, fallback: str | None) -> str:
+    """Extract ticker from markdown headers or use the provided fallback.
+
+    Tries multiple strategies:
+    1. Header with colon (most reliable)
+    2. "Инструмент:" field
+    3. Body text context ("позиции в XXX")
+    4. Fallback argument
+    """
+    m = _TICKER_HEADER_RE.search(text)
+    if m is not None:
+        return m.group(1).upper()
+
+    m = _TICKER_INSTRUMENT_RE.search(text)
+    if m is not None:
+        return m.group(1).upper()
+
+    # Only search in first ~20 lines for body ticker to avoid false positives
+    first_chunk = "\n".join(text.splitlines()[:20])
+    m = _TICKER_BODY_RE.search(first_chunk)
+    if m is not None:
+        return m.group(1).upper()
+
+    if fallback:
+        return fallback.upper()
+    return "UNKNOWN"
+
+
+# ── Confidence extraction ────────────────────────────────────────────────
+# Matches: "Убеждённость: 8/10", "убеждённость 7 / 10",
+#          "confidence: 8", "confidence 7/10", "7 из 10"
+_CONFIDENCE_RE = re.compile(
+    r"(?:убеждённость|убежденность|уверенность|confidence)"
+    r"[\s:]*(\d{1,2})\s*/?\s*10",
+    re.IGNORECASE,
+)
+_CONFIDENCE_IZ_RE = re.compile(
+    r"(\d{1,2})\s+из\s+10",
+    re.IGNORECASE,
+)
+
+
+def _extract_confidence(text: str) -> int | None:
+    """Extract confidence score (1-10) if present."""
+    m = _CONFIDENCE_RE.search(text)
+    if m is not None:
+        val = int(m.group(1))
+        if 1 <= val <= 10:
+            return val
+
+    m = _CONFIDENCE_IZ_RE.search(text)
+    if m is not None:
+        val = int(m.group(1))
+        if 1 <= val <= 10:
+            return val
+
+    return None
+
+
+# ── Stop-loss extraction ─────────────────────────────────────────────────
+# Russian and English keywords that precede or surround the stop-loss price.
+_STOP_LOSS_LINE_RE = re.compile(
+    r"(?:стоп[\s-]*лосс|stop[\s-]*loss)"
+    r"[^\n$]*?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+# Also check table rows like:  | Стоп-лосс | **$77** |
+_STOP_LOSS_TABLE_RE = re.compile(
+    r"\|\s*\**\s*(?:стоп[\s-]*лосс|stop[\s-]*loss)[^\|]*\|\s*\**\s*"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_stop_loss(text: str) -> float | None:
+    """Extract the stop-loss price."""
+    # Table row is most precise
+    m = _STOP_LOSS_TABLE_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    # Inline reference
+    m = _STOP_LOSS_LINE_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    return None
+
+
+# ── Entry trigger extraction ─────────────────────────────────────────────
+# Prefer specific action-oriented keywords over generic "вход" which
+# appears in debate/analysis context too.
+_ENTRY_SPECIFIC_RE = re.compile(
+    r"(?:закрытие\s*выше|триггер\s*входа|entry\s*trigger|breakout)"
+    r"[^\n$]*?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+_ENTRY_GENERIC_RE = re.compile(
+    r"(?:вход|entry)"
+    r"[^\n$]*?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_entry_trigger(text: str) -> float | None:
+    """Extract entry trigger price from nearby keywords.
+
+    Prefers specific action keywords (закрытие выше, триггер входа) over
+    generic "вход" which appears frequently in debate sections.
+    Searches the investment plan section (lower half) first.
+    """
+    # Search in the plan/action section (second half of doc) for specific triggers
+    midpoint = len(text) // 3
+    plan_text = text[midpoint:]
+
+    m = _ENTRY_SPECIFIC_RE.search(plan_text)
+    if m is not None:
+        val = _parse_price_str(m.group(1))
+        if val is not None:
+            return val
+
+    # Try specific pattern anywhere
+    m = _ENTRY_SPECIFIC_RE.search(text)
+    if m is not None:
+        val = _parse_price_str(m.group(1))
+        if val is not None:
+            return val
+
+    # Fall back to generic "вход" in plan section only
+    m = _ENTRY_GENERIC_RE.search(plan_text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    return None
+
+
+# ── Profit target extraction ─────────────────────────────────────────────
+_TARGET_LINE_RE = re.compile(
+    r"(?:целевая|цель|target|profit\s*target|фиксация|полная\s*фиксация)"
+    r"[^\n$]*?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+_TARGET_TABLE_RE = re.compile(
+    r"\|\s*\**\s*(?:целевая|цель|target|полная\s*фиксация|частичная\s*фиксация|фиксация)"
+    r"[^\|]*\|\s*\**\s*"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+
+# Dedicated pattern for "полная фиксация" (full take-profit) in tables.
+_FULL_TARGET_TABLE_RE = re.compile(
+    r"\|\s*\**\s*(?:полная\s*фиксация|full\s*target)"
+    r"[^\|]*\|\s*\**\s*"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_profit_target(text: str) -> float | None:
+    """Extract the profit target / take-profit price.
+
+    Prefers "полная фиксация" over "частичная фиксация" when both appear
+    in separate table rows.
+    """
+    # Try "полная фиксация" table row first
+    m = _FULL_TARGET_TABLE_RE.search(text)
+    if m is not None:
+        val = _parse_price_str(m.group(1))
+        if val is not None:
+            return val
+
+    # Any target table row
+    m = _TARGET_TABLE_RE.search(text)
+    if m is not None:
+        val = _parse_price_str(m.group(1))
+        if val is not None:
+            return val
+
+    # Inline reference
+    m = _TARGET_LINE_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    return None
+
+
+# ── Price at analysis time ───────────────────────────────────────────────
+# Looks for specific patterns indicating the current market price:
+#   "текущая цена $580", "текущей рыночной цене $87",
+#   "по текущей цене $87", "current price $580", "при цене $87"
+# NOTE: bare "по $X" is too common in Russian (means "at/by") and causes
+# false positives -- we require "по текущей" or "при цене" specificity.
+# High-confidence: nominative "текущая цена $X" (direct statement of price).
+_PRICE_DIRECT_RE = re.compile(
+    r"текуща[яй]\s+(?:рыноч\w*\s+)?цен\w*\s+\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+# Medium-confidence: oblique "текущей цены", "current price", "при цене".
+_PRICE_OBLIQUE_RE = re.compile(
+    r"(?:текущ\w*\s*(?:рыноч\w*\s*)?цен\w*|current\s*price|при\s*цене)"
+    r"[^\n$]{0,30}?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+# Pattern for "акция стоит $X" or "цена акции $X"
+_STOCK_PRICE_RE = re.compile(
+    r"(?:акци\w+\s+(?:стоит|торгуется)|цена\s+акци\w+)"
+    r"[^\n$]{0,20}?"
+    r"\$\s?([\d]+(?:[.,]\d{1,3})*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_price_at_analysis(text: str) -> float | None:
+    """Extract the price at analysis time (best-effort).
+
+    Prefers direct nominative statements ("текущая цена $580") over
+    oblique references ("текущей цены ($520"), which often appear in
+    descriptions of other parameters (trailing stops, ranges).
+    Returns None rather than risk a false positive.
+    """
+    # Highest confidence: "текущая цена $580"
+    m = _PRICE_DIRECT_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    # Medium confidence: oblique references
+    m = _PRICE_OBLIQUE_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    m = _STOCK_PRICE_RE.search(text)
+    if m is not None:
+        return _parse_price_str(m.group(1))
+
+    return None
+
+
+# ── Review date extraction ───────────────────────────────────────────────
+# Only match explicit review-date patterns, not bare "пересмотр" which
+# appears frequently in "пересмотр на Underweight" contexts.
+_REVIEW_DATE_RE = re.compile(
+    r"(?:горизонт\s*пересмотра|дата\s*пересмотра|review\s*date|re-?evaluation\s*date)"
+    r"[\s:]*([^\n|]{5,80})",
+    re.IGNORECASE,
+)
+# Also match "Горизонт пересмотра:" as a table/metadata field
+_REVIEW_FIELD_RE = re.compile(
+    r"(?:горизонт|срок)\s*(?:пересмотра|ревью)"
+    r"[\s:]+([^\n|]{5,80})",
+    re.IGNORECASE,
+)
+
+
+def _extract_review_date(text: str) -> str | None:
+    """Extract the review / re-evaluation date string if mentioned.
+
+    Only matches explicit review-horizon patterns to avoid false positives
+    from "пересмотр на Underweight" and similar rating-change phrases.
+    """
+    m = _REVIEW_DATE_RE.search(text)
+    if m is not None:
+        raw = m.group(1).strip().rstrip("|").strip()
+        cleaned = raw.replace("**", "").replace("*", "").strip()
+        if cleaned:
+            return cleaned[:100]
+
+    m = _REVIEW_FIELD_RE.search(text)
+    if m is not None:
+        raw = m.group(1).strip().rstrip("|").strip()
+        cleaned = raw.replace("**", "").replace("*", "").strip()
+        if cleaned:
+            return cleaned[:100]
+
+    return None
+
+
+# ── Notes extraction ─────────────────────────────────────────────────────
+# Match conclusion/summary headers but NOT "итоговый рейтинг" or
+# "итоговое решение" (which are verdict headers, not conclusions).
+_CONCLUSION_HEADER_RE = re.compile(
+    r"^#{1,4}\s*(?:заключение|вывод[ы]?\b|conclusion|summary|итог\b(?!\w))",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extract_notes(text: str) -> str | None:
+    """Extract key takeaway from the conclusion section.
+
+    Falls back to the last bold sentence in the document if no explicit
+    conclusion header is found.
+    """
+    m = _CONCLUSION_HEADER_RE.search(text)
+    if m is not None:
+        # Grab text after the header until the next header or end
+        after = text[m.end():]
+        lines = after.strip().splitlines()
+        # Collect non-empty, non-header lines
+        note_lines: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                break
+            if stripped:
+                note_lines.append(stripped)
+            if len("\n".join(note_lines)) >= _NOTES_MAX_LEN:
+                break
+        if note_lines:
+            joined = " ".join(note_lines)
+            # Strip markdown formatting
+            cleaned = joined.replace("**", "").replace("*", "").strip()
+            return cleaned[:_NOTES_MAX_LEN] if cleaned else None
+
+    # Fallback: find the last bold sentence that looks like a standalone
+    # remark (min 20 chars, contains a letter, not a fragment from a list).
+    bold_sentences = re.findall(r"\*\*([^*]{20,200})\*\*", text)
+    # Filter out list-item fragments and short labels
+    candidates = [
+        s.strip()
+        for s in bold_sentences
+        if re.search(r"[а-яА-Яa-zA-Z]{3,}", s)
+        and not s.strip().startswith(("—", "-", "|"))
+    ]
+    if candidates:
+        last = candidates[-1]
+        return last[:_NOTES_MAX_LEN] if last else None
+
+    return None
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def extract_recommendation(
+    markdown: str,
+    *,
+    ticker: str | None = None,
+    analysis_id: int | None = None,
+) -> ExtractedRecommendation:
+    """Parse a final_trade_decision.md and extract structured recommendation data.
+
+    Parameters
+    ----------
+    markdown:
+        The raw markdown content of the report.
+    ticker:
+        Override ticker (if already known from the caller context).
+        Falls back to extracting from the document header.
+    analysis_id:
+        Optional FK to the ``analyses`` table for traceability.
+
+    Returns
+    -------
+    ExtractedRecommendation
+        A frozen dataclass with all fields populated where data was found.
+        Fields that could not be extracted are set to ``None``.
+    """
+    if not markdown or not markdown.strip():
+        log.warning("Empty markdown provided to extract_recommendation")
+        return ExtractedRecommendation(
+            ticker=ticker.upper() if ticker else "UNKNOWN",
+            verdict="UNKNOWN",
+            analysis_id=analysis_id,
+        )
+
+    extracted_ticker = _extract_ticker(markdown, ticker)
+    verdict = _extract_verdict(markdown)
+    confidence = _extract_confidence(markdown)
+    price_at_analysis = _extract_price_at_analysis(markdown)
+    stop_loss = _extract_stop_loss(markdown)
+    entry_trigger = _extract_entry_trigger(markdown)
+    profit_target = _extract_profit_target(markdown)
+    review_date = _extract_review_date(markdown)
+    notes = _extract_notes(markdown)
+
+    log.debug(
+        "Extracted recommendation: ticker=%s verdict=%s confidence=%s "
+        "stop_loss=%s entry=%s target=%s",
+        extracted_ticker,
+        verdict,
+        confidence,
+        stop_loss,
+        entry_trigger,
+        profit_target,
+    )
+
+    return ExtractedRecommendation(
+        ticker=extracted_ticker,
+        verdict=verdict,
+        confidence=confidence,
+        price_at_analysis=price_at_analysis,
+        stop_loss=stop_loss,
+        entry_trigger=entry_trigger,
+        profit_target=profit_target,
+        review_date=review_date,
+        notes=notes,
+        analysis_id=analysis_id,
+    )
+
+
+def extract_from_file(
+    path: Path,
+    *,
+    ticker: str | None = None,
+    analysis_id: int | None = None,
+) -> ExtractedRecommendation:
+    """Read a ``final_trade_decision.md`` file and extract recommendation data.
+
+    Parameters
+    ----------
+    path:
+        Path to the markdown file.
+    ticker:
+        Override ticker (if already known).
+    analysis_id:
+        Optional FK to the ``analyses`` table.
+
+    Returns
+    -------
+    ExtractedRecommendation
+        Structured data from the file.  Returns a minimal object with
+        ``verdict="UNKNOWN"`` if the file cannot be read.
+    """
+    resolved = path.resolve()
+    if not resolved.is_file():
+        log.warning("Report file not found: %s", resolved)
+        return ExtractedRecommendation(
+            ticker=ticker.upper() if ticker else "UNKNOWN",
+            verdict="UNKNOWN",
+            analysis_id=analysis_id,
+        )
+
+    try:
+        markdown = resolved.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.error("Failed to read report file %s: %s", resolved, exc)
+        return ExtractedRecommendation(
+            ticker=ticker.upper() if ticker else "UNKNOWN",
+            verdict="UNKNOWN",
+            analysis_id=analysis_id,
+        )
+
+    return extract_recommendation(
+        markdown,
+        ticker=ticker,
+        analysis_id=analysis_id,
+    )

--- a/desktop/services/scheduler.py
+++ b/desktop/services/scheduler.py
@@ -1,0 +1,406 @@
+"""Scheduled pre-market analysis service.
+
+Wraps a lightweight cron-style scheduler that triggers batch analysis
+at user-configured times.  Uses **queue-with-wait** conflict resolution:
+if the ``PipelineRunner`` is already busy when a schedule fires, the
+scheduler queues the tickers and retries every 30 seconds until the
+runner becomes idle (up to ``max_wait`` minutes, default 30).
+
+No external dependency on APScheduler — uses ``threading.Timer`` with
+cron-expression parsing via a tiny ``CronExpr`` helper that covers the
+subset we expose in the UI (``HH:MM`` weekday combos).
+
+See also: PLAN-features-v3.md, Feature 4.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# ── Lightweight cron expression helpers ──────────────────────────────
+
+
+_DOW_MAP = {
+    "MON": 0, "TUE": 1, "WED": 2, "THU": 3, "FRI": 4,
+    "SAT": 5, "SUN": 6,
+}
+
+
+@dataclass(frozen=True)
+class CronExpr:
+    """Minimal cron expression: ``HH:MM`` + weekday set.
+
+    Examples
+    --------
+    - ``"08:30 MON-FRI"``   → weekdays at 8:30 AM
+    - ``"06:00 MON,WED,FRI"`` → MWF at 6 AM
+    - ``"09:00"``           → every day at 9 AM
+    """
+
+    hour: int
+    minute: int
+    weekdays: frozenset[int]  # 0=MON … 6=SUN; empty = every day
+
+    @classmethod
+    def parse(cls, expr: str) -> "CronExpr":
+        """Parse a schedule expression string.
+
+        Raises ``ValueError`` on unparseable input.
+        """
+        parts = expr.strip().split()
+        if not parts:
+            raise ValueError("Empty cron expression")
+
+        # Time part: HH:MM
+        time_part = parts[0]
+        if ":" not in time_part:
+            raise ValueError(f"Expected HH:MM, got {time_part!r}")
+        h_str, m_str = time_part.split(":", 1)
+        hour = int(h_str)
+        minute = int(m_str)
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError(f"Invalid time: {hour:02d}:{minute:02d}")
+
+        # Weekday part (optional)
+        weekdays: frozenset[int] = frozenset()
+        if len(parts) > 1:
+            weekdays = cls._parse_weekdays(parts[1])
+
+        return cls(hour=hour, minute=minute, weekdays=weekdays)
+
+    @staticmethod
+    def _parse_weekdays(token: str) -> frozenset[int]:
+        """Parse ``MON-FRI`` or ``MON,WED,FRI`` or ``*``."""
+        token = token.upper().strip()
+        if token == "*":
+            return frozenset()
+
+        days: set[int] = set()
+        for segment in token.split(","):
+            segment = segment.strip()
+            if "-" in segment:
+                start_s, end_s = segment.split("-", 1)
+                start = _DOW_MAP.get(start_s.strip())
+                end = _DOW_MAP.get(end_s.strip())
+                if start is None or end is None:
+                    raise ValueError(f"Unknown day in range: {segment!r}")
+                # Handle wrap-around (e.g., FRI-MON)
+                if start <= end:
+                    days.update(range(start, end + 1))
+                else:
+                    days.update(range(start, 7))
+                    days.update(range(0, end + 1))
+            else:
+                d = _DOW_MAP.get(segment)
+                if d is None:
+                    raise ValueError(f"Unknown day: {segment!r}")
+                days.add(d)
+        return frozenset(days)
+
+    def next_fire_time(self, after: datetime) -> datetime:
+        """Return the next datetime >= ``after`` that matches this schedule."""
+        # Start from the next full minute
+        candidate = after.replace(second=0, microsecond=0)
+        if candidate <= after:
+            candidate += timedelta(minutes=1)
+
+        for _guard in range(400):  # prevent infinite loop
+            if candidate.hour == self.hour and candidate.minute == self.minute:
+                if not self.weekdays or candidate.weekday() in self.weekdays:
+                    return candidate
+            # Advance: if we haven't reached the target time today, jump to it
+            today_target = candidate.replace(hour=self.hour, minute=self.minute)
+            if candidate < today_target:
+                candidate = today_target
+            else:
+                # Move to next day
+                candidate = (candidate + timedelta(days=1)).replace(
+                    hour=self.hour, minute=self.minute
+                )
+        raise RuntimeError("Could not find next fire time within 400 iterations")
+
+    def human_label(self) -> str:
+        """Return a human-readable label like ``08:30 Mon-Fri``."""
+        time_str = f"{self.hour:02d}:{self.minute:02d}"
+        if not self.weekdays:
+            return f"{time_str} Every day"
+        names = {v: k.capitalize() for k, v in _DOW_MAP.items()}
+        day_names = [names[d] for d in sorted(self.weekdays)]
+        return f"{time_str} {','.join(day_names)}"
+
+
+# ── Scheduler service ────────────────────────────────────────────────
+
+
+_QUEUE_RETRY_SECONDS = 30.0
+_MAX_WAIT_MINUTES = 30
+
+
+class Scheduler:
+    """Background scheduler for pre-market analysis runs.
+
+    Lifecycle::
+
+        scheduler = Scheduler(db=db, run_analysis=callback)
+        scheduler.start()   # loads schedules from DB, arms timers
+        scheduler.stop()    # cancels all timers
+
+    The ``run_analysis`` callback signature::
+
+        def run_analysis(
+            tickers: list[str],
+            schedule_id: int,
+        ) -> None: ...
+
+    It should start the ``BatchRunner`` or ``PipelineRunner`` for the
+    given tickers. The scheduler handles conflict detection itself.
+    """
+
+    def __init__(
+        self,
+        *,
+        db: Any,  # HistoryDB — avoid circular import
+        runner: Any,  # PipelineRunner
+        run_analysis: Callable[..., None],
+    ) -> None:
+        self._db = db
+        self._runner = runner
+        self._run_analysis = run_analysis
+        self._lock = threading.Lock()
+        self._timers: dict[int, threading.Timer] = {}  # schedule_id → Timer
+        self._stop_event = threading.Event()
+        self._started = False
+
+    # ── Lifecycle ────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Load all enabled schedules from DB and arm their timers."""
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+            self._stop_event.clear()
+
+        schedules = self._db.list_schedules()
+        armed = 0
+        for sched in schedules:
+            if sched.is_enabled:
+                self._arm_schedule(sched.id, sched.cron_expr, sched.timezone)
+                armed += 1
+        logger.info("Scheduler started: %d/%d schedules armed", armed, len(schedules))
+
+    def stop(self) -> None:
+        """Cancel all timers and shut down."""
+        self._stop_event.set()
+        with self._lock:
+            self._started = False
+            for sid, timer in self._timers.items():
+                timer.cancel()
+                logger.debug("Cancelled timer for schedule #%d", sid)
+            self._timers.clear()
+        logger.info("Scheduler stopped")
+
+    @property
+    def is_running(self) -> bool:
+        with self._lock:
+            return self._started
+
+    # ── Schedule management (called from UI) ─────────────────────────
+
+    def add_schedule(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
+        """Arm a newly created or re-enabled schedule."""
+        if self._started:
+            self._arm_schedule(schedule_id, cron_expr, timezone)
+
+    def remove_schedule(self, schedule_id: int) -> None:
+        """Disarm a disabled or deleted schedule."""
+        with self._lock:
+            timer = self._timers.pop(schedule_id, None)
+            if timer:
+                timer.cancel()
+
+    def reload_schedule(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
+        """Re-arm after a cron expression change."""
+        self.remove_schedule(schedule_id)
+        self.add_schedule(schedule_id, cron_expr, timezone)
+
+    # ── Timer internals ──────────────────────────────────────────────
+
+    def _arm_schedule(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
+        """Parse the cron expression and set a timer for the next fire."""
+        try:
+            parsed = CronExpr.parse(cron_expr)
+        except ValueError:
+            logger.error("Invalid cron expression for schedule #%d: %r", schedule_id, cron_expr)
+            return
+
+        now = datetime.now()
+        next_fire = parsed.next_fire_time(now)
+        delay = (next_fire - now).total_seconds()
+
+        # Update next_run in DB
+        try:
+            self._db.update_schedule_last_run(
+                schedule_id,
+                last_run=self._db.list_schedules()[0].last_run if False else "",  # keep existing
+                next_run=next_fire.isoformat(timespec="seconds"),
+            )
+        except Exception:
+            pass  # non-critical
+
+        with self._lock:
+            old = self._timers.pop(schedule_id, None)
+            if old:
+                old.cancel()
+
+            timer = threading.Timer(
+                delay,
+                self._on_fire,
+                args=(schedule_id, cron_expr, timezone),
+            )
+            timer.daemon = True
+            timer.name = f"sched-{schedule_id}"
+            timer.start()
+            self._timers[schedule_id] = timer
+
+        logger.info(
+            "Schedule #%d armed: next fire at %s (in %.0fs)",
+            schedule_id,
+            next_fire.strftime("%Y-%m-%d %H:%M"),
+            delay,
+        )
+
+    def _on_fire(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
+        """Timer callback — fires on the scheduled thread."""
+        if self._stop_event.is_set():
+            return
+
+        logger.info("Schedule #%d fired", schedule_id)
+
+        # Fetch the schedule from DB (it may have been disabled)
+        schedules = self._db.list_schedules()
+        sched = next((s for s in schedules if s.id == schedule_id), None)
+        if sched is None or not sched.is_enabled:
+            logger.info("Schedule #%d is disabled/deleted, skipping", schedule_id)
+            self._rearm(schedule_id, cron_expr, timezone)
+            return
+
+        # Parse watchlist
+        tickers = [t.strip().upper() for t in sched.watchlist.split(",") if t.strip()]
+        if not tickers:
+            logger.warning("Schedule #%d has empty watchlist, skipping", schedule_id)
+            self._rearm(schedule_id, cron_expr, timezone)
+            return
+
+        # Queue-with-wait: if runner is busy, retry
+        self._execute_with_wait(schedule_id, tickers, cron_expr, timezone)
+
+    def _execute_with_wait(
+        self,
+        schedule_id: int,
+        tickers: list[str],
+        cron_expr: str,
+        timezone: str,
+    ) -> None:
+        """Attempt to run; if runner is busy, retry up to max_wait."""
+        deadline = time.monotonic() + _MAX_WAIT_MINUTES * 60
+
+        while not self._stop_event.is_set():
+            if not self._runner.is_running:
+                # Runner is idle — go
+                self._run_scheduled(schedule_id, tickers)
+                break
+
+            if time.monotonic() > deadline:
+                logger.warning(
+                    "Schedule #%d: timed out waiting for runner (%d min), "
+                    "recording as skipped_conflict",
+                    schedule_id,
+                    _MAX_WAIT_MINUTES,
+                )
+                # Record a skipped run
+                now = datetime.now().isoformat(timespec="seconds")
+                try:
+                    run_id = self._db.insert_schedule_run(
+                        schedule_id=schedule_id, tickers=tickers,
+                    )
+                    self._db.update_schedule_run(
+                        run_id, status="skipped_conflict",
+                    )
+                    self._db.update_schedule_last_run(
+                        schedule_id, last_run=now, next_run=None,
+                    )
+                except Exception:
+                    logger.exception("Failed to record skipped run for schedule #%d", schedule_id)
+                break
+
+            logger.debug(
+                "Schedule #%d: runner busy, retrying in %.0fs",
+                schedule_id,
+                _QUEUE_RETRY_SECONDS,
+            )
+            # Sleep in small increments so stop_event can interrupt
+            for _ in range(int(_QUEUE_RETRY_SECONDS)):
+                if self._stop_event.is_set():
+                    return
+                time.sleep(1.0)
+
+        # Re-arm for the next fire time
+        self._rearm(schedule_id, cron_expr, timezone)
+
+    def _run_scheduled(self, schedule_id: int, tickers: list[str]) -> None:
+        """Actually launch the analysis for a schedule's tickers."""
+        now = datetime.now().isoformat(timespec="seconds")
+        run_id: int | None = None
+
+        try:
+            # Record the run
+            run_id = self._db.insert_schedule_run(
+                schedule_id=schedule_id, tickers=tickers,
+            )
+            self._db.update_schedule_last_run(
+                schedule_id, last_run=now, next_run=None,
+            )
+
+            # Invoke the callback (which starts BatchRunner or PipelineRunner)
+            self._run_analysis(tickers=tickers, schedule_id=schedule_id)
+
+            # Mark run completed (the actual analysis is async, so this
+            # just means "successfully dispatched")
+            if run_id is not None:
+                results = [{"ticker": t, "dispatched": True} for t in tickers]
+                self._db.update_schedule_run(
+                    run_id, status="completed", results=results,
+                )
+
+            logger.info(
+                "Schedule #%d: dispatched %d ticker(s): %s",
+                schedule_id,
+                len(tickers),
+                ", ".join(tickers),
+            )
+        except Exception as exc:
+            logger.exception("Schedule #%d: failed to dispatch", schedule_id)
+            if run_id is not None:
+                try:
+                    self._db.update_schedule_run(
+                        run_id,
+                        status="failed",
+                        results=[{"error": str(exc)}],
+                    )
+                except Exception:
+                    logger.exception("Failed to update schedule run #%d", run_id)
+
+    def _rearm(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
+        """Re-arm the timer for the next occurrence."""
+        if self._stop_event.is_set():
+            return
+        self._arm_schedule(schedule_id, cron_expr, timezone)

--- a/desktop/services/scheduler.py
+++ b/desktop/services/scheduler.py
@@ -232,6 +232,10 @@ class Scheduler:
         self.remove_schedule(schedule_id)
         self.add_schedule(schedule_id, cron_expr, timezone)
 
+    def run_now(self, schedule_id: int, tickers: list[str]) -> None:
+        """Public API: manually trigger a schedule immediately."""
+        self._run_scheduled(schedule_id, tickers)
+
     # ── Timer internals ──────────────────────────────────────────────
 
     def _arm_schedule(self, schedule_id: int, cron_expr: str, timezone: str) -> None:
@@ -246,15 +250,14 @@ class Scheduler:
         next_fire = parsed.next_fire_time(now)
         delay = (next_fire - now).total_seconds()
 
-        # Update next_run in DB
+        # Update next_run in DB (preserves last_run)
         try:
-            self._db.update_schedule_last_run(
+            self._db.update_schedule_next_run(
                 schedule_id,
-                last_run=self._db.list_schedules()[0].last_run if False else "",  # keep existing
                 next_run=next_fire.isoformat(timespec="seconds"),
             )
         except Exception:
-            pass  # non-critical
+            logger.debug("Non-critical: failed to update next_run for schedule #%d", schedule_id)
 
         with self._lock:
             old = self._timers.pop(schedule_id, None)
@@ -300,8 +303,16 @@ class Scheduler:
             self._rearm(schedule_id, cron_expr, timezone)
             return
 
-        # Queue-with-wait: if runner is busy, retry
-        self._execute_with_wait(schedule_id, tickers, cron_expr, timezone)
+        # Queue-with-wait: if runner is busy, spawn a wait thread so we
+        # don't block the Timer thread (CR-04 fix). The wait thread will
+        # retry until the runner is idle or the deadline passes.
+        wait_thread = threading.Thread(
+            target=self._execute_with_wait,
+            args=(schedule_id, tickers, cron_expr, timezone),
+            daemon=True,
+            name=f"sched-wait-{schedule_id}",
+        )
+        wait_thread.start()
 
     def _execute_with_wait(
         self,

--- a/desktop/state/batch.py
+++ b/desktop/state/batch.py
@@ -1,0 +1,256 @@
+"""Batch runner — sequential multi-ticker analysis orchestrator.
+
+Runs a list of tickers one at a time through ``PipelineRunner``,
+tracking per-ticker outcomes. The UI polls ``snapshot()`` to render
+the batch progress strip.
+
+Design: The batch runner does NOT subclass or modify PipelineRunner.
+It calls ``runner.start()`` for each ticker, waits for completion
+via polling, and advances to the next. This keeps the single-ticker
+path untouched.
+
+See also: PLAN-features-v2.md, Feature 3.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from desktop.state.runner import PipelineRunner, RunnerEvent
+
+logger = logging.getLogger(__name__)
+
+_INTER_TICKER_DELAY = 2.0  # seconds between tickers to avoid rate limits
+
+
+@dataclass
+class BatchState:
+    """Snapshot of batch progress — safe to read from any thread.
+
+    Returned by ``BatchRunner.snapshot()``. All list fields are copies.
+    """
+
+    tickers: list[str] = field(default_factory=list)
+    current_index: int = 0
+    current_ticker: str = ""
+    completed_tickers: list[str] = field(default_factory=list)
+    failed_tickers: list[str] = field(default_factory=list)
+    is_running: bool = False
+    is_done: bool = False
+
+
+class BatchRunner:
+    """Orchestrates sequential multi-ticker analysis runs.
+
+    Usage::
+
+        batch = BatchRunner(runner=runner, db=db)
+        batch.start(
+            tickers=["AAPL", "MSFT", "NVDA"],
+            config={...},
+            date="2026-05-15",
+            selected_analysts=["market", "news"],
+        )
+
+        # In ui.timer:
+        state = batch.snapshot()  # thread-safe copy
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: PipelineRunner,
+        db: Any,  # HistoryDB — avoid circular import
+    ) -> None:
+        self._runner = runner
+        self._db = db
+        self._lock = threading.Lock()
+        self._cancel_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._events: queue.Queue[RunnerEvent] = queue.Queue()
+
+        # Mutable state — only written under lock (CR-01 fix)
+        self._tickers: list[str] = []
+        self._current_index: int = 0
+        self._current_ticker: str = ""
+        self._completed_tickers: list[str] = []
+        self._failed_tickers: list[str] = []
+        self._is_running: bool = False
+        self._is_done: bool = False
+
+    def snapshot(self) -> BatchState:
+        """Return a thread-safe copy of the current batch state (CR-01 fix)."""
+        with self._lock:
+            return BatchState(
+                tickers=list(self._tickers),
+                current_index=self._current_index,
+                current_ticker=self._current_ticker,
+                completed_tickers=list(self._completed_tickers),
+                failed_tickers=list(self._failed_tickers),
+                is_running=self._is_running,
+                is_done=self._is_done,
+            )
+
+    @property
+    def is_running(self) -> bool:
+        with self._lock:
+            return self._is_running
+
+    def start(
+        self,
+        *,
+        tickers: list[str],
+        config: dict[str, Any],
+        date: str,
+        selected_analysts: list[str],
+    ) -> None:
+        """Launch the batch run in a background thread."""
+        with self._lock:
+            if self._is_running:
+                raise RuntimeError("Batch is already running")
+            self._tickers = list(tickers)
+            self._current_index = 0
+            self._current_ticker = ""
+            self._completed_tickers = []
+            self._failed_tickers = []
+            self._is_running = True
+            self._is_done = False
+
+        self._cancel_event.clear()
+
+        self._thread = threading.Thread(
+            target=self._run_batch,
+            kwargs={
+                "tickers": list(tickers),
+                "config": config,
+                "date": date,
+                "selected_analysts": selected_analysts,
+            },
+            daemon=True,
+            name="batch-runner",
+        )
+        self._thread.start()
+
+    def cancel(self) -> None:
+        """Cancel the batch run (finishes the current ticker, skips the rest)."""
+        self._cancel_event.set()
+        self._runner.cancel()
+
+    def join(self, timeout: float | None = None) -> None:
+        """Block until the batch thread finishes (LEAK-02 fix)."""
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+
+    def drain_events(self, max_events: int = 20) -> list[RunnerEvent]:
+        """Drain batch-level events (completion per ticker)."""
+        events: list[RunnerEvent] = []
+        for _ in range(max_events):
+            try:
+                events.append(self._events.get_nowait())
+            except queue.Empty:
+                break
+        return events
+
+    def _run_batch(
+        self,
+        *,
+        tickers: list[str],
+        config: dict[str, Any],
+        date: str,
+        selected_analysts: list[str],
+    ) -> None:
+        """Batch thread — runs tickers sequentially."""
+        try:
+            for i, ticker in enumerate(tickers):
+                if self._cancel_event.is_set():
+                    break
+
+                with self._lock:
+                    self._current_index = i
+                    self._current_ticker = ticker
+                logger.info("Batch: starting ticker %d/%d: %s", i + 1, len(tickers), ticker)
+
+                # Insert DB row for this ticker
+                try:
+                    analysis_id = self._db.insert_analysis(
+                        ticker=ticker,
+                        date=date,
+                        provider=config.get("llm_provider", ""),
+                        model=config.get("deep_think_llm", "default"),
+                        config=config,
+                        selected_analysts=selected_analysts,
+                    )
+                except Exception:
+                    logger.exception("Batch: failed to create DB row for %s", ticker)
+                    with self._lock:
+                        self._failed_tickers.append(ticker)
+                    continue
+
+                # WR-04 + BUG-04: Check cancel after DB insert, before starting
+                # pipeline. Mark the just-inserted row as interrupted so it
+                # doesn't stay "running" forever.
+                if self._cancel_event.is_set():
+                    try:
+                        self._db.mark_interrupted(analysis_id)
+                    except Exception:
+                        logger.exception("Batch: failed to mark %d interrupted", analysis_id)
+                    break
+
+                # Start pipeline for this ticker
+                try:
+                    self._runner.start(
+                        config=config,
+                        ticker=ticker,
+                        date=date,
+                        selected_analysts=list(selected_analysts),
+                        analysis_id=analysis_id,
+                    )
+                except RuntimeError as e:
+                    logger.error("Batch: runner failed to start for %s: %s", ticker, e)
+                    with self._lock:
+                        self._failed_tickers.append(ticker)
+                    continue
+
+                # Wait for pipeline to finish
+                self._wait_for_completion(ticker)
+
+                # Brief pause between tickers
+                if i < len(tickers) - 1 and not self._cancel_event.is_set():
+                    time.sleep(_INTER_TICKER_DELAY)
+
+        finally:
+            with self._lock:
+                self._current_index = len(self._completed_tickers)
+                self._is_running = False
+                self._is_done = True
+            logger.info(
+                "Batch complete: %d/%d succeeded, %d failed",
+                len(self._completed_tickers),
+                len(tickers),
+                len(self._failed_tickers),
+            )
+
+    def _wait_for_completion(self, ticker: str) -> None:
+        """Poll the runner until the current ticker finishes."""
+        while self._runner.is_running:
+            if self._cancel_event.is_set():
+                self._runner.cancel()
+            time.sleep(0.5)
+
+        # WR-01: Wait for pipeline thread to fully exit (including on_finished)
+        # so tracker isn't reset while persist_reports is still reading it.
+        self._runner.join(timeout=10.0)
+
+        # Check outcome
+        status = self._runner.status
+        with self._lock:
+            if status == "completed":
+                self._completed_tickers.append(ticker)
+            else:
+                self._failed_tickers.append(ticker)

--- a/desktop/state/database.py
+++ b/desktop/state/database.py
@@ -1,0 +1,324 @@
+"""SQLite database for analysis history and application settings.
+
+Uses WAL mode for safe concurrent reads (UI thread) alongside writes
+(pipeline thread). All public methods are short-lived and open/close
+their own connections -- no long-lived cursors.
+
+Schema
+------
+- ``analyses``  -- one row per analysis run (F3)
+- ``settings``  -- key/value pairs for user preferences (F5)
+
+See also: PLAN-desktop.md, Phase 2.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+# ── Data transfer objects ───────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class AnalysisRow:
+    """Immutable representation of one analysis run."""
+
+    id: int
+    ticker: str
+    date: str
+    provider: str
+    model: str
+    status: str  # running | completed | interrupted | failed
+    started_at: str
+    completed_at: str | None
+    config_json: str
+    result_dir: str | None
+    error_text: str | None
+    selected_analysts: str  # comma-separated analyst keys
+
+
+# ── Default database path ──────────────────────────────────────────────
+
+_DEFAULT_DB_DIR = Path.home() / ".tradingagents"
+
+
+# ── Database class ─────────────────────────────────────────────────────
+
+
+class HistoryDB:
+    """SQLite database for analysis history and settings.
+
+    Parameters
+    ----------
+    db_path : Path, optional
+        Override the database file location (useful for tests).
+        Defaults to ``~/.tradingagents/app.db``.
+    """
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        if db_path is None:
+            _DEFAULT_DB_DIR.mkdir(parents=True, exist_ok=True)
+            db_path = _DEFAULT_DB_DIR / "app.db"
+        self._db_path = db_path
+        self._ensure_schema()
+
+    # ── Connection helper ───────────────────────────────────────────
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a short-lived connection with WAL mode and busy timeout."""
+        conn = sqlite3.connect(str(self._db_path), timeout=5.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        """Create tables if they don't exist yet."""
+        conn = self._connect()
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS analyses (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker          TEXT    NOT NULL,
+                    date            TEXT    NOT NULL,
+                    provider        TEXT    NOT NULL,
+                    model           TEXT    NOT NULL,
+                    status          TEXT    NOT NULL DEFAULT 'running',
+                    started_at      TEXT    NOT NULL,
+                    completed_at    TEXT,
+                    config_json     TEXT    NOT NULL DEFAULT '{}',
+                    result_dir      TEXT,
+                    error_text      TEXT,
+                    selected_analysts TEXT  NOT NULL DEFAULT ''
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_analyses_ticker
+                    ON analyses(ticker);
+                CREATE INDEX IF NOT EXISTS idx_analyses_status
+                    ON analyses(status);
+
+                CREATE TABLE IF NOT EXISTS settings (
+                    key   TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ── Analyses CRUD ───────────────────────────────────────────────
+
+    def insert_analysis(
+        self,
+        *,
+        ticker: str,
+        date: str,
+        provider: str,
+        model: str,
+        config: dict[str, Any] | None = None,
+        result_dir: str | None = None,
+        selected_analysts: list[str] | None = None,
+    ) -> int:
+        """Insert a new analysis row (status='running'). Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        config_json = json.dumps(config or {}, ensure_ascii=False)
+        analysts_csv = ",".join(selected_analysts or [])
+
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO analyses
+                    (ticker, date, provider, model, status, started_at,
+                     config_json, result_dir, selected_analysts)
+                VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?)
+                """,
+                (ticker, date, provider, model, now, config_json, result_dir, analysts_csv),
+            )
+            conn.commit()
+            return cursor.lastrowid  # type: ignore[return-value]
+        finally:
+            conn.close()
+
+    def mark_completed(self, analysis_id: int) -> None:
+        """Mark an analysis as successfully completed."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE analyses SET status='completed', completed_at=? WHERE id=?",
+                (now, analysis_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_failed(self, analysis_id: int, error_text: str) -> None:
+        """Mark an analysis as failed with an error message."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE analyses SET status='failed', completed_at=?, error_text=? WHERE id=?",
+                (now, error_text, analysis_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_interrupted(self, analysis_id: int) -> None:
+        """Mark an analysis as interrupted (app quit / cancel / agent stuck)."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE analyses SET status='interrupted', completed_at=? WHERE id=?",
+                (now, analysis_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def update_result_dir(self, analysis_id: int, result_dir: str) -> None:
+        """Set the result directory path for an analysis."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE analyses SET result_dir=? WHERE id=?",
+                (result_dir, analysis_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_analysis(self, analysis_id: int) -> AnalysisRow | None:
+        """Fetch a single analysis by ID, or None if not found."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM analyses WHERE id=?", (analysis_id,)
+            ).fetchone()
+            return self._row_to_analysis(row) if row else None
+        finally:
+            conn.close()
+
+    def list_analyses(
+        self,
+        *,
+        ticker: str | None = None,
+        status: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[AnalysisRow]:
+        """List analyses with optional filtering, newest first."""
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if ticker:
+            conditions.append("ticker = ?")
+            params.append(ticker.upper())
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        query = f"SELECT * FROM analyses {where} ORDER BY id DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+
+        conn = self._connect()
+        try:
+            rows = conn.execute(query, params).fetchall()
+            return [self._row_to_analysis(r) for r in rows]
+        finally:
+            conn.close()
+
+    def count_analyses(
+        self, *, ticker: str | None = None, status: str | None = None
+    ) -> int:
+        """Count analyses matching optional filters."""
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if ticker:
+            conditions.append("ticker = ?")
+            params.append(ticker.upper())
+        if status:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        conn = self._connect()
+        try:
+            row = conn.execute(f"SELECT COUNT(*) FROM analyses {where}", params).fetchone()
+            return row[0]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_analysis(row: sqlite3.Row) -> AnalysisRow:
+        return AnalysisRow(
+            id=row["id"],
+            ticker=row["ticker"],
+            date=row["date"],
+            provider=row["provider"],
+            model=row["model"],
+            status=row["status"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            config_json=row["config_json"],
+            result_dir=row["result_dir"],
+            error_text=row["error_text"],
+            selected_analysts=row["selected_analysts"],
+        )
+
+    # ── Settings CRUD ───────────────────────────────────────────────
+
+    def get_setting(self, key: str, default: str | None = None) -> str | None:
+        """Read a setting value by key."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT value FROM settings WHERE key=?", (key,)
+            ).fetchone()
+            return row["value"] if row else default
+        finally:
+            conn.close()
+
+    def set_setting(self, key: str, value: str) -> None:
+        """Upsert a setting value."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (key, value),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_all_settings(self) -> dict[str, str]:
+        """Return all settings as a dictionary."""
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT key, value FROM settings").fetchall()
+            return {r["key"]: r["value"] for r in rows}
+        finally:
+            conn.close()
+
+    def delete_setting(self, key: str) -> None:
+        """Delete a setting by key."""
+        conn = self._connect()
+        try:
+            conn.execute("DELETE FROM settings WHERE key=?", (key,))
+            conn.commit()
+        finally:
+            conn.close()

--- a/desktop/state/database.py
+++ b/desktop/state/database.py
@@ -53,6 +53,111 @@ class LogEntryRow:
     content: str
 
 
+@dataclass(frozen=True)
+class RecommendationRow:
+    """Immutable representation of a recommendation extracted from an analysis."""
+
+    id: int
+    analysis_id: int
+    ticker: str
+    verdict: str  # BUY|HOLD|SELL|UNDERWEIGHT|OVERWEIGHT|UNKNOWN
+    confidence: int | None
+    price_at_analysis: float | None
+    stop_loss: float | None
+    entry_trigger: float | None
+    profit_target: float | None
+    review_date: str | None
+    is_active: int  # 1=active, 0=inactive
+    created_at: str
+    deactivated_at: str | None
+    notes: str | None
+
+
+@dataclass(frozen=True)
+class RecommendationOutcomeRow:
+    """Immutable representation of a recommendation outcome check."""
+
+    id: int
+    recommendation_id: int
+    check_date: str
+    days_elapsed: int
+    price_at_check: float
+    return_pct: float
+    stop_hit: int
+    target_hit: int
+    high_since: float | None
+    low_since: float | None
+
+
+@dataclass(frozen=True)
+class AlertRow:
+    """Immutable representation of a price alert."""
+
+    id: int
+    recommendation_id: int
+    ticker: str
+    alert_type: str  # stop_loss|entry_trigger|profit_target|custom
+    target_price: float
+    direction: str  # above|below
+    triggered_at: str | None
+    triggered_price: float | None
+    is_active: int
+    created_at: str
+
+
+@dataclass(frozen=True)
+class AlertHistoryRow:
+    """Immutable representation of a fired alert event."""
+
+    id: int
+    alert_id: int
+    fired_at: str
+    price: float
+    message: str
+    seen: int
+
+
+@dataclass(frozen=True)
+class ScheduleRow:
+    """Immutable representation of a recurring analysis schedule."""
+
+    id: int
+    name: str
+    watchlist: str
+    cron_expr: str
+    timezone: str
+    is_enabled: int
+    last_run: str | None
+    next_run: str | None
+    created_at: str
+
+
+@dataclass(frozen=True)
+class ScheduleRunRow:
+    """Immutable representation of a single schedule execution."""
+
+    id: int
+    schedule_id: int
+    started_at: str
+    completed_at: str | None
+    status: str  # running|completed|failed|skipped_conflict
+    tickers_json: str
+    results_json: str | None
+
+
+@dataclass(frozen=True)
+class PositionRow:
+    """Immutable representation of a portfolio position."""
+
+    id: int
+    ticker: str
+    quantity: float
+    avg_price: float
+    date_opened: str | None
+    notes: str | None
+    updated_at: str
+
+
 # ── Default database path ──────────────────────────────────────────────
 
 _DEFAULT_DB_DIR = Path.home() / ".tradingagents"
@@ -130,6 +235,97 @@ class HistoryDB:
                 CREATE TABLE IF NOT EXISTS settings (
                     key   TEXT PRIMARY KEY,
                     value TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS recommendations (
+                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                    analysis_id       INTEGER NOT NULL REFERENCES analyses(id),
+                    ticker            TEXT    NOT NULL,
+                    verdict           TEXT    NOT NULL,
+                    confidence        INTEGER,
+                    price_at_analysis REAL,
+                    stop_loss         REAL,
+                    entry_trigger     REAL,
+                    profit_target     REAL,
+                    review_date       TEXT,
+                    is_active         INTEGER NOT NULL DEFAULT 1,
+                    created_at        TEXT    NOT NULL,
+                    deactivated_at    TEXT,
+                    notes             TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_recommendations_active
+                    ON recommendations(is_active, ticker);
+                CREATE INDEX IF NOT EXISTS idx_recommendations_analysis
+                    ON recommendations(analysis_id);
+
+                CREATE TABLE IF NOT EXISTS recommendation_outcomes (
+                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                    recommendation_id INTEGER NOT NULL REFERENCES recommendations(id),
+                    check_date        TEXT    NOT NULL,
+                    days_elapsed      INTEGER NOT NULL,
+                    price_at_check    REAL    NOT NULL,
+                    return_pct        REAL    NOT NULL,
+                    stop_hit          INTEGER NOT NULL DEFAULT 0,
+                    target_hit        INTEGER NOT NULL DEFAULT 0,
+                    high_since        REAL,
+                    low_since         REAL,
+                    UNIQUE(recommendation_id, days_elapsed)
+                );
+
+                CREATE TABLE IF NOT EXISTS alerts (
+                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                    recommendation_id INTEGER NOT NULL REFERENCES recommendations(id),
+                    ticker            TEXT    NOT NULL,
+                    alert_type        TEXT    NOT NULL,
+                    target_price      REAL    NOT NULL,
+                    direction         TEXT    NOT NULL,
+                    triggered_at      TEXT,
+                    triggered_price   REAL,
+                    is_active         INTEGER NOT NULL DEFAULT 1,
+                    created_at        TEXT    NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_alerts_active
+                    ON alerts(is_active, ticker);
+
+                CREATE TABLE IF NOT EXISTS alert_history (
+                    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                    alert_id INTEGER NOT NULL REFERENCES alerts(id),
+                    fired_at TEXT    NOT NULL,
+                    price    REAL    NOT NULL,
+                    message  TEXT    NOT NULL,
+                    seen     INTEGER NOT NULL DEFAULT 0
+                );
+
+                CREATE TABLE IF NOT EXISTS schedules (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name       TEXT    NOT NULL,
+                    watchlist  TEXT    NOT NULL,
+                    cron_expr  TEXT    NOT NULL,
+                    timezone   TEXT    NOT NULL DEFAULT 'America/New_York',
+                    is_enabled INTEGER NOT NULL DEFAULT 1,
+                    last_run   TEXT,
+                    next_run   TEXT,
+                    created_at TEXT    NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS schedule_runs (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    schedule_id  INTEGER NOT NULL REFERENCES schedules(id),
+                    started_at   TEXT    NOT NULL,
+                    completed_at TEXT,
+                    status       TEXT    NOT NULL DEFAULT 'running',
+                    tickers_json TEXT    NOT NULL,
+                    results_json TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS positions (
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker      TEXT    NOT NULL UNIQUE,
+                    quantity    REAL    NOT NULL,
+                    avg_price   REAL    NOT NULL,
+                    date_opened TEXT,
+                    notes       TEXT,
+                    updated_at  TEXT    NOT NULL
                 );
                 """
             )
@@ -312,12 +508,12 @@ class HistoryDB:
         analysts_csv = ",".join(selected_analysts or [])
         conn = self._connect()
         try:
-            # CR-01: validate result_dir is under expected base
-            from pathlib import Path as _Path
+            # SEC-01: validate result_dir using is_relative_to
+            from desktop.utils.paths import validated_result_dir as _validate
 
-            resolved = _Path(result_dir).resolve()
-            expected_base = (_Path.home() / ".tradingagents" / "results").resolve()
-            if not str(resolved).startswith(str(expected_base)):
+            if _validate(result_dir) is None:
+                from pathlib import Path as _Path
+                expected_base = (_Path.home() / ".tradingagents" / "results").resolve()
                 raise ValueError(f"result_dir must be under {expected_base}")
 
             cursor = conn.execute(
@@ -487,3 +683,672 @@ class HistoryDB:
             conn.commit()
         finally:
             conn.close()
+
+    # ── Watchlists (stored in settings as watchlist:{name}) ──────────
+
+    _WATCHLIST_PREFIX = "watchlist:"
+
+    def list_watchlists(self) -> dict[str, list[str]]:
+        """Return all saved watchlists as {name: [tickers]}."""
+        all_settings = self.get_all_settings()
+        result: dict[str, list[str]] = {}
+        for key, value in all_settings.items():
+            if key.startswith(self._WATCHLIST_PREFIX):
+                name = key[len(self._WATCHLIST_PREFIX):]
+                tickers = [t.strip().upper() for t in value.split(",") if t.strip()]
+                result[name] = tickers
+        return result
+
+    def save_watchlist(self, name: str, tickers: list[str]) -> None:
+        """Save a named watchlist (overwrites if exists).
+
+        Raises ``ValueError`` if the name is invalid (CR-03 fix).
+        """
+        name = name.strip()
+        if not name or len(name) > 100:
+            raise ValueError("Watchlist name must be 1-100 characters")
+        if any(c in name for c in (":", "\n", "\r", "\0")):
+            raise ValueError("Watchlist name contains invalid characters")
+        key = f"{self._WATCHLIST_PREFIX}{name}"
+        value = ",".join(t.strip().upper() for t in tickers if t.strip())
+        self.set_setting(key, value)
+
+    def delete_watchlist(self, name: str) -> None:
+        """Remove a saved watchlist."""
+        self.delete_setting(f"{self._WATCHLIST_PREFIX}{name}")
+
+    # ── Recommendations CRUD ───────────────────────────────────────────
+
+    def insert_recommendation(
+        self,
+        *,
+        analysis_id: int,
+        ticker: str,
+        verdict: str,
+        confidence: int | None = None,
+        price_at_analysis: float | None = None,
+        stop_loss: float | None = None,
+        entry_trigger: float | None = None,
+        profit_target: float | None = None,
+        review_date: str | None = None,
+        notes: str | None = None,
+    ) -> int:
+        """Insert a new recommendation. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO recommendations
+                    (analysis_id, ticker, verdict, confidence,
+                     price_at_analysis, stop_loss, entry_trigger,
+                     profit_target, review_date, is_active, created_at, notes)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                """,
+                (
+                    analysis_id, ticker.upper(), verdict.upper(), confidence,
+                    price_at_analysis, stop_loss, entry_trigger,
+                    profit_target, review_date, now, notes,
+                ),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def get_recommendation(self, rec_id: int) -> RecommendationRow | None:
+        """Fetch a single recommendation by ID, or None if not found."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM recommendations WHERE id=?", (rec_id,)
+            ).fetchone()
+            return self._row_to_recommendation(row) if row else None
+        finally:
+            conn.close()
+
+    def get_recommendation_by_analysis(
+        self, analysis_id: int
+    ) -> RecommendationRow | None:
+        """Fetch the recommendation for a given analysis, or None."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM recommendations WHERE analysis_id=? "
+                "ORDER BY id DESC LIMIT 1",
+                (analysis_id,),
+            ).fetchone()
+            return self._row_to_recommendation(row) if row else None
+        finally:
+            conn.close()
+
+    def list_active_recommendations(self) -> list[RecommendationRow]:
+        """Return all active recommendations, newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM recommendations WHERE is_active=1 "
+                "ORDER BY id DESC"
+            ).fetchall()
+            return [self._row_to_recommendation(r) for r in rows]
+        finally:
+            conn.close()
+
+    def deactivate_recommendation(self, rec_id: int) -> None:
+        """Mark a recommendation as inactive."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE recommendations SET is_active=0, deactivated_at=? "
+                "WHERE id=?",
+                (now, rec_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def deactivate_older_for_ticker(self, ticker: str, keep_id: int) -> int:
+        """Deactivate all active recommendations for a ticker except *keep_id*.
+
+        Returns the number of rows deactivated.
+        """
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "UPDATE recommendations SET is_active=0, deactivated_at=? "
+                "WHERE ticker=? AND is_active=1 AND id!=?",
+                (now, ticker.upper(), keep_id),
+            )
+            conn.commit()
+            return cursor.rowcount
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_recommendation(row: sqlite3.Row) -> RecommendationRow:
+        return RecommendationRow(
+            id=row["id"],
+            analysis_id=row["analysis_id"],
+            ticker=row["ticker"],
+            verdict=row["verdict"],
+            confidence=row["confidence"],
+            price_at_analysis=row["price_at_analysis"],
+            stop_loss=row["stop_loss"],
+            entry_trigger=row["entry_trigger"],
+            profit_target=row["profit_target"],
+            review_date=row["review_date"],
+            is_active=row["is_active"],
+            created_at=row["created_at"],
+            deactivated_at=row["deactivated_at"],
+            notes=row["notes"],
+        )
+
+    # ── Recommendation Outcomes CRUD ───────────────────────────────────
+
+    def insert_outcome(
+        self,
+        *,
+        recommendation_id: int,
+        days_elapsed: int,
+        price_at_check: float,
+        return_pct: float,
+        stop_hit: bool = False,
+        target_hit: bool = False,
+        high_since: float | None = None,
+        low_since: float | None = None,
+    ) -> int:
+        """Insert a recommendation outcome check. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO recommendation_outcomes
+                    (recommendation_id, check_date, days_elapsed,
+                     price_at_check, return_pct, stop_hit, target_hit,
+                     high_since, low_since)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    recommendation_id, now, days_elapsed,
+                    price_at_check, return_pct,
+                    int(stop_hit), int(target_hit),
+                    high_since, low_since,
+                ),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def get_outcomes(
+        self, recommendation_id: int
+    ) -> list[RecommendationOutcomeRow]:
+        """Fetch all outcome checks for a recommendation, by days ascending."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM recommendation_outcomes "
+                "WHERE recommendation_id=? ORDER BY days_elapsed ASC",
+                (recommendation_id,),
+            ).fetchall()
+            return [self._row_to_outcome(r) for r in rows]
+        finally:
+            conn.close()
+
+    def list_all_outcomes(
+        self, *, min_days: int = 0
+    ) -> list[RecommendationOutcomeRow]:
+        """Fetch all outcomes with at least *min_days* elapsed."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM recommendation_outcomes "
+                "WHERE days_elapsed >= ? ORDER BY check_date DESC",
+                (min_days,),
+            ).fetchall()
+            return [self._row_to_outcome(r) for r in rows]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_outcome(row: sqlite3.Row) -> RecommendationOutcomeRow:
+        return RecommendationOutcomeRow(
+            id=row["id"],
+            recommendation_id=row["recommendation_id"],
+            check_date=row["check_date"],
+            days_elapsed=row["days_elapsed"],
+            price_at_check=row["price_at_check"],
+            return_pct=row["return_pct"],
+            stop_hit=row["stop_hit"],
+            target_hit=row["target_hit"],
+            high_since=row["high_since"],
+            low_since=row["low_since"],
+        )
+
+    # ── Alerts CRUD ────────────────────────────────────────────────────
+
+    def insert_alert(
+        self,
+        *,
+        recommendation_id: int,
+        ticker: str,
+        alert_type: str,
+        target_price: float,
+        direction: str,
+    ) -> int:
+        """Insert a new price alert. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO alerts
+                    (recommendation_id, ticker, alert_type, target_price,
+                     direction, is_active, created_at)
+                VALUES (?, ?, ?, ?, ?, 1, ?)
+                """,
+                (recommendation_id, ticker.upper(), alert_type,
+                 target_price, direction, now),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def list_active_alerts(self) -> list[AlertRow]:
+        """Return all active (untriggered) alerts."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM alerts WHERE is_active=1 ORDER BY ticker, alert_type"
+            ).fetchall()
+            return [self._row_to_alert(r) for r in rows]
+        finally:
+            conn.close()
+
+    def trigger_alert(self, alert_id: int, price: float) -> None:
+        """Mark an alert as triggered and deactivate it."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE alerts SET triggered_at=?, triggered_price=?, "
+                "is_active=0 WHERE id=?",
+                (now, price, alert_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_alert(row: sqlite3.Row) -> AlertRow:
+        return AlertRow(
+            id=row["id"],
+            recommendation_id=row["recommendation_id"],
+            ticker=row["ticker"],
+            alert_type=row["alert_type"],
+            target_price=row["target_price"],
+            direction=row["direction"],
+            triggered_at=row["triggered_at"],
+            triggered_price=row["triggered_price"],
+            is_active=row["is_active"],
+            created_at=row["created_at"],
+        )
+
+    # ── Alert History CRUD ─────────────────────────────────────────────
+
+    def insert_alert_history(
+        self, *, alert_id: int, price: float, message: str
+    ) -> int:
+        """Record a fired alert event. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "INSERT INTO alert_history (alert_id, fired_at, price, message, seen) "
+                "VALUES (?, ?, ?, ?, 0)",
+                (alert_id, now, price, message),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def list_unseen_alert_history(
+        self, limit: int = 50
+    ) -> list[AlertHistoryRow]:
+        """Return unseen alert history entries, newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM alert_history WHERE seen=0 "
+                "ORDER BY fired_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+            return [self._row_to_alert_history(r) for r in rows]
+        finally:
+            conn.close()
+
+    def mark_alerts_seen(self, alert_ids: list[int]) -> None:
+        """Mark alert history entries as seen."""
+        if not alert_ids:
+            return
+        placeholders = ",".join("?" for _ in alert_ids)
+        conn = self._connect()
+        try:
+            conn.execute(
+                f"UPDATE alert_history SET seen=1 WHERE id IN ({placeholders})",
+                alert_ids,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_all_alert_history(self, limit: int = 100) -> list[AlertHistoryRow]:
+        """Return all alert history entries, newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM alert_history ORDER BY fired_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+            return [self._row_to_alert_history(r) for r in rows]
+        finally:
+            conn.close()
+
+    def count_unseen_alert_history(self) -> int:
+        """Count unseen alert history entries."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM alert_history WHERE seen=0"
+            ).fetchone()
+            return row[0]
+        finally:
+            conn.close()
+
+    def list_alerts_for_recommendation(
+        self, recommendation_id: int
+    ) -> list[AlertRow]:
+        """Return all alerts (active and triggered) for a recommendation."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM alerts WHERE recommendation_id=? "
+                "ORDER BY alert_type",
+                (recommendation_id,),
+            ).fetchall()
+            return [self._row_to_alert(r) for r in rows]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_alert_history(row: sqlite3.Row) -> AlertHistoryRow:
+        return AlertHistoryRow(
+            id=row["id"],
+            alert_id=row["alert_id"],
+            fired_at=row["fired_at"],
+            price=row["price"],
+            message=row["message"],
+            seen=row["seen"],
+        )
+
+    # ── Schedules CRUD ─────────────────────────────────────────────────
+
+    def insert_schedule(
+        self,
+        *,
+        name: str,
+        watchlist: str,
+        cron_expr: str,
+        timezone: str = "America/New_York",
+    ) -> int:
+        """Insert a new recurring analysis schedule. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO schedules
+                    (name, watchlist, cron_expr, timezone, is_enabled, created_at)
+                VALUES (?, ?, ?, ?, 1, ?)
+                """,
+                (name, watchlist, cron_expr, timezone, now),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def list_schedules(self) -> list[ScheduleRow]:
+        """Return all schedules, newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM schedules ORDER BY id DESC"
+            ).fetchall()
+            return [self._row_to_schedule(r) for r in rows]
+        finally:
+            conn.close()
+
+    def update_schedule_enabled(
+        self, schedule_id: int, is_enabled: bool
+    ) -> None:
+        """Enable or disable a schedule."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE schedules SET is_enabled=? WHERE id=?",
+                (int(is_enabled), schedule_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def update_schedule_last_run(
+        self, schedule_id: int, last_run: str, next_run: str | None
+    ) -> None:
+        """Update the last/next run timestamps for a schedule."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE schedules SET last_run=?, next_run=? WHERE id=?",
+                (last_run, next_run, schedule_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def delete_schedule(self, schedule_id: int) -> None:
+        """Delete a schedule and its run history by ID."""
+        conn = self._connect()
+        try:
+            # Delete child rows first (FK constraint)
+            conn.execute(
+                "DELETE FROM schedule_runs WHERE schedule_id=?", (schedule_id,)
+            )
+            conn.execute(
+                "DELETE FROM schedules WHERE id=?", (schedule_id,)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_schedule(row: sqlite3.Row) -> ScheduleRow:
+        return ScheduleRow(
+            id=row["id"],
+            name=row["name"],
+            watchlist=row["watchlist"],
+            cron_expr=row["cron_expr"],
+            timezone=row["timezone"],
+            is_enabled=row["is_enabled"],
+            last_run=row["last_run"],
+            next_run=row["next_run"],
+            created_at=row["created_at"],
+        )
+
+    # ── Schedule Runs CRUD ─────────────────────────────────────────────
+
+    def insert_schedule_run(
+        self, *, schedule_id: int, tickers: list[str]
+    ) -> int:
+        """Insert a new schedule run record. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        tickers_json = json.dumps(tickers, ensure_ascii=False)
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO schedule_runs
+                    (schedule_id, started_at, status, tickers_json)
+                VALUES (?, ?, 'running', ?)
+                """,
+                (schedule_id, now, tickers_json),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def update_schedule_run(
+        self,
+        run_id: int,
+        *,
+        status: str,
+        results: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Update a schedule run's status and optional results."""
+        now = datetime.now().isoformat(timespec="seconds")
+        results_json = (
+            json.dumps(results, ensure_ascii=False) if results is not None else None
+        )
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE schedule_runs SET status=?, completed_at=?, "
+                "results_json=? WHERE id=?",
+                (status, now, results_json, run_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def list_schedule_runs(
+        self, schedule_id: int, limit: int = 20
+    ) -> list[ScheduleRunRow]:
+        """Return recent runs for a schedule, newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM schedule_runs WHERE schedule_id=? "
+                "ORDER BY id DESC LIMIT ?",
+                (schedule_id, limit),
+            ).fetchall()
+            return [self._row_to_schedule_run(r) for r in rows]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_schedule_run(row: sqlite3.Row) -> ScheduleRunRow:
+        return ScheduleRunRow(
+            id=row["id"],
+            schedule_id=row["schedule_id"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            status=row["status"],
+            tickers_json=row["tickers_json"],
+            results_json=row["results_json"],
+        )
+
+    # ── Positions CRUD ─────────────────────────────────────────────────
+
+    def upsert_position(
+        self,
+        *,
+        ticker: str,
+        quantity: float,
+        avg_price: float,
+        date_opened: str | None = None,
+        notes: str | None = None,
+    ) -> int:
+        """Insert or update a portfolio position. Returns the row id."""
+        now = datetime.now().isoformat(timespec="seconds")
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO positions
+                    (ticker, quantity, avg_price, date_opened, notes, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(ticker) DO UPDATE SET
+                    quantity=excluded.quantity,
+                    avg_price=excluded.avg_price,
+                    date_opened=excluded.date_opened,
+                    notes=excluded.notes,
+                    updated_at=excluded.updated_at
+                """,
+                (ticker.upper(), quantity, avg_price, date_opened, notes, now),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
+        finally:
+            conn.close()
+
+    def list_positions(self) -> list[PositionRow]:
+        """Return all portfolio positions, alphabetically by ticker."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM positions ORDER BY ticker ASC"
+            ).fetchall()
+            return [self._row_to_position(r) for r in rows]
+        finally:
+            conn.close()
+
+    def delete_position(self, ticker: str) -> None:
+        """Delete a position by ticker."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "DELETE FROM positions WHERE ticker=?", (ticker.upper(),)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_position(row: sqlite3.Row) -> PositionRow:
+        return PositionRow(
+            id=row["id"],
+            ticker=row["ticker"],
+            quantity=row["quantity"],
+            avg_price=row["avg_price"],
+            date_opened=row["date_opened"],
+            notes=row["notes"],
+            updated_at=row["updated_at"],
+        )

--- a/desktop/state/database.py
+++ b/desktop/state/database.py
@@ -797,6 +797,17 @@ class HistoryDB:
         finally:
             conn.close()
 
+    def list_all_recommendations(self) -> list[RecommendationRow]:
+        """Return all recommendations (active and inactive), newest first."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM recommendations ORDER BY id DESC"
+            ).fetchall()
+            return [self._row_to_recommendation(r) for r in rows]
+        finally:
+            conn.close()
+
     def deactivate_recommendation(self, rec_id: int) -> None:
         """Mark a recommendation as inactive."""
         now = datetime.now().isoformat(timespec="seconds")
@@ -1172,6 +1183,20 @@ class HistoryDB:
             conn.execute(
                 "UPDATE schedules SET last_run=?, next_run=? WHERE id=?",
                 (last_run, next_run, schedule_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def update_schedule_next_run(
+        self, schedule_id: int, next_run: str | None
+    ) -> None:
+        """Update only the next_run timestamp (preserves last_run)."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE schedules SET next_run=? WHERE id=?",
+                (next_run, schedule_id),
             )
             conn.commit()
         finally:

--- a/desktop/state/database.py
+++ b/desktop/state/database.py
@@ -42,6 +42,17 @@ class AnalysisRow:
     selected_analysts: str  # comma-separated analyst keys
 
 
+@dataclass(frozen=True)
+class LogEntryRow:
+    """Immutable representation of one log entry."""
+
+    id: int
+    analysis_id: int
+    timestamp: str
+    entry_type: str  # System | Agent | Tool | Data | Error | Control
+    content: str
+
+
 # ── Default database path ──────────────────────────────────────────────
 
 _DEFAULT_DB_DIR = Path.home() / ".tradingagents"
@@ -104,6 +115,18 @@ class HistoryDB:
                 CREATE INDEX IF NOT EXISTS idx_analyses_status
                     ON analyses(status);
 
+                CREATE TABLE IF NOT EXISTS log_entries (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    analysis_id  INTEGER NOT NULL,
+                    timestamp    TEXT    NOT NULL,
+                    entry_type   TEXT    NOT NULL,
+                    content      TEXT    NOT NULL,
+                    FOREIGN KEY (analysis_id) REFERENCES analyses(id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_log_entries_analysis
+                    ON log_entries(analysis_id);
+
                 CREATE TABLE IF NOT EXISTS settings (
                     key   TEXT PRIMARY KEY,
                     value TEXT NOT NULL
@@ -144,7 +167,11 @@ class HistoryDB:
                 (ticker, date, provider, model, now, config_json, result_dir, analysts_csv),
             )
             conn.commit()
-            return cursor.lastrowid  # type: ignore[return-value]
+            # WR-04: validate instead of type: ignore
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
         finally:
             conn.close()
 
@@ -223,8 +250,9 @@ class HistoryDB:
         params: list[Any] = []
 
         if ticker:
-            conditions.append("ticker = ?")
-            params.append(ticker.upper())
+            # WR-06: prefix match so "SP" finds "SPY", "SPXL", etc.
+            conditions.append("ticker LIKE ?")
+            params.append(ticker.upper() + "%")
         if status:
             conditions.append("status = ?")
             params.append(status)
@@ -248,8 +276,9 @@ class HistoryDB:
         params: list[Any] = []
 
         if ticker:
-            conditions.append("ticker = ?")
-            params.append(ticker.upper())
+            # WR-06: prefix match consistent with list_analyses
+            conditions.append("ticker LIKE ?")
+            params.append(ticker.upper() + "%")
         if status:
             conditions.append("status = ?")
             params.append(status)
@@ -259,6 +288,57 @@ class HistoryDB:
         try:
             row = conn.execute(f"SELECT COUNT(*) FROM analyses {where}", params).fetchone()
             return row[0]
+        finally:
+            conn.close()
+
+    def import_completed_analysis(
+        self,
+        *,
+        ticker: str,
+        date: str,
+        provider: str,
+        model: str,
+        result_dir: str,
+        selected_analysts: list[str] | None = None,
+        started_at: str | None = None,
+        completed_at: str | None = None,
+    ) -> int:
+        """Import a previously completed analysis from disk.
+
+        Used to backfill analyses that ran via CLI before the desktop app
+        existed, so they appear in the history table.
+        """
+        now = datetime.now().isoformat(timespec="seconds")
+        analysts_csv = ",".join(selected_analysts or [])
+        conn = self._connect()
+        try:
+            # CR-01: validate result_dir is under expected base
+            from pathlib import Path as _Path
+
+            resolved = _Path(result_dir).resolve()
+            expected_base = (_Path.home() / ".tradingagents" / "results").resolve()
+            if not str(resolved).startswith(str(expected_base)):
+                raise ValueError(f"result_dir must be under {expected_base}")
+
+            cursor = conn.execute(
+                """
+                INSERT INTO analyses
+                    (ticker, date, provider, model, status, started_at,
+                     completed_at, config_json, result_dir, selected_analysts)
+                VALUES (?, ?, ?, ?, 'completed', ?, ?, '{}', ?, ?)
+                """,
+                (
+                    ticker, date, provider, model,
+                    started_at or now, completed_at or now,
+                    result_dir, analysts_csv,
+                ),
+            )
+            conn.commit()
+            # WR-04: validate instead of type: ignore
+            row_id = cursor.lastrowid
+            if row_id is None:
+                raise RuntimeError("INSERT did not return a row ID")
+            return row_id
         finally:
             conn.close()
 
@@ -278,6 +358,91 @@ class HistoryDB:
             error_text=row["error_text"],
             selected_analysts=row["selected_analysts"],
         )
+
+    # ── Log entries CRUD ──────────────────────────────────────────────
+
+    def flush_logs(
+        self,
+        analysis_id: int,
+        messages: list[tuple[str, str, str]],
+        tool_calls: list[tuple[str, str, Any]],
+    ) -> int:
+        """Batch-insert log entries from a ProgressSnapshot.
+
+        Called once when an analysis finishes (completed / failed / cancelled).
+        Returns the number of rows inserted.
+        """
+        rows: list[tuple[int, str, str, str]] = []
+        for ts, msg_type, content in messages:
+            rows.append((analysis_id, ts, msg_type, str(content)))
+        for ts, tool_name, args in tool_calls:
+            args_str = str(args)
+            if len(args_str) > 500:
+                args_str = args_str[:497] + "..."
+            rows.append((analysis_id, ts, "Tool", f"{tool_name}: {args_str}"))
+
+        if not rows:
+            return 0
+
+        conn = self._connect()
+        try:
+            conn.executemany(
+                "INSERT INTO log_entries (analysis_id, timestamp, entry_type, content) "
+                "VALUES (?, ?, ?, ?)",
+                rows,
+            )
+            conn.commit()
+            return len(rows)
+        finally:
+            conn.close()
+
+    def get_log_entries(
+        self,
+        analysis_id: int,
+        *,
+        entry_type: str | None = None,
+        limit: int = 5000,
+    ) -> list[LogEntryRow]:
+        """Fetch persisted log entries for an analysis, chronologically."""
+        conditions = ["analysis_id = ?"]
+        params: list[Any] = [analysis_id]
+
+        if entry_type:
+            conditions.append("entry_type = ?")
+            params.append(entry_type)
+
+        where = " AND ".join(conditions)
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                f"SELECT * FROM log_entries WHERE {where} "
+                f"ORDER BY timestamp ASC LIMIT ?",
+                [*params, limit],
+            ).fetchall()
+            return [
+                LogEntryRow(
+                    id=r["id"],
+                    analysis_id=r["analysis_id"],
+                    timestamp=r["timestamp"],
+                    entry_type=r["entry_type"],
+                    content=r["content"],
+                )
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def count_log_entries(self, analysis_id: int) -> int:
+        """Count log entries for an analysis."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM log_entries WHERE analysis_id = ?",
+                (analysis_id,),
+            ).fetchone()
+            return row[0]
+        finally:
+            conn.close()
 
     # ── Settings CRUD ───────────────────────────────────────────────
 

--- a/desktop/state/runner.py
+++ b/desktop/state/runner.py
@@ -75,7 +75,7 @@ class RunnerEvent:
 # ── Runner ──────────────────────────────────────────────────────────────
 
 
-_WATCHDOG_TIMEOUT_DEFAULT = 900  # 15 minutes — Claude CLI calls can take 5+ min each
+_WATCHDOG_TIMEOUT_DEFAULT = 1200  # 20 minutes — Claude CLI: 300s timeout × 3 retries + backoff ≈ 906s worst-case per node
 
 
 class PipelineRunner:

--- a/desktop/state/runner.py
+++ b/desktop/state/runner.py
@@ -32,6 +32,25 @@ from tradingagents.progress import ProgressTracker
 logger = logging.getLogger(__name__)
 
 
+# ── Analyst status mapping (mirrors cli/main.py) ─────────────────────────
+
+_ANALYST_ORDER = ["market", "social", "news", "fundamentals"]
+
+_ANALYST_AGENT_NAMES: dict[str, str] = {
+    "market": "Market Analyst",
+    "social": "Sentiment Analyst",
+    "news": "News Analyst",
+    "fundamentals": "Fundamentals Analyst",
+}
+
+_ANALYST_REPORT_MAP: dict[str, str] = {
+    "market": "market_report",
+    "social": "sentiment_report",
+    "news": "news_report",
+    "fundamentals": "fundamentals_report",
+}
+
+
 # ── Event types pushed onto the queue ───────────────────────────────────
 
 
@@ -94,6 +113,11 @@ class PipelineRunner:
         self._status: str = "idle"  # idle | running | completed | failed | cancelled
         self._analysis_id: int | None = None
 
+        # App-level completion callback (CR-02).
+        # Called on the pipeline thread when the run finishes (any outcome).
+        # Set by app.py at startup so persistence happens regardless of UI state.
+        self.on_finished: Any | None = None  # Callable[[RunnerEvent], None]
+
     # ── Properties ──────────────────────────────────────────────────
 
     @property
@@ -131,9 +155,17 @@ class PipelineRunner:
         ticker: str,
         date: str,
         selected_analysts: list[str],
+        analysis_id: int | None = None,
         callbacks: list[Any] | None = None,
     ) -> None:
         """Launch the pipeline in a background thread.
+
+        Parameters
+        ----------
+        analysis_id : int, optional
+            Database row ID for this analysis. Set under the lock
+            *before* the thread starts so ``on_finished`` always
+            sees the correct ID (HI-01 race fix).
 
         Raises ``RuntimeError`` if a pipeline is already running.
         """
@@ -141,6 +173,7 @@ class PipelineRunner:
             if self._status == "running":
                 raise RuntimeError("Pipeline is already running")
             self._status = "running"
+            self._analysis_id = analysis_id  # set under lock before thread
             self._cancel_event.clear()
 
         # Reset tracker for the new run
@@ -179,6 +212,16 @@ class PipelineRunner:
                 break
         return events
 
+    def join(self, timeout: float | None = None) -> None:
+        """Block until the pipeline thread finishes (HI-03).
+
+        Called during app shutdown so the ``on_finished`` callback has
+        time to persist reports and logs before the process exits.
+        """
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+
     # ── Pipeline thread ─────────────────────────────────────────────
 
     def _run(
@@ -191,6 +234,8 @@ class PipelineRunner:
         callbacks: list[Any],
     ) -> None:
         """Entry point for the pipeline thread. Must not touch UI."""
+        watchdog: _WatchdogTimer | None = None
+        terminal_event: RunnerEvent | None = None
         try:
             # Desktop always enables checkpointing (F9)
             run_config = {**DEFAULT_CONFIG, **config, "checkpoint_enabled": True}
@@ -203,7 +248,6 @@ class PipelineRunner:
             )
 
             # Start watchdog if configured
-            watchdog: _WatchdogTimer | None = None
             if self._watchdog_timeout > 0:
                 watchdog = _WatchdogTimer(
                     tracker=self._tracker,
@@ -217,42 +261,182 @@ class PipelineRunner:
                 """Callback invoked by propagate() for each streamed chunk."""
                 if self._cancel_event.is_set():
                     raise _CancelledError("Analysis cancelled by user")
+                self._process_chunk(chunk)
                 self._queue.put(RunnerEvent(EventKind.CHUNK, chunk))
 
             final_state, decision = graph.propagate(
                 ticker, date, on_chunk=on_chunk
             )
 
-            if watchdog:
-                watchdog.stop()
-
             # Check for late cancel
             if self._cancel_event.is_set():
                 with self._lock:
                     self._status = "cancelled"
-                self._queue.put(RunnerEvent(EventKind.CANCELLED))
-                return
-
-            with self._lock:
-                self._status = "completed"
-            self._queue.put(
-                RunnerEvent(EventKind.COMPLETED, {"final_state": final_state, "decision": decision})
-            )
+                terminal_event = RunnerEvent(EventKind.CANCELLED)
+            else:
+                with self._lock:
+                    self._status = "completed"
+                terminal_event = RunnerEvent(
+                    EventKind.COMPLETED,
+                    {"final_state": final_state, "decision": decision},
+                )
 
         except _CancelledError:
-            if watchdog:  # type: ignore[possibly-undefined]
-                watchdog.stop()
             with self._lock:
                 self._status = "cancelled"
-            self._queue.put(RunnerEvent(EventKind.CANCELLED))
+            terminal_event = RunnerEvent(EventKind.CANCELLED)
 
         except Exception as exc:
-            if watchdog:  # type: ignore[possibly-undefined]
-                watchdog.stop()
             logger.exception("Pipeline failed for %s on %s", ticker, date)
             with self._lock:
                 self._status = "failed"
-            self._queue.put(RunnerEvent(EventKind.FAILED, str(exc)))
+            terminal_event = RunnerEvent(EventKind.FAILED, str(exc))
+
+        finally:
+            # Always stop watchdog
+            if watchdog:
+                watchdog.stop()
+
+            # CR-02: Always call the app-level persistence callback.
+            # This runs on the pipeline thread, so DB writes happen
+            # even if the user closed the browser tab.
+            if terminal_event is not None:
+                if self.on_finished:
+                    try:
+                        self.on_finished(terminal_event)
+                    except Exception:
+                        logger.exception("on_finished callback failed")
+
+                # Queue the event for the UI (if it's still listening)
+                self._queue.put(terminal_event)
+
+    # ── Chunk processing (mirrors cli/main.py logic) ─────────────────
+
+    def _process_chunk(self, chunk: dict[str, Any]) -> None:
+        """Extract messages, agent statuses, and reports from a LangGraph chunk.
+
+        Runs on the pipeline thread.  All writes go through the
+        thread-safe ProgressTracker so the UI can read snapshots safely.
+        """
+        # 1. Extract messages from the chunk
+        for message in chunk.get("messages", []):
+            msg_id = getattr(message, "id", None)
+            if msg_id is not None and self._tracker.has_seen_message(msg_id):
+                continue
+
+            msg_type, content = _classify_message(message)
+            if content and content.strip():
+                self._tracker.add_message(msg_type, content)
+
+            if hasattr(message, "tool_calls") and message.tool_calls:
+                for tc in message.tool_calls:
+                    name = tc["name"] if isinstance(tc, dict) else tc.name
+                    args = tc["args"] if isinstance(tc, dict) else tc.args
+                    self._tracker.add_tool_call(name, args)
+
+        # 2. Update analyst statuses based on report keys in chunk
+        # WR-01: use snapshot() instead of accessing private _selected_analysts
+        snap = self._tracker.snapshot()
+        selected = snap.selected_analysts
+        found_active = False
+        for analyst_key in _ANALYST_ORDER:
+            if analyst_key not in selected:
+                continue
+            agent_name = _ANALYST_AGENT_NAMES[analyst_key]
+            report_key = _ANALYST_REPORT_MAP[analyst_key]
+
+            if chunk.get(report_key):
+                self._tracker.update_report_section(report_key, chunk[report_key])
+
+            has_report = bool(snap.report_sections.get(report_key))
+            if has_report:
+                self._tracker.update_agent_status(agent_name, "completed")
+            elif not found_active:
+                self._tracker.update_agent_status(agent_name, "in_progress")
+                found_active = True
+
+        if not found_active and selected:
+            if snap.agent_status.get("Bull Researcher") == "pending":
+                self._tracker.update_agent_status("Bull Researcher", "in_progress")
+
+        # 3. Research team (investment debate)
+        # CR-03: accumulate bull/bear/judge into one combined section
+        debate = chunk.get("investment_debate_state")
+        if debate:
+            bull = (debate.get("bull_history") or "").strip()
+            bear = (debate.get("bear_history") or "").strip()
+            judge = (debate.get("judge_decision") or "").strip()
+            if bull or bear:
+                for agent in ("Bull Researcher", "Bear Researcher", "Research Manager"):
+                    self._tracker.update_agent_status(agent, "in_progress")
+
+            parts: list[str] = []
+            if bull:
+                parts.append(f"### Bull Researcher\n{bull}")
+            if bear:
+                parts.append(f"### Bear Researcher\n{bear}")
+            if judge:
+                parts.append(f"### Research Manager Decision\n{judge}")
+            if parts:
+                self._tracker.update_report_section(
+                    "investment_plan", "\n\n".join(parts),
+                )
+
+            if judge:
+                for agent in ("Bull Researcher", "Bear Researcher", "Research Manager"):
+                    self._tracker.update_agent_status(agent, "completed")
+                self._tracker.update_agent_status("Trader", "in_progress")
+
+        # 4. Trading team
+        if chunk.get("trader_investment_plan"):
+            self._tracker.update_report_section(
+                "trader_investment_plan", chunk["trader_investment_plan"],
+            )
+            self._tracker.update_agent_status("Trader", "completed")
+            self._tracker.update_agent_status("Aggressive Analyst", "in_progress")
+
+        # 5. Risk management team (CR-NEW-01/02/03: aligned with cli/main.py)
+        risk = chunk.get("risk_debate_state")
+        if risk:
+            agg = (risk.get("aggressive_history") or "").strip()
+            con = (risk.get("conservative_history") or "").strip()
+            neu = (risk.get("neutral_history") or "").strip()
+            judge_r = (risk.get("judge_decision") or "").strip()
+
+            # WR-02: take a fresh snapshot — the one from step 2 is stale
+            # after all the update_agent_status calls in steps 2-4.
+            snap_status = self._tracker.snapshot().agent_status
+
+            risk_parts: list[str] = []
+            if agg:
+                if snap_status.get("Aggressive Analyst") != "completed":
+                    self._tracker.update_agent_status("Aggressive Analyst", "in_progress")
+                risk_parts.append(f"### Aggressive Analyst\n{agg}")
+            if con:
+                if snap_status.get("Conservative Analyst") != "completed":
+                    self._tracker.update_agent_status("Conservative Analyst", "in_progress")
+                risk_parts.append(f"### Conservative Analyst\n{con}")
+            if neu:
+                if snap_status.get("Neutral Analyst") != "completed":
+                    self._tracker.update_agent_status("Neutral Analyst", "in_progress")
+                risk_parts.append(f"### Neutral Analyst\n{neu}")
+            if judge_r:
+                risk_parts.append(f"### Portfolio Manager Decision\n{judge_r}")
+                for agent in ("Aggressive Analyst", "Conservative Analyst", "Neutral Analyst"):
+                    self._tracker.update_agent_status(agent, "completed")
+                self._tracker.update_agent_status("Portfolio Manager", "in_progress")
+
+            if risk_parts:
+                self._tracker.update_report_section(
+                    "final_trade_decision", "\n\n".join(risk_parts),
+                )
+
+        # 6. Portfolio manager final decision (top-level key from PM node)
+        if chunk.get("final_trade_decision"):
+            self._tracker.update_report_section(
+                "final_trade_decision", chunk["final_trade_decision"],
+            )
+            self._tracker.update_agent_status("Portfolio Manager", "completed")
 
     def _on_watchdog_timeout(self) -> None:
         """Called by the watchdog when inactivity exceeds the threshold."""
@@ -262,6 +446,31 @@ class PipelineRunner:
 
 
 # ── Internal helpers ────────────────────────────────────────────────────
+
+
+def _classify_message(message: Any) -> tuple[str, str | None]:
+    """Classify a LangChain message into a display type and content string."""
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    raw = getattr(message, "content", None)
+    # Extract string from list-of-dicts content (vision messages etc.)
+    if isinstance(raw, list):
+        parts = [p.get("text", "") for p in raw if isinstance(p, dict) and "text" in p]
+        content = "\n".join(parts) if parts else None
+    elif isinstance(raw, str) and raw.strip():
+        content = raw
+    else:
+        content = None
+
+    if isinstance(message, HumanMessage):
+        if content and content.strip() == "Continue":
+            return ("Control", content)
+        return ("User", content)
+    if isinstance(message, ToolMessage):
+        return ("Data", content)
+    if isinstance(message, AIMessage):
+        return ("Agent", content)
+    return ("System", content)
 
 
 class _CancelledError(Exception):

--- a/desktop/state/runner.py
+++ b/desktop/state/runner.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 import queue
 import threading
-import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -268,29 +267,44 @@ class PipelineRunner:
                 ticker, date, on_chunk=on_chunk
             )
 
+            # WR-05: Capture analysis_id for event payload so on_finished
+            # doesn't rely on the runner's mutable state.
+            aid = self._analysis_id
+
             # Check for late cancel
             if self._cancel_event.is_set():
                 with self._lock:
                     self._status = "cancelled"
-                terminal_event = RunnerEvent(EventKind.CANCELLED)
+                terminal_event = RunnerEvent(
+                    EventKind.CANCELLED, {"analysis_id": aid},
+                )
             else:
                 with self._lock:
                     self._status = "completed"
                 terminal_event = RunnerEvent(
                     EventKind.COMPLETED,
-                    {"final_state": final_state, "decision": decision},
+                    {
+                        "analysis_id": aid,
+                        "final_state": final_state,
+                        "decision": decision,
+                    },
                 )
 
         except _CancelledError:
             with self._lock:
                 self._status = "cancelled"
-            terminal_event = RunnerEvent(EventKind.CANCELLED)
+            terminal_event = RunnerEvent(
+                EventKind.CANCELLED, {"analysis_id": self._analysis_id},
+            )
 
         except Exception as exc:
             logger.exception("Pipeline failed for %s on %s", ticker, date)
             with self._lock:
                 self._status = "failed"
-            terminal_event = RunnerEvent(EventKind.FAILED, str(exc))
+            terminal_event = RunnerEvent(
+                EventKind.FAILED,
+                {"analysis_id": self._analysis_id, "error": str(exc)},
+            )
 
         finally:
             # Always stop watchdog
@@ -370,22 +384,23 @@ class PipelineRunner:
                 for agent in ("Bull Researcher", "Bear Researcher", "Research Manager"):
                     self._tracker.update_agent_status(agent, "in_progress")
 
-            parts: list[str] = []
-            if bull:
-                parts.append(f"### Bull Researcher\n{bull}")
-            if bear:
-                parts.append(f"### Bear Researcher\n{bear}")
             if judge:
-                parts.append(f"### Research Manager Decision\n{judge}")
-            if parts:
-                self._tracker.update_report_section(
-                    "investment_plan", "\n\n".join(parts),
-                )
-
-            if judge:
+                # Research Manager has decided — write the full debate to
+                # the report section (not before, to avoid inflating the
+                # progress counter while the debate is still ongoing).
                 for agent in ("Bull Researcher", "Bear Researcher", "Research Manager"):
                     self._tracker.update_agent_status(agent, "completed")
                 self._tracker.update_agent_status("Trader", "in_progress")
+
+                parts: list[str] = []
+                if bull:
+                    parts.append(f"### Bull Researcher\n{bull}")
+                if bear:
+                    parts.append(f"### Bear Researcher\n{bear}")
+                parts.append(f"### Research Manager Decision\n{judge}")
+                self._tracker.update_report_section(
+                    "investment_plan", "\n\n".join(parts),
+                )
 
         # 4. Trading team
         if chunk.get("trader_investment_plan"):
@@ -396,6 +411,10 @@ class PipelineRunner:
             self._tracker.update_agent_status("Aggressive Analyst", "in_progress")
 
         # 5. Risk management team (CR-NEW-01/02/03: aligned with cli/main.py)
+        #
+        # Risk debate histories go to the dedicated ``risk_debate``
+        # section so they get their own card.  ``final_trade_decision``
+        # is reserved for the PM's actual decision (written in step 6).
         risk = chunk.get("risk_debate_state")
         if risk:
             agg = (risk.get("aggressive_history") or "").strip()
@@ -407,29 +426,36 @@ class PipelineRunner:
             # after all the update_agent_status calls in steps 2-4.
             snap_status = self._tracker.snapshot().agent_status
 
-            risk_parts: list[str] = []
+            # Update agent statuses from debate progress
             if agg:
                 if snap_status.get("Aggressive Analyst") != "completed":
                     self._tracker.update_agent_status("Aggressive Analyst", "in_progress")
-                risk_parts.append(f"### Aggressive Analyst\n{agg}")
             if con:
                 if snap_status.get("Conservative Analyst") != "completed":
                     self._tracker.update_agent_status("Conservative Analyst", "in_progress")
-                risk_parts.append(f"### Conservative Analyst\n{con}")
             if neu:
                 if snap_status.get("Neutral Analyst") != "completed":
                     self._tracker.update_agent_status("Neutral Analyst", "in_progress")
+
+            # Write risk debate histories to their own report section
+            # (progressively, so the user sees the debate in real-time).
+            risk_parts: list[str] = []
+            if agg:
+                risk_parts.append(f"### Aggressive Analyst\n{agg}")
+            if con:
+                risk_parts.append(f"### Conservative Analyst\n{con}")
+            if neu:
                 risk_parts.append(f"### Neutral Analyst\n{neu}")
+            if risk_parts:
+                self._tracker.update_report_section(
+                    "risk_debate", "\n\n".join(risk_parts),
+                )
+
             if judge_r:
-                risk_parts.append(f"### Portfolio Manager Decision\n{judge_r}")
+                # PM has decided — mark all risk analysts completed.
                 for agent in ("Aggressive Analyst", "Conservative Analyst", "Neutral Analyst"):
                     self._tracker.update_agent_status(agent, "completed")
                 self._tracker.update_agent_status("Portfolio Manager", "in_progress")
-
-            if risk_parts:
-                self._tracker.update_report_section(
-                    "final_trade_decision", "\n\n".join(risk_parts),
-                )
 
         # 6. Portfolio manager final decision (top-level key from PM node)
         if chunk.get("final_trade_decision"):

--- a/desktop/state/runner.py
+++ b/desktop/state/runner.py
@@ -75,7 +75,7 @@ class RunnerEvent:
 # ── Runner ──────────────────────────────────────────────────────────────
 
 
-_WATCHDOG_TIMEOUT_DEFAULT = 300  # 5 minutes
+_WATCHDOG_TIMEOUT_DEFAULT = 900  # 15 minutes — Claude CLI calls can take 5+ min each
 
 
 class PipelineRunner:

--- a/desktop/state/runner.py
+++ b/desktop/state/runner.py
@@ -1,0 +1,317 @@
+"""Pipeline runner — manages the analysis thread lifecycle.
+
+Wraps ``TradingAgentsGraph`` in a dedicated ``threading.Thread`` so the
+NiceGUI event loop stays responsive.  Communicates results back via a
+``queue.Queue`` that the UI polls with ``ui.timer(0.25)``.
+
+Key features
+------------
+- **on_chunk streaming** via ``propagate(on_chunk=...)``
+- **Watchdog** — kills the thread and auto-retries when no activity for
+  ``watchdog_timeout`` seconds (F8/F9)
+- **Status lifecycle** — idle → running → completed / failed / cancelled
+- **Thread safety** — public API is safe to call from any thread
+
+See also: PLAN-desktop.md, Phase 2.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.progress import ProgressTracker
+
+logger = logging.getLogger(__name__)
+
+
+# ── Event types pushed onto the queue ───────────────────────────────────
+
+
+class EventKind(Enum):
+    """Discriminator for events on the runner's output queue."""
+
+    CHUNK = "chunk"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    WATCHDOG = "watchdog"
+
+
+@dataclass(frozen=True)
+class RunnerEvent:
+    """Immutable event produced by the pipeline thread."""
+
+    kind: EventKind
+    data: Any = None  # chunk dict, final_state, error string, etc.
+
+
+# ── Runner ──────────────────────────────────────────────────────────────
+
+
+_WATCHDOG_TIMEOUT_DEFAULT = 300  # 5 minutes
+
+
+class PipelineRunner:
+    """Manages the pipeline thread and exposes events via a queue.
+
+    Usage (from NiceGUI page)::
+
+        runner = PipelineRunner()
+        runner.start(config={...}, ticker="AAPL", date="2026-05-14",
+                     selected_analysts=["market", "news"])
+
+        # In ui.timer(0.25):
+        for event in runner.drain_events():
+            if event.kind == EventKind.CHUNK:
+                process_chunk(event.data)
+            elif event.kind == EventKind.COMPLETED:
+                show_result(event.data)
+
+    Parameters
+    ----------
+    watchdog_timeout : float
+        Seconds of inactivity before the watchdog kills the pipeline
+        and enqueues a ``WATCHDOG`` event. Set to 0 to disable.
+    """
+
+    def __init__(self, watchdog_timeout: float = _WATCHDOG_TIMEOUT_DEFAULT) -> None:
+        self._lock = threading.Lock()
+        self._queue: queue.Queue[RunnerEvent] = queue.Queue()
+        self._tracker = ProgressTracker()
+        self._thread: threading.Thread | None = None
+        self._cancel_event = threading.Event()
+        self._watchdog_timeout = watchdog_timeout
+
+        # Public read-only state
+        self._status: str = "idle"  # idle | running | completed | failed | cancelled
+        self._analysis_id: int | None = None
+
+    # ── Properties ──────────────────────────────────────────────────
+
+    @property
+    def tracker(self) -> ProgressTracker:
+        """The shared progress tracker (safe to read from any thread)."""
+        return self._tracker
+
+    @property
+    def status(self) -> str:
+        with self._lock:
+            return self._status
+
+    @property
+    def is_running(self) -> bool:
+        with self._lock:
+            return self._status == "running"
+
+    @property
+    def analysis_id(self) -> int | None:
+        """Database row ID of the current/last analysis, if set."""
+        with self._lock:
+            return self._analysis_id
+
+    @analysis_id.setter
+    def analysis_id(self, value: int | None) -> None:
+        with self._lock:
+            self._analysis_id = value
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    def start(
+        self,
+        *,
+        config: dict[str, Any],
+        ticker: str,
+        date: str,
+        selected_analysts: list[str],
+        callbacks: list[Any] | None = None,
+    ) -> None:
+        """Launch the pipeline in a background thread.
+
+        Raises ``RuntimeError`` if a pipeline is already running.
+        """
+        with self._lock:
+            if self._status == "running":
+                raise RuntimeError("Pipeline is already running")
+            self._status = "running"
+            self._cancel_event.clear()
+
+        # Reset tracker for the new run
+        self._tracker.init_for_analysis(selected_analysts)
+
+        self._thread = threading.Thread(
+            target=self._run,
+            kwargs={
+                "config": config,
+                "ticker": ticker,
+                "date": date,
+                "selected_analysts": selected_analysts,
+                "callbacks": callbacks or [],
+            },
+            daemon=True,
+            name=f"pipeline-{ticker}-{date}",
+        )
+        self._thread.start()
+
+    def cancel(self) -> None:
+        """Request cancellation of the running pipeline.
+
+        The pipeline thread checks ``_cancel_event`` between chunks and
+        exits early. This is a *cooperative* cancel — if the pipeline
+        is stuck inside a single LLM call, the watchdog handles it.
+        """
+        self._cancel_event.set()
+
+    def drain_events(self, max_events: int = 50) -> list[RunnerEvent]:
+        """Non-blocking drain of queued events (call from UI timer)."""
+        events: list[RunnerEvent] = []
+        for _ in range(max_events):
+            try:
+                events.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return events
+
+    # ── Pipeline thread ─────────────────────────────────────────────
+
+    def _run(
+        self,
+        *,
+        config: dict[str, Any],
+        ticker: str,
+        date: str,
+        selected_analysts: list[str],
+        callbacks: list[Any],
+    ) -> None:
+        """Entry point for the pipeline thread. Must not touch UI."""
+        try:
+            # Desktop always enables checkpointing (F9)
+            run_config = {**DEFAULT_CONFIG, **config, "checkpoint_enabled": True}
+
+            graph = TradingAgentsGraph(
+                selected_analysts,
+                config=run_config,
+                debug=False,
+                callbacks=callbacks,
+            )
+
+            # Start watchdog if configured
+            watchdog: _WatchdogTimer | None = None
+            if self._watchdog_timeout > 0:
+                watchdog = _WatchdogTimer(
+                    tracker=self._tracker,
+                    timeout=self._watchdog_timeout,
+                    cancel_event=self._cancel_event,
+                    on_timeout=self._on_watchdog_timeout,
+                )
+                watchdog.start()
+
+            def on_chunk(chunk: dict[str, Any]) -> None:
+                """Callback invoked by propagate() for each streamed chunk."""
+                if self._cancel_event.is_set():
+                    raise _CancelledError("Analysis cancelled by user")
+                self._queue.put(RunnerEvent(EventKind.CHUNK, chunk))
+
+            final_state, decision = graph.propagate(
+                ticker, date, on_chunk=on_chunk
+            )
+
+            if watchdog:
+                watchdog.stop()
+
+            # Check for late cancel
+            if self._cancel_event.is_set():
+                with self._lock:
+                    self._status = "cancelled"
+                self._queue.put(RunnerEvent(EventKind.CANCELLED))
+                return
+
+            with self._lock:
+                self._status = "completed"
+            self._queue.put(
+                RunnerEvent(EventKind.COMPLETED, {"final_state": final_state, "decision": decision})
+            )
+
+        except _CancelledError:
+            if watchdog:  # type: ignore[possibly-undefined]
+                watchdog.stop()
+            with self._lock:
+                self._status = "cancelled"
+            self._queue.put(RunnerEvent(EventKind.CANCELLED))
+
+        except Exception as exc:
+            if watchdog:  # type: ignore[possibly-undefined]
+                watchdog.stop()
+            logger.exception("Pipeline failed for %s on %s", ticker, date)
+            with self._lock:
+                self._status = "failed"
+            self._queue.put(RunnerEvent(EventKind.FAILED, str(exc)))
+
+    def _on_watchdog_timeout(self) -> None:
+        """Called by the watchdog when inactivity exceeds the threshold."""
+        logger.warning("Watchdog: pipeline inactive for %ds, signalling cancel", self._watchdog_timeout)
+        self._queue.put(RunnerEvent(EventKind.WATCHDOG, "Inactivity timeout"))
+        self._cancel_event.set()
+
+
+# ── Internal helpers ────────────────────────────────────────────────────
+
+
+class _CancelledError(Exception):
+    """Raised inside the pipeline thread to unwind on cancellation."""
+
+
+class _WatchdogTimer:
+    """Background thread that monitors ProgressTracker activity.
+
+    If ``seconds_since_last_activity()`` exceeds ``timeout``, the
+    ``on_timeout`` callback is invoked (which typically sets the
+    cancel event).
+    """
+
+    def __init__(
+        self,
+        *,
+        tracker: ProgressTracker,
+        timeout: float,
+        cancel_event: threading.Event,
+        on_timeout: Any,
+        poll_interval: float = 10.0,
+    ) -> None:
+        self._tracker = tracker
+        self._timeout = timeout
+        self._cancel_event = cancel_event
+        self._on_timeout = on_timeout
+        self._poll_interval = poll_interval
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll, daemon=True, name="watchdog"
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+
+    def _poll(self) -> None:
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self._poll_interval)
+            if self._stop_event.is_set() or self._cancel_event.is_set():
+                return
+
+            secs = self._tracker.seconds_since_last_activity()
+            if secs is not None and secs > self._timeout:
+                self._on_timeout()
+                return

--- a/desktop/utils/migrate_historical.py
+++ b/desktop/utils/migrate_historical.py
@@ -1,0 +1,250 @@
+"""One-time migration: backfill historical analyses into recommendations table.
+
+Scans all completed analyses in the database, finds their
+``final_trade_decision.md`` files, and runs the extractor to populate
+the ``recommendations`` table.
+
+Reports that fail to parse get ``verdict='UNKNOWN'`` and ``is_active=0``
+so they don't pollute the dashboard but are available for manual review.
+
+Usage
+-----
+From the project root::
+
+    python -m desktop.utils.migrate_historical          # dry-run (default)
+    python -m desktop.utils.migrate_historical --apply   # actually write to DB
+
+Or from Python::
+
+    from desktop.utils.migrate_historical import migrate
+    stats = migrate(dry_run=False)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from desktop.services.recommendation_extractor import (
+    ExtractedRecommendation,
+    extract_from_file,
+)
+from desktop.state.database import HistoryDB
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MigrationStats:
+    """Summary of a migration run."""
+
+    total_analyses: int
+    already_migrated: int
+    migrated_ok: int
+    migrated_unknown: int
+    skipped_no_file: int
+    skipped_error: int
+
+
+def migrate(
+    *,
+    db: HistoryDB | None = None,
+    dry_run: bool = True,
+) -> MigrationStats:
+    """Backfill the recommendations table from historical analyses.
+
+    Parameters
+    ----------
+    db : HistoryDB, optional
+        Database instance. Uses the default if not provided.
+    dry_run : bool
+        If True, log what would happen but don't write to DB.
+
+    Returns
+    -------
+    MigrationStats
+        Summary of the migration results.
+    """
+    if db is None:
+        db = HistoryDB()
+
+    analyses = db.list_analyses(status="completed", limit=10_000)
+    total = len(analyses)
+    already = 0
+    ok = 0
+    unknown = 0
+    no_file = 0
+    errors = 0
+
+    logger.info(
+        "Migration %s: processing %d completed analyses",
+        "DRY-RUN" if dry_run else "APPLY",
+        total,
+    )
+
+    for analysis in analyses:
+        # Skip if recommendation already exists for this analysis
+        existing = db.get_recommendation_by_analysis(analysis.id)
+        if existing is not None:
+            already += 1
+            continue
+
+        # Find the final_trade_decision.md file
+        if not analysis.result_dir:
+            no_file += 1
+            logger.debug("Analysis #%d: no result_dir, skipping", analysis.id)
+            continue
+
+        decision_path = Path(analysis.result_dir) / "final_trade_decision.md"
+        if not decision_path.exists():
+            no_file += 1
+            logger.debug(
+                "Analysis #%d: %s not found, skipping",
+                analysis.id,
+                decision_path,
+            )
+            continue
+
+        # Extract recommendation
+        try:
+            rec = extract_from_file(
+                decision_path,
+                ticker=analysis.ticker,
+                analysis_id=analysis.id,
+            )
+        except Exception:
+            logger.exception(
+                "Analysis #%d: extraction failed for %s",
+                analysis.id,
+                decision_path,
+            )
+            errors += 1
+            rec = None
+
+        if dry_run:
+            if rec and rec.verdict != "UNKNOWN":
+                logger.info(
+                    "  [DRY] #%d %s: %s stop=%s entry=%s target=%s",
+                    analysis.id,
+                    rec.ticker or analysis.ticker,
+                    rec.verdict,
+                    rec.stop_loss,
+                    rec.entry_trigger,
+                    rec.profit_target,
+                )
+                ok += 1
+            elif rec:
+                logger.info(
+                    "  [DRY] #%d %s: UNKNOWN (would be inactive)",
+                    analysis.id,
+                    analysis.ticker,
+                )
+                unknown += 1
+            continue
+
+        # Write to DB
+        if rec is None or rec.verdict == "UNKNOWN":
+            # Fallback: create an UNKNOWN inactive record
+            ticker = analysis.ticker
+            rec_id = db.insert_recommendation(
+                analysis_id=analysis.id,
+                ticker=ticker,
+                verdict="UNKNOWN",
+                notes="Migration: extraction failed or returned UNKNOWN",
+            )
+            # Immediately deactivate
+            db.deactivate_recommendation(rec_id)
+            unknown += 1
+            logger.info(
+                "  #%d %s: UNKNOWN (inactive) → rec #%d",
+                analysis.id,
+                ticker,
+                rec_id,
+            )
+        else:
+            # Deactivate older recommendations for same ticker
+            ticker = rec.ticker or analysis.ticker
+            rec_id = db.insert_recommendation(
+                analysis_id=analysis.id,
+                ticker=ticker,
+                verdict=rec.verdict,
+                confidence=rec.confidence,
+                price_at_analysis=rec.price_at_analysis,
+                stop_loss=rec.stop_loss,
+                entry_trigger=rec.entry_trigger,
+                profit_target=rec.profit_target,
+                review_date=rec.review_date,
+                notes=rec.notes,
+            )
+            # Deactivate older recs for this ticker
+            deactivated = db.deactivate_older_for_ticker(ticker, keep_id=rec_id)
+            if deactivated:
+                logger.info(
+                    "  Deactivated %d older recommendation(s) for %s",
+                    deactivated,
+                    ticker,
+                )
+            ok += 1
+            logger.info(
+                "  #%d %s: %s → rec #%d",
+                analysis.id,
+                ticker,
+                rec.verdict,
+                rec_id,
+            )
+
+    stats = MigrationStats(
+        total_analyses=total,
+        already_migrated=already,
+        migrated_ok=ok,
+        migrated_unknown=unknown,
+        skipped_no_file=no_file,
+        skipped_error=errors,
+    )
+
+    logger.info(
+        "Migration %s complete: %d total, %d already done, "
+        "%d OK, %d UNKNOWN, %d no-file, %d errors",
+        "DRY-RUN" if dry_run else "APPLY",
+        stats.total_analyses,
+        stats.already_migrated,
+        stats.migrated_ok,
+        stats.migrated_unknown,
+        stats.skipped_no_file,
+        stats.skipped_error,
+    )
+
+    return stats
+
+
+def main() -> None:
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    dry_run = "--apply" not in sys.argv
+
+    if dry_run:
+        print("=== DRY RUN (pass --apply to write to DB) ===\n")
+
+    stats = migrate(dry_run=dry_run)
+
+    print(f"\n{'='*50}")
+    print(f"Total analyses:     {stats.total_analyses}")
+    print(f"Already migrated:   {stats.already_migrated}")
+    print(f"Migrated OK:        {stats.migrated_ok}")
+    print(f"Migrated UNKNOWN:   {stats.migrated_unknown}")
+    print(f"Skipped (no file):  {stats.skipped_no_file}")
+    print(f"Skipped (error):    {stats.skipped_error}")
+
+    if dry_run and (stats.migrated_ok + stats.migrated_unknown) > 0:
+        print("\nRe-run with --apply to persist these changes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop/utils/paths.py
+++ b/desktop/utils/paths.py
@@ -1,0 +1,31 @@
+"""Shared path validation utilities.
+
+Centralises the result-directory path traversal check used by
+detail.py, compare.py, and database.py (SEC-01 fix).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RESULTS_BASE = Path.home() / ".tradingagents" / "results"
+
+
+def validated_result_dir(raw_path: str) -> Path | None:
+    """Resolve and validate a result directory path.
+
+    Returns the resolved ``Path`` if it falls under
+    ``~/.tradingagents/results/``, or ``None`` otherwise.
+
+    Uses ``Path.is_relative_to`` (Python 3.9+) instead of the
+    fragile ``str.startswith`` approach that allowed prefix
+    collisions like ``results_evil/`` (SEC-01 fix).
+    """
+    try:
+        resolved = Path(raw_path).resolve()
+        expected_base = _RESULTS_BASE.resolve()
+        if resolved.is_relative_to(expected_base):
+            return resolved
+    except (ValueError, OSError):
+        pass
+    return None

--- a/desktop/utils/reports.py
+++ b/desktop/utils/reports.py
@@ -1,0 +1,135 @@
+"""Shared report file discovery and display constants.
+
+Extracted from detail.py and compare.py to eliminate the 70-line
+duplication of ``_FILE_TITLES``, ``_PHASE_TITLES``, and the
+``discover_report_files()`` function.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# ── Markdown rendering extras (shared by report_section.py, detail.py, compare.py)
+
+MD_EXTRAS: list[str] = [
+    "tables",
+    "fenced-code-blocks",
+    "strike",
+    "task_list",
+    "cuddled-lists",
+    "header-ids",
+]
+
+# ── Phase directory titles (numbered subdirs)
+
+PHASE_TITLES: dict[str, str] = {
+    "1_analysts": "Analysts",
+    "2_research": "Research Team",
+    "3_trading": "Trading Team",
+    "4_risk": "Risk Management",
+    "5_portfolio": "Portfolio Management",
+}
+
+# ── Individual file display titles
+
+FILE_TITLES: dict[str, str] = {
+    # New format (short names in subdirs)
+    "fundamentals": "Fundamentals Analysis",
+    "market": "Market Analysis",
+    "news": "News Analysis",
+    "sentiment": "Social Sentiment",
+    "bull": "Bull Researcher",
+    "bear": "Bear Researcher",
+    "manager": "Research Manager Decision",
+    "trader": "Trading Team Plan",
+    "aggressive": "Aggressive Risk Analyst",
+    "neutral": "Neutral Risk Analyst",
+    "conservative": "Conservative Risk Analyst",
+    "decision": "Portfolio Management Decision",
+    # Old format (flat reports/ directory)
+    "market_report": "Market Analysis",
+    "sentiment_report": "Social Sentiment",
+    "news_report": "News Analysis",
+    "fundamentals_report": "Fundamentals Analysis",
+    "investment_plan": "Research Team Decision",
+    "trader_investment_plan": "Trading Team Plan",
+    "final_trade_decision": "Portfolio Management Decision",
+}
+
+# ── Log entry type → Quasar color mapping
+
+TYPE_COLORS: dict[str, str] = {
+    "System": "blue-4",
+    "Agent": "green-4",
+    "User": "yellow-4",
+    "Data": "purple-4",
+    "Tool": "orange-4",
+    "Control": "grey-5",
+    "Error": "red-4",
+}
+
+# ── Status badge color mapping
+
+STATUS_COLORS: dict[str, str] = {
+    "completed": "green",
+    "running": "blue",
+    "failed": "red",
+    "interrupted": "orange",
+}
+
+
+def discover_report_files(root: Path) -> list[tuple[str, Path]]:
+    """Find all report markdown files in either directory layout.
+
+    Returns a list of ``(display_title, path)`` tuples in a logical
+    order (analysts -> research -> trading -> risk -> portfolio).
+
+    Supports three layouts:
+    - Numbered subdirectories (``1_analysts/``, ``2_research/``, ...)
+    - Flat ``reports/`` subdirectory
+    - Markdown files directly in root
+    """
+    sections: list[tuple[str, Path]] = []
+
+    # New format: numbered subdirectories
+    phase_dirs = sorted(
+        (d for d in root.iterdir() if d.is_dir() and d.name[0].isdigit()),
+        key=lambda d: d.name,
+    )
+    if phase_dirs:
+        for phase_dir in phase_dirs:
+            phase_label = PHASE_TITLES.get(phase_dir.name, phase_dir.name)
+            for md in sorted(phase_dir.glob("*.md")):
+                title = FILE_TITLES.get(
+                    md.stem,
+                    f"{phase_label} — {md.stem.replace('_', ' ').title()}",
+                )
+                sections.append((f"{phase_label} / {title}", md))
+        return sections
+
+    # Old format: flat reports/ subdirectory
+    reports_dir = root / "reports"
+    if reports_dir.is_dir():
+        for md in sorted(reports_dir.glob("*.md")):
+            title = FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
+            sections.append((title, md))
+        return sections
+
+    # Fallback: any .md files directly in root (excluding complete_report)
+    for md in sorted(root.glob("*.md")):
+        if md.name == "complete_report.md":
+            continue
+        title = FILE_TITLES.get(md.stem, md.stem.replace("_", " ").title())
+        sections.append((title, md))
+
+    return sections
+
+
+def status_chip(status: str) -> None:
+    """Render a small colored status chip (shared by detail.py & compare.py)."""
+    from nicegui import ui
+
+    color = STATUS_COLORS.get(status, "grey")
+    ui.label(status.capitalize()).classes(
+        f"text-caption text-white bg-{color} q-px-sm q-py-xs rounded-borders"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "TradingAgents: Multi-Agents LLM Financial Trading Framework"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "certifi>=2024.2.2",
     "langchain-core>=0.3.81",
     "backtrader>=1.9.78.123",
     "langchain-anthropic>=0.3.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,17 @@ dependencies = [
     "yfinance>=0.2.63",
 ]
 
+[project.optional-dependencies]
+desktop = [
+    "nicegui>=3.10",
+]
+
 [project.scripts]
 tradingagents = "cli.main:app"
+tradingagents-desktop = "desktop.app:run_app"
 
 [tool.setuptools.packages.find]
-include = ["tradingagents*", "cli*"]
+include = ["tradingagents*", "cli*", "desktop*"]
 
 [tool.setuptools.package-data]
 cli = ["static/*"]

--- a/tests/test_claude_cli_chat.py
+++ b/tests/test_claude_cli_chat.py
@@ -1,0 +1,353 @@
+"""Unit tests for the Claude CLI Chat model wrapper.
+
+Tests cover:
+- Message formatting (system, human, assistant, multi-turn, multi-part content)
+- JSON response parsing
+- Stop sequence handling
+- Subprocess invocation (mocked)
+- Error handling (timeout, exit codes, empty output, auth errors)
+- Retry logic with exponential backoff
+- bind_tools no-op behavior
+- with_structured_output rejection
+- Factory integration
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from tradingagents.llm_clients.claude_cli_chat import (
+    ClaudeCLIChat,
+    _apply_stop_sequences,
+    _extract_text,
+    _find_claude_binary,
+    _format_messages,
+    _parse_json_response,
+)
+
+
+# ── Binary discovery ─────────────────────────────────────────────────────
+
+
+class TestFindClaudeBinary:
+    @patch("tradingagents.llm_clients.claude_cli_chat.shutil.which", return_value=None)
+    def test_raises_when_not_on_path(self, _):
+        with pytest.raises(FileNotFoundError, match="not found on PATH"):
+            _find_claude_binary()
+
+    @patch("tradingagents.llm_clients.claude_cli_chat.shutil.which", return_value="/usr/bin/claude")
+    def test_returns_path_when_found(self, _):
+        assert _find_claude_binary() == "/usr/bin/claude"
+
+
+# ── Message formatting ────────────────────────────────────────────────────
+
+
+class TestFormatMessages:
+    def test_system_and_human(self):
+        msgs = [SystemMessage(content="You are helpful"), HumanMessage(content="Hi")]
+        system, user = _format_messages(msgs)
+        assert system == "You are helpful"
+        assert "[Human]" in user
+        assert "Hi" in user
+
+    def test_multi_turn(self):
+        msgs = [
+            SystemMessage(content="System"),
+            HumanMessage(content="Q1"),
+            AIMessage(content="A1"),
+            HumanMessage(content="Q2"),
+        ]
+        system, user = _format_messages(msgs)
+        assert system == "System"
+        assert "[Human]\nQ1" in user
+        assert "[Assistant]\nA1" in user
+        assert "[Human]\nQ2" in user
+
+    def test_no_system_message(self):
+        msgs = [HumanMessage(content="Hello")]
+        system, user = _format_messages(msgs)
+        assert system == ""
+        assert "Hello" in user
+
+    def test_multiple_system_messages(self):
+        msgs = [SystemMessage(content="Part 1"), SystemMessage(content="Part 2")]
+        system, user = _format_messages(msgs)
+        assert "Part 1" in system
+        assert "Part 2" in system
+
+    def test_empty_messages(self):
+        system, user = _format_messages([])
+        assert system == ""
+        assert user == ""
+
+
+class TestExtractText:
+    def test_string_content(self):
+        assert _extract_text("hello") == "hello"
+
+    def test_list_content(self):
+        content = [
+            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "world"},
+        ]
+        assert _extract_text(content) == "hello\nworld"
+
+    def test_list_with_non_text_blocks(self):
+        content = [
+            {"type": "reasoning", "text": "thinking..."},
+            {"type": "text", "text": "answer"},
+        ]
+        result = _extract_text(content)
+        assert "answer" in result
+
+    def test_non_string_non_list(self):
+        assert _extract_text(42) == "42"
+
+
+# ── JSON response parsing ────────────────────────────────────────────────
+
+
+class TestParseJsonResponse:
+    def test_success_response(self):
+        raw = json.dumps({
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "Hello world",
+        })
+        assert _parse_json_response(raw) == "Hello world"
+
+    def test_error_response(self):
+        raw = json.dumps({
+            "type": "result",
+            "is_error": True,
+            "result": "Rate limited",
+        })
+        with pytest.raises(RuntimeError, match="Rate limited"):
+            _parse_json_response(raw)
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            _parse_json_response("not json at all")
+
+    def test_missing_result_field(self):
+        raw = json.dumps({"type": "something_else"})
+        result = _parse_json_response(raw)
+        assert isinstance(result, str)
+
+    def test_null_result(self):
+        raw = json.dumps({"type": "result", "result": None})
+        # None result → unexpected shape fallback
+        result = _parse_json_response(raw)
+        assert isinstance(result, str)
+
+
+# ── Stop sequences ───────────────────────────────────────────────────────
+
+
+class TestStopSequences:
+    def test_no_stop(self):
+        assert _apply_stop_sequences("hello world", None) == "hello world"
+
+    def test_empty_stop_list(self):
+        assert _apply_stop_sequences("hello world", []) == "hello world"
+
+    def test_single_stop(self):
+        assert _apply_stop_sequences("hello STOP world", ["STOP"]) == "hello "
+
+    def test_multiple_stops_earliest_wins(self):
+        text = "aaa BBB ccc DDD eee"
+        assert _apply_stop_sequences(text, ["DDD", "BBB"]) == "aaa "
+
+    def test_stop_not_found(self):
+        assert _apply_stop_sequences("hello world", ["MISSING"]) == "hello world"
+
+
+# ── ClaudeCLIChat properties ─────────────────────────────────────────────
+
+
+class TestClaudeCLIChatProperties:
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_llm_type(self, _):
+        llm = ClaudeCLIChat()
+        assert llm._llm_type == "claude_cli"
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_supports_tool_calls_false(self, _):
+        llm = ClaudeCLIChat()
+        assert llm.supports_tool_calls is False
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_bind_tools_returns_self(self, _):
+        llm = ClaudeCLIChat()
+        bound = llm.bind_tools([MagicMock(name="tool1")])
+        assert bound is llm
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_with_structured_output_raises(self, _):
+        llm = ClaudeCLIChat()
+        with pytest.raises(NotImplementedError, match="structured output"):
+            llm.with_structured_output({"type": "object"})
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_identifying_params(self, _):
+        llm = ClaudeCLIChat(model_name="test-model", timeout=60)
+        params = llm._identifying_params
+        assert params["model_name"] == "test-model"
+        assert params["timeout"] == 60
+
+
+# ── Subprocess invocation (mocked) ───────────────────────────────────────
+
+
+class TestGenerate:
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    def test_successful_generation(self, mock_run, _):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Test response",
+            }).encode(),
+            stderr=b"",
+        )
+
+        llm = ClaudeCLIChat()
+        result = llm._generate([HumanMessage(content="Hello")])
+
+        assert len(result.generations) == 1
+        assert result.generations[0].message.content == "Test response"
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    def test_stop_sequences_applied(self, mock_run, _):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "type": "result",
+                "is_error": False,
+                "result": "Part 1 STOP Part 2",
+            }).encode(),
+            stderr=b"",
+        )
+
+        llm = ClaudeCLIChat()
+        result = llm._generate(
+            [HumanMessage(content="Hello")],
+            stop=["STOP"],
+        )
+        assert result.generations[0].message.content == "Part 1 "
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    @patch("tradingagents.llm_clients.claude_cli_chat.time.sleep")
+    def test_timeout_retries(self, mock_sleep, mock_run, _):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=300)
+
+        llm = ClaudeCLIChat(max_retries=2)
+        with pytest.raises(TimeoutError):
+            llm._generate([HumanMessage(content="Hello")])
+
+        assert mock_run.call_count == 2
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    def test_auth_error_no_retry(self, mock_run, _):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout=b"",
+            stderr=b"401 authentication error",
+        )
+
+        llm = ClaudeCLIChat(max_retries=3)
+        with pytest.raises(RuntimeError, match="authentication"):
+            llm._generate([HumanMessage(content="Hello")])
+
+        # Auth errors should NOT retry
+        assert mock_run.call_count == 1
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    @patch("tradingagents.llm_clients.claude_cli_chat.time.sleep")
+    def test_rate_limit_retries(self, mock_sleep, mock_run, _):
+        # First call rate limited, second succeeds
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=1,
+                stdout=b"",
+                stderr=b"rate limit exceeded",
+            ),
+            MagicMock(
+                returncode=0,
+                stdout=json.dumps({
+                    "type": "result",
+                    "is_error": False,
+                    "result": "Success after retry",
+                }).encode(),
+                stderr=b"",
+            ),
+        ]
+
+        llm = ClaudeCLIChat(max_retries=3)
+        result = llm._generate([HumanMessage(content="Hello")])
+
+        assert result.generations[0].message.content == "Success after retry"
+        assert mock_run.call_count == 2
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    @patch("tradingagents.llm_clients.claude_cli_chat.subprocess.run")
+    def test_env_minimal(self, mock_run, _):
+        """Verify subprocess receives minimal environment (WR-01 fix)."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "type": "result",
+                "is_error": False,
+                "result": "ok",
+            }).encode(),
+            stderr=b"",
+        )
+
+        llm = ClaudeCLIChat()
+        llm._generate([HumanMessage(content="Hello")])
+
+        call_kwargs = mock_run.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert env is not None, "subprocess should receive explicit env"
+        assert "OPENAI_API_KEY" not in env, "API keys should not leak to subprocess"
+
+
+# ── Factory integration ──────────────────────────────────────────────────
+
+
+class TestFactoryIntegration:
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_create_via_factory(self, _):
+        from tradingagents.llm_clients.factory import create_llm_client
+        client = create_llm_client("claude_cli", "default")
+        llm = client.get_llm()
+        assert type(llm).__name__ == "ClaudeCLIChat"
+        assert llm.supports_tool_calls is False
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_create_with_model(self, _):
+        from tradingagents.llm_clients.factory import create_llm_client
+        client = create_llm_client("claude_cli", "claude-opus-4-6")
+        llm = client.get_llm()
+        assert llm.model_name == "claude-opus-4-6"
+
+    @patch("tradingagents.llm_clients.claude_cli_chat._find_claude_binary", return_value="/usr/bin/claude")
+    def test_create_with_timeout(self, _):
+        from tradingagents.llm_clients.factory import create_llm_client
+        client = create_llm_client("claude_cli", "default", timeout=60)
+        llm = client.get_llm()
+        assert llm.timeout == 60

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from desktop.state.database import AnalysisRow, HistoryDB
+from desktop.state.database import AnalysisRow, HistoryDB, LogEntryRow
 
 
 @pytest.fixture
@@ -225,3 +225,91 @@ class TestSettingsCRUD:
 
     def test_delete_nonexistent_no_error(self, db: HistoryDB) -> None:
         db.delete_setting("does_not_exist")  # No exception
+
+
+# ---------------------------------------------------------------------------
+# Log entries CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def analysis_id(db: HistoryDB) -> int:
+    """Insert a dummy analysis and return its ID."""
+    return db.insert_analysis(
+        ticker="TEST", date="2026-01-01", provider="test", model="m"
+    )
+
+
+@pytest.mark.unit
+class TestLogEntriesCRUD:
+    def test_flush_and_read(self, db: HistoryDB, analysis_id: int) -> None:
+        messages = [
+            ("2026-01-01T10:00:01", "System", "Pipeline started"),
+            ("2026-01-01T10:00:02", "Agent", "Market Analyst working"),
+        ]
+        tool_calls = [
+            ("2026-01-01T10:00:03", "get_stock_data", {"ticker": "TEST"}),
+        ]
+        count = db.flush_logs(analysis_id, messages, tool_calls)
+        assert count == 3
+
+        entries = db.get_log_entries(analysis_id)
+        assert len(entries) == 3
+        assert all(isinstance(e, LogEntryRow) for e in entries)
+        # Chronological order
+        assert entries[0].content == "Pipeline started"
+        assert entries[1].content == "Market Analyst working"
+        assert entries[2].entry_type == "Tool"
+        assert "get_stock_data" in entries[2].content
+
+    def test_flush_empty(self, db: HistoryDB, analysis_id: int) -> None:
+        count = db.flush_logs(analysis_id, [], [])
+        assert count == 0
+        assert db.get_log_entries(analysis_id) == []
+
+    def test_filter_by_type(self, db: HistoryDB, analysis_id: int) -> None:
+        messages = [
+            ("2026-01-01T10:00:01", "System", "msg1"),
+            ("2026-01-01T10:00:02", "Error", "something broke"),
+            ("2026-01-01T10:00:03", "System", "msg2"),
+        ]
+        db.flush_logs(analysis_id, messages, [])
+
+        errors = db.get_log_entries(analysis_id, entry_type="Error")
+        assert len(errors) == 1
+        assert errors[0].content == "something broke"
+
+        systems = db.get_log_entries(analysis_id, entry_type="System")
+        assert len(systems) == 2
+
+    def test_count_log_entries(self, db: HistoryDB, analysis_id: int) -> None:
+        assert db.count_log_entries(analysis_id) == 0
+        messages = [("ts", "Agent", f"msg{i}") for i in range(5)]
+        db.flush_logs(analysis_id, messages, [])
+        assert db.count_log_entries(analysis_id) == 5
+
+    def test_long_args_truncated(self, db: HistoryDB, analysis_id: int) -> None:
+        long_args = "x" * 1000
+        tool_calls = [("ts", "tool_name", long_args)]
+        db.flush_logs(analysis_id, [], tool_calls)
+
+        entries = db.get_log_entries(analysis_id)
+        assert len(entries) == 1
+        assert len(entries[0].content) < 600  # truncated to ~500 + tool name
+
+    def test_log_entry_row_is_frozen(self, db: HistoryDB, analysis_id: int) -> None:
+        db.flush_logs(analysis_id, [("ts", "System", "msg")], [])
+        entry = db.get_log_entries(analysis_id)[0]
+        with pytest.raises(AttributeError):
+            entry.content = "mutated"  # type: ignore[misc]
+
+    def test_schema_includes_log_entries(self, db: HistoryDB) -> None:
+        conn = db._connect()
+        try:
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            ).fetchall()
+            names = [r["name"] for r in tables]
+            assert "log_entries" in names
+        finally:
+            conn.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,227 @@
+"""Tests for the SQLite history database.
+
+Uses a temp-file DB per test to avoid cross-test contamination.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from desktop.state.database import AnalysisRow, HistoryDB
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> HistoryDB:
+    """Create a fresh HistoryDB in a temp directory."""
+    return HistoryDB(db_path=tmp_path / "test.db")
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSchema:
+    def test_tables_created(self, db: HistoryDB) -> None:
+        conn = db._connect()
+        try:
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            ).fetchall()
+            names = [r["name"] for r in tables]
+            assert "analyses" in names
+            assert "settings" in names
+        finally:
+            conn.close()
+
+    def test_wal_mode_enabled(self, db: HistoryDB) -> None:
+        conn = db._connect()
+        try:
+            mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert mode == "wal"
+        finally:
+            conn.close()
+
+    def test_idempotent_schema_creation(self, tmp_path: Path) -> None:
+        """Creating HistoryDB twice on the same file must not error."""
+        path = tmp_path / "reuse.db"
+        HistoryDB(db_path=path)
+        HistoryDB(db_path=path)  # No exception
+
+
+# ---------------------------------------------------------------------------
+# Analyses CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAnalysesCRUD:
+    def test_insert_and_get(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="AAPL",
+            date="2026-05-14",
+            provider="anthropic",
+            model="claude-opus-4-20250514",
+            config={"max_debate_rounds": 2},
+            result_dir="/tmp/results/AAPL",
+            selected_analysts=["market", "news"],
+        )
+        assert row_id >= 1
+
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        assert analysis.ticker == "AAPL"
+        assert analysis.date == "2026-05-14"
+        assert analysis.provider == "anthropic"
+        assert analysis.model == "claude-opus-4-20250514"
+        assert analysis.status == "running"
+        assert analysis.started_at is not None
+        assert analysis.completed_at is None
+        assert analysis.error_text is None
+        assert analysis.selected_analysts == "market,news"
+
+        config = json.loads(analysis.config_json)
+        assert config["max_debate_rounds"] == 2
+
+    def test_get_nonexistent_returns_none(self, db: HistoryDB) -> None:
+        assert db.get_analysis(9999) is None
+
+    def test_mark_completed(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="SPY", date="2026-01-01", provider="openai", model="gpt-4o"
+        )
+        db.mark_completed(row_id)
+
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        assert analysis.status == "completed"
+        assert analysis.completed_at is not None
+
+    def test_mark_failed(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="SPY", date="2026-01-01", provider="openai", model="gpt-4o"
+        )
+        db.mark_failed(row_id, "API rate limit exceeded")
+
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        assert analysis.status == "failed"
+        assert analysis.error_text == "API rate limit exceeded"
+        assert analysis.completed_at is not None
+
+    def test_mark_interrupted(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="SPY", date="2026-01-01", provider="openai", model="gpt-4o"
+        )
+        db.mark_interrupted(row_id)
+
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        assert analysis.status == "interrupted"
+
+    def test_update_result_dir(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="TSLA", date="2026-03-01", provider="google", model="gemini-2.5"
+        )
+        db.update_result_dir(row_id, "/home/user/results/TSLA_20260301")
+
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        assert analysis.result_dir == "/home/user/results/TSLA_20260301"
+
+    def test_list_analyses_default_order(self, db: HistoryDB) -> None:
+        """Newest first."""
+        id1 = db.insert_analysis(
+            ticker="AAA", date="2026-01-01", provider="x", model="m"
+        )
+        id2 = db.insert_analysis(
+            ticker="BBB", date="2026-01-02", provider="x", model="m"
+        )
+
+        rows = db.list_analyses()
+        assert len(rows) == 2
+        assert rows[0].id == id2  # newest first
+        assert rows[1].id == id1
+
+    def test_list_analyses_filter_by_ticker(self, db: HistoryDB) -> None:
+        db.insert_analysis(ticker="AAPL", date="2026-01-01", provider="x", model="m")
+        db.insert_analysis(ticker="TSLA", date="2026-01-02", provider="x", model="m")
+
+        rows = db.list_analyses(ticker="AAPL")
+        assert len(rows) == 1
+        assert rows[0].ticker == "AAPL"
+
+    def test_list_analyses_filter_by_status(self, db: HistoryDB) -> None:
+        id1 = db.insert_analysis(ticker="A", date="d", provider="x", model="m")
+        id2 = db.insert_analysis(ticker="B", date="d", provider="x", model="m")
+        db.mark_completed(id1)
+
+        rows = db.list_analyses(status="completed")
+        assert len(rows) == 1
+        assert rows[0].status == "completed"
+
+    def test_list_analyses_pagination(self, db: HistoryDB) -> None:
+        for i in range(5):
+            db.insert_analysis(ticker=f"T{i}", date="d", provider="x", model="m")
+
+        page1 = db.list_analyses(limit=2, offset=0)
+        page2 = db.list_analyses(limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 2
+        assert page1[0].id != page2[0].id
+
+    def test_count_analyses(self, db: HistoryDB) -> None:
+        db.insert_analysis(ticker="A", date="d", provider="x", model="m")
+        db.insert_analysis(ticker="B", date="d", provider="x", model="m")
+        assert db.count_analyses() == 2
+        assert db.count_analyses(ticker="A") == 1
+
+    def test_analysis_row_is_frozen(self, db: HistoryDB) -> None:
+        row_id = db.insert_analysis(
+            ticker="X", date="d", provider="p", model="m"
+        )
+        analysis = db.get_analysis(row_id)
+        assert analysis is not None
+        with pytest.raises(AttributeError):
+            analysis.ticker = "Y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Settings CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSettingsCRUD:
+    def test_set_and_get(self, db: HistoryDB) -> None:
+        db.set_setting("default_provider", "anthropic")
+        assert db.get_setting("default_provider") == "anthropic"
+
+    def test_get_missing_returns_default(self, db: HistoryDB) -> None:
+        assert db.get_setting("nonexistent") is None
+        assert db.get_setting("nonexistent", "fallback") == "fallback"
+
+    def test_upsert(self, db: HistoryDB) -> None:
+        db.set_setting("key", "v1")
+        db.set_setting("key", "v2")
+        assert db.get_setting("key") == "v2"
+
+    def test_get_all_settings(self, db: HistoryDB) -> None:
+        db.set_setting("a", "1")
+        db.set_setting("b", "2")
+
+        settings = db.get_all_settings()
+        assert settings == {"a": "1", "b": "2"}
+
+    def test_delete_setting(self, db: HistoryDB) -> None:
+        db.set_setting("temp", "value")
+        db.delete_setting("temp")
+        assert db.get_setting("temp") is None
+
+    def test_delete_nonexistent_no_error(self, db: HistoryDB) -> None:
+        db.delete_setting("does_not_exist")  # No exception

--- a/tests/test_prefetch_analysts.py
+++ b/tests/test_prefetch_analysts.py
@@ -1,0 +1,285 @@
+"""Backward-compatibility tests for the analyst dual code paths.
+
+Each analyst supports two modes:
+  1. Tool-call path  — API providers with bind_tools() (original behavior)
+  2. Pre-fetch path  — CLI provider where data is fetched before LLM call
+
+Tests verify:
+  - supports_tool_calls=True  → bind_tools called, tool_calls checked
+  - supports_tool_calls=False → .func() called on tools, data injected into prompt
+  - Graceful degradation when a data source raises in pre-fetch path
+  - Report key names match expected state keys
+  - supports_tool_calls helper defaults to True for unknown LLMs
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from tradingagents.agents.utils.agent_utils import supports_tool_calls
+
+
+# ── supports_tool_calls helper ───────────────────────────────────────────
+
+
+class TestSupportsToolCalls:
+    def test_true_by_default(self):
+        """Unknown LLMs default to True (backward compat)."""
+        llm = MagicMock(spec=[])  # no supports_tool_calls attr
+        assert supports_tool_calls(llm) is True
+
+    def test_explicit_true(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = True
+        assert supports_tool_calls(llm) is True
+
+    def test_explicit_false(self):
+        llm = MagicMock()
+        llm.supports_tool_calls = False
+        assert supports_tool_calls(llm) is False
+
+
+# ── Shared fixtures ─────────────────────────────────────────────────────
+
+
+def _make_state(ticker: str = "AAPL", trade_date: str = "2025-01-15"):
+    return {
+        "trade_date": trade_date,
+        "company_of_interest": ticker,
+        "messages": [],
+    }
+
+
+def _make_llm(tool_calls: bool, response_text: str = "Test report"):
+    """Create a mock LLM with configurable supports_tool_calls."""
+    llm = MagicMock()
+    llm.supports_tool_calls = tool_calls
+
+    ai_msg = AIMessage(content=response_text)
+    ai_msg.tool_calls = []
+
+    # For tool-call path: bind_tools returns an object whose __or__ works
+    bound = MagicMock()
+    bound.__or__ = MagicMock(return_value=MagicMock(invoke=MagicMock(return_value=ai_msg)))
+    llm.bind_tools = MagicMock(return_value=bound)
+
+    # For pre-fetch path: llm itself is piped via prompt | llm
+    llm.__or__ = MagicMock(return_value=MagicMock(invoke=MagicMock(return_value=ai_msg)))
+
+    return llm
+
+
+# ── Market analyst ──────────────────────────────────────────────────────
+
+
+class TestMarketAnalyst:
+    @patch("tradingagents.agents.analysts.market_analyst.get_indicators")
+    @patch("tradingagents.agents.analysts.market_analyst.get_stock_data")
+    def test_prefetch_path_calls_func(self, mock_stock, mock_indicators):
+        """Pre-fetch path calls .func() on tools, not bind_tools."""
+        mock_stock.func = MagicMock(return_value="stock,data,csv")
+        mock_indicators.func = MagicMock(return_value="indicator data")
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.market_analyst import create_market_analyst
+        node = create_market_analyst(llm)
+        result = node(_make_state())
+
+        mock_stock.func.assert_called_once()
+        assert mock_indicators.func.call_count == 12  # _ALL_INDICATORS has 12 items
+        llm.bind_tools.assert_not_called()
+        assert "market_report" in result
+
+    @patch("tradingagents.agents.analysts.market_analyst.get_indicators")
+    @patch("tradingagents.agents.analysts.market_analyst.get_stock_data")
+    def test_tool_call_path_uses_bind_tools(self, mock_stock, mock_indicators):
+        """Tool-call path uses bind_tools (original behavior)."""
+        mock_stock.name = "get_stock_data"
+        mock_indicators.name = "get_indicators"
+
+        llm = _make_llm(tool_calls=True)
+        from tradingagents.agents.analysts.market_analyst import create_market_analyst
+        node = create_market_analyst(llm)
+        result = node(_make_state())
+
+        llm.bind_tools.assert_called_once()
+        assert "market_report" in result
+
+    @patch("tradingagents.agents.analysts.market_analyst.get_indicators")
+    @patch("tradingagents.agents.analysts.market_analyst.get_stock_data")
+    def test_prefetch_graceful_stock_failure(self, mock_stock, mock_indicators):
+        """Stock data failure degrades gracefully, doesn't crash."""
+        mock_stock.func = MagicMock(side_effect=ConnectionError("API down"))
+        mock_indicators.func = MagicMock(return_value="indicator data")
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.market_analyst import create_market_analyst
+        node = create_market_analyst(llm)
+        result = node(_make_state())
+
+        assert "market_report" in result
+
+    @patch("tradingagents.agents.analysts.market_analyst.get_indicators")
+    @patch("tradingagents.agents.analysts.market_analyst.get_stock_data")
+    def test_prefetch_graceful_indicator_failure(self, mock_stock, mock_indicators):
+        """Individual indicator failure degrades gracefully."""
+        mock_stock.func = MagicMock(return_value="stock data")
+        mock_indicators.func = MagicMock(side_effect=ValueError("bad indicator"))
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.market_analyst import create_market_analyst
+        node = create_market_analyst(llm)
+        result = node(_make_state())
+
+        assert "market_report" in result
+
+
+# ── News analyst ────────────────────────────────────────────────────────
+
+
+class TestNewsAnalyst:
+    @patch("tradingagents.agents.analysts.news_analyst.get_global_news")
+    @patch("tradingagents.agents.analysts.news_analyst.get_news")
+    def test_prefetch_path_calls_func(self, mock_news, mock_global):
+        """Pre-fetch path calls .func() on news tools."""
+        mock_news.func = MagicMock(return_value="ticker news")
+        mock_global.func = MagicMock(return_value="global news")
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.news_analyst import create_news_analyst
+        node = create_news_analyst(llm)
+        result = node(_make_state())
+
+        mock_news.func.assert_called_once()
+        mock_global.func.assert_called_once()
+        llm.bind_tools.assert_not_called()
+        assert "news_report" in result
+
+    @patch("tradingagents.agents.analysts.news_analyst.get_global_news")
+    @patch("tradingagents.agents.analysts.news_analyst.get_news")
+    def test_tool_call_path_uses_bind_tools(self, mock_news, mock_global):
+        """Tool-call path uses bind_tools (original behavior)."""
+        mock_news.name = "get_news"
+        mock_global.name = "get_global_news"
+
+        llm = _make_llm(tool_calls=True)
+        from tradingagents.agents.analysts.news_analyst import create_news_analyst
+        node = create_news_analyst(llm)
+        result = node(_make_state())
+
+        llm.bind_tools.assert_called_once()
+        assert "news_report" in result
+
+    @patch("tradingagents.agents.analysts.news_analyst.get_global_news")
+    @patch("tradingagents.agents.analysts.news_analyst.get_news")
+    def test_prefetch_graceful_news_failure(self, mock_news, mock_global):
+        """News fetch failure degrades gracefully."""
+        mock_news.func = MagicMock(side_effect=ConnectionError("news API down"))
+        mock_global.func = MagicMock(return_value="global news")
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.news_analyst import create_news_analyst
+        node = create_news_analyst(llm)
+        result = node(_make_state())
+
+        assert "news_report" in result
+
+    @patch("tradingagents.agents.analysts.news_analyst.get_global_news")
+    @patch("tradingagents.agents.analysts.news_analyst.get_news")
+    def test_prefetch_graceful_global_failure(self, mock_news, mock_global):
+        """Global news failure degrades gracefully."""
+        mock_news.func = MagicMock(return_value="ticker news")
+        mock_global.func = MagicMock(side_effect=TimeoutError("timeout"))
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.news_analyst import create_news_analyst
+        node = create_news_analyst(llm)
+        result = node(_make_state())
+
+        assert "news_report" in result
+
+
+# ── Fundamentals analyst ────────────────────────────────────────────────
+
+
+class TestFundamentalsAnalyst:
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_income_statement")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_cashflow")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_balance_sheet")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_fundamentals")
+    def test_prefetch_path_calls_func(self, mock_fund, mock_bs, mock_cf, mock_inc):
+        """Pre-fetch path calls .func() on all 4 financial tools."""
+        mock_fund.func = MagicMock(return_value="fundamentals")
+        mock_bs.func = MagicMock(return_value="balance sheet")
+        mock_cf.func = MagicMock(return_value="cashflow")
+        mock_inc.func = MagicMock(return_value="income")
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.fundamentals_analyst import create_fundamentals_analyst
+        node = create_fundamentals_analyst(llm)
+        result = node(_make_state())
+
+        mock_fund.func.assert_called_once()
+        mock_bs.func.assert_called_once()
+        mock_cf.func.assert_called_once()
+        mock_inc.func.assert_called_once()
+        llm.bind_tools.assert_not_called()
+        assert "fundamentals_report" in result
+
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_income_statement")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_cashflow")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_balance_sheet")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_fundamentals")
+    def test_tool_call_path_uses_bind_tools(self, mock_fund, mock_bs, mock_cf, mock_inc):
+        """Tool-call path uses bind_tools (original behavior)."""
+        mock_fund.name = "get_fundamentals"
+        mock_bs.name = "get_balance_sheet"
+        mock_cf.name = "get_cashflow"
+        mock_inc.name = "get_income_statement"
+
+        llm = _make_llm(tool_calls=True)
+        from tradingagents.agents.analysts.fundamentals_analyst import create_fundamentals_analyst
+        node = create_fundamentals_analyst(llm)
+        result = node(_make_state())
+
+        llm.bind_tools.assert_called_once()
+        assert "fundamentals_report" in result
+
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_income_statement")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_cashflow")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_balance_sheet")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_fundamentals")
+    def test_prefetch_graceful_partial_failure(self, mock_fund, mock_bs, mock_cf, mock_inc):
+        """Partial data failure degrades gracefully — other sources still work."""
+        mock_fund.func = MagicMock(return_value="fundamentals")
+        mock_bs.func = MagicMock(side_effect=ConnectionError("API down"))
+        mock_cf.func = MagicMock(return_value="cashflow")
+        mock_inc.func = MagicMock(side_effect=TimeoutError("timeout"))
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.fundamentals_analyst import create_fundamentals_analyst
+        node = create_fundamentals_analyst(llm)
+        result = node(_make_state())
+
+        assert "fundamentals_report" in result
+
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_income_statement")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_cashflow")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_balance_sheet")
+    @patch("tradingagents.agents.analysts.fundamentals_analyst.get_fundamentals")
+    def test_prefetch_all_sources_fail(self, mock_fund, mock_bs, mock_cf, mock_inc):
+        """All data sources failing still produces a report (LLM gets <unavailable> blocks)."""
+        mock_fund.func = MagicMock(side_effect=Exception("fail 1"))
+        mock_bs.func = MagicMock(side_effect=Exception("fail 2"))
+        mock_cf.func = MagicMock(side_effect=Exception("fail 3"))
+        mock_inc.func = MagicMock(side_effect=Exception("fail 4"))
+
+        llm = _make_llm(tool_calls=False)
+        from tradingagents.agents.analysts.fundamentals_analyst import create_fundamentals_analyst
+        node = create_fundamentals_analyst(llm)
+        result = node(_make_state())
+
+        assert "fundamentals_report" in result

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,374 @@
+"""Tests for the thread-safe ProgressTracker.
+
+Covers:
+- Initialization and dynamic agent/section setup
+- Write methods (add_message, add_tool_call, update_agent_status, etc.)
+- Snapshot immutability — mutations to the tracker must not leak
+- Deduplication via has_seen_message()
+- Thread safety — concurrent writers must not corrupt state
+- Deep-copy of tool_call args (CR-01 fix)
+- Logging on unknown agent/section (WR-03 fix)
+"""
+
+import threading
+import time
+
+import pytest
+
+from tradingagents.progress import (
+    ANALYST_MAPPING,
+    FIXED_AGENTS,
+    REPORT_SECTIONS,
+    SECTION_TITLES,
+    ProgressSnapshot,
+    ProgressTracker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInitForAnalysis:
+    def test_builds_agent_status_from_selected_analysts(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market", "news"])
+
+        snap = tracker.snapshot()
+        assert "Market Analyst" in snap.agent_status
+        assert "News Analyst" in snap.agent_status
+        # Not selected — must be absent from analyst slots
+        assert "Sentiment Analyst" not in snap.agent_status
+        assert "Fundamentals Analyst" not in snap.agent_status
+
+    def test_includes_fixed_agents(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        snap = tracker.snapshot()
+        for agents in FIXED_AGENTS.values():
+            for agent in agents:
+                assert agent in snap.agent_status
+                assert snap.agent_status[agent] == "pending"
+
+    def test_builds_report_sections_for_selected_analysts(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market", "fundamentals"])
+
+        snap = tracker.snapshot()
+        assert "market_report" in snap.report_sections
+        assert "fundamentals_report" in snap.report_sections
+        # Always-included sections (analyst_key is None)
+        assert "investment_plan" in snap.report_sections
+        assert "trader_investment_plan" in snap.report_sections
+        assert "final_trade_decision" in snap.report_sections
+        # Not selected
+        assert "sentiment_report" not in snap.report_sections
+        assert "news_report" not in snap.report_sections
+
+    def test_case_insensitive_analyst_keys(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["Market", "NEWS"])
+
+        snap = tracker.snapshot()
+        assert "Market Analyst" in snap.agent_status
+        assert "News Analyst" in snap.agent_status
+
+    def test_reset_clears_prior_state(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.add_message("System", "first run")
+        tracker.update_agent_status("Market Analyst", "completed")
+
+        # Second init should clear everything
+        tracker.init_for_analysis(["news"])
+        snap = tracker.snapshot()
+        assert len(snap.messages) == 0
+        assert "Market Analyst" not in snap.agent_status
+        assert "News Analyst" in snap.agent_status
+        assert snap.agent_status["News Analyst"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Write methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWriteMethods:
+    def test_add_message(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.add_message("System", "Hello world")
+
+        snap = tracker.snapshot()
+        assert len(snap.messages) == 1
+        ts, msg_type, content = snap.messages[0]
+        assert msg_type == "System"
+        assert content == "Hello world"
+        assert len(ts) == 8  # HH:MM:SS
+
+    def test_add_tool_call(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.add_tool_call("search", {"query": "AAPL"})
+
+        snap = tracker.snapshot()
+        assert len(snap.tool_calls) == 1
+        ts, name, args = snap.tool_calls[0]
+        assert name == "search"
+        assert args == {"query": "AAPL"}
+
+    def test_update_agent_status(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.update_agent_status("Market Analyst", "in_progress")
+
+        snap = tracker.snapshot()
+        assert snap.agent_status["Market Analyst"] == "in_progress"
+        assert snap.current_agent == "Market Analyst"
+
+    def test_update_report_section(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.update_report_section("market_report", "# Analysis")
+
+        snap = tracker.snapshot()
+        assert snap.report_sections["market_report"] == "# Analysis"
+
+    def test_message_deque_bounded(self) -> None:
+        tracker = ProgressTracker(max_messages=3)
+        tracker.init_for_analysis(["market"])
+        for i in range(5):
+            tracker.add_message("System", f"msg-{i}")
+
+        snap = tracker.snapshot()
+        assert len(snap.messages) == 3
+        # Oldest messages evicted
+        assert snap.messages[0][2] == "msg-2"
+
+    def test_last_activity_updated_on_writes(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        secs = tracker.seconds_since_last_activity()
+        assert secs is not None
+        assert secs < 1.0  # just initialized
+
+
+# ---------------------------------------------------------------------------
+# Snapshot immutability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSnapshotImmutability:
+    def test_snapshot_agent_status_is_a_copy(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        snap1 = tracker.snapshot()
+        tracker.update_agent_status("Market Analyst", "completed")
+        snap2 = tracker.snapshot()
+
+        # snap1 should still show old value
+        assert snap1.agent_status["Market Analyst"] == "pending"
+        assert snap2.agent_status["Market Analyst"] == "completed"
+
+    def test_snapshot_messages_is_a_copy(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.add_message("System", "before")
+
+        snap = tracker.snapshot()
+        tracker.add_message("System", "after")
+
+        assert len(snap.messages) == 1
+        assert snap.messages[0][2] == "before"
+
+    def test_tool_call_args_deep_copied(self) -> None:
+        """CR-01: mutable args must not leak through snapshot."""
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        original_args = {"query": "AAPL", "nested": {"key": "value"}}
+        tracker.add_tool_call("search", original_args)
+
+        # Mutate the original — should NOT affect tracker
+        original_args["nested"]["key"] = "MUTATED"
+
+        snap = tracker.snapshot()
+        assert snap.tool_calls[0][2]["nested"]["key"] == "value"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeduplication:
+    def test_has_seen_message_first_call_returns_false(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        assert tracker.has_seen_message("msg-001") is False
+
+    def test_has_seen_message_second_call_returns_true(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.has_seen_message("msg-001")
+        assert tracker.has_seen_message("msg-001") is True
+
+    def test_init_clears_dedup_set(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+        tracker.has_seen_message("msg-001")
+
+        tracker.init_for_analysis(["market"])
+        # Same ID should return False after reset
+        assert tracker.has_seen_message("msg-001") is False
+
+
+# ---------------------------------------------------------------------------
+# Report counting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReportCounting:
+    def test_completed_reports_requires_both_content_and_agent_done(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        # Content without agent completion -> not counted
+        tracker.update_report_section("market_report", "# Report")
+        assert tracker.get_completed_reports_count() == 0
+
+        # Agent completion without content -> not counted
+        tracker.update_agent_status("Market Analyst", "completed")
+        # Now both conditions met
+        assert tracker.get_completed_reports_count() == 1
+
+    def test_total_reports_count(self) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market", "news"])
+        # 2 analyst sections + 3 always-included = 5
+        assert tracker.get_total_reports_count() == 5
+
+
+# ---------------------------------------------------------------------------
+# Unknown agent/section logging (WR-03)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUnknownAgentWarning:
+    def test_unknown_agent_logged(self, caplog) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        with caplog.at_level("WARNING", logger="tradingagents.progress"):
+            tracker.update_agent_status("Nonexistent Agent", "in_progress")
+
+        assert "Unknown agent" in caplog.text
+        assert "Nonexistent Agent" in caplog.text
+
+    def test_unknown_section_logged(self, caplog) -> None:
+        tracker = ProgressTracker()
+        tracker.init_for_analysis(["market"])
+
+        with caplog.at_level("WARNING", logger="tradingagents.progress"):
+            tracker.update_report_section("nonexistent_report", "content")
+
+        assert "Unknown report section" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestThreadSafety:
+    def test_concurrent_writers_do_not_corrupt_state(self) -> None:
+        """Hammer the tracker from multiple threads and verify consistency."""
+        tracker = ProgressTracker(max_messages=500)
+        tracker.init_for_analysis(["market", "news", "social", "fundamentals"])
+
+        errors: list[str] = []
+        iterations = 50
+
+        def writer(thread_id: int) -> None:
+            try:
+                for i in range(iterations):
+                    tracker.add_message("System", f"t{thread_id}-msg-{i}")
+                    tracker.add_tool_call("tool", {"t": thread_id, "i": i})
+                    # Rotate through agents
+                    agents = list(ANALYST_MAPPING.values())
+                    agent = agents[i % len(agents)]
+                    tracker.update_agent_status(agent, "in_progress")
+            except Exception as e:
+                errors.append(f"Thread {thread_id}: {e}")
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+
+        # Snapshot should be internally consistent
+        snap = tracker.snapshot()
+        assert len(snap.messages) > 0
+        assert len(snap.tool_calls) > 0
+
+    def test_snapshot_while_writing(self) -> None:
+        """Reader thread takes snapshots while writer is active."""
+        tracker = ProgressTracker(max_messages=200)
+        tracker.init_for_analysis(["market"])
+
+        snapshots: list[ProgressSnapshot] = []
+        stop_event = threading.Event()
+
+        def writer() -> None:
+            for i in range(100):
+                tracker.add_message("Agent", f"msg-{i}")
+            stop_event.set()
+
+        def reader() -> None:
+            while not stop_event.is_set():
+                snapshots.append(tracker.snapshot())
+                time.sleep(0.001)
+
+        w = threading.Thread(target=writer)
+        r = threading.Thread(target=reader)
+        r.start()
+        w.start()
+        w.join(timeout=10)
+        r.join(timeout=10)
+
+        # All snapshots must be valid ProgressSnapshot objects
+        assert len(snapshots) > 0
+        for snap in snapshots:
+            assert isinstance(snap, ProgressSnapshot)
+            assert isinstance(snap.messages, list)
+
+
+# ---------------------------------------------------------------------------
+# Constants consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConstants:
+    def test_section_titles_cover_all_report_sections(self) -> None:
+        for section_key in REPORT_SECTIONS:
+            assert section_key in SECTION_TITLES, (
+                f"SECTION_TITLES missing key {section_key!r}"
+            )
+
+    def test_analyst_mapping_values_unique(self) -> None:
+        values = list(ANALYST_MAPPING.values())
+        assert len(values) == len(set(values)), "Duplicate analyst display names"

--- a/tests/test_ssl_helpers.py
+++ b/tests/test_ssl_helpers.py
@@ -1,0 +1,29 @@
+"""Tests for the shared SSL context helper."""
+
+import ssl
+
+import pytest
+
+from tradingagents.dataflows.ssl_helpers import default_ssl_context
+
+
+class TestDefaultSslContext:
+    """default_ssl_context() returns a usable SSLContext."""
+
+    def test_returns_ssl_context(self) -> None:
+        ctx = default_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_cached_singleton(self) -> None:
+        ctx1 = default_ssl_context()
+        ctx2 = default_ssl_context()
+        assert ctx1 is ctx2
+
+    def test_verify_mode_is_cert_required(self) -> None:
+        ctx = default_ssl_context()
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_has_ca_certs_loaded(self) -> None:
+        ctx = default_ssl_context()
+        stats = ctx.cert_store_stats()
+        assert stats["x509_ca"] > 0, "expected at least one CA cert loaded"

--- a/tests/test_v3_database.py
+++ b/tests/test_v3_database.py
@@ -1,0 +1,1237 @@
+"""Unit tests for TradingAgents Desktop v3 database layer and utility modules.
+
+Tests cover:
+- HistoryDB: all 7 new table CRUD operations
+- Frozen dataclass immutability
+- Foreign key cascade on schedule delete
+- validated_result_dir path validation
+- discover_report_files report discovery
+- migrate() dry-run mode
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from desktop.state.database import (
+    AlertHistoryRow,
+    AlertRow,
+    AnalysisRow,
+    HistoryDB,
+    LogEntryRow,
+    PositionRow,
+    RecommendationOutcomeRow,
+    RecommendationRow,
+    ScheduleRow,
+    ScheduleRunRow,
+)
+from desktop.utils.paths import validated_result_dir
+from desktop.utils.reports import discover_report_files
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> HistoryDB:
+    """Create a fresh HistoryDB backed by a temp file."""
+    return HistoryDB(db_path=tmp_path / "test.db")
+
+
+@pytest.fixture()
+def db_with_analysis(db: HistoryDB) -> tuple[HistoryDB, int]:
+    """DB with one completed analysis row (needed as FK parent for recommendations)."""
+    aid = db.insert_analysis(
+        ticker="AAPL",
+        date="2026-01-15",
+        provider="openai",
+        model="gpt-4o",
+    )
+    db.mark_completed(aid)
+    return db, aid
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Frozen dataclass immutability
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFrozenDataclasses:
+    """Verify that all DTO dataclasses are truly frozen."""
+
+    @pytest.mark.unit
+    def test_analysis_row_frozen(self) -> None:
+        row = AnalysisRow(
+            id=1, ticker="AAPL", date="2026-01-01", provider="openai",
+            model="gpt-4o", status="completed", started_at="2026-01-01T00:00:00",
+            completed_at=None, config_json="{}", result_dir=None,
+            error_text=None, selected_analysts="",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.ticker = "MSFT"  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_recommendation_row_frozen(self) -> None:
+        row = RecommendationRow(
+            id=1, analysis_id=1, ticker="AAPL", verdict="BUY",
+            confidence=8, price_at_analysis=150.0, stop_loss=140.0,
+            entry_trigger=148.0, profit_target=170.0, review_date=None,
+            is_active=1, created_at="2026-01-01T00:00:00",
+            deactivated_at=None, notes=None,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.verdict = "SELL"  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_recommendation_outcome_row_frozen(self) -> None:
+        row = RecommendationOutcomeRow(
+            id=1, recommendation_id=1, check_date="2026-01-10",
+            days_elapsed=10, price_at_check=155.0, return_pct=3.33,
+            stop_hit=0, target_hit=0, high_since=156.0, low_since=149.0,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.return_pct = 5.0  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_alert_row_frozen(self) -> None:
+        row = AlertRow(
+            id=1, recommendation_id=1, ticker="AAPL", alert_type="stop_loss",
+            target_price=140.0, direction="below", triggered_at=None,
+            triggered_price=None, is_active=1, created_at="2026-01-01T00:00:00",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.is_active = 0  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_alert_history_row_frozen(self) -> None:
+        row = AlertHistoryRow(
+            id=1, alert_id=1, fired_at="2026-01-05T12:00:00",
+            price=139.50, message="Stop loss hit", seen=0,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.seen = 1  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_schedule_row_frozen(self) -> None:
+        row = ScheduleRow(
+            id=1, name="Daily scan", watchlist="AAPL,MSFT",
+            cron_expr="0 9 * * 1-5", timezone="America/New_York",
+            is_enabled=1, last_run=None, next_run=None,
+            created_at="2026-01-01T00:00:00",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.is_enabled = 0  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_schedule_run_row_frozen(self) -> None:
+        row = ScheduleRunRow(
+            id=1, schedule_id=1, started_at="2026-01-01T09:00:00",
+            completed_at=None, status="running",
+            tickers_json='["AAPL"]', results_json=None,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.status = "completed"  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_position_row_frozen(self) -> None:
+        row = PositionRow(
+            id=1, ticker="AAPL", quantity=100.0, avg_price=150.0,
+            date_opened="2026-01-01", notes=None,
+            updated_at="2026-01-01T00:00:00",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.quantity = 200.0  # type: ignore[misc]
+
+    @pytest.mark.unit
+    def test_log_entry_row_frozen(self) -> None:
+        row = LogEntryRow(
+            id=1, analysis_id=1, timestamp="2026-01-01T00:00:00",
+            entry_type="System", content="started",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            row.content = "changed"  # type: ignore[misc]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Recommendations CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRecommendationsCRUD:
+    """Test recommendations table insert, get, list, deactivate."""
+
+    @pytest.mark.unit
+    def test_insert_and_get(self, db_with_analysis: tuple[HistoryDB, int]) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid,
+            ticker="AAPL",
+            verdict="BUY",
+            confidence=8,
+            price_at_analysis=150.0,
+            stop_loss=140.0,
+            entry_trigger=148.0,
+            profit_target=170.0,
+            review_date="2026-02-15",
+            notes="Strong earnings",
+        )
+        assert rec_id >= 1
+
+        rec = db.get_recommendation(rec_id)
+        assert rec is not None
+        assert rec.ticker == "AAPL"
+        assert rec.verdict == "BUY"
+        assert rec.confidence == 8
+        assert rec.price_at_analysis == 150.0
+        assert rec.stop_loss == 140.0
+        assert rec.entry_trigger == 148.0
+        assert rec.profit_target == 170.0
+        assert rec.review_date == "2026-02-15"
+        assert rec.is_active == 1
+        assert rec.deactivated_at is None
+        assert rec.notes == "Strong earnings"
+
+    @pytest.mark.unit
+    def test_get_nonexistent_returns_none(self, db: HistoryDB) -> None:
+        assert db.get_recommendation(999) is None
+
+    @pytest.mark.unit
+    def test_ticker_uppercased(self, db_with_analysis: tuple[HistoryDB, int]) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="aapl", verdict="hold",
+        )
+        rec = db.get_recommendation(rec_id)
+        assert rec is not None
+        assert rec.ticker == "AAPL"
+        assert rec.verdict == "HOLD"
+
+    @pytest.mark.unit
+    def test_list_active_recommendations(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        r1 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        r2 = db.insert_recommendation(
+            analysis_id=aid, ticker="MSFT", verdict="HOLD",
+        )
+        db.deactivate_recommendation(r1)
+
+        active = db.list_active_recommendations()
+        assert len(active) == 1
+        assert active[0].id == r2
+
+    @pytest.mark.unit
+    def test_list_all_recommendations(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        db.insert_recommendation(analysis_id=aid, ticker="AAPL", verdict="BUY")
+        db.insert_recommendation(analysis_id=aid, ticker="MSFT", verdict="HOLD")
+
+        all_recs = db.list_all_recommendations()
+        assert len(all_recs) == 2
+        # Newest first
+        assert all_recs[0].ticker == "MSFT"
+        assert all_recs[1].ticker == "AAPL"
+
+    @pytest.mark.unit
+    def test_deactivate_recommendation(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        db.deactivate_recommendation(rec_id)
+
+        rec = db.get_recommendation(rec_id)
+        assert rec is not None
+        assert rec.is_active == 0
+        assert rec.deactivated_at is not None
+
+    @pytest.mark.unit
+    def test_deactivate_older_for_ticker(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        r1 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        r2 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="HOLD",
+        )
+        r3 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="SELL",
+        )
+
+        count = db.deactivate_older_for_ticker("AAPL", keep_id=r3)
+        assert count == 2
+
+        # r3 should still be active
+        rec3 = db.get_recommendation(r3)
+        assert rec3 is not None
+        assert rec3.is_active == 1
+
+        # r1 and r2 should be inactive
+        for rid in (r1, r2):
+            rec = db.get_recommendation(rid)
+            assert rec is not None
+            assert rec.is_active == 0
+
+    @pytest.mark.unit
+    def test_deactivate_older_for_ticker_case_insensitive(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        """deactivate_older_for_ticker uppercases the ticker argument."""
+        db, aid = db_with_analysis
+        r1 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        r2 = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="SELL",
+        )
+        count = db.deactivate_older_for_ticker("aapl", keep_id=r2)
+        assert count == 1
+
+    @pytest.mark.unit
+    def test_get_recommendation_by_analysis(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        rec = db.get_recommendation_by_analysis(aid)
+        assert rec is not None
+        assert rec.ticker == "AAPL"
+
+    @pytest.mark.unit
+    def test_get_recommendation_by_analysis_none(self, db: HistoryDB) -> None:
+        assert db.get_recommendation_by_analysis(999) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Recommendation Outcomes CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRecommendationOutcomesCRUD:
+    """Test recommendation_outcomes table insert and list."""
+
+    @pytest.mark.unit
+    def test_insert_and_list(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+            price_at_analysis=150.0,
+        )
+
+        oid1 = db.insert_outcome(
+            recommendation_id=rec_id,
+            days_elapsed=7,
+            price_at_check=155.0,
+            return_pct=3.33,
+            stop_hit=False,
+            target_hit=False,
+            high_since=156.0,
+            low_since=149.0,
+        )
+        oid2 = db.insert_outcome(
+            recommendation_id=rec_id,
+            days_elapsed=30,
+            price_at_check=165.0,
+            return_pct=10.0,
+            stop_hit=False,
+            target_hit=True,
+            high_since=167.0,
+            low_since=148.0,
+        )
+        assert oid1 >= 1
+        assert oid2 >= 1
+
+        outcomes = db.get_outcomes(rec_id)
+        assert len(outcomes) == 2
+        # Ordered by days_elapsed ASC
+        assert outcomes[0].days_elapsed == 7
+        assert outcomes[1].days_elapsed == 30
+        assert outcomes[1].target_hit == 1
+
+    @pytest.mark.unit
+    def test_list_for_nonexistent_recommendation(self, db: HistoryDB) -> None:
+        outcomes = db.get_outcomes(999)
+        assert outcomes == []
+
+    @pytest.mark.unit
+    def test_list_all_outcomes_with_min_days(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        db.insert_outcome(
+            recommendation_id=rec_id, days_elapsed=3,
+            price_at_check=151.0, return_pct=0.67,
+        )
+        db.insert_outcome(
+            recommendation_id=rec_id, days_elapsed=14,
+            price_at_check=158.0, return_pct=5.33,
+        )
+
+        all_outcomes = db.list_all_outcomes(min_days=10)
+        assert len(all_outcomes) == 1
+        assert all_outcomes[0].days_elapsed == 14
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Alerts CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAlertsCRUD:
+    """Test alerts table insert, list_active, list_for_recommendation, trigger."""
+
+    @pytest.mark.unit
+    def test_insert_and_list_active(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+
+        a1 = db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="AAPL",
+            alert_type="stop_loss",
+            target_price=140.0,
+            direction="below",
+        )
+        a2 = db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="AAPL",
+            alert_type="profit_target",
+            target_price=170.0,
+            direction="above",
+        )
+        assert a1 >= 1
+        assert a2 >= 1
+
+        active = db.list_active_alerts()
+        assert len(active) == 2
+
+    @pytest.mark.unit
+    def test_list_alerts_for_recommendation(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="AAPL",
+            alert_type="stop_loss",
+            target_price=140.0,
+            direction="below",
+        )
+        db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="AAPL",
+            alert_type="entry_trigger",
+            target_price=148.0,
+            direction="below",
+        )
+
+        alerts = db.list_alerts_for_recommendation(rec_id)
+        assert len(alerts) == 2
+        # Ordered by alert_type ASC
+        assert alerts[0].alert_type == "entry_trigger"
+        assert alerts[1].alert_type == "stop_loss"
+
+    @pytest.mark.unit
+    def test_trigger_alert(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="AAPL",
+            alert_type="stop_loss",
+            target_price=140.0,
+            direction="below",
+        )
+
+        db.trigger_alert(alert_id, price=139.50)
+
+        # Should no longer appear in active alerts
+        active = db.list_active_alerts()
+        assert len(active) == 0
+
+        # Should appear in full list for the recommendation with trigger data
+        all_alerts = db.list_alerts_for_recommendation(rec_id)
+        assert len(all_alerts) == 1
+        triggered = all_alerts[0]
+        assert triggered.is_active == 0
+        assert triggered.triggered_price == 139.50
+        assert triggered.triggered_at is not None
+
+    @pytest.mark.unit
+    def test_ticker_uppercased_on_insert(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id,
+            ticker="aapl",
+            alert_type="custom",
+            target_price=160.0,
+            direction="above",
+        )
+        alerts = db.list_alerts_for_recommendation(rec_id)
+        assert alerts[0].ticker == "AAPL"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Alert History CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAlertHistoryCRUD:
+    """Test alert_history table insert, list_all, count_unseen, mark_all_seen."""
+
+    @pytest.mark.unit
+    def test_insert_and_list_all(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id, ticker="AAPL",
+            alert_type="stop_loss", target_price=140.0, direction="below",
+        )
+
+        h1 = db.insert_alert_history(
+            alert_id=alert_id, price=139.50, message="Stop loss triggered",
+        )
+        h2 = db.insert_alert_history(
+            alert_id=alert_id, price=138.00, message="Price still falling",
+        )
+        assert h1 >= 1
+        assert h2 >= 1
+
+        history = db.list_all_alert_history()
+        assert len(history) == 2
+        # Both inserted in the same second, so ORDER BY fired_at DESC
+        # falls back to insertion order. Just verify both are present.
+        messages = {h.message for h in history}
+        assert messages == {"Stop loss triggered", "Price still falling"}
+
+    @pytest.mark.unit
+    def test_count_unseen(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id, ticker="AAPL",
+            alert_type="stop_loss", target_price=140.0, direction="below",
+        )
+
+        db.insert_alert_history(
+            alert_id=alert_id, price=139.50, message="Alert 1",
+        )
+        db.insert_alert_history(
+            alert_id=alert_id, price=138.00, message="Alert 2",
+        )
+
+        assert db.count_unseen_alert_history() == 2
+
+    @pytest.mark.unit
+    def test_mark_all_seen(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id, ticker="AAPL",
+            alert_type="stop_loss", target_price=140.0, direction="below",
+        )
+
+        h1 = db.insert_alert_history(
+            alert_id=alert_id, price=139.50, message="Alert 1",
+        )
+        h2 = db.insert_alert_history(
+            alert_id=alert_id, price=138.00, message="Alert 2",
+        )
+
+        db.mark_alerts_seen([h1, h2])
+
+        assert db.count_unseen_alert_history() == 0
+
+        all_history = db.list_all_alert_history()
+        for entry in all_history:
+            assert entry.seen == 1
+
+    @pytest.mark.unit
+    def test_mark_seen_empty_list_is_noop(self, db: HistoryDB) -> None:
+        """mark_alerts_seen with empty list should not error."""
+        db.mark_alerts_seen([])  # should not raise
+
+    @pytest.mark.unit
+    def test_list_unseen_alert_history(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        db, aid = db_with_analysis
+        rec_id = db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+        alert_id = db.insert_alert(
+            recommendation_id=rec_id, ticker="AAPL",
+            alert_type="stop_loss", target_price=140.0, direction="below",
+        )
+
+        h1 = db.insert_alert_history(
+            alert_id=alert_id, price=139.50, message="Unseen alert",
+        )
+        h2 = db.insert_alert_history(
+            alert_id=alert_id, price=138.00, message="Also unseen",
+        )
+        db.mark_alerts_seen([h1])
+
+        unseen = db.list_unseen_alert_history()
+        assert len(unseen) == 1
+        assert unseen[0].id == h2
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Schedules CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSchedulesCRUD:
+    """Test schedules table insert, list, update_enabled, update_last_run,
+    update_next_run, and delete with cascade."""
+
+    @pytest.mark.unit
+    def test_insert_and_list(self, db: HistoryDB) -> None:
+        s1 = db.insert_schedule(
+            name="Morning scan",
+            watchlist="AAPL,MSFT,GOOG",
+            cron_expr="0 9 * * 1-5",
+        )
+        s2 = db.insert_schedule(
+            name="Weekly review",
+            watchlist="SPY,QQQ",
+            cron_expr="0 18 * * 5",
+            timezone="UTC",
+        )
+        assert s1 >= 1
+        assert s2 >= 1
+
+        schedules = db.list_schedules()
+        assert len(schedules) == 2
+        # Newest first
+        assert schedules[0].name == "Weekly review"
+        assert schedules[0].timezone == "UTC"
+        assert schedules[1].name == "Morning scan"
+        assert schedules[1].timezone == "America/New_York"
+
+    @pytest.mark.unit
+    def test_update_enabled(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        schedules = db.list_schedules()
+        assert schedules[0].is_enabled == 1
+
+        db.update_schedule_enabled(sid, is_enabled=False)
+
+        schedules = db.list_schedules()
+        assert schedules[0].is_enabled == 0
+
+        db.update_schedule_enabled(sid, is_enabled=True)
+        schedules = db.list_schedules()
+        assert schedules[0].is_enabled == 1
+
+    @pytest.mark.unit
+    def test_update_last_run(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        db.update_schedule_last_run(
+            sid, last_run="2026-01-15T09:00:00", next_run="2026-01-16T09:00:00"
+        )
+
+        schedules = db.list_schedules()
+        assert schedules[0].last_run == "2026-01-15T09:00:00"
+        assert schedules[0].next_run == "2026-01-16T09:00:00"
+
+    @pytest.mark.unit
+    def test_update_next_run(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        db.update_schedule_last_run(
+            sid, last_run="2026-01-15T09:00:00", next_run="2026-01-16T09:00:00"
+        )
+
+        # Update only next_run, last_run should be preserved
+        db.update_schedule_next_run(sid, next_run="2026-01-17T09:00:00")
+
+        schedules = db.list_schedules()
+        assert schedules[0].last_run == "2026-01-15T09:00:00"
+        assert schedules[0].next_run == "2026-01-17T09:00:00"
+
+    @pytest.mark.unit
+    def test_delete_schedule(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="To delete", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        assert len(db.list_schedules()) == 1
+
+        db.delete_schedule(sid)
+        assert len(db.list_schedules()) == 0
+
+    @pytest.mark.unit
+    def test_delete_schedule_cascades_runs(self, db: HistoryDB) -> None:
+        """Deleting a schedule must also remove its schedule_runs."""
+        sid = db.insert_schedule(
+            name="Cascade test", watchlist="AAPL,MSFT", cron_expr="0 9 * * *",
+        )
+        rid1 = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL", "MSFT"])
+        rid2 = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL"])
+
+        runs_before = db.list_schedule_runs(sid)
+        assert len(runs_before) == 2
+
+        db.delete_schedule(sid)
+
+        # Schedule gone
+        assert len(db.list_schedules()) == 0
+        # Runs also gone
+        runs_after = db.list_schedule_runs(sid)
+        assert len(runs_after) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Schedule Runs CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestScheduleRunsCRUD:
+    """Test schedule_runs table insert, update, and list."""
+
+    @pytest.mark.unit
+    def test_insert_and_list(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL,MSFT", cron_expr="0 9 * * *",
+        )
+        rid = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL", "MSFT"])
+        assert rid >= 1
+
+        runs = db.list_schedule_runs(sid)
+        assert len(runs) == 1
+        assert runs[0].status == "running"
+        assert runs[0].tickers_json == '["AAPL", "MSFT"]'
+        assert runs[0].results_json is None
+
+    @pytest.mark.unit
+    def test_update_run_status(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        rid = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL"])
+
+        db.update_schedule_run(
+            rid,
+            status="completed",
+            results=[{"ticker": "AAPL", "verdict": "BUY"}],
+        )
+
+        runs = db.list_schedule_runs(sid)
+        assert runs[0].status == "completed"
+        assert runs[0].completed_at is not None
+        assert '"verdict": "BUY"' in (runs[0].results_json or "")
+
+    @pytest.mark.unit
+    def test_update_run_without_results(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        rid = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL"])
+
+        db.update_schedule_run(rid, status="failed")
+
+        runs = db.list_schedule_runs(sid)
+        assert runs[0].status == "failed"
+        assert runs[0].results_json is None
+
+    @pytest.mark.unit
+    def test_list_respects_limit(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        for _ in range(5):
+            db.insert_schedule_run(schedule_id=sid, tickers=["AAPL"])
+
+        runs = db.list_schedule_runs(sid, limit=3)
+        assert len(runs) == 3
+
+    @pytest.mark.unit
+    def test_runs_ordered_newest_first(self, db: HistoryDB) -> None:
+        sid = db.insert_schedule(
+            name="Test", watchlist="AAPL", cron_expr="0 9 * * *",
+        )
+        r1 = db.insert_schedule_run(schedule_id=sid, tickers=["AAPL"])
+        r2 = db.insert_schedule_run(schedule_id=sid, tickers=["MSFT"])
+
+        runs = db.list_schedule_runs(sid)
+        assert runs[0].id == r2
+        assert runs[1].id == r1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Positions CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPositionsCRUD:
+    """Test positions table insert (upsert), list, update, and delete."""
+
+    @pytest.mark.unit
+    def test_upsert_and_list(self, db: HistoryDB) -> None:
+        pid = db.upsert_position(
+            ticker="AAPL",
+            quantity=100.0,
+            avg_price=150.0,
+            date_opened="2026-01-15",
+            notes="Core holding",
+        )
+        assert pid >= 1
+
+        positions = db.list_positions()
+        assert len(positions) == 1
+        pos = positions[0]
+        assert pos.ticker == "AAPL"
+        assert pos.quantity == 100.0
+        assert pos.avg_price == 150.0
+        assert pos.date_opened == "2026-01-15"
+        assert pos.notes == "Core holding"
+
+    @pytest.mark.unit
+    def test_upsert_updates_existing(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="AAPL", quantity=100.0, avg_price=150.0)
+        db.upsert_position(ticker="AAPL", quantity=200.0, avg_price=155.0)
+
+        positions = db.list_positions()
+        assert len(positions) == 1
+        assert positions[0].quantity == 200.0
+        assert positions[0].avg_price == 155.0
+
+    @pytest.mark.unit
+    def test_ticker_uppercased(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="aapl", quantity=50.0, avg_price=145.0)
+        positions = db.list_positions()
+        assert positions[0].ticker == "AAPL"
+
+    @pytest.mark.unit
+    def test_delete_position(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="AAPL", quantity=100.0, avg_price=150.0)
+        db.upsert_position(ticker="MSFT", quantity=50.0, avg_price=400.0)
+
+        db.delete_position("AAPL")
+
+        positions = db.list_positions()
+        assert len(positions) == 1
+        assert positions[0].ticker == "MSFT"
+
+    @pytest.mark.unit
+    def test_delete_case_insensitive(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="AAPL", quantity=100.0, avg_price=150.0)
+        db.delete_position("aapl")
+        assert len(db.list_positions()) == 0
+
+    @pytest.mark.unit
+    def test_positions_ordered_alphabetically(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="MSFT", quantity=50.0, avg_price=400.0)
+        db.upsert_position(ticker="AAPL", quantity=100.0, avg_price=150.0)
+        db.upsert_position(ticker="GOOG", quantity=25.0, avg_price=175.0)
+
+        positions = db.list_positions()
+        tickers = [p.ticker for p in positions]
+        assert tickers == ["AAPL", "GOOG", "MSFT"]
+
+    @pytest.mark.unit
+    def test_upsert_with_none_optionals(self, db: HistoryDB) -> None:
+        db.upsert_position(ticker="AAPL", quantity=100.0, avg_price=150.0)
+        positions = db.list_positions()
+        assert positions[0].date_opened is None
+        assert positions[0].notes is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# validated_result_dir
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestValidatedResultDir:
+    """Test the SEC-01 path traversal prevention in validated_result_dir."""
+
+    @pytest.mark.unit
+    def test_valid_path_under_results(self) -> None:
+        base = Path.home() / ".tradingagents" / "results"
+        valid_path = str(base / "2026-01-15_AAPL")
+        result = validated_result_dir(valid_path)
+        assert result is not None
+        assert result == Path(valid_path).resolve()
+
+    @pytest.mark.unit
+    def test_path_outside_results_returns_none(self) -> None:
+        assert validated_result_dir("/tmp/evil_results") is None
+
+    @pytest.mark.unit
+    def test_traversal_attack_returns_none(self) -> None:
+        base = Path.home() / ".tradingagents" / "results"
+        attack = str(base / ".." / ".." / "etc" / "passwd")
+        assert validated_result_dir(attack) is None
+
+    @pytest.mark.unit
+    def test_prefix_collision_returns_none(self) -> None:
+        """results_evil/ should NOT match results/."""
+        base = Path.home() / ".tradingagents" / "results_evil"
+        assert validated_result_dir(str(base / "some_dir")) is None
+
+    @pytest.mark.unit
+    def test_empty_string_returns_none(self) -> None:
+        assert validated_result_dir("") is None
+
+    @pytest.mark.unit
+    def test_results_base_itself_is_valid(self) -> None:
+        base = Path.home() / ".tradingagents" / "results"
+        result = validated_result_dir(str(base))
+        assert result is not None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# discover_report_files
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDiscoverReportFiles:
+    """Test report file discovery across all three layout formats."""
+
+    @pytest.mark.unit
+    def test_numbered_subdirectories_layout(self, tmp_path: Path) -> None:
+        """New format: 1_analysts/, 2_research/, etc."""
+        analysts = tmp_path / "1_analysts"
+        analysts.mkdir()
+        (analysts / "fundamentals.md").write_text("# Fundamentals")
+        (analysts / "market.md").write_text("# Market")
+
+        research = tmp_path / "2_research"
+        research.mkdir()
+        (research / "bull.md").write_text("# Bull")
+
+        sections = discover_report_files(tmp_path)
+        assert len(sections) == 3
+        # Check titles contain phase and file labels
+        titles = [title for title, _ in sections]
+        assert any("Analysts" in t and "Fundamentals" in t for t in titles)
+        assert any("Research" in t and "Bull" in t for t in titles)
+
+    @pytest.mark.unit
+    def test_flat_reports_directory_layout(self, tmp_path: Path) -> None:
+        """Old format: reports/ subdirectory."""
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        (reports_dir / "market_report.md").write_text("# Market")
+        (reports_dir / "sentiment_report.md").write_text("# Sentiment")
+
+        sections = discover_report_files(tmp_path)
+        assert len(sections) == 2
+        titles = [title for title, _ in sections]
+        assert "Market Analysis" in titles
+        assert "Social Sentiment" in titles
+
+    @pytest.mark.unit
+    def test_fallback_root_md_files(self, tmp_path: Path) -> None:
+        """Fallback: .md files directly in root."""
+        (tmp_path / "fundamentals_report.md").write_text("# Fundamentals")
+        (tmp_path / "news_report.md").write_text("# News")
+        # complete_report.md should be excluded
+        (tmp_path / "complete_report.md").write_text("# Complete")
+
+        sections = discover_report_files(tmp_path)
+        assert len(sections) == 2
+        titles = [title for title, _ in sections]
+        assert "Fundamentals Analysis" in titles
+        assert "News Analysis" in titles
+
+    @pytest.mark.unit
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        sections = discover_report_files(tmp_path)
+        assert sections == []
+
+    @pytest.mark.unit
+    def test_numbered_dirs_take_priority_over_reports_subdir(
+        self, tmp_path: Path
+    ) -> None:
+        """If numbered subdirs exist, reports/ is ignored."""
+        analysts = tmp_path / "1_analysts"
+        analysts.mkdir()
+        (analysts / "fundamentals.md").write_text("# Fund")
+
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        (reports_dir / "market_report.md").write_text("# Market")
+
+        sections = discover_report_files(tmp_path)
+        assert len(sections) == 1
+        assert "Analysts" in sections[0][0]
+
+    @pytest.mark.unit
+    def test_unknown_file_gets_fallback_title(self, tmp_path: Path) -> None:
+        """Files not in FILE_TITLES get a humanized stem."""
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        (reports_dir / "custom_analysis.md").write_text("# Custom")
+
+        sections = discover_report_files(tmp_path)
+        assert len(sections) == 1
+        assert sections[0][0] == "Custom Analysis"
+
+    @pytest.mark.unit
+    def test_paths_are_correct(self, tmp_path: Path) -> None:
+        """Returned paths should be the actual file paths."""
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        md_file = reports_dir / "market_report.md"
+        md_file.write_text("# Market")
+
+        sections = discover_report_files(tmp_path)
+        assert sections[0][1] == md_file
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# migrate() dry-run
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestMigrateDryRun:
+    """Test the migration module in dry_run mode with mock data."""
+
+    @pytest.mark.unit
+    def test_dry_run_with_no_analyses(self, db: HistoryDB) -> None:
+        from desktop.utils.migrate_historical import MigrationStats, migrate
+
+        stats = migrate(db=db, dry_run=True)
+        assert isinstance(stats, MigrationStats)
+        assert stats.total_analyses == 0
+        assert stats.already_migrated == 0
+        assert stats.migrated_ok == 0
+        assert stats.migrated_unknown == 0
+        assert stats.skipped_no_file == 0
+        assert stats.skipped_error == 0
+
+    @pytest.mark.unit
+    def test_dry_run_skips_no_result_dir(self, db: HistoryDB) -> None:
+        from desktop.utils.migrate_historical import migrate
+
+        # Insert analysis with no result_dir
+        aid = db.insert_analysis(
+            ticker="AAPL", date="2026-01-15", provider="openai", model="gpt-4o",
+        )
+        db.mark_completed(aid)
+
+        stats = migrate(db=db, dry_run=True)
+        assert stats.total_analyses == 1
+        assert stats.skipped_no_file == 1
+
+    @pytest.mark.unit
+    def test_dry_run_skips_missing_file(self, db: HistoryDB, tmp_path: Path) -> None:
+        from desktop.utils.migrate_historical import migrate
+
+        # result_dir exists but no final_trade_decision.md inside it
+        result_dir = tmp_path / "results" / "2026-01-15_AAPL"
+        result_dir.mkdir(parents=True)
+
+        aid = db.insert_analysis(
+            ticker="AAPL", date="2026-01-15", provider="openai", model="gpt-4o",
+            result_dir=str(result_dir),
+        )
+        db.mark_completed(aid)
+
+        stats = migrate(db=db, dry_run=True)
+        assert stats.total_analyses == 1
+        assert stats.skipped_no_file == 1
+
+    @pytest.mark.unit
+    def test_dry_run_counts_successful_extraction(
+        self, db: HistoryDB, tmp_path: Path
+    ) -> None:
+        from desktop.services.recommendation_extractor import (
+            ExtractedRecommendation,
+        )
+        from desktop.utils.migrate_historical import migrate
+
+        result_dir = tmp_path / "results" / "2026-01-15_AAPL"
+        result_dir.mkdir(parents=True)
+        decision_file = result_dir / "final_trade_decision.md"
+        decision_file.write_text("# Decision\n## Verdict: **BUY**\n")
+
+        aid = db.insert_analysis(
+            ticker="AAPL", date="2026-01-15", provider="openai", model="gpt-4o",
+            result_dir=str(result_dir),
+        )
+        db.mark_completed(aid)
+
+        mock_rec = ExtractedRecommendation(
+            ticker="AAPL", verdict="BUY", confidence=8,
+            stop_loss=140.0, entry_trigger=148.0, profit_target=170.0,
+        )
+        with patch(
+            "desktop.utils.migrate_historical.extract_from_file",
+            return_value=mock_rec,
+        ):
+            stats = migrate(db=db, dry_run=True)
+
+        assert stats.total_analyses == 1
+        assert stats.migrated_ok == 1
+        # Dry run: no actual DB writes
+        assert len(db.list_all_recommendations()) == 0
+
+    @pytest.mark.unit
+    def test_dry_run_counts_unknown_verdict(
+        self, db: HistoryDB, tmp_path: Path
+    ) -> None:
+        from desktop.services.recommendation_extractor import (
+            ExtractedRecommendation,
+        )
+        from desktop.utils.migrate_historical import migrate
+
+        result_dir = tmp_path / "results" / "2026-01-15_AAPL"
+        result_dir.mkdir(parents=True)
+        (result_dir / "final_trade_decision.md").write_text("# No verdict\n")
+
+        aid = db.insert_analysis(
+            ticker="AAPL", date="2026-01-15", provider="openai", model="gpt-4o",
+            result_dir=str(result_dir),
+        )
+        db.mark_completed(aid)
+
+        mock_rec = ExtractedRecommendation(ticker="AAPL", verdict="UNKNOWN")
+        with patch(
+            "desktop.utils.migrate_historical.extract_from_file",
+            return_value=mock_rec,
+        ):
+            stats = migrate(db=db, dry_run=True)
+
+        assert stats.migrated_unknown == 1
+        assert stats.migrated_ok == 0
+
+    @pytest.mark.unit
+    def test_dry_run_skips_already_migrated(
+        self, db_with_analysis: tuple[HistoryDB, int]
+    ) -> None:
+        from desktop.utils.migrate_historical import migrate
+
+        db, aid = db_with_analysis
+        # Pre-create a recommendation for this analysis
+        db.insert_recommendation(
+            analysis_id=aid, ticker="AAPL", verdict="BUY",
+        )
+
+        stats = migrate(db=db, dry_run=True)
+        assert stats.already_migrated == 1
+        assert stats.migrated_ok == 0
+
+    @pytest.mark.unit
+    def test_dry_run_handles_extraction_error(
+        self, db: HistoryDB, tmp_path: Path
+    ) -> None:
+        from desktop.utils.migrate_historical import migrate
+
+        result_dir = tmp_path / "results" / "2026-01-15_AAPL"
+        result_dir.mkdir(parents=True)
+        (result_dir / "final_trade_decision.md").write_text("corrupt data")
+
+        aid = db.insert_analysis(
+            ticker="AAPL", date="2026-01-15", provider="openai", model="gpt-4o",
+            result_dir=str(result_dir),
+        )
+        db.mark_completed(aid)
+
+        with patch(
+            "desktop.utils.migrate_historical.extract_from_file",
+            side_effect=ValueError("Parse error"),
+        ):
+            stats = migrate(db=db, dry_run=True)
+
+        assert stats.skipped_error == 1
+
+    @pytest.mark.unit
+    def test_migration_stats_frozen(self) -> None:
+        from desktop.utils.migrate_historical import MigrationStats
+
+        stats = MigrationStats(
+            total_analyses=10, already_migrated=2, migrated_ok=5,
+            migrated_unknown=1, skipped_no_file=1, skipped_error=1,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            stats.total_analyses = 20  # type: ignore[misc]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Schema and DB init
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDBInit:
+    """Test database initialisation and schema creation."""
+
+    @pytest.mark.unit
+    def test_creates_db_file(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "new.db"
+        assert not db_path.exists()
+        HistoryDB(db_path=db_path)
+        assert db_path.exists()
+
+    @pytest.mark.unit
+    def test_idempotent_schema(self, tmp_path: Path) -> None:
+        """Creating HistoryDB twice on same file should not error."""
+        db_path = tmp_path / "test.db"
+        HistoryDB(db_path=db_path)
+        HistoryDB(db_path=db_path)  # should not raise
+
+    @pytest.mark.unit
+    def test_foreign_keys_enabled(self, tmp_path: Path) -> None:
+        """Verify that PRAGMA foreign_keys is ON."""
+        db = HistoryDB(db_path=tmp_path / "fk_test.db")
+        conn = db._connect()
+        try:
+            row = conn.execute("PRAGMA foreign_keys").fetchone()
+            assert row[0] == 1
+        finally:
+            conn.close()

--- a/tests/test_v3_services.py
+++ b/tests/test_v3_services.py
@@ -1,0 +1,1289 @@
+"""Unit tests for TradingAgents Desktop v3 services layer.
+
+Tests cover:
+1. recommendation_extractor -- extract_recommendation() and extract_from_file()
+2. price_service -- PriceService with TTL cache
+3. alert_engine -- AlertEngine lifecycle + market hours
+4. outcome_tracker -- OutcomeTracker lifecycle
+5. scheduler -- CronExpr parsing + Scheduler lifecycle
+6. pdf_export -- PDFExporter (without weasyprint)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Module imports ──────────────────────────────────────────────────────
+
+from desktop.services.recommendation_extractor import (
+    ExtractedRecommendation,
+    _extract_confidence,
+    _extract_verdict,
+    _first_price,
+    _parse_price_str,
+    extract_from_file,
+    extract_recommendation,
+)
+from desktop.services.price_service import (
+    PriceResult,
+    PriceService,
+    _CachedPrice,
+    _compute_change_pct,
+)
+from desktop.services.alert_engine import (
+    AlertEngine,
+    _is_market_hours,
+    _poll_interval,
+)
+from desktop.services.outcome_tracker import (
+    OutcomeTracker,
+    _check_stop_hit,
+    _check_target_hit,
+    _compute_return_pct,
+    _days_since,
+)
+from desktop.services.scheduler import CronExpr, Scheduler
+from desktop.services.pdf_export import (
+    PDFExporter,
+    _md_to_html,
+    _verdict_class,
+)
+from desktop.state.database import (
+    AlertHistoryRow,
+    AlertRow,
+    HistoryDB,
+    RecommendationRow,
+)
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Recommendation Extractor
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestParsePrice:
+    """Tests for the _parse_price_str helper."""
+
+    @pytest.mark.unit
+    def test_english_decimal(self) -> None:
+        assert _parse_price_str("89.17") == 89.17
+
+    @pytest.mark.unit
+    def test_russian_decimal(self) -> None:
+        assert _parse_price_str("89,17") == 89.17
+
+    @pytest.mark.unit
+    def test_thousands_separator(self) -> None:
+        assert _parse_price_str("1,283") == 1283.0
+
+    @pytest.mark.unit
+    def test_thousands_with_decimal(self) -> None:
+        assert _parse_price_str("2,850.50") == 2850.50
+
+    @pytest.mark.unit
+    def test_integer(self) -> None:
+        assert _parse_price_str("77") == 77.0
+
+    @pytest.mark.unit
+    def test_empty_string(self) -> None:
+        assert _parse_price_str("") is None
+
+    @pytest.mark.unit
+    def test_russian_decimal_94_70(self) -> None:
+        assert _parse_price_str("94,70") == 94.70
+
+
+class TestFirstPrice:
+    """Tests for _first_price (regex + parsing combined)."""
+
+    @pytest.mark.unit
+    def test_dollar_price(self) -> None:
+        assert _first_price("стоп-лосс $77") == 77.0
+
+    @pytest.mark.unit
+    def test_dollar_with_space(self) -> None:
+        assert _first_price("цена $ 580.25") == 580.25
+
+    @pytest.mark.unit
+    def test_no_dollar(self) -> None:
+        assert _first_price("no price here") is None
+
+
+class TestExtractVerdict:
+    """Tests for _extract_verdict with Russian markdown headers."""
+
+    @pytest.mark.unit
+    def test_header_hold(self) -> None:
+        md = "## Итоговый рейтинг: **HOLD**\nsome text"
+        assert _extract_verdict(md) == "HOLD"
+
+    @pytest.mark.unit
+    def test_header_buy(self) -> None:
+        md = "## ВЕРДИКТ: **BUY**\n\ntext"
+        assert _extract_verdict(md) == "BUY"
+
+    @pytest.mark.unit
+    def test_header_sell_no_bold(self) -> None:
+        md = "### Рейтинг: SELL\ntext"
+        assert _extract_verdict(md) == "SELL"
+
+    @pytest.mark.unit
+    def test_header_overweight(self) -> None:
+        md = "## Итоговый рейтинг: **OVERWEIGHT**\nsome body"
+        assert _extract_verdict(md) == "OVERWEIGHT"
+
+    @pytest.mark.unit
+    def test_header_underweight(self) -> None:
+        md = "## Рейтинг: **Underweight**"
+        assert _extract_verdict(md) == "UNDERWEIGHT"
+
+    @pytest.mark.unit
+    def test_bold_fallback(self) -> None:
+        md = "# Title\nsome intro\n**SELL** is the recommendation\n" + "\n" * 30
+        assert _extract_verdict(md) == "SELL"
+
+    @pytest.mark.unit
+    def test_bare_keyword_fallback(self) -> None:
+        md = "# Report\nWe recommend BUY\nmore text"
+        assert _extract_verdict(md) == "BUY"
+
+    @pytest.mark.unit
+    def test_unknown_when_missing(self) -> None:
+        md = "# Report\nNo clear recommendation\n" * 20
+        assert _extract_verdict(md) == "UNKNOWN"
+
+
+class TestExtractConfidence:
+    """Tests for _extract_confidence."""
+
+    @pytest.mark.unit
+    def test_russian_confidence(self) -> None:
+        md = "Убеждённость: 8/10"
+        assert _extract_confidence(md) == 8
+
+    @pytest.mark.unit
+    def test_english_confidence(self) -> None:
+        md = "confidence: 7/10"
+        assert _extract_confidence(md) == 7
+
+    @pytest.mark.unit
+    def test_iz_pattern(self) -> None:
+        md = "уровень уверенности 9 из 10 баллов"
+        assert _extract_confidence(md) == 9
+
+    @pytest.mark.unit
+    def test_out_of_range_returns_none(self) -> None:
+        md = "Убеждённость: 15/10"
+        assert _extract_confidence(md) is None
+
+    @pytest.mark.unit
+    def test_no_confidence_returns_none(self) -> None:
+        assert _extract_confidence("no confidence info here") is None
+
+
+class TestExtractRecommendation:
+    """Tests for the main extract_recommendation() function."""
+
+    @pytest.mark.unit
+    def test_empty_markdown(self) -> None:
+        rec = extract_recommendation("")
+        assert rec.ticker == "UNKNOWN"
+        assert rec.verdict == "UNKNOWN"
+
+    @pytest.mark.unit
+    def test_empty_with_ticker_override(self) -> None:
+        rec = extract_recommendation("", ticker="AAPL")
+        assert rec.ticker == "AAPL"
+        assert rec.verdict == "UNKNOWN"
+
+    @pytest.mark.unit
+    def test_full_report_extraction(self) -> None:
+        md = """# Вердикт Портфельного Менеджера: NFLX
+
+## Итоговый рейтинг: **HOLD**
+
+Убеждённость: 7/10
+
+Текущая цена $580.25.
+
+| **Стоп-лосс** | **$540** |
+| **Целевая** | **$640** |
+
+Entry trigger: закрытие выше $590
+
+Горизонт пересмотра: 2 недели
+
+## Заключение
+Netflix remains well-positioned despite near-term volatility.
+"""
+        rec = extract_recommendation(md, analysis_id=42)
+        assert rec.ticker == "NFLX"
+        assert rec.verdict == "HOLD"
+        assert rec.confidence == 7
+        assert rec.price_at_analysis == 580.25
+        assert rec.stop_loss == 540.0
+        assert rec.profit_target == 640.0
+        assert rec.entry_trigger == 590.0
+        assert rec.review_date is not None
+        assert rec.notes is not None
+        assert rec.analysis_id == 42
+
+    @pytest.mark.unit
+    def test_ticker_from_instrument_field(self) -> None:
+        md = "# Финальное решение\n**Инструмент:** CRWD (CrowdStrike)\n## Рейтинг: **BUY**"
+        rec = extract_recommendation(md)
+        assert rec.ticker == "CRWD"
+        assert rec.verdict == "BUY"
+
+    @pytest.mark.unit
+    def test_ticker_override_takes_precedence_on_no_match(self) -> None:
+        md = "# Some report with no ticker\n## Рейтинг: **SELL**"
+        rec = extract_recommendation(md, ticker="SPY")
+        assert rec.ticker == "SPY"
+
+    @pytest.mark.unit
+    def test_frozen_dataclass(self) -> None:
+        rec = extract_recommendation("## Рейтинг: **BUY**", ticker="TSLA")
+        with pytest.raises(AttributeError):
+            rec.verdict = "SELL"  # type: ignore[misc]
+
+
+class TestExtractFromFile:
+    """Tests for extract_from_file() reading actual files."""
+
+    @pytest.mark.unit
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        rec = extract_from_file(tmp_path / "nonexistent.md", ticker="ABC")
+        assert rec.ticker == "ABC"
+        assert rec.verdict == "UNKNOWN"
+
+    @pytest.mark.unit
+    def test_valid_file(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "final_trade_decision.md"
+        md_file.write_text(
+            "# Вердикт Портфельного Менеджера: AAPL\n"
+            "## Итоговый рейтинг: **BUY**\n"
+            "Убеждённость: 9/10\n",
+            encoding="utf-8",
+        )
+        rec = extract_from_file(md_file, analysis_id=7)
+        assert rec.ticker == "AAPL"
+        assert rec.verdict == "BUY"
+        assert rec.confidence == 9
+        assert rec.analysis_id == 7
+
+    @pytest.mark.unit
+    def test_empty_file(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "empty.md"
+        md_file.write_text("", encoding="utf-8")
+        rec = extract_from_file(md_file)
+        assert rec.verdict == "UNKNOWN"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. Price Service
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestComputeChangePct:
+    """Tests for _compute_change_pct helper."""
+
+    @pytest.mark.unit
+    def test_positive_change(self) -> None:
+        assert _compute_change_pct(110.0, 100.0) == 10.0
+
+    @pytest.mark.unit
+    def test_negative_change(self) -> None:
+        assert _compute_change_pct(90.0, 100.0) == -10.0
+
+    @pytest.mark.unit
+    def test_none_price(self) -> None:
+        assert _compute_change_pct(None, 100.0) is None
+
+    @pytest.mark.unit
+    def test_none_previous_close(self) -> None:
+        assert _compute_change_pct(100.0, None) is None
+
+    @pytest.mark.unit
+    def test_zero_previous_close(self) -> None:
+        assert _compute_change_pct(100.0, 0.0) is None
+
+
+class TestPriceServiceFetchSingle:
+    """Tests for PriceService._fetch_single with mocked yfinance."""
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_successful_fetch(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=150.50, previous_close=148.00)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=60)
+        result = svc._fetch_single("AAPL", stale_fallback=None)
+
+        assert result.ticker == "AAPL"
+        assert result.price == 150.50
+        assert result.previous_close == 148.00
+        assert result.is_stale is False
+        assert result.error is None
+        assert result.change_pct is not None
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_fetch_returns_none_price(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=None, previous_close=100.0)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=60)
+        result = svc._fetch_single("BAD", stale_fallback=None)
+
+        assert result.price is None
+        assert result.error is not None
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_stale_fallback_on_error(self, mock_yf: MagicMock) -> None:
+        mock_yf.Ticker.side_effect = Exception("Network error")
+
+        stale_result = PriceResult(
+            ticker="AAPL",
+            price=145.0,
+            previous_close=144.0,
+            change_pct=0.6944,
+            is_stale=False,
+            fetched_at="2025-01-01T00:00:00Z",
+            error=None,
+        )
+        stale_fallback = _CachedPrice(
+            result=stale_result,
+            fetched_at_dt=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+        svc = PriceService(ttl_seconds=60)
+        result = svc._fetch_single("AAPL", stale_fallback=stale_fallback)
+
+        assert result.is_stale is True
+        assert result.price == 145.0
+        assert result.error is not None
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_error_result_without_stale(self, mock_yf: MagicMock) -> None:
+        mock_yf.Ticker.side_effect = Exception("Timeout")
+
+        svc = PriceService(ttl_seconds=60)
+        result = svc._fetch_single("AAPL", stale_fallback=None)
+
+        assert result.price is None
+        assert result.error is not None
+        assert result.is_stale is False
+
+
+class TestPriceServiceCache:
+    """Tests for TTL cache behavior."""
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_cache_hit_within_ttl(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=200.0, previous_close=199.0)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=300)
+        result1 = svc.get_price("MSFT")
+        result2 = svc.get_price("MSFT")
+
+        # yfinance should only be called once (second call hits cache)
+        assert mock_yf.Ticker.call_count == 1
+        assert result1.price == result2.price
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_invalidate_single(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=200.0, previous_close=199.0)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=300)
+        svc.get_price("MSFT")
+        svc.invalidate("MSFT")
+        svc.get_price("MSFT")
+
+        # After invalidation, yfinance should be called again
+        assert mock_yf.Ticker.call_count == 2
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_invalidate_all(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=200.0, previous_close=199.0)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=300)
+        svc.get_price("AAPL")
+        svc.get_price("MSFT")
+        svc.invalidate()  # clear all
+        svc.get_price("AAPL")
+
+        # AAPL: first call + after invalidation = at least 2 Ticker calls for AAPL
+        assert mock_yf.Ticker.call_count >= 3
+
+    @pytest.mark.unit
+    def test_yfinance_not_available(self) -> None:
+        with patch("desktop.services.price_service._YF_AVAILABLE", False):
+            svc = PriceService()
+            result = svc.get_price("AAPL")
+            assert result.error is not None
+            assert result.price is None
+
+
+class TestPriceServiceGetPrices:
+    """Tests for batch get_prices."""
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_empty_tickers(self, mock_yf: MagicMock) -> None:
+        svc = PriceService(ttl_seconds=60)
+        result = svc.get_prices([])
+        assert result == {}
+
+    @pytest.mark.unit
+    @patch("desktop.services.price_service._YF_AVAILABLE", True)
+    @patch("desktop.services.price_service.yf")
+    def test_multiple_tickers(self, mock_yf: MagicMock) -> None:
+        fast_info = SimpleNamespace(last_price=100.0, previous_close=99.0)
+        mock_yf.Ticker.return_value.fast_info = fast_info
+
+        svc = PriceService(ttl_seconds=60)
+        results = svc.get_prices(["AAPL", "MSFT", "GOOG"])
+
+        assert len(results) == 3
+        assert "AAPL" in results
+        assert "MSFT" in results
+        assert "GOOG" in results
+        for pr in results.values():
+            assert pr.price == 100.0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Alert Engine
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestAlertEngineMarketHours:
+    """Tests for market hours detection."""
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine.datetime")
+    def test_market_open_weekday(self, mock_dt: MagicMock) -> None:
+        # Wednesday 10:00 ET -> market open
+        mock_now = MagicMock()
+        mock_now.weekday.return_value = 2  # Wednesday
+        mock_now.hour = 10
+        mock_now.minute = 0
+        mock_dt.now.return_value = mock_now
+        assert _is_market_hours() is True
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine.datetime")
+    def test_market_closed_weekend(self, mock_dt: MagicMock) -> None:
+        mock_now = MagicMock()
+        mock_now.weekday.return_value = 5  # Saturday
+        mock_now.hour = 12
+        mock_now.minute = 0
+        mock_dt.now.return_value = mock_now
+        assert _is_market_hours() is False
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine.datetime")
+    def test_market_closed_early_morning(self, mock_dt: MagicMock) -> None:
+        mock_now = MagicMock()
+        mock_now.weekday.return_value = 1  # Tuesday
+        mock_now.hour = 7
+        mock_now.minute = 0
+        mock_dt.now.return_value = mock_now
+        assert _is_market_hours() is False
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine.datetime")
+    def test_market_closed_after_hours(self, mock_dt: MagicMock) -> None:
+        mock_now = MagicMock()
+        mock_now.weekday.return_value = 3  # Thursday
+        mock_now.hour = 17
+        mock_now.minute = 0
+        mock_dt.now.return_value = mock_now
+        assert _is_market_hours() is False
+
+
+class TestAlertEngineIsTriggered:
+    """Tests for AlertEngine._is_triggered static method."""
+
+    @pytest.mark.unit
+    def test_above_triggered(self) -> None:
+        alert = AlertRow(
+            id=1, recommendation_id=1, ticker="AAPL",
+            alert_type="profit_target", target_price=200.0,
+            direction="above", triggered_at=None, triggered_price=None,
+            is_active=1, created_at="2025-01-01",
+        )
+        assert AlertEngine._is_triggered(alert, 200.0) is True
+        assert AlertEngine._is_triggered(alert, 210.0) is True
+        assert AlertEngine._is_triggered(alert, 199.99) is False
+
+    @pytest.mark.unit
+    def test_below_triggered(self) -> None:
+        alert = AlertRow(
+            id=2, recommendation_id=1, ticker="AAPL",
+            alert_type="stop_loss", target_price=150.0,
+            direction="below", triggered_at=None, triggered_price=None,
+            is_active=1, created_at="2025-01-01",
+        )
+        assert AlertEngine._is_triggered(alert, 150.0) is True
+        assert AlertEngine._is_triggered(alert, 140.0) is True
+        assert AlertEngine._is_triggered(alert, 150.01) is False
+
+    @pytest.mark.unit
+    def test_unknown_direction(self) -> None:
+        alert = AlertRow(
+            id=3, recommendation_id=1, ticker="AAPL",
+            alert_type="custom", target_price=100.0,
+            direction="sideways", triggered_at=None, triggered_price=None,
+            is_active=1, created_at="2025-01-01",
+        )
+        assert AlertEngine._is_triggered(alert, 100.0) is False
+
+
+class TestAlertEngineLifecycle:
+    """Tests for AlertEngine start/stop lifecycle."""
+
+    @pytest.mark.unit
+    def test_start_stop(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        engine = AlertEngine(db=db, price_service=price_svc)
+        assert engine.is_running is False
+
+        engine.start()
+        assert engine.is_running is True
+
+        engine.stop()
+        assert engine.is_running is False
+
+    @pytest.mark.unit
+    def test_double_start_is_idempotent(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        engine = AlertEngine(db=db, price_service=price_svc)
+        engine.start()
+        engine.start()  # Should not raise
+        assert engine.is_running is True
+        engine.stop()
+
+    @pytest.mark.unit
+    def test_stop_without_start(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        engine = AlertEngine(db=db, price_service=price_svc)
+        engine.stop()  # Should not raise
+        assert engine.is_running is False
+
+    @pytest.mark.unit
+    def test_on_alert_callback_registration(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        engine = AlertEngine(db=db, price_service=price_svc)
+        callback = MagicMock()
+        engine.on_alert(callback)
+        assert callback in engine._callbacks
+
+    @pytest.mark.unit
+    def test_initial_properties(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        engine = AlertEngine(db=db, price_service=price_svc)
+        assert engine.is_degraded is False
+        assert engine.backoff_seconds == 0
+        assert engine.last_poll_at is None
+        assert engine.unseen_count == 0
+
+
+class TestAlertEnginePollInterval:
+    """Tests for adaptive poll interval."""
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine._is_market_hours", return_value=True)
+    def test_market_hours_interval(self, _mock: MagicMock) -> None:
+        assert _poll_interval() == 300  # 5 min
+
+    @pytest.mark.unit
+    @patch("desktop.services.alert_engine._is_market_hours", return_value=False)
+    def test_off_hours_interval(self, _mock: MagicMock) -> None:
+        assert _poll_interval() == 1800  # 30 min
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Outcome Tracker
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOutcomeTrackerHelpers:
+    """Tests for outcome tracker helper functions."""
+
+    @pytest.mark.unit
+    def test_days_since_recent(self) -> None:
+        # 1 day ago
+        one_day_ago = (datetime.now(tz=timezone.utc) - timedelta(days=1)).isoformat()
+        result = _days_since(one_day_ago)
+        assert 0.9 < result < 1.1
+
+    @pytest.mark.unit
+    def test_days_since_naive_datetime(self) -> None:
+        # Should handle naive datetimes (treated as UTC)
+        naive_iso = datetime.now(tz=timezone.utc).replace(
+            tzinfo=None,
+        ).isoformat()
+        result = _days_since(naive_iso)
+        assert 0.0 <= result < 0.01
+
+    @pytest.mark.unit
+    def test_check_stop_hit_true(self) -> None:
+        rec = _make_recommendation_row(stop_loss=100.0)
+        assert _check_stop_hit(99.0, rec) is True
+        assert _check_stop_hit(100.0, rec) is True
+
+    @pytest.mark.unit
+    def test_check_stop_hit_false(self) -> None:
+        rec = _make_recommendation_row(stop_loss=100.0)
+        assert _check_stop_hit(101.0, rec) is False
+
+    @pytest.mark.unit
+    def test_check_stop_hit_none(self) -> None:
+        rec = _make_recommendation_row(stop_loss=None)
+        assert _check_stop_hit(99.0, rec) is False
+
+    @pytest.mark.unit
+    def test_check_target_hit_true(self) -> None:
+        rec = _make_recommendation_row(profit_target=200.0)
+        assert _check_target_hit(200.0, rec) is True
+        assert _check_target_hit(210.0, rec) is True
+
+    @pytest.mark.unit
+    def test_check_target_hit_false(self) -> None:
+        rec = _make_recommendation_row(profit_target=200.0)
+        assert _check_target_hit(199.0, rec) is False
+
+    @pytest.mark.unit
+    def test_check_target_hit_none(self) -> None:
+        rec = _make_recommendation_row(profit_target=None)
+        assert _check_target_hit(300.0, rec) is False
+
+    @pytest.mark.unit
+    def test_compute_return_pct_positive(self) -> None:
+        assert _compute_return_pct(100.0, 110.0) == 10.0
+
+    @pytest.mark.unit
+    def test_compute_return_pct_negative(self) -> None:
+        assert _compute_return_pct(100.0, 90.0) == -10.0
+
+    @pytest.mark.unit
+    def test_compute_return_pct_none_base(self) -> None:
+        assert _compute_return_pct(None, 100.0) == 0.0
+
+    @pytest.mark.unit
+    def test_compute_return_pct_zero_base(self) -> None:
+        assert _compute_return_pct(0.0, 100.0) == 0.0
+
+
+class TestOutcomeTrackerLifecycle:
+    """Tests for OutcomeTracker start/stop."""
+
+    @pytest.mark.unit
+    def test_start_stop(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        tracker = OutcomeTracker(db=db, price_service=price_svc)
+        tracker.start()
+        # Give it a moment for the initial check to complete
+        time.sleep(0.05)
+        tracker.stop()
+
+    @pytest.mark.unit
+    def test_double_start_is_idempotent(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        tracker = OutcomeTracker(db=db, price_service=price_svc)
+        tracker.start()
+        tracker.start()  # Should not raise, should be no-op
+        time.sleep(0.05)
+        tracker.stop()
+
+    @pytest.mark.unit
+    def test_stop_without_start(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        tracker = OutcomeTracker(db=db, price_service=price_svc)
+        tracker.stop()  # Should not raise
+
+    @pytest.mark.unit
+    def test_run_check_empty_db(self, tmp_path: Path) -> None:
+        db = HistoryDB(db_path=tmp_path / "test.db")
+        price_svc = PriceService(ttl_seconds=60)
+
+        tracker = OutcomeTracker(db=db, price_service=price_svc)
+        recorded = tracker.run_check()
+        assert recorded == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Scheduler — CronExpr parsing
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCronExprParse:
+    """Tests for CronExpr.parse with various expression formats."""
+
+    @pytest.mark.unit
+    def test_basic_time(self) -> None:
+        expr = CronExpr.parse("08:30")
+        assert expr.hour == 8
+        assert expr.minute == 30
+        assert expr.weekdays == frozenset()
+
+    @pytest.mark.unit
+    def test_weekday_range(self) -> None:
+        expr = CronExpr.parse("08:30 MON-FRI")
+        assert expr.hour == 8
+        assert expr.minute == 30
+        assert expr.weekdays == frozenset({0, 1, 2, 3, 4})
+
+    @pytest.mark.unit
+    def test_specific_days(self) -> None:
+        expr = CronExpr.parse("06:00 MON,WED,FRI")
+        assert expr.weekdays == frozenset({0, 2, 4})
+
+    @pytest.mark.unit
+    def test_wildcard_days(self) -> None:
+        expr = CronExpr.parse("09:00 *")
+        assert expr.weekdays == frozenset()
+
+    @pytest.mark.unit
+    def test_midnight(self) -> None:
+        expr = CronExpr.parse("00:00")
+        assert expr.hour == 0
+        assert expr.minute == 0
+
+    @pytest.mark.unit
+    def test_end_of_day(self) -> None:
+        expr = CronExpr.parse("23:59")
+        assert expr.hour == 23
+        assert expr.minute == 59
+
+    @pytest.mark.unit
+    def test_weekend_only(self) -> None:
+        expr = CronExpr.parse("10:00 SAT,SUN")
+        assert expr.weekdays == frozenset({5, 6})
+
+    @pytest.mark.unit
+    def test_wrap_around_range(self) -> None:
+        expr = CronExpr.parse("09:00 FRI-MON")
+        assert expr.weekdays == frozenset({4, 5, 6, 0})
+
+    @pytest.mark.unit
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="Empty"):
+            CronExpr.parse("")
+
+    @pytest.mark.unit
+    def test_no_colon_raises(self) -> None:
+        with pytest.raises(ValueError, match="Expected HH:MM"):
+            CronExpr.parse("0830")
+
+    @pytest.mark.unit
+    def test_invalid_hour_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid time"):
+            CronExpr.parse("25:00")
+
+    @pytest.mark.unit
+    def test_invalid_minute_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid time"):
+            CronExpr.parse("08:61")
+
+    @pytest.mark.unit
+    def test_unknown_day_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown day"):
+            CronExpr.parse("08:00 BLAH")
+
+    @pytest.mark.unit
+    def test_unknown_day_in_range_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown day"):
+            CronExpr.parse("08:00 MON-XYZ")
+
+
+class TestCronExprNextFireTime:
+    """Tests for CronExpr.next_fire_time."""
+
+    @pytest.mark.unit
+    def test_later_today(self) -> None:
+        expr = CronExpr(hour=14, minute=0, weekdays=frozenset())
+        after = datetime(2025, 6, 10, 10, 0, 0)  # Tuesday 10:00
+        nft = expr.next_fire_time(after)
+        assert nft == datetime(2025, 6, 10, 14, 0, 0)
+
+    @pytest.mark.unit
+    def test_tomorrow_when_past_time(self) -> None:
+        expr = CronExpr(hour=8, minute=0, weekdays=frozenset())
+        after = datetime(2025, 6, 10, 15, 0, 0)  # Tuesday 15:00, target 08:00
+        nft = expr.next_fire_time(after)
+        assert nft == datetime(2025, 6, 11, 8, 0, 0)
+
+    @pytest.mark.unit
+    def test_weekday_filter_skips_weekend(self) -> None:
+        expr = CronExpr(hour=9, minute=0, weekdays=frozenset({0, 1, 2, 3, 4}))
+        # Friday 17:00 -> next valid is Monday 09:00
+        after = datetime(2025, 6, 13, 17, 0, 0)  # Friday
+        nft = expr.next_fire_time(after)
+        assert nft.weekday() == 0  # Monday
+        assert nft == datetime(2025, 6, 16, 9, 0, 0)
+
+    @pytest.mark.unit
+    def test_exact_time_advances(self) -> None:
+        expr = CronExpr(hour=8, minute=30, weekdays=frozenset())
+        # At exactly 08:30, should return the NEXT occurrence (tomorrow)
+        after = datetime(2025, 6, 10, 8, 30, 0)
+        nft = expr.next_fire_time(after)
+        assert nft == datetime(2025, 6, 11, 8, 30, 0)
+
+    @pytest.mark.unit
+    def test_single_day_filter(self) -> None:
+        expr = CronExpr(hour=10, minute=0, weekdays=frozenset({2}))  # Wednesday
+        after = datetime(2025, 6, 9, 12, 0, 0)  # Monday
+        nft = expr.next_fire_time(after)
+        assert nft.weekday() == 2  # Wednesday
+        assert nft == datetime(2025, 6, 11, 10, 0, 0)
+
+
+class TestCronExprHumanLabel:
+    """Tests for CronExpr.human_label."""
+
+    @pytest.mark.unit
+    def test_every_day(self) -> None:
+        expr = CronExpr(hour=8, minute=30, weekdays=frozenset())
+        assert expr.human_label() == "08:30 Every day"
+
+    @pytest.mark.unit
+    def test_weekdays(self) -> None:
+        expr = CronExpr(hour=6, minute=0, weekdays=frozenset({0, 2, 4}))
+        label = expr.human_label()
+        assert "06:00" in label
+        assert "Mon" in label
+        assert "Wed" in label
+        assert "Fri" in label
+
+
+class TestSchedulerLifecycle:
+    """Tests for Scheduler start/stop and arm/disarm."""
+
+    @pytest.mark.unit
+    def test_start_stop(self, tmp_path: Path) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        runner = MagicMock()
+        runner.is_running = False
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        assert scheduler.is_running is False
+
+        scheduler.start()
+        assert scheduler.is_running is True
+        db.list_schedules.assert_called_once()
+
+        scheduler.stop()
+        assert scheduler.is_running is False
+
+    @pytest.mark.unit
+    def test_double_start_is_idempotent(self) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+        scheduler.start()  # Should not raise, db only queried once
+        assert db.list_schedules.call_count == 1
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_stop_without_start(self) -> None:
+        db = MagicMock()
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.stop()  # Should not raise
+
+    @pytest.mark.unit
+    def test_add_and_remove_schedule(self) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        db.update_schedule_next_run = MagicMock()
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+
+        # Arm a new schedule
+        scheduler.add_schedule(1, "09:00 MON-FRI", "America/New_York")
+        assert 1 in scheduler._timers
+
+        # Disarm it
+        scheduler.remove_schedule(1)
+        assert 1 not in scheduler._timers
+
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_reload_schedule(self) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        db.update_schedule_next_run = MagicMock()
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+
+        scheduler.add_schedule(5, "08:00 MON-FRI", "UTC")
+        scheduler.reload_schedule(5, "07:30 MON-FRI", "UTC")
+        assert 5 in scheduler._timers
+
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_arm_invalid_cron_does_not_raise(self) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+
+        # Invalid cron should be logged but not raise
+        scheduler.add_schedule(99, "not-a-cron", "UTC")
+        assert 99 not in scheduler._timers
+
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_remove_nonexistent_schedule(self) -> None:
+        db = MagicMock()
+        db.list_schedules.return_value = []
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+        scheduler.remove_schedule(999)  # Should not raise
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_start_with_enabled_schedules(self) -> None:
+        sched_row = SimpleNamespace(
+            id=1,
+            name="Pre-market",
+            watchlist="AAPL,MSFT",
+            cron_expr="08:30 MON-FRI",
+            timezone="America/New_York",
+            is_enabled=1,
+            last_run=None,
+            next_run=None,
+            created_at="2025-01-01",
+        )
+        db = MagicMock()
+        db.list_schedules.return_value = [sched_row]
+        db.update_schedule_next_run = MagicMock()
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+
+        assert 1 in scheduler._timers
+        scheduler.stop()
+
+    @pytest.mark.unit
+    def test_start_skips_disabled_schedules(self) -> None:
+        sched_row = SimpleNamespace(
+            id=2,
+            name="Disabled",
+            watchlist="GOOG",
+            cron_expr="06:00",
+            timezone="UTC",
+            is_enabled=0,
+            last_run=None,
+            next_run=None,
+            created_at="2025-01-01",
+        )
+        db = MagicMock()
+        db.list_schedules.return_value = [sched_row]
+        runner = MagicMock()
+        callback = MagicMock()
+
+        scheduler = Scheduler(db=db, runner=runner, run_analysis=callback)
+        scheduler.start()
+
+        assert 2 not in scheduler._timers
+        scheduler.stop()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. PDF Export
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVerdictClass:
+    """Tests for _verdict_class CSS mapping."""
+
+    @pytest.mark.unit
+    def test_buy(self) -> None:
+        assert _verdict_class("BUY") == "verdict-buy"
+
+    @pytest.mark.unit
+    def test_overweight(self) -> None:
+        assert _verdict_class("OVERWEIGHT") == "verdict-buy"
+
+    @pytest.mark.unit
+    def test_sell(self) -> None:
+        assert _verdict_class("SELL") == "verdict-sell"
+
+    @pytest.mark.unit
+    def test_underweight(self) -> None:
+        assert _verdict_class("UNDERWEIGHT") == "verdict-sell"
+
+    @pytest.mark.unit
+    def test_hold(self) -> None:
+        assert _verdict_class("HOLD") == "verdict-hold"
+
+    @pytest.mark.unit
+    def test_unknown_verdict(self) -> None:
+        assert _verdict_class("UNKNOWN") == "verdict-default"
+
+    @pytest.mark.unit
+    def test_case_insensitive(self) -> None:
+        assert _verdict_class("buy") == "verdict-buy"
+        assert _verdict_class("sell") == "verdict-sell"
+
+
+class TestMdToHtml:
+    """Tests for _md_to_html conversion."""
+
+    @pytest.mark.unit
+    def test_fallback_without_markdown2(self) -> None:
+        with patch("desktop.services.pdf_export._MD_AVAILABLE", False):
+            result = _md_to_html("# Hello **World**")
+            assert "<pre>" in result
+            # HTML should be escaped in fallback
+            assert "&lt;" not in result or "Hello" in result
+
+    @pytest.mark.unit
+    def test_with_markdown2(self) -> None:
+        # Only test if markdown2 is actually available
+        try:
+            import markdown2  # noqa: F401
+        except ImportError:
+            pytest.skip("markdown2 not installed")
+
+        result = _md_to_html("# Hello\n\n**Bold text**")
+        assert "<h1>" in result or "<strong>" in result
+
+
+class TestPDFExporterWithoutWeasyprint:
+    """Tests for PDFExporter that verify behavior without weasyprint."""
+
+    @pytest.mark.unit
+    def test_export_analysis_raises_without_weasyprint(self, tmp_path: Path) -> None:
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            side_effect=ImportError("weasyprint not installed"),
+        ):
+            with pytest.raises(ImportError, match="weasyprint"):
+                exporter.export_analysis(
+                    result_dir=tmp_path,
+                    ticker="AAPL",
+                    verdict="BUY",
+                    date="2025-01-01",
+                )
+
+    @pytest.mark.unit
+    def test_export_summary_raises_without_weasyprint(self) -> None:
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            side_effect=ImportError("weasyprint not installed"),
+        ):
+            with pytest.raises(ImportError, match="weasyprint"):
+                exporter.export_summary(
+                    recommendations=[],
+                    prices={},
+                )
+
+    @pytest.mark.unit
+    def test_export_analysis_with_mocked_weasyprint(self, tmp_path: Path) -> None:
+        # Create a fake markdown file in result_dir
+        md_file = tmp_path / "report.md"
+        md_file.write_text("# Test Report\n\nSome content.", encoding="utf-8")
+
+        mock_weasyprint = MagicMock()
+        mock_html_instance = MagicMock()
+        mock_weasyprint.HTML.return_value = mock_html_instance
+
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            return_value=mock_weasyprint,
+        ):
+            result_path = exporter.export_analysis(
+                result_dir=tmp_path,
+                ticker="AAPL",
+                verdict="BUY",
+                date="2025-01-01",
+            )
+
+        assert "AAPL" in str(result_path)
+        assert "2025-01-01" in str(result_path)
+        mock_weasyprint.HTML.assert_called_once()
+        mock_html_instance.write_pdf.assert_called_once()
+
+    @pytest.mark.unit
+    def test_export_analysis_no_md_files(self, tmp_path: Path) -> None:
+        mock_weasyprint = MagicMock()
+        mock_weasyprint.HTML.return_value = MagicMock()
+
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            return_value=mock_weasyprint,
+        ):
+            exporter.export_analysis(
+                result_dir=tmp_path,
+                ticker="MSFT",
+                verdict="HOLD",
+                date="2025-06-01",
+            )
+
+        # Verify HTML was generated (contains "No report files found")
+        call_args = mock_weasyprint.HTML.call_args
+        html_content = call_args[1]["string"] if "string" in call_args[1] else call_args[0][0]
+        assert "No report files found" in html_content
+
+    @pytest.mark.unit
+    def test_export_analysis_escapes_html(self, tmp_path: Path) -> None:
+        mock_weasyprint = MagicMock()
+        mock_weasyprint.HTML.return_value = MagicMock()
+
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            return_value=mock_weasyprint,
+        ):
+            exporter.export_analysis(
+                result_dir=tmp_path,
+                ticker="<script>alert('xss')</script>",
+                verdict="BUY",
+                date="2025-01-01",
+            )
+
+        call_args = mock_weasyprint.HTML.call_args
+        html_content = call_args[1]["string"] if "string" in call_args[1] else call_args[0][0]
+        # The raw script tag should be escaped
+        assert "<script>" not in html_content
+        assert "&lt;script&gt;" in html_content
+
+    @pytest.mark.unit
+    def test_export_summary_with_mocked_weasyprint(self) -> None:
+        rec = SimpleNamespace(
+            ticker="AAPL",
+            verdict="BUY",
+            confidence=8,
+            price_at_analysis=150.0,
+        )
+        price_result = PriceResult(
+            ticker="AAPL",
+            price=155.0,
+            previous_close=150.0,
+            change_pct=3.33,
+            is_stale=False,
+            fetched_at="2025-01-01T00:00:00Z",
+            error=None,
+        )
+
+        mock_weasyprint = MagicMock()
+        mock_weasyprint.HTML.return_value = MagicMock()
+
+        exporter = PDFExporter()
+        with patch(
+            "desktop.services.pdf_export._require_weasyprint",
+            return_value=mock_weasyprint,
+        ):
+            with patch("desktop.services.pdf_export.Path.home") as mock_home:
+                mock_home.return_value = Path("/tmp/test_home")
+                result_path = exporter.export_summary(
+                    recommendations=[rec],
+                    prices={"AAPL": price_result},
+                )
+
+        assert "summary_" in str(result_path)
+        mock_weasyprint.HTML.assert_called_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _make_recommendation_row(
+    *,
+    stop_loss: float | None = None,
+    profit_target: float | None = None,
+    price_at_analysis: float | None = 100.0,
+) -> RecommendationRow:
+    """Build a RecommendationRow with sensible defaults for tests."""
+    return RecommendationRow(
+        id=1,
+        analysis_id=1,
+        ticker="TEST",
+        verdict="HOLD",
+        confidence=5,
+        price_at_analysis=price_at_analysis,
+        stop_loss=stop_loss,
+        entry_trigger=None,
+        profit_target=profit_target,
+        review_date=None,
+        is_active=1,
+        created_at=datetime.now(tz=timezone.utc).isoformat(),
+        deactivated_at=None,
+        notes=None,
+    )

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -5,65 +5,178 @@ from tradingagents.agents.utils.agent_utils import (
     get_cashflow,
     get_fundamentals,
     get_income_statement,
-    get_insider_transactions,
     get_language_instruction,
+    supports_tool_calls,
 )
-from tradingagents.dataflows.config import get_config
 
 
 def create_fundamentals_analyst(llm):
     def fundamentals_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        ticker = state["company_of_interest"]
+        instrument_context = build_instrument_context(ticker)
 
-        tools = [
-            get_fundamentals,
-            get_balance_sheet,
-            get_cashflow,
-            get_income_statement,
-        ]
-
-        system_message = (
-            "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
-            + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
-            + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
-            + get_language_instruction(),
-        )
-
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                (
-                    "system",
-                    "You are a helpful AI assistant, collaborating with other assistants."
-                    " Use the provided tools to progress towards answering the question."
-                    " If you are unable to fully answer, that's OK; another assistant with different tools"
-                    " will help where you left off. Execute what you can to make progress."
-                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
-                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
-                ),
-                MessagesPlaceholder(variable_name="messages"),
-            ]
-        )
-
-        prompt = prompt.partial(system_message=system_message)
-        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
-        prompt = prompt.partial(current_date=current_date)
-        prompt = prompt.partial(instrument_context=instrument_context)
-
-        chain = prompt | llm.bind_tools(tools)
-
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
-
-        return {
-            "messages": [result],
-            "fundamentals_report": report,
-        }
+        if supports_tool_calls(llm):
+            return _tool_call_path(llm, state, current_date, ticker, instrument_context)
+        return _prefetch_path(llm, state, current_date, ticker, instrument_context)
 
     return fundamentals_analyst_node
+
+
+# ── Tool-call path (API providers) ────────────────────────────────────────
+
+def _tool_call_path(llm, state, current_date, ticker, instrument_context):
+    """Original flow: bind_tools → LLM selects and calls tools."""
+    tools = [
+        get_fundamentals,
+        get_balance_sheet,
+        get_cashflow,
+        get_income_statement,
+    ]
+
+    system_message = (
+        "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+        + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
+        + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
+        + get_language_instruction()
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " Use the provided tools to progress towards answering the question."
+                " If you are unable to fully answer, that's OK; another assistant with different tools"
+                " will help where you left off. Execute what you can to make progress."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                " You have access to the following tools: {tool_names}.\n{system_message}"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+        ]
+    )
+
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm.bind_tools(tools)
+
+    result = chain.invoke(state["messages"])
+
+    report = ""
+    if len(result.tool_calls) == 0:
+        report = result.content
+
+    return {
+        "messages": [result],
+        "fundamentals_report": report,
+    }
+
+
+# ── Pre-fetch path (CLI provider) ────────────────────────────────────────
+
+def _prefetch_path(llm, state, current_date, ticker, instrument_context):
+    """Pre-fetch all financial data and inject into prompt."""
+    def _safe_fetch(fn, *args):
+        try:
+            return fn(*args)
+        except Exception as e:
+            return f"<unavailable: {e}>"
+
+    fundamentals_data = _safe_fetch(get_fundamentals.func, ticker, current_date)
+    balance_sheet_data = _safe_fetch(get_balance_sheet.func, ticker, "quarterly", current_date)
+    cashflow_data = _safe_fetch(get_cashflow.func, ticker, "quarterly", current_date)
+    income_data = _safe_fetch(get_income_statement.func, ticker, "quarterly", current_date)
+
+    system_message = _build_prefetch_system_message(
+        ticker=ticker,
+        current_date=current_date,
+        fundamentals_data=fundamentals_data,
+        balance_sheet_data=balance_sheet_data,
+        cashflow_data=cashflow_data,
+        income_data=income_data,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                "\n{system_message}\n"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+        ]
+    )
+
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm
+    result = chain.invoke(state["messages"])
+
+    return {
+        "messages": [result],
+        "fundamentals_report": result.content,
+    }
+
+
+# ── System message for pre-fetch path ────────────────────────────────────
+
+def _build_prefetch_system_message(
+    *,
+    ticker: str,
+    current_date: str,
+    fundamentals_data: str,
+    balance_sheet_data: str,
+    cashflow_data: str,
+    income_data: str,
+) -> str:
+    """Assemble the fundamentals analyst system message with pre-fetched data."""
+    return f"""You are a researcher tasked with analyzing fundamental information about {ticker} as of {current_date}. All financial data has been pre-fetched and is included below.
+
+## Data sources (pre-fetched, in this prompt)
+
+### Company Fundamentals
+Comprehensive overview: profile, key metrics, valuation ratios, growth rates.
+
+<start_of_fundamentals>
+{fundamentals_data}
+<end_of_fundamentals>
+
+### Balance Sheet (Quarterly)
+
+<start_of_balance_sheet>
+{balance_sheet_data}
+<end_of_balance_sheet>
+
+### Cash Flow Statement (Quarterly)
+
+<start_of_cashflow>
+{cashflow_data}
+<end_of_cashflow>
+
+### Income Statement (Quarterly)
+
+<start_of_income_statement>
+{income_data}
+<end_of_income_statement>
+
+## Instructions
+
+1. Analyze the company profile, sector positioning, and competitive landscape.
+2. Evaluate financial health: liquidity, solvency, and profitability trends across quarters.
+3. Assess cash flow quality: operating cash flow vs net income, capex trends, free cash flow.
+4. Identify revenue growth trends, margin compression/expansion, and earnings quality.
+5. Flag any red flags: declining margins, rising debt, cash burn, or accounting anomalies.
+6. Write a comprehensive fundamental analysis report with specific, actionable insights.
+7. Append a Markdown table at the end summarizing key financial metrics and their implications.
+
+{get_language_instruction()}"""

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,26 +1,150 @@
+from datetime import datetime, timedelta
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_indicators,
     get_language_instruction,
     get_stock_data,
+    supports_tool_calls,
 )
-from tradingagents.dataflows.config import get_config
+
+
+# All indicator keys the market analyst may select from.
+_ALL_INDICATORS = (
+    "close_50_sma", "close_200_sma", "close_10_ema",
+    "macd", "macds", "macdh",
+    "rsi",
+    "boll", "boll_ub", "boll_lb", "atr",
+    "vwma",
+)
+
+
+def _seven_days_back(trade_date: str) -> str:
+    return (datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
 
 
 def create_market_analyst(llm):
 
     def market_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        ticker = state["company_of_interest"]
+        instrument_context = build_instrument_context(ticker)
 
-        tools = [
-            get_stock_data,
-            get_indicators,
+        if supports_tool_calls(llm):
+            return _tool_call_path(llm, state, current_date, ticker, instrument_context)
+        return _prefetch_path(llm, state, current_date, ticker, instrument_context)
+
+    return market_analyst_node
+
+
+# ── Tool-call path (API providers) ────────────────────────────────────────
+
+def _tool_call_path(llm, state, current_date, ticker, instrument_context):
+    """Original flow: bind_tools → LLM selects and calls tools."""
+    tools = [get_stock_data, get_indicators]
+
+    system_message = _base_system_message()
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " Use the provided tools to progress towards answering the question."
+                " If you are unable to fully answer, that's OK; another assistant with different tools"
+                " will help where you left off. Execute what you can to make progress."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                " You have access to the following tools: {tool_names}.\n{system_message}"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
         ]
+    )
 
-        system_message = (
-            """You are a trading assistant tasked with analyzing financial markets. Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy. Categories and each category's indicators are:
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm.bind_tools(tools)
+    result = chain.invoke(state["messages"])
+
+    report = ""
+    if len(result.tool_calls) == 0:
+        report = result.content
+
+    return {
+        "messages": [result],
+        "market_report": report,
+    }
+
+
+# ── Pre-fetch path (CLI provider) ────────────────────────────────────────
+
+def _prefetch_path(llm, state, current_date, ticker, instrument_context):
+    """Pre-fetch all data and inject into prompt (no tool-calling needed)."""
+    start_date = _seven_days_back(current_date)
+
+    # Fetch stock price data
+    try:
+        stock_data = get_stock_data.func(ticker, start_date, current_date)
+    except Exception as e:
+        stock_data = f"<unavailable: {e}>"
+
+    # Fetch all indicators — let the LLM pick what's relevant
+    indicator_blocks: list[str] = []
+    for ind in _ALL_INDICATORS:
+        try:
+            result = get_indicators.func(ticker, ind, current_date, 30)
+            indicator_blocks.append(f"### {ind}\n{result}")
+        except Exception as e:
+            indicator_blocks.append(f"### {ind}\n<unavailable: {e}>")
+
+    indicators_text = "\n\n".join(indicator_blocks)
+
+    system_message = _build_prefetch_system_message(
+        ticker=ticker,
+        start_date=start_date,
+        end_date=current_date,
+        stock_data=stock_data,
+        indicators_text=indicators_text,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                "\n{system_message}\n"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+        ]
+    )
+
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm
+    result = chain.invoke(state["messages"])
+
+    return {
+        "messages": [result],
+        "market_report": result.content,
+    }
+
+
+# ── System messages ──────────────────────────────────────────────────────
+
+def _base_system_message() -> str:
+    """System message for the tool-calling path (unchanged from original)."""
+    return (
+        """You are a trading assistant tasked with analyzing financial markets. Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy. Categories and each category's indicators are:
 
 Moving Averages:
 - close_50_sma: 50 SMA: A medium-term trend indicator. Usage: Identify trend direction and serve as dynamic support/resistance. Tips: It lags price; combine with faster indicators for timely signals.
@@ -45,44 +169,45 @@ Volume-Based Indicators:
 - vwma: VWMA: A moving average weighted by volume. Usage: Confirm trends by integrating price action with volume data. Tips: Watch for skewed results from volume spikes; use in combination with other volume analyses.
 
 - Select indicators that provide diverse and complementary information. Avoid redundancy (e.g., do not select both rsi and stochrsi). Also briefly explain why they are suitable for the given market context. When you tool call, please use the exact name of the indicators provided above as they are defined parameters, otherwise your call will fail. Please make sure to call get_stock_data first to retrieve the CSV that is needed to generate indicators. Then use get_indicators with the specific indicator names. Write a very detailed and nuanced report of the trends you observe. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."""
-            + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
-            + get_language_instruction()
-        )
+        + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
+        + get_language_instruction()
+    )
 
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                (
-                    "system",
-                    "You are a helpful AI assistant, collaborating with other assistants."
-                    " Use the provided tools to progress towards answering the question."
-                    " If you are unable to fully answer, that's OK; another assistant with different tools"
-                    " will help where you left off. Execute what you can to make progress."
-                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
-                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
-                ),
-                MessagesPlaceholder(variable_name="messages"),
-            ]
-        )
 
-        prompt = prompt.partial(system_message=system_message)
-        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
-        prompt = prompt.partial(current_date=current_date)
-        prompt = prompt.partial(instrument_context=instrument_context)
+def _build_prefetch_system_message(
+    *,
+    ticker: str,
+    start_date: str,
+    end_date: str,
+    stock_data: str,
+    indicators_text: str,
+) -> str:
+    """System message for the pre-fetch path with data already injected."""
+    return f"""You are a trading assistant tasked with analyzing financial markets for {ticker} over the period {start_date} to {end_date}.
 
-        chain = prompt | llm.bind_tools(tools)
+All market data has been pre-fetched and is included below. Select the **most relevant indicators** (up to 8) from the data for the current market context. Provide diverse and complementary insights without redundancy.
 
-        result = chain.invoke(state["messages"])
+## Stock Price Data (OHLCV)
 
-        report = ""
+<start_of_stock_data>
+{stock_data}
+<end_of_stock_data>
 
-        if len(result.tool_calls) == 0:
-            report = result.content
+## Technical Indicators
 
-        return {
-            "messages": [result],
-            "market_report": report,
-        }
+All available indicators are below. Select the most relevant ones for your analysis and explain why they are suitable for the current market conditions.
 
-    return market_analyst_node
+<start_of_indicators>
+{indicators_text}
+<end_of_indicators>
+
+## Instructions
+
+1. Analyze the stock price data for trends, support/resistance, and volume patterns.
+2. Select up to 8 of the most relevant indicators from the data above.
+3. For each selected indicator, explain why it is suitable for the current market context.
+4. Write a very detailed and nuanced report of the trends you observe.
+5. Provide specific, actionable insights with supporting evidence to help traders make informed decisions.
+6. Append a Markdown table at the end summarizing key points.
+
+{get_language_instruction()}"""

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,62 +1,168 @@
+from datetime import datetime, timedelta
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_global_news,
     get_language_instruction,
     get_news,
+    supports_tool_calls,
 )
-from tradingagents.dataflows.config import get_config
+
+
+def _seven_days_back(trade_date: str) -> str:
+    return (datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
 
 
 def create_news_analyst(llm):
     def news_analyst_node(state):
         current_date = state["trade_date"]
-        instrument_context = build_instrument_context(state["company_of_interest"])
+        ticker = state["company_of_interest"]
+        instrument_context = build_instrument_context(ticker)
 
-        tools = [
-            get_news,
-            get_global_news,
-        ]
-
-        system_message = (
-            "You are a news researcher tasked with analyzing recent news and trends over the past week. Please write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics. Use the available tools: get_news(query, start_date, end_date) for company-specific or targeted news searches, and get_global_news(curr_date, look_back_days, limit) for broader macroeconomic news. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
-            + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
-            + get_language_instruction()
-        )
-
-        prompt = ChatPromptTemplate.from_messages(
-            [
-                (
-                    "system",
-                    "You are a helpful AI assistant, collaborating with other assistants."
-                    " Use the provided tools to progress towards answering the question."
-                    " If you are unable to fully answer, that's OK; another assistant with different tools"
-                    " will help where you left off. Execute what you can to make progress."
-                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
-                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
-                ),
-                MessagesPlaceholder(variable_name="messages"),
-            ]
-        )
-
-        prompt = prompt.partial(system_message=system_message)
-        prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
-        prompt = prompt.partial(current_date=current_date)
-        prompt = prompt.partial(instrument_context=instrument_context)
-
-        chain = prompt | llm.bind_tools(tools)
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
-
-        return {
-            "messages": [result],
-            "news_report": report,
-        }
+        if supports_tool_calls(llm):
+            return _tool_call_path(llm, state, current_date, ticker, instrument_context)
+        return _prefetch_path(llm, state, current_date, ticker, instrument_context)
 
     return news_analyst_node
+
+
+# ── Tool-call path (API providers) ────────────────────────────────────────
+
+def _tool_call_path(llm, state, current_date, ticker, instrument_context):
+    """Original flow: bind_tools → LLM selects and calls tools."""
+    tools = [get_news, get_global_news]
+
+    system_message = (
+        "You are a news researcher tasked with analyzing recent news and trends over the past week. Please write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics. Use the available tools: get_news(query, start_date, end_date) for company-specific or targeted news searches, and get_global_news(curr_date, look_back_days, limit) for broader macroeconomic news. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+        + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
+        + get_language_instruction()
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " Use the provided tools to progress towards answering the question."
+                " If you are unable to fully answer, that's OK; another assistant with different tools"
+                " will help where you left off. Execute what you can to make progress."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                " You have access to the following tools: {tool_names}.\n{system_message}"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+        ]
+    )
+
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm.bind_tools(tools)
+    result = chain.invoke(state["messages"])
+
+    report = ""
+    if len(result.tool_calls) == 0:
+        report = result.content
+
+    return {
+        "messages": [result],
+        "news_report": report,
+    }
+
+
+# ── Pre-fetch path (CLI provider) ────────────────────────────────────────
+
+def _prefetch_path(llm, state, current_date, ticker, instrument_context):
+    """Pre-fetch news data and inject into prompt (no tool-calling needed)."""
+    start_date = _seven_days_back(current_date)
+
+    # Fetch ticker-specific news
+    try:
+        ticker_news = get_news.func(ticker, start_date, current_date)
+    except Exception as e:
+        ticker_news = f"<unavailable: {e}>"
+
+    # Fetch global macro news
+    try:
+        global_news = get_global_news.func(current_date, None, None)
+    except Exception as e:
+        global_news = f"<unavailable: {e}>"
+
+    system_message = _build_prefetch_system_message(
+        ticker=ticker,
+        start_date=start_date,
+        end_date=current_date,
+        ticker_news=ticker_news,
+        global_news=global_news,
+    )
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful AI assistant, collaborating with other assistants."
+                " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
+                " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
+                "\n{system_message}\n"
+                "For your reference, the current date is {current_date}. {instrument_context}",
+            ),
+            MessagesPlaceholder(variable_name="messages"),
+        ]
+    )
+
+    prompt = prompt.partial(system_message=system_message)
+    prompt = prompt.partial(current_date=current_date)
+    prompt = prompt.partial(instrument_context=instrument_context)
+
+    chain = prompt | llm
+    result = chain.invoke(state["messages"])
+
+    return {
+        "messages": [result],
+        "news_report": result.content,
+    }
+
+
+# ── System message for pre-fetch path ────────────────────────────────────
+
+def _build_prefetch_system_message(
+    *,
+    ticker: str,
+    start_date: str,
+    end_date: str,
+    ticker_news: str,
+    global_news: str,
+) -> str:
+    """Assemble the news analyst system message with pre-fetched data."""
+    return f"""You are a news researcher tasked with analyzing recent news and trends over the past week for {ticker}, covering {start_date} to {end_date}. All news data has been pre-fetched and is included below.
+
+## Data sources (pre-fetched, in this prompt)
+
+### Ticker-specific news — {ticker}
+Company-specific news, earnings, product announcements, analyst ratings.
+
+<start_of_ticker_news>
+{ticker_news}
+<end_of_ticker_news>
+
+### Global / macroeconomic news
+Broader market, Fed policy, GDP, geopolitical, sector-wide trends.
+
+<start_of_global_news>
+{global_news}
+<end_of_global_news>
+
+## Instructions
+
+1. Analyze the ticker-specific news for material events, catalysts, and sentiment shifts.
+2. Analyze the global news for macroeconomic factors that impact {ticker} and its sector.
+3. Identify connections between ticker-specific and macro news (e.g., sector rotation, policy impact).
+4. Write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics.
+5. Provide specific, actionable insights with supporting evidence to help traders make informed decisions.
+6. Append a Markdown table at the end summarizing key points, organized and easy to read.
+
+{get_language_instruction()}"""

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -20,6 +20,16 @@ from tradingagents.agents.utils.news_data_tools import (
 )
 
 
+def supports_tool_calls(llm: object) -> bool:
+    """Check whether the LLM supports native tool-calling.
+
+    Returns True for all standard API-backed LLMs (the default).
+    Returns False for providers like ClaudeCLIChat that pre-fetch data
+    instead of using bind_tools().
+    """
+    return getattr(llm, "supports_tool_calls", True)
+
+
 def get_language_instruction() -> str:
     """Return a prompt instruction for the configured output language.
 

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -20,6 +20,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from tradingagents.dataflows.ssl_helpers import default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 _API = "https://www.reddit.com/r/{sub}/search.json?{qs}"
@@ -47,7 +49,7 @@ def _fetch_subreddit(
     url = _API.format(sub=sub, qs=qs)
     req = Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
     try:
-        with urlopen(req, timeout=timeout) as resp:
+        with urlopen(req, timeout=timeout, context=default_ssl_context()) as resp:
             payload = json.loads(resp.read())
     except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as exc:
         logger.warning("Reddit fetch failed for r/%s · %s: %s", sub, ticker, exc)

--- a/tradingagents/dataflows/ssl_helpers.py
+++ b/tradingagents/dataflows/ssl_helpers.py
@@ -1,0 +1,39 @@
+"""Shared SSL context for outbound HTTP requests.
+
+macOS ships Python *without* linking the system certificate store into
+``ssl.create_default_context()``.  The well-known symptom is::
+
+    SSL: CERTIFICATE_VERIFY_FAILED — unable to get local issuer certificate
+
+The ``certifi`` package (a transitive dependency of ``requests``, which is
+already in the project requirements) bundles Mozilla's root CA bundle.
+Building the default context with ``cafile=certifi.where()`` fixes the
+problem on every platform without requiring the user to manually run
+``/Applications/Python 3.x/Install Certificates.command``.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def default_ssl_context() -> ssl.SSLContext:
+    """Return a cached SSL context with proper CA certificates.
+
+    Tries ``certifi`` first (works everywhere, including macOS).
+    Falls back to the platform default (works on most Linux distros).
+    """
+    try:
+        import certifi  # noqa: WPS433 — optional runtime import
+
+        ctx = ssl.create_default_context(cafile=certifi.where())
+        logger.debug("SSL context built with certifi CA bundle")
+        return ctx
+    except ImportError:
+        logger.debug("certifi not installed; using platform default SSL context")
+        return ssl.create_default_context()

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -21,6 +21,8 @@ from typing import Optional
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from tradingagents.dataflows.ssl_helpers import default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 _API = "https://api.stocktwits.com/api/2/streams/symbol/{ticker}.json"
@@ -38,7 +40,7 @@ def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.
     url = _API.format(ticker=ticker.upper())
     req = Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
     try:
-        with urlopen(req, timeout=timeout) as resp:
+        with urlopen(req, timeout=timeout, context=default_ssl_context()) as resp:
             data = json.loads(resp.read())
     except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as exc:
         logger.warning("StockTwits fetch failed for %s: %s", ticker, exc)

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -291,8 +291,21 @@ class TradingAgentsGraph:
         if updates:
             self.memory_log.batch_update_with_outcomes(updates)
 
-    def propagate(self, company_name, trade_date):
+    def propagate(self, company_name, trade_date, *, on_chunk=None):
         """Run the trading agents graph for a company on a specific date.
+
+        Parameters
+        ----------
+        company_name : str
+            Ticker symbol to analyse.
+        trade_date : str
+            Date string in ``YYYY-MM-DD`` format.
+        on_chunk : callable, optional
+            ``on_chunk(chunk: dict) -> None`` is invoked for every streamed
+            chunk when the graph runs in streaming mode (``debug=True`` or
+            when the desktop app drives the pipeline).  The callback runs
+            on the **pipeline thread** -- the caller is responsible for
+            cross-thread dispatch if needed.
 
         When ``checkpoint_enabled`` is set in config, the graph is recompiled
         with a per-ticker SqliteSaver so a crashed run can resume from the last
@@ -322,15 +335,22 @@ class TradingAgentsGraph:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
         try:
-            return self._run_graph(company_name, trade_date)
+            return self._run_graph(company_name, trade_date, on_chunk=on_chunk)
         finally:
             if self._checkpointer_ctx is not None:
                 self._checkpointer_ctx.__exit__(None, None, None)
                 self._checkpointer_ctx = None
                 self.graph = self.workflow.compile()
 
-    def _run_graph(self, company_name, trade_date):
-        """Execute the graph and write the resulting state to disk and memory log."""
+    def _run_graph(self, company_name, trade_date, *, on_chunk=None):
+        """Execute the graph and write the resulting state to disk and memory log.
+
+        Parameters
+        ----------
+        on_chunk : callable, optional
+            Forwarded from ``propagate()``.  Called with each streamed chunk
+            dict so UI layers can react in real time.
+        """
         # Initialize state — inject memory log context for PM.
         past_context = self.memory_log.get_past_context(company_name)
         init_agent_state = self.propagator.create_initial_state(
@@ -343,14 +363,14 @@ class TradingAgentsGraph:
             tid = thread_id(company_name, str(trade_date))
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
 
-        if self.debug:
+        if self.debug or on_chunk is not None:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
-                if len(chunk["messages"]) == 0:
-                    pass
-                else:
+                if on_chunk is not None:
+                    on_chunk(dict(chunk))  # shallow copy so callback can't mutate trace
+                if self.debug and chunk.get("messages"):
                     chunk["messages"][-1].pretty_print()
-                    trace.append(chunk)
+                trace.append(chunk)
             # Streamed chunks are per-node deltas. Merge them so the returned
             # state matches what graph.invoke() yields in the non-debug path.
             final_state = {}

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -39,7 +39,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_global_news
 )
 
-from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
+from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, has_checkpoint, thread_id
 from .conditional_logic import ConditionalLogic
 from .setup import GraphSetup
 from .propagation import Propagator
@@ -359,13 +359,22 @@ class TradingAgentsGraph:
         args = self.propagator.get_graph_args()
 
         # Inject thread_id so same ticker+date resumes, different date starts fresh.
+        # When resuming from a checkpoint, pass None instead of init_agent_state
+        # so LangGraph picks up from the last saved node (not starting over).
+        resuming = False
         if self.config.get("checkpoint_enabled"):
             tid = thread_id(company_name, str(trade_date))
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
+            resuming = has_checkpoint(
+                self.config["data_cache_dir"], company_name, str(trade_date)
+            )
+
+        # None = resume from checkpoint; init_agent_state = fresh start
+        graph_input = None if resuming else init_agent_state
 
         if self.debug or on_chunk is not None:
             trace = []
-            for chunk in self.graph.stream(init_agent_state, **args):
+            for chunk in self.graph.stream(graph_input, **args):
                 if on_chunk is not None:
                     on_chunk(dict(chunk))  # shallow copy so callback can't mutate trace
                 if self.debug and chunk.get("messages"):
@@ -377,7 +386,7 @@ class TradingAgentsGraph:
             for chunk in trace:
                 final_state.update(chunk)
         else:
-            final_state = self.graph.invoke(init_agent_state, **args)
+            final_state = self.graph.invoke(graph_input, **args)
 
         # Store current state for reflection.
         self.curr_state = final_state

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -32,6 +32,8 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "openrouter": "OPENROUTER_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
+    # Claude CLI authenticates via 'claude auth login' session, not an API key.
+    "claude_cli": None,
 }
 
 

--- a/tradingagents/llm_clients/claude_cli_chat.py
+++ b/tradingagents/llm_clients/claude_cli_chat.py
@@ -1,0 +1,406 @@
+"""LangChain BaseChatModel backed by the ``claude -p`` CLI subprocess.
+
+Each ``invoke()`` call spawns a fresh ``claude -p`` process, pipes the
+formatted prompt via stdin, and parses the JSON response. This lets
+users with a Claude Max subscription run the full TradingAgents pipeline
+at $0 additional API cost.
+
+Design notes
+------------
+- **No tool-call support.** ``supports_tool_calls`` is ``False`` so
+  analyst nodes can branch to the pre-fetch path instead of ``bind_tools``.
+- **Subprocess-per-call.** No persistent daemon; auth is handled by the
+  user's existing ``claude auth login`` session.
+- **JSON output.** ``--output-format json`` gives structured
+  ``{"result": "..."}`` output, eliminating ANSI-escape parsing.
+- **stdin pipe.** Prompts are piped via stdin to avoid shell arg-length
+  limits (debate histories can be 10-20 K tokens).
+
+See also: PLAN.md Phase 1, Task 1.1.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from typing import Any, Optional, Sequence
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+logger = logging.getLogger(__name__)
+
+# Defaults -----------------------------------------------------------------
+
+_DEFAULT_TIMEOUT_S = 300  # Opus reasoning can be slow
+_DEFAULT_MAX_RETRIES = 3
+_RETRY_BASE_DELAY_S = 2.0
+_CLAUDE_BIN = "claude"
+
+
+def _find_claude_binary() -> str:
+    """Return the absolute path to the ``claude`` binary, or raise."""
+    path = shutil.which(_CLAUDE_BIN)
+    if path is None:
+        raise FileNotFoundError(
+            f"'{_CLAUDE_BIN}' not found on PATH. Install Claude Code CLI "
+            "and run 'claude auth login' first."
+        )
+    return path
+
+
+# Environment --------------------------------------------------------------
+
+def _minimal_env() -> dict[str, str]:
+    """Build a minimal environment for the claude subprocess.
+
+    Only forward variables the CLI actually needs — PATH, HOME, auth
+    config dirs. This avoids leaking unrelated API keys (OPENAI_API_KEY,
+    etc.) into the subprocess as a defense-in-depth measure.
+    """
+    env: dict[str, str] = {}
+    for key in (
+        "PATH", "HOME", "USER", "TERM", "LANG", "SHELL",
+        # Claude CLI config / auth directories
+        "CLAUDE_CONFIG_DIR", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+        # macOS keychain access
+        "TMPDIR",
+    ):
+        val = os.environ.get(key)
+        if val is not None:
+            env[key] = val
+    return env
+
+
+# Message formatting -------------------------------------------------------
+
+def _extract_text(content: Any) -> str:
+    """Extract plain text from LangChain message content.
+
+    Content can be a string, a list of typed blocks (e.g.
+    ``[{"type": "text", "text": "..."}]``), or something else.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            item.get("text", "") if isinstance(item, dict) else str(item)
+            for item in content
+        )
+    return str(content)
+
+
+def _format_messages(messages: Sequence[BaseMessage]) -> tuple[str, str]:
+    """Convert LangChain messages to (system_prompt, user_prompt) strings.
+
+    Returns a 2-tuple so the system message can be passed via
+    ``--system-prompt`` and the rest via stdin. If there is no explicit
+    system message, the system prompt is empty and everything goes to
+    stdin.
+    """
+    system_parts: list[str] = []
+    conversation_parts: list[str] = []
+
+    for msg in messages:
+        text = _extract_text(msg.content)
+        if isinstance(msg, SystemMessage):
+            system_parts.append(text)
+        elif isinstance(msg, HumanMessage):
+            conversation_parts.append(f"[Human]\n{text}")
+        elif isinstance(msg, AIMessage):
+            conversation_parts.append(f"[Assistant]\n{text}")
+        else:
+            # ToolMessage, FunctionMessage, etc. — stringify generically
+            role = getattr(msg, "type", "unknown")
+            conversation_parts.append(f"[{role}]\n{text}")
+
+    system_prompt = "\n\n".join(system_parts)
+    user_prompt = "\n\n".join(conversation_parts)
+    return system_prompt, user_prompt
+
+
+# Subprocess call ----------------------------------------------------------
+
+def _call_cli(
+    user_prompt: str,
+    *,
+    system_prompt: str = "",
+    model: str | None = None,
+    timeout: int = _DEFAULT_TIMEOUT_S,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
+    claude_bin: str | None = None,
+) -> str:
+    """Run ``claude -p`` and return the response text.
+
+    Retries with exponential back-off on transient errors (timeout,
+    non-zero exit). Raises on permanent failures after exhausting retries.
+    """
+    bin_path = claude_bin or _find_claude_binary()
+
+    cmd: list[str] = [bin_path, "-p", "--output-format", "json"]
+    if system_prompt:
+        cmd += ["--system-prompt", system_prompt]
+    if model:
+        cmd += ["--model", model]
+
+    env = _minimal_env()
+    last_error: Exception | None = None
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            logger.debug(
+                "claude -p attempt %d/%d  prompt=%d chars  system=%d chars",
+                attempt,
+                max_retries,
+                len(user_prompt),
+                len(system_prompt),
+            )
+            proc = subprocess.run(
+                cmd,
+                input=user_prompt.encode("utf-8"),
+                capture_output=True,
+                timeout=timeout,
+                env=env,
+            )
+
+            stdout = proc.stdout.decode("utf-8", errors="replace").strip()
+            stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+
+            if proc.returncode != 0:
+                error_detail = stderr or stdout or f"exit code {proc.returncode}"
+                # Check for rate limiting keywords
+                combined = (stderr + stdout).lower()
+                if any(kw in combined for kw in ("rate", "limit", "429", "throttl")):
+                    logger.warning("Rate limited on attempt %d: %s", attempt, error_detail)
+                    _backoff(attempt)
+                    last_error = RuntimeError(f"CLI rate limited: {error_detail}")
+                    continue
+
+                # Auth errors are permanent — don't retry
+                if "401" in combined or "authentication" in combined:
+                    raise RuntimeError(
+                        f"Claude CLI authentication failed: {error_detail}. "
+                        "Run 'claude auth login' in a terminal."
+                    )
+
+                logger.warning("CLI error attempt %d: %s", attempt, error_detail)
+                last_error = RuntimeError(f"claude -p failed: {error_detail}")
+                _backoff(attempt)
+                continue
+
+            if not stdout:
+                logger.warning("Empty stdout on attempt %d", attempt)
+                last_error = RuntimeError("claude -p returned empty output")
+                _backoff(attempt)
+                continue
+
+            # Parse JSON response — extract the "result" field
+            return _parse_json_response(stdout)
+
+        except subprocess.TimeoutExpired:
+            logger.warning("Timeout (%ds) on attempt %d/%d", timeout, attempt, max_retries)
+            last_error = TimeoutError(
+                f"claude -p timed out after {timeout}s on attempt {attempt}"
+            )
+            _backoff(attempt)
+            continue
+
+    raise last_error or RuntimeError("claude -p failed after all retries")
+
+
+def _parse_json_response(raw: str) -> str:
+    """Extract the LLM response text from ``--output-format json`` output.
+
+    Expected shape::
+
+        {
+          "type": "result",
+          "subtype": "success",
+          "result": "<actual LLM text>",
+          ...
+        }
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Do NOT silently accept garbage — raise so the retry loop can handle it.
+        # Truncated output (e.g. from a killed subprocess) would otherwise
+        # propagate through the pipeline as a corrupt "report".
+        logger.warning("Failed to parse JSON from claude output: %.200s", raw)
+        raise RuntimeError(
+            f"Claude CLI returned invalid JSON (possibly truncated): {raw[:200]}"
+        )
+
+    if isinstance(data, dict):
+        if data.get("is_error"):
+            error_msg = data.get("result", "Unknown CLI error")
+            raise RuntimeError(f"Claude CLI returned error: {error_msg}")
+        result = data.get("result")
+        if result is not None:
+            return str(result)
+
+    # Unexpected shape — return stringified output
+    logger.warning("Unexpected JSON shape from claude CLI: %s", type(data))
+    return raw
+
+
+def _backoff(attempt: int) -> None:
+    """Exponential back-off sleep, capped at 60 seconds."""
+    delay = min(_RETRY_BASE_DELAY_S * (2 ** (attempt - 1)), 60.0)
+    logger.debug("Backing off %.1fs before retry", delay)
+    time.sleep(delay)
+
+
+def _apply_stop_sequences(text: str, stop: list[str] | None) -> str:
+    """Truncate ``text`` at the first occurrence of any stop sequence."""
+    if not stop:
+        return text
+    earliest_idx = len(text)
+    for seq in stop:
+        idx = text.find(seq)
+        if idx != -1 and idx < earliest_idx:
+            earliest_idx = idx
+    return text[:earliest_idx]
+
+
+# LangChain BaseChatModel --------------------------------------------------
+
+class ClaudeCLIChat(BaseChatModel):
+    """LangChain chat model that delegates to ``claude -p`` subprocess.
+
+    Parameters
+    ----------
+    model_name : str
+        Model identifier passed to ``--model`` flag. When ``None``, the
+        CLI uses whatever model is configured in the user's session.
+    timeout : int
+        Per-call subprocess timeout in seconds (default 300).
+    max_retries : int
+        Retries with exponential back-off (default 3).
+
+    Attributes
+    ----------
+    supports_tool_calls : bool
+        Always ``False``. Analyst nodes check this property to decide
+        whether to use the pre-fetch path or ``bind_tools``.
+    """
+
+    model_name: Optional[str] = None
+    timeout: int = _DEFAULT_TIMEOUT_S
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    _claude_bin: str = ""
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def model_post_init(self, __context: Any) -> None:
+        """Resolve the claude binary path once at construction time."""
+        super().model_post_init(__context)
+        self._claude_bin = _find_claude_binary()
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def _llm_type(self) -> str:
+        return "claude_cli"
+
+    @property
+    def supports_tool_calls(self) -> bool:
+        """Signal to analyst nodes that tool-calling is not available."""
+        return False
+
+    # ------------------------------------------------------------------
+    # Tool-call guard
+    # ------------------------------------------------------------------
+
+    def bind_tools(
+        self,
+        tools: Sequence[Any],
+        *,
+        tool_choice: Any = None,
+        **kwargs: Any,
+    ) -> "ClaudeCLIChat":
+        """No-op override — returns ``self`` unchanged.
+
+        The ``claude -p`` CLI does not support native tool-calling.
+        Analyst nodes that use ``bind_tools`` will get back this same
+        model instance. Because the LLM response will never contain
+        ``tool_calls``, the existing analyst code already falls through
+        to treating ``result.content`` as the report (e.g.
+        ``market_analyst.py`` checks ``len(result.tool_calls) == 0``).
+
+        Phase 2 (pre-fetch refactor) will add a ``supports_tool_calls``
+        guard so analysts pre-fetch data into the prompt instead.
+        """
+        logger.warning(
+            "bind_tools() called on ClaudeCLIChat (no-op) — "
+            "%d tools ignored: %s. This should only happen during "
+            "initialization, not during active inference.",
+            len(tools),
+            [getattr(t, "name", str(t)) for t in tools],
+        )
+        return self
+
+    def with_structured_output(self, schema: Any, **kwargs: Any) -> Any:
+        """Not supported — raise with a clear message."""
+        raise NotImplementedError(
+            "ClaudeCLIChat does not support structured output. "
+            "The claude -p CLI has no JSON-mode or tool-calling support. "
+            "Use the pre-fetch pattern instead."
+        )
+
+    # ------------------------------------------------------------------
+    # Core generation
+    # ------------------------------------------------------------------
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Synchronous generation via ``claude -p``."""
+        system_prompt, user_prompt = _format_messages(messages)
+
+        # Fall back to runtime lookup if _claude_bin was lost (e.g. after
+        # serialization/deserialization — Pydantic private attrs don't survive).
+        claude_bin = self._claude_bin or _find_claude_binary()
+
+        response_text = _call_cli(
+            user_prompt,
+            system_prompt=system_prompt,
+            model=self.model_name,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            claude_bin=claude_bin,
+        )
+
+        # Honour stop sequences by truncating output (CR-02 fix)
+        response_text = _apply_stop_sequences(response_text, stop)
+
+        message = AIMessage(content=response_text)
+        generation = ChatGeneration(message=message)
+        return ChatResult(generations=[generation])
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {
+            "model_name": self.model_name,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+        }

--- a/tradingagents/llm_clients/claude_cli_client.py
+++ b/tradingagents/llm_clients/claude_cli_client.py
@@ -1,0 +1,69 @@
+"""LLM client for the Claude CLI (``claude -p``) provider.
+
+Follows the same ``BaseLLMClient`` contract as ``anthropic_client.py``
+and ``openai_client.py``.  The key difference: no API key is required.
+Auth is handled by the user's existing ``claude auth login`` session
+(Claude Max subscription).
+
+See also: PLAN.md Phase 1, Task 1.2.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from .base_client import BaseLLMClient
+from .claude_cli_chat import ClaudeCLIChat, _find_claude_binary
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeCLIClient(BaseLLMClient):
+    """Client for Claude CLI (``claude -p``) provider.
+
+    Both ``deep_think_llm`` and ``quick_think_llm`` route through the
+    same CLI binary — model selection is handled by the ``--model`` flag
+    (or the user's default session model when ``model`` is ``None``).
+    """
+
+    def __init__(
+        self,
+        model: str,
+        base_url: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(model, base_url, **kwargs)
+
+    def get_llm(self) -> Any:
+        """Return a configured :class:`ClaudeCLIChat` instance.
+
+        Validates that the ``claude`` binary exists on PATH before
+        constructing the model. Raises ``FileNotFoundError`` if missing.
+        """
+        self._validate_cli_available()
+
+        llm_kwargs: dict[str, Any] = {}
+
+        # model_name=None means "use whatever the CLI session default is"
+        if self.model and self.model != "default":
+            llm_kwargs["model_name"] = self.model
+
+        # Forward optional config overrides
+        if "timeout" in self.kwargs:
+            llm_kwargs["timeout"] = int(self.kwargs["timeout"])
+        if "max_retries" in self.kwargs:
+            llm_kwargs["max_retries"] = int(self.kwargs["max_retries"])
+
+        return ClaudeCLIChat(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        """Any model string is accepted — the CLI validates server-side."""
+        if self.model and self.model != "default":
+            logger.debug("Claude CLI will use model=%s (validated server-side)", self.model)
+        return True
+
+    @staticmethod
+    def _validate_cli_available() -> None:
+        """Raise early if ``claude`` is not on PATH."""
+        _find_claude_binary()  # raises FileNotFoundError with clear message

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -54,4 +54,8 @@ def create_llm_client(
         from .azure_client import AzureOpenAIClient
         return AzureOpenAIClient(model, base_url, **kwargs)
 
+    if provider_lower == "claude_cli":
+        from .claude_cli_client import ClaudeCLIClient
+        return ClaudeCLIClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/progress.py
+++ b/tradingagents/progress.py
@@ -1,0 +1,248 @@
+"""Thread-safe progress tracker for the TradingAgents pipeline.
+
+Shared data layer between CLI (Rich TUI) and Desktop (NiceGUI).
+The pipeline thread writes updates; the UI thread reads snapshots.
+All public methods are protected by a ``threading.Lock``.
+
+See also: PLAN-desktop.md, Phase 1.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime
+import logging
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+# Fixed teams that always run (not user-selectable)
+FIXED_AGENTS: dict[str, list[str]] = {
+    "Research Team": ["Bull Researcher", "Bear Researcher", "Research Manager"],
+    "Trading Team": ["Trader"],
+    "Risk Management": [
+        "Aggressive Analyst",
+        "Neutral Analyst",
+        "Conservative Analyst",
+    ],
+    "Portfolio Management": ["Portfolio Manager"],
+}
+
+# Analyst key -> display name
+ANALYST_MAPPING: dict[str, str] = {
+    "market": "Market Analyst",
+    "social": "Sentiment Analyst",
+    "news": "News Analyst",
+    "fundamentals": "Fundamentals Analyst",
+}
+
+# Report section -> (analyst_key for filtering, finalizing_agent)
+# analyst_key ``None`` means the section is always included.
+REPORT_SECTIONS: dict[str, tuple[str | None, str]] = {
+    "market_report": ("market", "Market Analyst"),
+    "sentiment_report": ("social", "Sentiment Analyst"),
+    "news_report": ("news", "News Analyst"),
+    "fundamentals_report": ("fundamentals", "Fundamentals Analyst"),
+    "investment_plan": (None, "Research Manager"),
+    "trader_investment_plan": (None, "Trader"),
+    "final_trade_decision": (None, "Portfolio Manager"),
+}
+
+SECTION_TITLES: dict[str, str] = {
+    "market_report": "Market Analysis",
+    "sentiment_report": "Social Sentiment",
+    "news_report": "News Analysis",
+    "fundamentals_report": "Fundamentals Analysis",
+    "investment_plan": "Research Team Decision",
+    "trader_investment_plan": "Trading Team Plan",
+    "final_trade_decision": "Portfolio Management Decision",
+}
+
+# ── Immutable snapshot returned to UI ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ProgressSnapshot:
+    """Read-only snapshot of pipeline progress.
+
+    Returned by ``ProgressTracker.snapshot()`` for safe cross-thread
+    consumption. All fields are copies -- mutating them does not affect
+    the tracker.
+    """
+
+    agent_status: dict[str, str]
+    report_sections: dict[str, str | None]
+    messages: list[tuple[str, str, str]]
+    tool_calls: list[tuple[str, str, Any]]
+    current_agent: str | None
+    selected_analysts: list[str]
+    last_activity: datetime.datetime | None
+
+
+# ── Thread-safe tracker ──────────────────────────────────────────────────
+
+
+class ProgressTracker:
+    """Thread-safe progress state shared between pipeline and UI.
+
+    The pipeline thread calls ``add_message``, ``update_agent_status``,
+    etc.  The UI thread calls ``snapshot()`` to get an immutable copy
+    of the current state.
+
+    Parameters
+    ----------
+    max_messages : int
+        Maximum number of messages and tool calls to retain (FIFO).
+    """
+
+    def __init__(self, max_messages: int = 100) -> None:
+        self._lock = threading.Lock()
+        self._max_messages = max_messages
+
+        # Mutable state -- only written under lock
+        self._agent_status: dict[str, str] = {}
+        self._report_sections: dict[str, str | None] = {}
+        self._messages: deque[tuple[str, str, str]] = deque(maxlen=max_messages)
+        self._tool_calls: deque[tuple[str, str, Any]] = deque(maxlen=max_messages)
+        self._current_agent: str | None = None
+        self._selected_analysts: list[str] = []
+        self._processed_message_ids: set[str] = set()
+        self._last_activity: datetime.datetime | None = None
+
+    # ── Initialization ───────────────────────────────────────────────
+
+    def init_for_analysis(self, selected_analysts: list[str]) -> None:
+        """Reset and configure for a new analysis run.
+
+        Must be called before the pipeline starts streaming.
+        """
+        with self._lock:
+            analysts = [a.lower() for a in selected_analysts]
+            self._selected_analysts = analysts
+
+            # Build agent_status dynamically
+            self._agent_status = {}
+            for key in analysts:
+                name = ANALYST_MAPPING.get(key)
+                if name:
+                    self._agent_status[name] = "pending"
+            for team_agents in FIXED_AGENTS.values():
+                for agent in team_agents:
+                    self._agent_status[agent] = "pending"
+
+            # Build report_sections dynamically
+            self._report_sections = {}
+            for section, (analyst_key, _) in REPORT_SECTIONS.items():
+                if analyst_key is None or analyst_key in analysts:
+                    self._report_sections[section] = None
+
+            # Reset transient state
+            self._current_agent = None
+            self._messages.clear()
+            self._tool_calls.clear()
+            self._processed_message_ids.clear()
+            self._last_activity = datetime.datetime.now()
+
+    # ── Pipeline-side writes ─────────────────────────────────────────
+
+    def add_message(self, message_type: str, content: str) -> None:
+        """Append a timestamped message to the log."""
+        with self._lock:
+            now = datetime.datetime.now()
+            ts = now.strftime("%H:%M:%S")
+            self._messages.append((ts, message_type, content))
+            self._last_activity = now
+
+    def add_tool_call(self, tool_name: str, args: Any) -> None:
+        """Record a tool invocation.
+
+        ``args`` is deep-copied so the snapshot never shares mutable
+        references with the caller (CR-01).
+        """
+        safe_args = copy.deepcopy(args)
+        with self._lock:
+            now = datetime.datetime.now()
+            ts = now.strftime("%H:%M:%S")
+            self._tool_calls.append((ts, tool_name, safe_args))
+            self._last_activity = now
+
+    def update_agent_status(self, agent: str, status: str) -> None:
+        """Set an agent's status (pending / in_progress / completed / error)."""
+        with self._lock:
+            if agent in self._agent_status:
+                self._agent_status[agent] = status
+                self._current_agent = agent
+                self._last_activity = datetime.datetime.now()
+            else:
+                logger.warning("Unknown agent %r ignored (known: %s)", agent, list(self._agent_status))
+
+    def update_report_section(self, section_name: str, content: str) -> None:
+        """Store (or overwrite) a report section's content."""
+        with self._lock:
+            if section_name in self._report_sections:
+                self._report_sections[section_name] = content
+                self._last_activity = datetime.datetime.now()
+            else:
+                logger.warning("Unknown report section %r ignored", section_name)
+
+    def has_seen_message(self, message_id: str) -> bool:
+        """Check and mark a message ID as processed (deduplication)."""
+        with self._lock:
+            if message_id in self._processed_message_ids:
+                return True
+            self._processed_message_ids.add(message_id)
+            return False
+
+    # ── UI-side reads ────────────────────────────────────────────────
+
+    def snapshot(self) -> ProgressSnapshot:
+        """Return an immutable copy of the current state.
+
+        Safe to call from any thread. The returned object contains
+        only copies -- the caller can read it at leisure without
+        holding the lock.
+        """
+        with self._lock:
+            return ProgressSnapshot(
+                agent_status=dict(self._agent_status),
+                report_sections=dict(self._report_sections),
+                messages=list(self._messages),
+                tool_calls=list(self._tool_calls),
+                current_agent=self._current_agent,
+                selected_analysts=list(self._selected_analysts),
+                last_activity=self._last_activity,
+            )
+
+    def get_completed_reports_count(self) -> int:
+        """Count reports whose finalizing agent has completed."""
+        with self._lock:
+            count = 0
+            for section in self._report_sections:
+                meta = REPORT_SECTIONS.get(section)
+                if meta is None:
+                    continue
+                _, finalizing_agent = meta
+                has_content = self._report_sections.get(section) is not None
+                agent_done = self._agent_status.get(finalizing_agent) == "completed"
+                if has_content and agent_done:
+                    count += 1
+            return count
+
+    def get_total_reports_count(self) -> int:
+        """Return total number of expected report sections."""
+        with self._lock:
+            return len(self._report_sections)
+
+    def seconds_since_last_activity(self) -> float | None:
+        """Seconds elapsed since the last pipeline write, or None if idle."""
+        with self._lock:
+            if self._last_activity is None:
+                return None
+            delta = datetime.datetime.now() - self._last_activity
+            return delta.total_seconds()


### PR DESCRIPTION
## Summary

- **New `claude_cli` LLM provider** that routes all calls through `claude -p` subprocess, enabling $0 cost for Claude Max subscribers
- **Dual code paths** in market, news, and fundamentals analysts: API providers use original `bind_tools()`, CLI uses pre-fetch pattern with graceful degradation
- **50 new tests** (35 unit + 15 backward-compat) with zero regressions on the full 250-test suite

## Motivation

Users with a Claude Max subscription pay a flat monthly fee but still need separate API keys ($$$) to run TradingAgents. This PR lets them use their existing subscription at zero additional cost by routing LLM calls through the `claude -p` CLI.

## What changed

| File | Change |
|------|--------|
| `tradingagents/llm_clients/claude_cli_chat.py` | New `BaseChatModel` wrapper — subprocess, JSON parsing, retry, minimal env |
| `tradingagents/llm_clients/claude_cli_client.py` | New `BaseLLMClient` implementation |
| `tradingagents/llm_clients/factory.py` | Added `claude_cli` provider |
| `tradingagents/llm_clients/api_key_env.py` | Added `claude_cli: None` (no key needed) |
| `tradingagents/agents/analysts/*.py` | Dual path: `supports_tool_calls()` guard |
| `tradingagents/agents/utils/agent_utils.py` | Shared `supports_tool_calls()` helper |
| `cli/main.py` + `cli/utils.py` | CLI flow: provider selection, binary check |
| `tests/test_claude_cli_chat.py` | 35 unit tests |
| `tests/test_prefetch_analysts.py` | 15 backward-compat tests |

## How it works

1. User selects "Claude CLI (Max subscription, $0 cost)" in the CLI
2. `ClaudeCLIChat._generate()` formats messages → pipes via stdin to `claude -p --output-format json`
3. Analysts check `supports_tool_calls(llm)`:
   - `True` (API) → original `bind_tools()` path
   - `False` (CLI) → pre-fetch data via `.func()`, inject into prompt
4. Graceful degradation: if any data source fails, `<unavailable: error>` is injected instead of crashing

## Test plan

- [x] 35 unit tests for ClaudeCLIChat (message formatting, JSON parsing, stop sequences, retries, auth errors, env isolation)
- [x] 15 backward-compat tests (dual path routing, graceful degradation on data source failures)
- [x] Full suite: 250/250 pass, zero regressions
- [ ] Manual: run `python3 -m cli.main`, select Claude CLI, analyze a ticker end-to-end
- [ ] Manual: verify `claude auth login` error message when not authenticated

## Prerequisites

- Claude Code CLI installed (`npm install -g @anthropic-ai/claude-code`)
- Authenticated via `claude auth login`
- Active Claude Max subscription