### PR TITLE
Skip Anthropic effort for unsupported Claude models

### DIFF
--- a/tests/test_anthropic_effort.py
+++ b/tests/test_anthropic_effort.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tradingagents.llm_clients import anthropic_client as mod
+
+
+@pytest.mark.unit
+def test_haiku_does_not_receive_effort(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        mod,
+        "NormalizedChatAnthropic",
+        lambda **kwargs: captured.setdefault("kwargs", kwargs),
+    )
+
+    client = mod.AnthropicClient(
+        model="claude-haiku-4-5", effort="medium", api_key="placeholder"
+    )
+    client.get_llm()
+
+    assert "effort" not in captured["kwargs"]
+    assert captured["kwargs"]["api_key"] == "placeholder"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-sonnet-4-6",
+    ],
+)
+def test_effort_capable_models_receive_effort(monkeypatch, model):
+    captured = {}
+    monkeypatch.setattr(
+        mod,
+        "NormalizedChatAnthropic",
+        lambda **kwargs: captured.setdefault("kwargs", kwargs),
+    )
+
+    client = mod.AnthropicClient(
+        model=model, effort="medium", api_key="placeholder"
+    )
+    client.get_llm()
+
+    assert captured["kwargs"]["effort"] == "medium"
+

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -10,6 +10,19 @@ _PASSTHROUGH_KWARGS = (
     "callbacks", "http_client", "http_async_client", "effort",
 )
 
+_EFFORT_CAPABLE_MODELS = {
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-6",
+    "claude-mythos-preview",
+}
+
+
+def _supports_effort(model: str) -> bool:
+    """Whether Anthropic accepts the effort parameter for this model."""
+    return model.lower() in _EFFORT_CAPABLE_MODELS
+
 
 class NormalizedChatAnthropic(ChatAnthropic):
     """ChatAnthropic with normalized content output.
@@ -39,6 +52,8 @@ class AnthropicClient(BaseLLMClient):
 
         for key in _PASSTHROUGH_KWARGS:
             if key in self.kwargs:
+                if key == "effort" and not _supports_effort(self.model):
+                    continue
                 llm_kwargs[key] = self.kwargs[key]
 
         return NormalizedChatAnthropic(**llm_kwargs)


### PR DESCRIPTION
## Issue
Closes #831

## Root cause
`anthropic_effort` is currently forwarded to every Anthropic model. Mixed setups that use Haiku as the quick-think model and Opus/Sonnet as the deep-think model therefore send `effort` to Haiku, which rejects the parameter.

## Fix
Add a small Anthropic model capability check before forwarding `effort`. Opus 4.5/4.6/4.7, Sonnet 4.6, and Mythos Preview keep receiving the configured effort value; unsupported models such as Haiku 4.5 omit it while preserving other kwargs.

## Tests
- `uv run --with-editable . --with pytest python -m pytest tests/test_anthropic_effort.py tests/test_model_validation.py`
