### PR TITLE
[codex] feat: add local OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ OPENROUTER_API_KEY=
 # the broader Ollama ecosystem; both the CLI dropdown and programmatic
 # client pick this up.
 #OLLAMA_BASE_URL=http://your-ollama-host:11434/v1
+# Optional: OpenAI-compatible local model servers.
+#LM_STUDIO_BASE_URL=http://localhost:8000/v1
+#LLAMA_CPP_BASE_URL=http://localhost:8001/v1
 
 # Optional: override DEFAULT_CONFIG without editing code.
 # Any TRADINGAGENTS_* variable below, when set, replaces the matching key

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -261,10 +261,11 @@ def select_deep_thinking_agent(provider) -> str:
 
 def select_llm_provider() -> tuple[str, str | None]:
     """Select the LLM provider and its API endpoint."""
-    # Ollama users can point at a remote ollama-serve via OLLAMA_BASE_URL
-    # (convention from the broader Ollama ecosystem); falls back to the
-    # localhost default when unset.
+    # Local OpenAI-compatible runtimes can be remoted via env vars; fall back
+    # to their common localhost defaults when unset.
     ollama_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
+    lm_studio_url = os.environ.get("LM_STUDIO_BASE_URL") or "http://localhost:8000/v1"
+    llama_cpp_url = os.environ.get("LLAMA_CPP_BASE_URL") or "http://localhost:8001/v1"
     # (display_name, provider_key, base_url)
     PROVIDERS = [
         ("OpenAI", "openai", "https://api.openai.com/v1"),
@@ -278,6 +279,8 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", ollama_url),
+        ("LM Studio", "lm-studio", lm_studio_url),
+        ("Llama.cpp", "llama-cpp", llama_cpp_url),
     ]
 
     choice = questionary.select(

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -24,7 +24,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         "qwen", "qwen-cn",
         "glm", "glm-cn",
         "minimax", "minimax-cn",
-        "openrouter", "azure", "ollama",
+        "openrouter", "azure", "ollama", "lm-studio", "llama-cpp",
     }
     assert expected.issubset(PROVIDER_API_KEY_ENV.keys())
 
@@ -51,8 +51,9 @@ def test_known_providers_resolve(provider, env_var):
     assert get_api_key_env(provider) == env_var
 
 
-def test_ollama_has_no_key():
-    assert get_api_key_env("ollama") is None
+@pytest.mark.parametrize("provider", ["ollama", "lm-studio", "llama-cpp"])
+def test_local_runtimes_have_no_key(provider):
+    assert get_api_key_env(provider) is None
 
 
 def test_unknown_provider_returns_none():

--- a/tests/test_local_openai_compatible_providers.py
+++ b/tests/test_local_openai_compatible_providers.py
@@ -1,0 +1,106 @@
+"""Tests for local OpenAI-compatible provider plumbing."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from tradingagents.llm_clients.api_key_env import get_api_key_env
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.model_catalog import get_model_options
+from tradingagents.llm_clients.validators import validate_model
+
+
+def _reload_openai_client():
+    import tradingagents.llm_clients.openai_client as mod
+    return importlib.reload(mod)
+
+
+@pytest.mark.parametrize(
+    "provider,default_url",
+    [
+        ("lm-studio", "http://localhost:8000/v1"),
+        ("llama-cpp", "http://localhost:8001/v1"),
+    ],
+)
+def test_local_provider_default_base_urls(monkeypatch, provider, default_url):
+    monkeypatch.delenv("LM_STUDIO_BASE_URL", raising=False)
+    monkeypatch.delenv("LLAMA_CPP_BASE_URL", raising=False)
+    mod = _reload_openai_client()
+
+    assert mod._resolve_provider_base_url(provider) == default_url
+
+
+def test_local_provider_base_url_env_overrides_are_call_time(monkeypatch):
+    mod = _reload_openai_client()
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://studio-host:9000/v1")
+    monkeypatch.setenv("LLAMA_CPP_BASE_URL", "http://llama-host:9001/v1")
+
+    assert mod._resolve_provider_base_url("lm-studio") == "http://studio-host:9000/v1"
+    assert mod._resolve_provider_base_url("llama-cpp") == "http://llama-host:9001/v1"
+
+
+def test_explicit_local_base_url_overrides_env(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://env-studio:8000/v1")
+    mod = _reload_openai_client()
+
+    client = mod.OpenAIClient(
+        model="local-model",
+        provider="lm-studio",
+        base_url="http://explicit-studio:8000/v1",
+    )
+    llm = client.get_llm()
+
+    assert "explicit-studio" in str(llm.openai_api_base)
+    assert "env-studio" not in str(llm.openai_api_base)
+
+
+@pytest.mark.parametrize("provider", ["lm-studio", "llama-cpp"])
+def test_local_providers_use_openai_compatible_client(provider):
+    client = create_llm_client(provider=provider, model="local-model")
+
+    assert client.__class__.__name__ == "OpenAIClient"
+    assert client.provider == provider
+
+
+@pytest.mark.parametrize("provider", ["lm-studio", "llama-cpp"])
+def test_local_providers_do_not_require_api_keys(provider):
+    assert get_api_key_env(provider) is None
+
+
+@pytest.mark.parametrize("provider", ["lm-studio", "llama-cpp"])
+def test_local_providers_accept_custom_model_ids(provider):
+    assert validate_model(provider, "anything-loaded-locally")
+
+
+@pytest.mark.parametrize("provider", ["lm-studio", "llama-cpp"])
+def test_local_provider_model_catalog_prompts_for_custom_model(provider):
+    for mode in ("quick", "deep"):
+        entries = get_model_options(provider, mode)
+        assert entries == [("Custom local model ID", "custom")]
+
+
+def test_cli_provider_selection_uses_local_runtime_env(monkeypatch):
+    import cli.utils as cli_utils
+
+    captured = {}
+
+    class Prompt:
+        def ask(self):
+            return ("lm-studio", "http://studio-host:9000/v1")
+
+    def fake_select(message, choices, **kwargs):
+        captured["choices"] = choices
+        return Prompt()
+
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://studio-host:9000/v1")
+    monkeypatch.setattr(cli_utils.questionary, "select", fake_select)
+
+    provider, url = cli_utils.select_llm_provider()
+
+    assert provider == "lm-studio"
+    assert url == "http://studio-host:9000/v1"
+    assert ("lm-studio", "http://studio-host:9000/v1") in [
+        choice.value for choice in captured["choices"]
+    ]

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -25,7 +25,7 @@ class DummyLLMClient(BaseLLMClient):
 class ModelValidationTests(unittest.TestCase):
     def test_cli_catalog_models_are_all_validator_approved(self):
         for provider, models in get_known_models().items():
-            if provider in ("ollama", "openrouter"):
+            if provider in ("ollama", "openrouter", "lm-studio", "llama-cpp"):
                 continue
 
             for model in models:
@@ -43,8 +43,8 @@ class ModelValidationTests(unittest.TestCase):
         self.assertIn("not-a-real-openai-model", str(caught[0].message))
         self.assertIn("openai", str(caught[0].message))
 
-    def test_openrouter_and_ollama_accept_custom_models_without_warning(self):
-        for provider in ("openrouter", "ollama"):
+    def test_custom_model_providers_accept_custom_models_without_warning(self):
+        for provider in ("openrouter", "ollama", "lm-studio", "llama-cpp"):
             client = DummyLLMClient(provider, "custom-model-name")
 
             with self.subTest(provider=provider):

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -32,6 +32,8 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "openrouter": "OPENROUTER_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
+    "lm-studio":  None,
+    "llama-cpp":  None,
 }
 
 

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -9,6 +9,7 @@ _OPENAI_COMPATIBLE = (
     "glm", "glm-cn",
     "minimax", "minimax-cn",
     "ollama", "openrouter",
+    "lm-studio", "llama-cpp",
 )
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -73,6 +73,16 @@ _MINIMAX_MODELS: Dict[str, List[ModelOption]] = {
 }
 
 
+_LOCAL_OPENAI_COMPATIBLE_MODELS: Dict[str, List[ModelOption]] = {
+    "quick": [
+        ("Custom local model ID", "custom"),
+    ],
+    "deep": [
+        ("Custom local model ID", "custom"),
+    ],
+}
+
+
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
         "quick": [
@@ -175,6 +185,10 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Custom model ID", "custom"),
         ],
     },
+    # LM Studio and llama.cpp expose OpenAI-compatible endpoints, but model
+    # names are whatever the local server loaded, so always prompt the user.
+    "lm-studio": _LOCAL_OPENAI_COMPATIBLE_MODELS,
+    "llama-cpp": _LOCAL_OPENAI_COMPATIBLE_MODELS,
 }
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -158,32 +158,40 @@ _PROVIDER_BASE_URL = {
     "minimax-cn": "https://api.minimaxi.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama":     "http://localhost:11434/v1",
+    "lm-studio":  "http://localhost:8000/v1",
+    "llama-cpp":  "http://localhost:8001/v1",
+}
+
+_PROVIDER_BASE_URL_ENV = {
+    "ollama":    "OLLAMA_BASE_URL",
+    "lm-studio": "LM_STUDIO_BASE_URL",
+    "llama-cpp": "LLAMA_CPP_BASE_URL",
 }
 
 
 def _resolve_provider_base_url(provider: str) -> Optional[str]:
     """Default base URL for ``provider``, with env-var overrides where defined.
 
-    Currently only Ollama supports an env-var override (``OLLAMA_BASE_URL``),
-    matching the convention in the broader Ollama tooling ecosystem so users
-    can point at a remote ollama-serve without editing code. The check is
-    call-time, not import-time, so tests that monkeypatch the env after
-    import behave correctly.
+    Local OpenAI-compatible runtimes support env-var overrides (for example
+    ``OLLAMA_BASE_URL`` and ``LM_STUDIO_BASE_URL``). The lookup stays call-time,
+    not import-time, so ``load_dotenv()`` and tests that monkeypatch the env
+    after import behave correctly.
     """
-    if provider == "ollama":
-        env_url = os.environ.get("OLLAMA_BASE_URL")
+    env_var = _PROVIDER_BASE_URL_ENV.get(provider)
+    if env_var:
+        env_url = os.environ.get(env_var)
         if env_url:
             return env_url
     return _PROVIDER_BASE_URL.get(provider)
 
 
 class OpenAIClient(BaseLLMClient):
-    """Client for OpenAI, Ollama, OpenRouter, and xAI providers.
+    """Client for OpenAI and OpenAI-compatible providers.
 
     For native OpenAI models, uses the Responses API (/v1/responses) which
     supports reasoning_effort with function tools across all model families
     (GPT-4.1, GPT-5). Third-party compatible providers (xAI, OpenRouter,
-    Ollama) use standard Chat Completions.
+    Ollama, LM Studio, Llama.cpp) use standard Chat Completions.
     """
 
     def __init__(
@@ -218,7 +226,7 @@ class OpenAIClient(BaseLLMClient):
                         f"(e.g. add {api_key_env}=your_key to your .env file)."
                     )
             else:
-                llm_kwargs["api_key"] = "ollama"
+                llm_kwargs["api_key"] = self.provider
         elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -3,21 +3,24 @@
 from .model_catalog import get_known_models
 
 
+CUSTOM_MODEL_PROVIDERS = ("ollama", "openrouter", "lm-studio", "llama-cpp")
+
+
 VALID_MODELS = {
     provider: models
     for provider, models in get_known_models().items()
-    if provider not in ("ollama", "openrouter")
+    if provider not in CUSTOM_MODEL_PROVIDERS
 }
 
 
 def validate_model(provider: str, model: str) -> bool:
     """Check if model name is valid for the given provider.
 
-    For ollama, openrouter - any model is accepted.
+    For providers backed by user-managed model catalogs, any model is accepted.
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in CUSTOM_MODEL_PROVIDERS:
         return True
 
     if provider_lower not in VALID_MODELS:


### PR DESCRIPTION
## Summary
- add LM Studio and Llama.cpp as OpenAI-compatible local LLM providers
- resolve `LM_STUDIO_BASE_URL` and `LLAMA_CPP_BASE_URL` at call time so `.env` loading works
- skip API-key prompts for local runtimes and allow arbitrary local model IDs
- expose the providers in the CLI and document their optional base URL env vars

## Why
Issue #710 asks for OpenAI-compatible local provider support for LM Studio and Llama.cpp. A follow-up comment also notes that base URL env vars need to be resolved lazily, after `.env` loading, rather than at import time.

## Validation
- `uv run --python 3.13 --with pytest --with questionary python -m pytest tests/test_local_openai_compatible_providers.py tests/test_api_key_env.py tests/test_model_validation.py tests/test_ollama_base_url.py` (56 passed)
- `uv run --python 3.13 --with pytest --with questionary python -m pytest` (246 passed, 1 skipped)

Closes #710.