### PR TITLE
fix(llm): pass MiniMax reasoning_split via extra_body

### DIFF
--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -132,7 +132,9 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         if get_capabilities(self.model_name).requires_reasoning_split:
-            payload.setdefault("reasoning_split", True)
+            extra_body = payload.get("extra_body") or {}
+            extra_body.setdefault("reasoning_split", True)
+            payload["extra_body"] = extra_body
         return payload
 
 


### PR DESCRIPTION
## Summary
- MiniMax's `reasoning_split` flag was being placed at the top level of the request payload, where the openai SDK's strict kwarg validation rejects it.
- Moves it into `extra_body` so the SDK forwards it untouched, following the gating already added in #826.

## Test plan
- [ ] Call a MiniMax reasoning model (e.g. MiniMax-M2) and confirm `reasoning_split` reaches the API without an SDK validation error.
- [ ] Call a non-reasoning MiniMax endpoint (Coding Plan, MiniMax-Text-01) and confirm the flag is still gated off by `requires_reasoning_split`.