### PR TITLE
feat(docker): allow binding tradingagents_data volume to a host path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,11 @@ OPENROUTER_API_KEY=
 #TRADINGAGENTS_MAX_DEBATE_ROUNDS=1
 #TRADINGAGENTS_MAX_RISK_ROUNDS=1
 #TRADINGAGENTS_CHECKPOINT_ENABLED=false
+
+# Optional (Docker only): where to persist /home/appuser/.tradingagents
+# (reports, cache, decision log). Unset = use the named volume
+# `tradingagents_data` (default; data lives inside the Docker engine).
+# Set to a host path (e.g. ./tradingagents_data) to bind-mount, so the
+# generated reports under logs/<TICKER>/<DATE>/reports/ appear directly
+# on your host filesystem.
+#TRADINGAGENTS_DATA_DIR=./tradingagents_data

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Docker bind-mount target when TRADINGAGENTS_DATA_DIR is set (reports, logs, decision memory)
+tradingagents_data/

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ from the host. To have reports appear on your host filesystem instead — e.g.
 under `./tradingagents_data/logs/<TICKER>/<DATE>/reports/` — set
 `TRADINGAGENTS_DATA_DIR` in `.env` to a host path before bringing the stack up:
 ```bash
+mkdir -p ./tradingagents_data
 echo "TRADINGAGENTS_DATA_DIR=./tradingagents_data" >> .env
 docker compose run --rm tradingagents
 ```

--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ For local models with Ollama:
 docker compose --profile ollama run --rm tradingagents-ollama
 ```
 
+By default, generated reports, caches, and the decision log are persisted in a
+Docker named volume (`tradingagents_data`), which is not directly browsable
+from the host. To have reports appear on your host filesystem instead — e.g.
+under `./tradingagents_data/logs/<TICKER>/<DATE>/reports/` — set
+`TRADINGAGENTS_DATA_DIR` in `.env` to a host path before bringing the stack up:
+```bash
+echo "TRADINGAGENTS_DATA_DIR=./tradingagents_data" >> .env
+docker compose run --rm tradingagents
+```
+
 ### Required APIs
 
 TradingAgents supports multiple LLM providers. Set the API key for your chosen provider:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     env_file:
       - .env
     volumes:
-      - tradingagents_data:/home/appuser/.tradingagents
+      - ${TRADINGAGENTS_DATA_DIR:-tradingagents_data}:/home/appuser/.tradingagents
     tty: true
     stdin_open: true
 
@@ -22,7 +22,7 @@ services:
     environment:
       - LLM_PROVIDER=ollama
     volumes:
-      - tradingagents_data:/home/appuser/.tradingagents
+      - ${TRADINGAGENTS_DATA_DIR:-tradingagents_data}:/home/appuser/.tradingagents
     depends_on:
       - ollama
     tty: true


### PR DESCRIPTION
The compose stack persists reports, cache, and the decision log under /home/appuser/.tradingagents via a named volume. That volume is opaque to the host, so users running stock analyses through Docker have no direct way to read the generated reports under
logs/<TICKER>/<DATE>/reports/.

Make the mount source overridable through the TRADINGAGENTS_DATA_DIR environment variable (consumed by docker compose, not by default_config.py). Unset, behavior is unchanged: the named volume 'tradingagents_data' is still used. Set it to a host path (e.g. ./tradingagents_data) to bind-mount instead, exposing all reports on the host filesystem.

- docker-compose.yml: parameterize both service mounts with ${TRADINGAGENTS_DATA_DIR:-tradingagents_data}
- .env.example: document the new variable in its own section so it is not confused with the TRADINGAGENTS_* DEFAULT_CONFIG overlay
- .gitignore: ignore tradingagents_data/ for users who opt into the bind mount under the project root
- README.md: add a short note in the Docker section explaining how to switch to a host-visible directory