### PR TITLE
fix: move reasoning_split into extra_body to fix openai SDK compatibi…

### DIFF
--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -132,7 +132,10 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         if get_capabilities(self.model_name).requires_reasoning_split:
-            payload.setdefault("reasoning_split", True)
+            # reasoning_split goes in extra_body so the OpenAI SDK doesn't
+            # reject it as an unknown top-level kwarg (openai SDK >= 1.56
+            # validates top-level params against Completions.create signature).
+            payload.setdefault("extra_body", {})["reasoning_split"] = True
         return payload
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -135,7 +135,10 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
             # reasoning_split goes in extra_body so the OpenAI SDK doesn't
             # reject it as an unknown top-level kwarg (openai SDK >= 1.56
             # validates top-level params against Completions.create signature).
-            payload.setdefault("extra_body", {})["reasoning_split"] = True
+            payload.pop("reasoning_split", None)
+            extra_body = payload.get("extra_body") or {}
+            extra_body["reasoning_split"] = True
+            payload["extra_body"] = extra_body
         return payload
 
 


### PR DESCRIPTION
…lity

Minimax M2.x models require reasoning_split=True in the request body to redirect thinking blocks into reasoning_details. This worked with older openai SDK versions that didn't validate top-level params, but openai SDK >= 1.56 validates against Completions.create signature and rejects reasoning_split as unknown.

The fix puts reasoning_split in extra_body instead of at top-level, which is the correct location for provider-specific parameters and avoids the SDK validation error.