### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ ZHIPU_CN_API_KEY=
 MINIMAX_API_KEY=
 MINIMAX_CN_API_KEY=
 OPENROUTER_API_KEY=
+ASTRAFLOW_API_KEY=
+ASTRAFLOW_CN_API_KEY=
 
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -275,6 +275,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("Qwen", "qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
         ("MiniMax", "minimax", "https://api.minimax.io/v1"),
+        ("Astraflow", "astraflow", "https://api-us-ca.umodelverse.ai/v1"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", ollama_url),
@@ -434,6 +435,33 @@ def ask_minimax_region() -> tuple[str, str]:
             questionary.Choice(
                 "China — api.minimaxi.com (uses MINIMAX_CN_API_KEY)",
                 value=("minimax-cn", "https://api.minimaxi.com/v1"),
+            ),
+        ],
+        style=questionary.Style([
+            ("selected", "fg:cyan noinherit"),
+            ("highlighted", "fg:cyan noinherit"),
+            ("pointer", "fg:cyan noinherit"),
+        ]),
+    ).ask()
+
+
+def ask_astraflow_region() -> tuple[str, str]:
+    """Ask which Astraflow region (global vs China) to use.
+
+    Astraflow by UCloud exposes two endpoints with separate accounts —
+    a key from one region does NOT authenticate against the other.
+    Returns (provider_key, backend_url).
+    """
+    return questionary.select(
+        "Select Astraflow region:",
+        choices=[
+            questionary.Choice(
+                "Global — api-us-ca.umodelverse.ai (uses ASTRAFLOW_API_KEY)",
+                value=("astraflow", "https://api-us-ca.umodelverse.ai/v1"),
+            ),
+            questionary.Choice(
+                "China — api.modelverse.cn (uses ASTRAFLOW_CN_API_KEY)",
+                value=("astraflow-cn", "https://api.modelverse.cn/v1"),
             ),
         ],
         style=questionary.Style([

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -30,6 +30,10 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "minimax":    "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    # Astraflow by UCloud — dual-region OpenAI-compatible platform (200+ models).
+    # Global and China endpoints use separate accounts; keys are not interchangeable.
+    "astraflow":    "ASTRAFLOW_API_KEY",
+    "astraflow-cn": "ASTRAFLOW_CN_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
 }

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -8,6 +8,7 @@ _OPENAI_COMPATIBLE = (
     "qwen", "qwen-cn",
     "glm", "glm-cn",
     "minimax", "minimax-cn",
+    "astraflow", "astraflow-cn",
     "ollama", "openrouter",
 )
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -153,6 +153,38 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # so the two provider keys share one model list.
     "minimax": _MINIMAX_MODELS,
     "minimax-cn": _MINIMAX_MODELS,
+    # Astraflow: same model IDs across global (api-us-ca.umodelverse.ai) and
+    # China (api.modelverse.cn) endpoints; both provider keys share one list.
+    # Astraflow supports 200+ models — these are popular OpenAI-compatible picks.
+    # Users can select any model they have access to via "Custom model ID".
+    "astraflow": {
+        "quick": [
+            ("GPT-4.1 Mini - Fast, cost-efficient", "gpt-4.1-mini"),
+            ("GPT-4.1 Nano - Cheapest, high-volume tasks", "gpt-4.1-nano"),
+            ("DeepSeek V3 - Strong coding and reasoning", "deepseek-chat"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("GPT-4.1 - Smartest non-reasoning model", "gpt-4.1"),
+            ("DeepSeek R1 - Advanced reasoning", "deepseek-reasoner"),
+            ("GPT-4o - Multimodal flagship", "gpt-4o"),
+            ("Custom model ID", "custom"),
+        ],
+    },
+    "astraflow-cn": {
+        "quick": [
+            ("GPT-4.1 Mini - Fast, cost-efficient", "gpt-4.1-mini"),
+            ("GPT-4.1 Nano - Cheapest, high-volume tasks", "gpt-4.1-nano"),
+            ("DeepSeek V3 - Strong coding and reasoning", "deepseek-chat"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("GPT-4.1 - Smartest non-reasoning model", "gpt-4.1"),
+            ("DeepSeek R1 - Advanced reasoning", "deepseek-reasoner"),
+            ("GPT-4o - Multimodal flagship", "gpt-4o"),
+            ("Custom model ID", "custom"),
+        ],
+    },
     # OpenRouter: fetched dynamically. Azure: any deployed model name.
     # Ollama display labels intentionally omit a "local" marker — the
     # endpoint is now configurable via OLLAMA_BASE_URL, so the same labels


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, available via a global endpoint and a China endpoint.

Because Astraflow is fully OpenAI-compatible, no new SDK or subpackage is needed — integration is just `base_url + api_key` on the existing `OpenAIClient`.

## Changes

### `tradingagents/llm_clients/factory.py`
- Added `"astraflow"` and `"astraflow-cn"` to the `_OPENAI_COMPATIBLE` tuple so both are routed to `OpenAIClient`.

### `tradingagents/llm_clients/api_key_env.py`
- Registered `ASTRAFLOW_API_KEY` (global) and `ASTRAFLOW_CN_API_KEY` (China) in `PROVIDER_API_KEY_ENV`, following the same dual-region pattern as Qwen, GLM, and MiniMax.

### `tradingagents/llm_clients/model_catalog.py`
- Added `"astraflow"` and `"astraflow-cn"` model catalog entries with quick/deep model lists (popular OpenAI-compatible models available on the platform, plus a "Custom model ID" escape hatch).

### `cli/utils.py`
- Added `ask_astraflow_region()` helper (mirrors `ask_minimax_region`, `ask_qwen_region`, `ask_glm_region`) for the interactive CLI region selection.
- Added `"Astraflow"` to the `PROVIDERS` list in `select_llm_provider()` so it appears in the provider dropdown. The global endpoint is the default; the region helper can override to the China endpoint.

### `.env.example`
- Added `ASTRAFLOW_API_KEY=` and `ASTRAFLOW_CN_API_KEY=` alongside the other provider keys.

## Provider Details

| | Global | China |
|---|---|---|
| **Endpoint** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| **Sign-up / docs** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
| **Provider key** | `astraflow` | `astraflow-cn` |
