### PR TITLE
feat: add Korean market data enrichment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,17 @@ MINIMAX_API_KEY=
 MINIMAX_CN_API_KEY=
 OPENROUTER_API_KEY=
 
+# Optional Korean-market enrichment for .KS/.KQ tickers
+# OpenDART powers corp-code mapping, recent filings, and financial summaries.
+DART_API_KEY=
+# OPENDART_API_KEY=  # Alternative env var name for the same OpenDART key.
+
+# Naver Search API powers Korean-language news augmentation.
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+# NAVER_NEWS_CLIENT_ID=      # Alternative env var names if you want to keep
+# NAVER_NEWS_CLIENT_SECRET=  # general Naver credentials separate from news.
+
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows
 # the broader Ollama ecosystem; both the CLI dropdown and programmatic

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Local dashboard runtime status
+dashboard/status.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 # TradingAgents: Multi-Agents LLM Financial Trading Framework
 
 ## News
+- [2026-05] **Korean market data path** added for KOSPI/KOSDAQ tickers (`.KS`, `.KQ`) with pykrx-first OHLCV, optional OpenDART filings/financial statements, Naver Korean-language news augmentation, and regional benchmark mapping (`^KS11`, `^KQ11`).
 - [2026-05] **TradingAgents v0.2.5** released with the grounded Sentiment Analyst, GPT-5.5 etc. model coverage, Qwen/GLM/MiniMax dual-region support, `TRADINGAGENTS_*` env-var configurability with API-key auto-detection, remote Ollama support, non-US alpha benchmarks, and ticker path-traversal hardening. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 - [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix.
 - [2026-03] **TradingAgents v0.2.3** released with multi-language support, GPT-5.4 family models, unified model catalog, backtesting date fidelity, and proxy support.
@@ -151,6 +152,11 @@ export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io, M2.x, 2
 export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com, M2.x, 204K ctx)
 export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
+
+# Optional Korean-market enrichment for .KS/.KQ tickers
+export DART_API_KEY=...            # OpenDART filings and financial statements
+export NAVER_CLIENT_ID=...         # Naver Search API client ID for Korean news
+export NAVER_CLIENT_SECRET=...     # Naver Search API client secret
 ```
 
 For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
@@ -161,6 +167,31 @@ Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash
 cp .env.example .env
 ```
+
+### Korean Market Data
+
+KOSPI and KOSDAQ tickers use Yahoo-style suffixes such as `005930.KS` and `247540.KQ`. When a Korean ticker is analyzed and the default Yahoo data path is selected, TradingAgents automatically tries the Korea-specific vendor before falling back to Yahoo Finance.
+
+The Korea path includes:
+- pykrx-first OHLCV for KRX-native prices and trading values, with yfinance fallback when pykrx is unavailable or returns no rows.
+- Best-effort pykrx investor supply/demand sections when KRX exposes the data for the requested window.
+- Regional benchmark mapping for reflection/alpha calculations: `.KS` → `^KS11`, `.KQ` → `^KQ11`.
+- Optional OpenDART context when `DART_API_KEY` or `OPENDART_API_KEY` is set: listed-company corp-code mapping, recent disclosure links, and annual financial-statement summaries.
+- Optional Korean-language news when Naver Search API credentials are set via either `NAVER_CLIENT_ID`/`NAVER_CLIENT_SECRET` or `NAVER_NEWS_CLIENT_ID`/`NAVER_NEWS_CLIENT_SECRET`.
+
+Minimal setup for Korean-market enrichment:
+```bash
+cp .env.example .env
+# Fill in your LLM provider key, then optionally add:
+# DART_API_KEY=...
+# NAVER_CLIENT_ID=...
+# NAVER_CLIENT_SECRET=...
+
+tradingagents
+# Try: 005930.KS or 247540.KQ
+```
+
+All Korean-market enrichments are fail-soft. Missing credentials, API errors, or empty upstream responses are surfaced as analyst notes while the baseline report continues.
 
 ### CLI Usage
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -12,7 +12,7 @@ from tradingagents.llm_clients.model_catalog import get_model_options
 
 console = Console()
 
-TICKER_INPUT_EXAMPLES = "Examples: SPY, CNC.TO, 7203.T, 0700.HK"
+TICKER_INPUT_EXAMPLES = "Examples: SPY, 005930.KS, 247540.KQ, 7203.T, 0700.HK"
 
 ANALYST_ORDER = [
     ("Market Analyst", AnalystType.MARKET),

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TradingAgents Korea Progress</title>
+  <style>
+    :root {
+      --bg: #0b0d10; --panel: #14171c; --panel2:#101318; --ink:#f2f4f8; --muted:#9aa4b2;
+      --line:#252b34; --accent:#7dd3fc; --good:#86efac; --warn:#fde68a; --todo:#64748b;
+      --radius: 18px; --shadow: 0 18px 60px rgba(0,0,0,.35);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin:0; background: radial-gradient(circle at top left, rgba(125,211,252,.14), transparent 34%), var(--bg); color:var(--ink); }
+    main { max-width: 1120px; margin: 0 auto; padding: 42px 22px 70px; }
+    header { display:flex; justify-content:space-between; gap:18px; align-items:flex-start; margin-bottom:26px; }
+    h1 { margin:0; font-size: clamp(30px, 5vw, 54px); letter-spacing:-.05em; line-height:.95; }
+    .subtitle { margin: 14px 0 0; color:var(--muted); font-size:16px; line-height:1.65; max-width:720px; }
+    .badge { border:1px solid var(--line); border-radius:999px; padding:10px 14px; background:rgba(20,23,28,.72); color:var(--accent); white-space:nowrap; font-size:13px; }
+    .grid { display:grid; grid-template-columns: 1.2fr .8fr; gap:18px; }
+    @media (max-width: 860px) { .grid, header { grid-template-columns:1fr; display:block; } .badge{display:inline-block;margin-top:18px;} }
+    .card { background: linear-gradient(180deg, rgba(20,23,28,.95), rgba(16,19,24,.95)); border:1px solid var(--line); border-radius:var(--radius); padding:22px; box-shadow:var(--shadow); }
+    .card h2 { margin:0 0 16px; font-size:18px; letter-spacing:-.02em; }
+    .progress { height:13px; background:#1e2530; border-radius:99px; overflow:hidden; border:1px solid #2c3441; }
+    .bar { height:100%; width:0%; background:linear-gradient(90deg, var(--accent), var(--good)); transition: width .5s ease; }
+    .steps { display:grid; gap:10px; margin-top:18px; }
+    .step { display:grid; grid-template-columns: 24px 1fr auto; gap:12px; align-items:center; padding:13px 14px; background:rgba(255,255,255,.025); border:1px solid var(--line); border-radius:14px; }
+    .dot { width:12px; height:12px; border-radius:50%; background:var(--todo); box-shadow:0 0 0 5px rgba(100,116,139,.12); justify-self:center; }
+    .step.done .dot { background:var(--good); box-shadow:0 0 0 5px rgba(134,239,172,.12); }
+    .step.active .dot { background:var(--accent); box-shadow:0 0 0 5px rgba(125,211,252,.16); animation:pulse 1.6s infinite; }
+    @keyframes pulse { 50% { transform: scale(1.25); } }
+    .step-title { font-weight:700; }
+    .step-note { color:var(--muted); font-size:13px; margin-top:3px; line-height:1.45; }
+    .status { font-size:12px; color:var(--muted); border:1px solid var(--line); border-radius:999px; padding:5px 9px; }
+    .metric-row { display:grid; grid-template-columns:1fr auto; gap:12px; padding:13px 0; border-bottom:1px solid var(--line); }
+    .metric-row:last-child { border-bottom:0; }
+    .label { color:var(--muted); }
+    code { color:#bae6fd; background:#0b1220; border:1px solid #1f2a3a; padding:2px 6px; border-radius:7px; }
+    .log { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size:12px; line-height:1.6; color:#cbd5e1; max-height:260px; overflow:auto; background:#090b0f; border:1px solid var(--line); border-radius:14px; padding:14px; white-space:pre-wrap; }
+    a { color: var(--accent); text-decoration: none; }
+    .footer { color:var(--muted); margin-top:16px; font-size:12px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div>
+      <h1>TradingAgents<br/>Korea Track</h1>
+      <p class="subtitle">한국 종목 데이터 수집 → 한국 뉴스/공시/커뮤니티 확장 → 구조화 signal → paper trading → broker API 자동매매 순서로 진행 상황을 보는 대시보드.</p>
+    </div>
+    <div class="badge" id="updated">loading…</div>
+  </header>
+  <section class="grid">
+    <div class="card">
+      <h2>진행률</h2>
+      <div class="progress"><div class="bar" id="bar"></div></div>
+      <div class="steps" id="steps"></div>
+    </div>
+    <aside class="card">
+      <h2>현재 설정</h2>
+      <div id="metrics"></div>
+          <p class="footer">Local preview: <code>python -m http.server 8787 --directory dashboard</code>. Copy <code>status.example.json</code> to <code>status.json</code> for a live local status file.</p>
+    </aside>
+  </section>
+  <section class="card" style="margin-top:18px">
+    <h2>작업 로그</h2>
+    <div class="log" id="log">loading…</div>
+  </section>
+</main>
+<script>
+const fallback = {
+  updated_at: new Date().toISOString(),
+  metrics: { provider:'openai', language:'Korean', tests:'pending' },
+  steps: [], log: ['status.json not loaded yet']
+};
+function badge(status){ return status === 'done' ? '완료' : status === 'active' ? '진행중' : '대기'; }
+function render(data){
+  const rawSteps = data.steps || data.tasks || [];
+  const steps = rawSteps.map(s => ({
+    title: s.title || s.name || 'Untitled step',
+    note: s.note || '',
+    status: s.status === 'completed' ? 'done' : s.status === 'in_progress' ? 'active' : s.status
+  }));
+  document.getElementById('updated').textContent = 'updated · ' + (data.updated_at || 'unknown');
+  const done = steps.filter(s => s.status === 'done').length;
+  const total = steps.length || 1;
+  document.getElementById('bar').style.width = Math.round(done/total*100) + '%';
+  document.getElementById('steps').innerHTML = steps.map(s => `<div class="step ${s.status}"><div class="dot"></div><div><div class="step-title">${s.title}</div><div class="step-note">${s.note || ''}</div></div><div class="status">${badge(s.status)}</div></div>`).join('');
+  document.getElementById('metrics').innerHTML = Object.entries(data.metrics || {}).map(([k,v]) => `<div class="metric-row"><div class="label">${k}</div><div><code>${v}</code></div></div>`).join('');
+  document.getElementById('log').textContent = (data.log || steps.map(s => `${s.status}: ${s.title}${s.note ? ' — ' + s.note : ''}`)).join('\n');
+}
+fetch('./status.json?ts=' + Date.now()).then(r=>r.json()).then(render).catch(()=>render(fallback));
+setInterval(() => fetch('./status.json?ts=' + Date.now()).then(r=>r.json()).then(render).catch(()=>{}), 10000);
+</script>
+</body>
+</html>

--- a/dashboard/status.example.json
+++ b/dashboard/status.example.json
@@ -1,0 +1,37 @@
+{
+  "updated_at": "2026-05-22 11:10 KST",
+  "metrics": {
+    "provider": "openai",
+    "language": "Korean",
+    "tests": "251 passed, 1 skipped",
+    "korea_vendor": "pykrx + yfinance fallback",
+    "optional_sources": "OpenDART, Naver Search API"
+  },
+  "steps": [
+    {
+      "title": "Korean ticker routing",
+      "status": "done",
+      "note": ".KS/.KQ tickers route to korea_stock before yfinance when the default vendor is selected."
+    },
+    {
+      "title": "KRX price data",
+      "status": "done",
+      "note": "pykrx OHLCV is preferred, with yfinance fallback for missing or failed responses."
+    },
+    {
+      "title": "DART filings and financials",
+      "status": "done",
+      "note": "Enable with DART_API_KEY or OPENDART_API_KEY. Missing credentials degrade to analyst notes."
+    },
+    {
+      "title": "Korean-language news",
+      "status": "done",
+      "note": "Enable with NAVER_CLIENT_ID/NAVER_CLIENT_SECRET or NAVER_NEWS_CLIENT_ID/NAVER_NEWS_CLIENT_SECRET."
+    }
+  ],
+  "log": [
+    "Added Korean-market data path for KOSPI/KOSDAQ tickers.",
+    "Documented user-supplied API keys in README and .env.example.",
+    "All enrichment sources are fail-soft so baseline reports continue."
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langgraph-checkpoint-sqlite>=2.0.0",
     "pandas>=2.3.0",
     "parsel>=1.10.0",
+    "pykrx>=1.0.45",
     "pytz>=2025.2",
     "questionary>=2.1.0",
     "redis>=6.2.0",

--- a/scripts/deploy_dashboard_ngrok.sh
+++ b/scripts/deploy_dashboard_ngrok.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${TRADINGAGENTS_DASHBOARD_PORT:-8787}"
+DASHBOARD_DIR="$ROOT/dashboard"
+
+if ! command -v ngrok >/dev/null 2>&1; then
+  echo "ngrok is not installed. Install with: brew install ngrok/ngrok/ngrok" >&2
+  exit 1
+fi
+
+if [ ! -d "$DASHBOARD_DIR" ]; then
+  echo "Dashboard dir not found: $DASHBOARD_DIR" >&2
+  exit 1
+fi
+
+if ! pgrep -f "python3 -m http.server ${PORT} --directory dashboard" >/dev/null 2>&1; then
+  echo "Starting local dashboard server on http://127.0.0.1:${PORT}/"
+  (cd "$ROOT" && nohup python3 -m http.server "$PORT" --directory dashboard > /tmp/tradingagents-dashboard-${PORT}.log 2>&1 &)
+else
+  echo "Local dashboard server already running on http://127.0.0.1:${PORT}/"
+fi
+
+echo "Starting ngrok tunnel for http://127.0.0.1:${PORT}/"
+echo "After startup, open http://127.0.0.1:4040/api/tunnels to see the public URL."
+exec ngrok http "$PORT"

--- a/tests/test_korea_stock_vendor.py
+++ b/tests/test_korea_stock_vendor.py
@@ -1,0 +1,710 @@
+"""Korean market data vendor behavior."""
+
+from __future__ import annotations
+
+import copy
+import io
+import sys
+import types
+import zipfile
+
+import pandas as pd
+import pytest
+
+import tradingagents.default_config as default_config
+from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows import interface
+from tradingagents.dataflows import korea_stock
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    set_config(copy.deepcopy(default_config.DEFAULT_CONFIG))
+
+
+def test_korea_stock_vendor_is_registered_for_core_news_and_fundamentals():
+    assert "korea_stock" in interface.VENDOR_LIST
+    for method in [
+        "get_stock_data",
+        "get_news",
+        "get_fundamentals",
+        "get_balance_sheet",
+        "get_cashflow",
+        "get_income_statement",
+    ]:
+        assert "korea_stock" in interface.VENDOR_METHODS[method]
+
+
+def test_korea_stock_routes_stock_data_with_yahoo_suffix(monkeypatch):
+    calls = []
+
+    def fake_yfinance(ticker: str, start_date: str, end_date: str) -> str:
+        calls.append((ticker, start_date, end_date))
+        return "YF DATA"
+
+    monkeypatch.setitem(
+        interface.VENDOR_METHODS["get_stock_data"], "korea_stock", fake_yfinance
+    )
+    set_config({"tool_vendors": {"get_stock_data": "korea_stock"}})
+
+    result = interface.route_to_vendor("get_stock_data", "005930.KS", "2026-05-15", "2026-05-22")
+
+    assert result == "YF DATA"
+    assert calls == [("005930.KS", "2026-05-15", "2026-05-22")]
+
+
+def test_default_benchmark_map_contains_kospi_and_kosdaq():
+    assert default_config.DEFAULT_CONFIG["benchmark_map"][".KS"] == "^KS11"
+    assert default_config.DEFAULT_CONFIG["benchmark_map"][".KQ"] == "^KQ11"
+
+
+def test_korean_ticker_auto_prefers_korea_stock_when_default_vendor_is_yfinance(monkeypatch):
+    calls = []
+
+    def fake_korea(ticker: str, start_date: str, end_date: str) -> str:
+        calls.append(("korea", ticker, start_date, end_date))
+        return "KOREA DATA"
+
+    def fake_yfinance(ticker: str, start_date: str, end_date: str) -> str:
+        calls.append(("yfinance", ticker, start_date, end_date))
+        return "YF DATA"
+
+    monkeypatch.setitem(interface.VENDOR_METHODS["get_stock_data"], "korea_stock", fake_korea)
+    monkeypatch.setitem(interface.VENDOR_METHODS["get_stock_data"], "yfinance", fake_yfinance)
+
+    result = interface.route_to_vendor("get_stock_data", "005930.KS", "2026-05-15", "2026-05-22")
+
+    assert result == "KOREA DATA"
+    assert calls == [("korea", "005930.KS", "2026-05-15", "2026-05-22")]
+
+
+def test_non_korean_ticker_keeps_default_yfinance_route(monkeypatch):
+    calls = []
+
+    def fake_korea(ticker: str, start_date: str, end_date: str) -> str:
+        calls.append(("korea", ticker, start_date, end_date))
+        return "KOREA DATA"
+
+    def fake_yfinance(ticker: str, start_date: str, end_date: str) -> str:
+        calls.append(("yfinance", ticker, start_date, end_date))
+        return "YF DATA"
+
+    monkeypatch.setitem(interface.VENDOR_METHODS["get_stock_data"], "korea_stock", fake_korea)
+    monkeypatch.setitem(interface.VENDOR_METHODS["get_stock_data"], "yfinance", fake_yfinance)
+    set_config({"tool_vendors": {"get_stock_data": "yfinance"}})
+
+    result = interface.route_to_vendor("get_stock_data", "AAPL", "2026-05-15", "2026-05-22")
+
+    assert result == "YF DATA"
+    assert calls == [("yfinance", "AAPL", "2026-05-15", "2026-05-22")]
+
+
+def _install_fake_pykrx(monkeypatch, stock_module):
+    """Register a fake ``pykrx.stock`` so ``from pykrx import stock`` succeeds."""
+    pykrx_pkg = types.ModuleType("pykrx")
+    pykrx_pkg.stock = stock_module
+    monkeypatch.setitem(sys.modules, "pykrx", pykrx_pkg)
+    monkeypatch.setitem(sys.modules, "pykrx.stock", stock_module)
+
+
+def _sample_ohlcv_frame():
+    index = pd.DatetimeIndex(["2026-05-15", "2026-05-18"], name="날짜")
+    return pd.DataFrame(
+        {
+            "시가": [78000.0, 78500.0],
+            "고가": [79000.0, 79100.0],
+            "저가": [77500.0, 78200.0],
+            "종가": [78800.0, 78900.0],
+            "거래량": [12_345_678, 11_111_111],
+            "거래대금": [970_000_000_000, 870_000_000_000],
+            "등락률": [0.51, 0.13],
+        },
+        index=index,
+    )
+
+
+def _sample_investor_frame():
+    index = pd.DatetimeIndex(["2026-05-15", "2026-05-18"], name="날짜")
+    return pd.DataFrame(
+        {
+            "기관합계": [100_000, -50_000],
+            "외국인합계": [-20_000, 30_000],
+            "개인": [-80_000, 20_000],
+        },
+        index=index,
+    )
+
+
+def test_to_pykrx_ticker_strips_yahoo_suffix():
+    assert korea_stock.to_pykrx_ticker("005930.KS") == "005930"
+    assert korea_stock.to_pykrx_ticker("247540.KQ") == "247540"
+    assert korea_stock.to_pykrx_ticker("005930.ks") == "005930"
+    # Plain symbols pass through unchanged (uppercased).
+    assert korea_stock.to_pykrx_ticker("AAPL") == "AAPL"
+
+
+def test_pykrx_success_returns_markdown_and_skips_yfinance(monkeypatch):
+    ohlcv_calls = []
+    investor_value_calls = []
+    investor_volume_calls = []
+
+    def fake_get_market_ohlcv(start, end, ticker):
+        ohlcv_calls.append((start, end, ticker))
+        return _sample_ohlcv_frame()
+
+    def fake_trading_value(start, end, ticker):
+        investor_value_calls.append((start, end, ticker))
+        return _sample_investor_frame()
+
+    def fake_trading_volume(start, end, ticker):
+        investor_volume_calls.append((start, end, ticker))
+        return _sample_investor_frame()
+
+    stock_module = types.SimpleNamespace(
+        get_market_ohlcv=fake_get_market_ohlcv,
+        get_market_trading_value_by_date=fake_trading_value,
+        get_market_trading_volume_by_date=fake_trading_volume,
+    )
+    _install_fake_pykrx(monkeypatch, stock_module)
+
+    def explode_yfinance(*args, **kwargs):
+        raise AssertionError("yfinance must not be called when pykrx succeeds")
+
+    monkeypatch.setattr(korea_stock, "get_YFin_data_online", explode_yfinance)
+
+    result = korea_stock.get_stock_data("005930.KS", "2026-05-15", "2026-05-18")
+
+    assert ohlcv_calls == [("20260515", "20260518", "005930")]
+    assert investor_value_calls == [("20260515", "20260518", "005930")]
+    assert investor_volume_calls == [("20260515", "20260518", "005930")]
+    # Markdown report should include OHLCV section and the bilingual Close column header.
+    assert "OHLCV (pykrx) for 005930.KS" in result
+    assert "종가 (Close)" in result
+    assert "Investor trading value (KRW)" in result
+    assert "Investor trading volume (shares)" in result
+    # Korea context preamble is attached around the pykrx report.
+    assert "Korean stock price data" in result
+
+
+def test_pykrx_missing_falls_back_to_yfinance(monkeypatch):
+    # Remove any cached pykrx import and block future imports.
+    monkeypatch.delitem(sys.modules, "pykrx", raising=False)
+    monkeypatch.delitem(sys.modules, "pykrx.stock", raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pykrx" or name.startswith("pykrx."):
+            raise ImportError("pykrx not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    if isinstance(__builtins__, dict):
+        monkeypatch.setitem(__builtins__, "__import__", fake_import)
+    else:
+        monkeypatch.setattr(__builtins__, "__import__", fake_import)
+
+    yfinance_calls = []
+
+    def fake_yfinance(ticker, start, end):
+        yfinance_calls.append((ticker, start, end))
+        return "YF FALLBACK DATA"
+
+    monkeypatch.setattr(korea_stock, "get_YFin_data_online", fake_yfinance)
+
+    result = korea_stock.get_stock_data("005930.KS", "2026-05-15", "2026-05-18")
+
+    assert yfinance_calls == [("005930.KS", "2026-05-15", "2026-05-18")]
+    assert "YF FALLBACK DATA" in result
+    assert "Korean stock price data" in result
+
+
+def test_pykrx_ohlcv_exception_falls_back_to_yfinance(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("KRX upstream error")
+
+    stock_module = types.SimpleNamespace(get_market_ohlcv=boom)
+    _install_fake_pykrx(monkeypatch, stock_module)
+
+    yfinance_calls = []
+
+    def fake_yfinance(ticker, start, end):
+        yfinance_calls.append((ticker, start, end))
+        return "YF FALLBACK DATA"
+
+    monkeypatch.setattr(korea_stock, "get_YFin_data_online", fake_yfinance)
+
+    result = korea_stock.get_stock_data("247540.KQ", "2026-05-15", "2026-05-18")
+
+    assert yfinance_calls == [("247540.KQ", "2026-05-15", "2026-05-18")]
+    assert "YF FALLBACK DATA" in result
+
+
+def test_pykrx_empty_ohlcv_falls_back_to_yfinance(monkeypatch):
+    def empty_ohlcv(*args, **kwargs):
+        return pd.DataFrame()
+
+    stock_module = types.SimpleNamespace(get_market_ohlcv=empty_ohlcv)
+    _install_fake_pykrx(monkeypatch, stock_module)
+
+    yfinance_calls = []
+
+    def fake_yfinance(ticker, start, end):
+        yfinance_calls.append((ticker, start, end))
+        return "YF FALLBACK DATA"
+
+    monkeypatch.setattr(korea_stock, "get_YFin_data_online", fake_yfinance)
+
+    result = korea_stock.get_stock_data("005930.KS", "2026-05-15", "2026-05-18")
+
+    assert yfinance_calls == [("005930.KS", "2026-05-15", "2026-05-18")]
+    assert "YF FALLBACK DATA" in result
+
+
+def test_pykrx_supply_demand_failure_does_not_block_price_data(monkeypatch):
+    def fake_ohlcv(start, end, ticker):
+        return _sample_ohlcv_frame()
+
+    def trading_value_boom(*args, **kwargs):
+        raise RuntimeError("supply/demand endpoint down")
+
+    def empty_trading_volume(*args, **kwargs):
+        return pd.DataFrame()
+
+    stock_module = types.SimpleNamespace(
+        get_market_ohlcv=fake_ohlcv,
+        get_market_trading_value_by_date=trading_value_boom,
+        get_market_trading_volume_by_date=empty_trading_volume,
+    )
+    _install_fake_pykrx(monkeypatch, stock_module)
+
+    def explode_yfinance(*args, **kwargs):
+        raise AssertionError("yfinance must not be called when pykrx OHLCV succeeds")
+
+    monkeypatch.setattr(korea_stock, "get_YFin_data_online", explode_yfinance)
+
+    result = korea_stock.get_stock_data("005930.KS", "2026-05-15", "2026-05-18")
+
+    # Price section is still produced.
+    assert "OHLCV (pykrx) for 005930.KS" in result
+    # Supply/demand failure leaves a note, not an exception.
+    assert "Supply/demand notes" in result
+    assert "trading_value fetch failed" in result
+    assert "trading_volume: no rows returned" in result
+    # And no investor tables made it through.
+    assert "Investor trading value (KRW)" not in result
+    assert "Investor trading volume (shares)" not in result
+
+
+# ---------------------------------------------------------------------------
+# DART (OpenDART) augmentation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_dart_corp_cache():
+    """Each test starts with a fresh corp-code cache so monkeypatched env vars apply."""
+    korea_stock._load_corp_code_map.cache_clear()
+    yield
+    korea_stock._load_corp_code_map.cache_clear()
+
+
+def _build_corp_code_zip(records):
+    """Build the OpenDART corpCode.xml ZIP payload from ``records``."""
+    root = "<result>" + "".join(
+        "<list>"
+        f"<corp_code>{r['corp_code']}</corp_code>"
+        f"<corp_name>{r['corp_name']}</corp_name>"
+        f"<stock_code>{r.get('stock_code', '')}</stock_code>"
+        f"<modify_date>{r.get('modify_date', '')}</modify_date>"
+        "</list>"
+        for r in records
+    ) + "</result>"
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("CORPCODE.xml", root)
+    return buffer.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, *, content=b"", json_data=None, status_code=200):
+        self.content = content
+        self._json = json_data
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("no json")
+        return self._json
+
+
+def _stub_yfinance_baseline(monkeypatch):
+    """Stub every yfinance call surface so DART tests do not hit the network."""
+    monkeypatch.setattr(korea_stock, "get_yfinance_fundamentals", lambda t, d: "YF FUNDAMENTALS")
+    monkeypatch.setattr(korea_stock, "get_yfinance_balance_sheet", lambda t, d: "YF BALANCE")
+    monkeypatch.setattr(korea_stock, "get_yfinance_cashflow", lambda t, d: "YF CASHFLOW")
+    monkeypatch.setattr(korea_stock, "get_yfinance_income_statement", lambda t, d: "YF INCOME")
+
+
+def test_get_fundamentals_without_dart_api_key_keeps_yfinance_baseline(monkeypatch):
+    monkeypatch.delenv("DART_API_KEY", raising=False)
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_yfinance_baseline(monkeypatch)
+
+    def explode_requests(*args, **kwargs):
+        raise AssertionError("requests.get must not run without an API key")
+
+    monkeypatch.setattr(korea_stock.requests, "get", explode_requests)
+
+    result = korea_stock.get_fundamentals("005930.KS", "2026-05-22")
+
+    assert "Korean fundamentals baseline" in result
+    assert "YF FUNDAMENTALS" in result
+    assert "DART API key not configured" in result
+
+
+def test_get_fundamentals_with_dart_api_key_renders_filings_and_financials(monkeypatch):
+    monkeypatch.setenv("DART_API_KEY", "test-key")
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_yfinance_baseline(monkeypatch)
+
+    corp_zip = _build_corp_code_zip(
+        [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+                "modify_date": "20260101",
+            },
+            # Unlisted issuer must be filtered out.
+            {
+                "corp_code": "99999999",
+                "corp_name": "비상장회사",
+                "stock_code": "",
+            },
+        ]
+    )
+
+    list_payload = {
+        "status": "000",
+        "message": "정상",
+        "list": [
+            {
+                "rcept_no": "20260515000123",
+                "report_nm": "분기보고서 (2026.03)",
+                "rcept_dt": "20260515",
+                "flr_nm": "삼성전자",
+            },
+            {
+                "rcept_no": "20260420000456",
+                "report_nm": "주요사항보고서",
+                "rcept_dt": "20260420",
+                "flr_nm": "삼성전자",
+            },
+        ],
+    }
+    fnltt_payload = {
+        "status": "000",
+        "message": "정상",
+        "list": [
+            {
+                "account_id": "ifrs-full_Revenue",
+                "sj_div": "IS",
+                "thstrm_amount": "300,000,000,000,000",
+                "frmtrm_amount": "279,000,000,000,000",
+            },
+            {
+                "account_id": "ifrs-full_ProfitLoss",
+                "sj_div": "IS",
+                "thstrm_amount": "26,000,000,000,000",
+                "frmtrm_amount": "15,000,000,000,000",
+            },
+            {
+                "account_id": "ifrs-full_Assets",
+                "sj_div": "BS",
+                "thstrm_amount": "450,000,000,000,000",
+                "frmtrm_amount": "430,000,000,000,000",
+            },
+            # Unknown account_id should be ignored.
+            {
+                "account_id": "ifrs-full_Unrecognized",
+                "thstrm_amount": "1",
+                "frmtrm_amount": "1",
+            },
+        ],
+    }
+
+    captured = []
+
+    def fake_get(url, params=None, timeout=None):
+        captured.append((url, dict(params or {})))
+        if url == korea_stock.DART_CORPCODE_URL:
+            return _FakeResponse(content=corp_zip)
+        if url == korea_stock.DART_LIST_URL:
+            return _FakeResponse(json_data=list_payload)
+        if url == korea_stock.DART_FNLTT_URL:
+            return _FakeResponse(json_data=fnltt_payload)
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(korea_stock.requests, "get", fake_get)
+
+    result = korea_stock.get_fundamentals("005930.KS", "2026-05-22")
+
+    # yfinance baseline is preserved.
+    assert "YF FUNDAMENTALS" in result
+    # corp_code mapping appears.
+    assert "corp_code `00126380`" in result
+    assert "삼성전자" in result
+    # Recent filings table includes the DART viewer link.
+    assert "### DART recent filings" in result
+    assert "https://dart.fss.or.kr/dsaf001/main.do?rcpNo=20260515000123" in result
+    assert "분기보고서 (2026.03)" in result
+    # Financial summary table includes mapped account labels.
+    assert "### DART financial summary" in result
+    assert "FY2025" in result  # curr_date.year - 1
+    assert "Revenue" in result
+    assert "300,000,000,000,000" in result
+    assert "Total assets" in result
+    # Unknown account_id is filtered out of the summary.
+    assert "ifrs-full_Unrecognized" not in result
+
+    # list.json was called with the expected window (~365 days) and page_count=10.
+    list_calls = [params for url, params in captured if url == korea_stock.DART_LIST_URL]
+    assert list_calls, "list.json was not called"
+    assert list_calls[0]["corp_code"] == "00126380"
+    assert list_calls[0]["page_count"] == 10
+    assert list_calls[0]["end_de"] == "20260522"
+    assert list_calls[0]["bgn_de"] == "20250522"
+
+    # fnlttSinglAcntAll.json was called for FY2025 with the annual report code.
+    fnltt_calls = [params for url, params in captured if url == korea_stock.DART_FNLTT_URL]
+    assert fnltt_calls[0]["bsns_year"] == "2025"
+    assert fnltt_calls[0]["reprt_code"] == "11011"
+
+
+def test_dart_failures_do_not_break_get_fundamentals(monkeypatch):
+    monkeypatch.setenv("DART_API_KEY", "test-key")
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_yfinance_baseline(monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("DART upstream is down")
+
+    monkeypatch.setattr(korea_stock.requests, "get", boom)
+
+    result = korea_stock.get_fundamentals("005930.KS", "2026-05-22")
+
+    # The yfinance baseline is still rendered.
+    assert "YF FUNDAMENTALS" in result
+    # And the DART section degrades to a note (no exception).
+    assert "No corp_code mapping" in result
+
+
+def test_get_balance_sheet_appends_dart_financial_summary_only(monkeypatch):
+    monkeypatch.setenv("DART_API_KEY", "test-key")
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_yfinance_baseline(monkeypatch)
+
+    corp_zip = _build_corp_code_zip(
+        [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+            }
+        ]
+    )
+    fnltt_payload = {
+        "status": "000",
+        "list": [
+            {
+                "account_id": "ifrs-full_Assets",
+                "thstrm_amount": "450,000,000,000,000",
+                "frmtrm_amount": "430,000,000,000,000",
+            }
+        ],
+    }
+
+    seen_urls = []
+
+    def fake_get(url, params=None, timeout=None):
+        seen_urls.append(url)
+        if url == korea_stock.DART_CORPCODE_URL:
+            return _FakeResponse(content=corp_zip)
+        if url == korea_stock.DART_FNLTT_URL:
+            return _FakeResponse(json_data=fnltt_payload)
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(korea_stock.requests, "get", fake_get)
+
+    result = korea_stock.get_balance_sheet("005930.KS", "2026-05-22")
+
+    assert "YF BALANCE" in result
+    assert "### DART financial summary" in result
+    assert "Total assets" in result
+    # Balance sheet view skips the filings section to keep output focused.
+    assert "### DART recent filings" not in result
+    assert korea_stock.DART_LIST_URL not in seen_urls
+
+
+def test_resolve_corp_code_strips_yahoo_suffix(monkeypatch):
+    monkeypatch.setenv("DART_API_KEY", "test-key")
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+
+    corp_zip = _build_corp_code_zip(
+        [
+            {
+                "corp_code": "00126380",
+                "corp_name": "삼성전자",
+                "stock_code": "005930",
+            },
+            {
+                "corp_code": "00164779",
+                "corp_name": "에코프로비엠",
+                "stock_code": "247540",
+            },
+        ]
+    )
+
+    def fake_get(url, params=None, timeout=None):
+        assert url == korea_stock.DART_CORPCODE_URL
+        assert params == {"crtfc_key": "test-key"}
+        return _FakeResponse(content=corp_zip)
+
+    monkeypatch.setattr(korea_stock.requests, "get", fake_get)
+
+    kospi = korea_stock._resolve_corp_code("005930.KS")
+    kosdaq = korea_stock._resolve_corp_code("247540.KQ")
+    missing = korea_stock._resolve_corp_code("000000.KS")
+
+    assert kospi == {
+        "corp_code": "00126380",
+        "corp_name": "삼성전자",
+        "stock_code": "005930",
+        "modify_date": "",
+    }
+    assert kosdaq["corp_code"] == "00164779"
+    assert missing is None
+
+
+# ---------------------------------------------------------------------------
+# Korean-language news augmentation tests
+# ---------------------------------------------------------------------------
+
+
+def _stub_news_baseline(monkeypatch):
+    monkeypatch.setattr(korea_stock, "get_news_yfinance", lambda t, s, e: "YF NEWS BASELINE")
+
+
+def test_get_news_without_naver_credentials_keeps_yfinance_baseline(monkeypatch):
+    monkeypatch.delenv("NAVER_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NAVER_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("NAVER_NEWS_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NAVER_NEWS_CLIENT_SECRET", raising=False)
+    _stub_news_baseline(monkeypatch)
+
+    def explode_requests(*args, **kwargs):
+        raise AssertionError("requests.get must not run without Naver credentials")
+
+    monkeypatch.setattr(korea_stock.requests, "get", explode_requests)
+
+    result = korea_stock.get_news("005930.KS", "2026-05-15", "2026-05-22")
+
+    assert "YF NEWS BASELINE" in result
+    assert "Korean-language news (Naver)" in result
+    assert "Naver Search API credentials not configured" in result
+
+
+def test_get_news_with_naver_credentials_sanitizes_html_and_links(monkeypatch):
+    monkeypatch.setenv("NAVER_CLIENT_ID", "naver-id")
+    monkeypatch.setenv("NAVER_CLIENT_SECRET", "naver-secret")
+    monkeypatch.delenv("NAVER_NEWS_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NAVER_NEWS_CLIENT_SECRET", raising=False)
+    # Corp-name lookup should use DART only when DART key exists; keep this path code-only.
+    monkeypatch.delenv("DART_API_KEY", raising=False)
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_news_baseline(monkeypatch)
+
+    captured = []
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured.append((url, dict(params or {}), dict(headers or {})))
+        assert url == korea_stock.NAVER_NEWS_URL
+        return _FakeResponse(
+            json_data={
+                "items": [
+                    {
+                        "title": "<b>삼성전자</b> AI 반도체 &amp; 실적",
+                        "description": "<b>외국인</b> 순매수 확대 &quot;기대&quot;",
+                        "originallink": "https://news.example.com/original",
+                        "link": "https://news.naver.com/wrapped",
+                        "pubDate": "Fri, 22 May 2026 10:00:00 +0900",
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(korea_stock.requests, "get", fake_get)
+
+    result = korea_stock.get_news("005930.KS", "2026-05-15", "2026-05-22")
+
+    assert "YF NEWS BASELINE" in result
+    assert "Query: `005930 주식`" in result
+    assert "Requested analysis window: 2026-05-15 → 2026-05-22" in result
+    assert "does not provide strict date-range filtering" in result
+    assert "[삼성전자 AI 반도체 & 실적](https://news.example.com/original)" in result
+    assert "외국인 순매수 확대 \"기대\"" in result
+    assert "<b>" not in result
+    assert captured[0][1] == {"query": "005930 주식", "display": 10, "sort": "date"}
+    assert captured[0][2]["X-Naver-Client-Id"] == "naver-id"
+    assert captured[0][2]["X-Naver-Client-Secret"] == "naver-secret"
+
+
+def test_get_news_uses_dart_corp_name_when_available(monkeypatch):
+    monkeypatch.setenv("NAVER_NEWS_CLIENT_ID", "news-id")
+    monkeypatch.setenv("NAVER_NEWS_CLIENT_SECRET", "news-secret")
+    monkeypatch.setenv("DART_API_KEY", "dart-key")
+    _stub_news_baseline(monkeypatch)
+    korea_stock._load_corp_code_map.cache_clear()
+
+    corp_zip = _build_corp_code_zip(
+        [{"corp_code": "00126380", "corp_name": "삼성전자", "stock_code": "005930"}]
+    )
+    captured = []
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured.append((url, dict(params or {})))
+        if url == korea_stock.DART_CORPCODE_URL:
+            return _FakeResponse(content=corp_zip)
+        if url == korea_stock.NAVER_NEWS_URL:
+            return _FakeResponse(json_data={"items": []})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(korea_stock.requests, "get", fake_get)
+
+    result = korea_stock.get_news("005930.KS", "2026-05-15", "2026-05-22")
+
+    assert "Query: `삼성전자 005930 주식`" in result
+    naver_calls = [params for url, params in captured if url == korea_stock.NAVER_NEWS_URL]
+    assert naver_calls[0]["query"] == "삼성전자 005930 주식"
+
+
+def test_get_news_naver_request_failure_keeps_yfinance_baseline(monkeypatch):
+    monkeypatch.setenv("NAVER_CLIENT_ID", "naver-id")
+    monkeypatch.setenv("NAVER_CLIENT_SECRET", "naver-secret")
+    monkeypatch.delenv("DART_API_KEY", raising=False)
+    monkeypatch.delenv("OPENDART_API_KEY", raising=False)
+    _stub_news_baseline(monkeypatch)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("Naver upstream down")
+
+    monkeypatch.setattr(korea_stock.requests, "get", boom)
+
+    result = korea_stock.get_news("005930.KS", "2026-05-15", "2026-05-22")
+
+    assert "YF NEWS BASELINE" in result
+    assert "Naver news API call failed: RuntimeError: Naver upstream down" in result

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -23,6 +23,18 @@ from .alpha_vantage import (
     get_global_news as get_alpha_vantage_global_news,
 )
 from .alpha_vantage_common import AlphaVantageRateLimitError
+from .korea_stock import (
+    is_korean_ticker,
+    get_stock_data as get_korea_stock_data,
+    get_indicators as get_korea_indicators,
+    get_fundamentals as get_korea_fundamentals,
+    get_balance_sheet as get_korea_balance_sheet,
+    get_cashflow as get_korea_cashflow,
+    get_income_statement as get_korea_income_statement,
+    get_news as get_korea_news,
+    get_global_news as get_korea_global_news,
+    get_insider_transactions as get_korea_insider_transactions,
+)
 
 # Configuration and routing logic
 from .config import get_config
@@ -63,6 +75,7 @@ TOOLS_CATEGORIES = {
 VENDOR_LIST = [
     "yfinance",
     "alpha_vantage",
+    "korea_stock",
 ]
 
 # Mapping of methods to their vendor-specific implementations
@@ -71,41 +84,50 @@ VENDOR_METHODS = {
     "get_stock_data": {
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
+        "korea_stock": get_korea_stock_data,
     },
     # technical_indicators
     "get_indicators": {
         "alpha_vantage": get_alpha_vantage_indicator,
         "yfinance": get_stock_stats_indicators_window,
+        "korea_stock": get_korea_indicators,
     },
     # fundamental_data
     "get_fundamentals": {
         "alpha_vantage": get_alpha_vantage_fundamentals,
         "yfinance": get_yfinance_fundamentals,
+        "korea_stock": get_korea_fundamentals,
     },
     "get_balance_sheet": {
         "alpha_vantage": get_alpha_vantage_balance_sheet,
         "yfinance": get_yfinance_balance_sheet,
+        "korea_stock": get_korea_balance_sheet,
     },
     "get_cashflow": {
         "alpha_vantage": get_alpha_vantage_cashflow,
         "yfinance": get_yfinance_cashflow,
+        "korea_stock": get_korea_cashflow,
     },
     "get_income_statement": {
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
+        "korea_stock": get_korea_income_statement,
     },
     # news_data
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "korea_stock": get_korea_news,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "korea_stock": get_korea_global_news,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,
         "yfinance": get_yfinance_insider_transactions,
+        "korea_stock": get_korea_insider_transactions,
     },
 }
 
@@ -136,6 +158,19 @@ def route_to_vendor(method: str, *args, **kwargs):
     category = get_category_for_method(method)
     vendor_config = get_vendor(category, method)
     primary_vendors = [v.strip() for v in vendor_config.split(',')]
+
+    # Korean listed tickers should use the Korean vendor first when the user is
+    # otherwise on the default Yahoo path.  This keeps US/global behavior
+    # unchanged while letting .KS/.KQ tickers pick up Korean-market context and
+    # future Korea-only sources automatically.
+    if (
+        args
+        and isinstance(args[0], str)
+        and is_korean_ticker(args[0])
+        and "korea_stock" not in primary_vendors
+        and primary_vendors == ["yfinance"]
+    ):
+        primary_vendors = ["korea_stock", *primary_vendors]
 
     if method not in VENDOR_METHODS:
         raise ValueError(f"Method '{method}' not supported")

--- a/tradingagents/dataflows/korea_stock.py
+++ b/tradingagents/dataflows/korea_stock.py
@@ -1,0 +1,610 @@
+"""Korean market data vendor.
+
+Stage 2 prefers ``pykrx`` (KRX-native OHLCV + supply/demand) when it is
+installed and the request returns usable data, and falls back to the existing
+Yahoo Finance vendor for Korean tickers (``.KS``/``.KQ``) when pykrx is
+unavailable, errors out, or returns an empty frame. This keeps Korean-only
+sources opt-in while leaving the analyst tools wired the same way.
+
+Stage 3 layers in OpenDART (https://opendart.fss.or.kr/) disclosure and
+financial-statement context on top of the yfinance fundamentals baseline.
+DART access is fully optional: it activates only when ``DART_API_KEY`` or
+``OPENDART_API_KEY`` is set, and any network/API failure degrades to a note
+section rather than blocking the baseline report.
+"""
+
+from __future__ import annotations
+
+import html
+import io
+import os
+import re
+import zipfile
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+from functools import lru_cache
+
+import requests
+
+from .y_finance import (
+    get_YFin_data_online,
+    get_balance_sheet as get_yfinance_balance_sheet,
+    get_cashflow as get_yfinance_cashflow,
+    get_fundamentals as get_yfinance_fundamentals,
+    get_income_statement as get_yfinance_income_statement,
+    get_insider_transactions as get_yfinance_insider_transactions,
+)
+from .yfinance_news import get_news_yfinance, get_global_news_yfinance
+
+KOREA_SUFFIXES = (".KS", ".KQ")
+
+DART_CORPCODE_URL = "https://opendart.fss.or.kr/api/corpCode.xml"
+DART_LIST_URL = "https://opendart.fss.or.kr/api/list.json"
+DART_FNLTT_URL = "https://opendart.fss.or.kr/api/fnlttSinglAcntAll.json"
+DART_VIEWER_URL = "https://dart.fss.or.kr/dsaf001/main.do?rcpNo={rcept_no}"
+DART_HTTP_TIMEOUT = 10
+NAVER_NEWS_URL = "https://openapi.naver.com/v1/search/news.json"
+NAVER_HTTP_TIMEOUT = 10
+
+
+def is_korean_ticker(ticker: str) -> bool:
+    """Return True for Yahoo-style KOSPI/KOSDAQ tickers."""
+    return ticker.upper().endswith(KOREA_SUFFIXES)
+
+
+def _with_korea_context(title: str, ticker: str, body: str) -> str:
+    market_note = (
+        "Korea market context: treat Yahoo Finance data as a baseline only. "
+        "For stronger Korean-stock analysis, augment with DART filings, KRX/pykrx "
+        "supply-demand data, Korean-language news, and local investor-community signals."
+    )
+    return f"# {title} for {ticker}\n\n{market_note}\n\n{body}"
+
+
+def to_pykrx_ticker(ticker: str) -> str:
+    """Strip the Yahoo ``.KS``/``.KQ`` suffix so pykrx receives the bare KRX code."""
+    upper = ticker.upper()
+    for suffix in KOREA_SUFFIXES:
+        if upper.endswith(suffix):
+            return upper[: -len(suffix)]
+    return upper
+
+
+def _to_pykrx_date(date_str: str) -> str:
+    """Convert ``YYYY-MM-DD`` to pykrx's ``YYYYMMDD`` format."""
+    return datetime.strptime(date_str, "%Y-%m-%d").strftime("%Y%m%d")
+
+
+# Korean → English column hints used in the markdown table header so LLM
+# consumers do not need to interpret Hangul column names directly.
+_OHLCV_COLUMN_LABELS = {
+    "시가": "Open",
+    "고가": "High",
+    "저가": "Low",
+    "종가": "Close",
+    "거래량": "Volume",
+    "거래대금": "TradingValue",
+    "등락률": "ChangePct",
+}
+
+
+def _format_pykrx_ohlcv_markdown(df, ticker: str, start_date: str, end_date: str) -> str:
+    """Render a pykrx OHLCV frame as a markdown table with bilingual headers."""
+    import pandas as pd  # local import keeps module importable without pandas at parse time
+
+    frame = df.copy()
+    if isinstance(frame.index, pd.DatetimeIndex):
+        frame.index = frame.index.strftime("%Y-%m-%d")
+    frame.index.name = "날짜 (Date)"
+
+    rounded_columns = ("시가", "고가", "저가", "종가", "등락률")
+    for col in rounded_columns:
+        if col in frame.columns:
+            frame[col] = frame[col].round(2)
+
+    renamed = {col: f"{col} ({_OHLCV_COLUMN_LABELS[col]})" for col in frame.columns if col in _OHLCV_COLUMN_LABELS}
+    frame = frame.rename(columns=renamed)
+
+    header = (
+        f"## OHLCV (pykrx) for {ticker} from {start_date} to {end_date}\n"
+        f"Rows: {len(frame)}\n"
+    )
+    return header + "\n" + frame.to_markdown()
+
+
+_INVESTOR_TABLE_LABELS = {
+    "trading_value": ("Investor trading value (KRW)", "거래대금 / Trading Value (KRW)"),
+    "trading_volume": ("Investor trading volume (shares)", "거래량 / Trading Volume (shares)"),
+}
+
+
+def _format_investor_table(df, kind: str) -> str:
+    import pandas as pd
+
+    title, axis_label = _INVESTOR_TABLE_LABELS[kind]
+    frame = df.copy()
+    if isinstance(frame.index, pd.DatetimeIndex):
+        frame.index = frame.index.strftime("%Y-%m-%d")
+    frame.index.name = "날짜 (Date)"
+    return f"### {title}\n_{axis_label}_\n\n" + frame.to_markdown()
+
+
+def _fetch_pykrx_stock_data(ticker: str, start_date: str, end_date: str) -> str | None:
+    """Return a markdown report using pykrx, or ``None`` to signal fallback.
+
+    Returns ``None`` when pykrx is not installed, the OHLCV frame is empty, or
+    the OHLCV call raises — letting the caller route to the yfinance baseline.
+    Supply/demand sections are best-effort: a failure there only adds a note.
+    """
+    try:
+        from pykrx import stock as krx_stock  # type: ignore
+    except ImportError:
+        return None
+
+    krx_ticker = to_pykrx_ticker(ticker)
+    pkx_start = _to_pykrx_date(start_date)
+    pkx_end = _to_pykrx_date(end_date)
+
+    try:
+        ohlcv = krx_stock.get_market_ohlcv(pkx_start, pkx_end, krx_ticker)
+    except Exception:
+        return None
+
+    if ohlcv is None or getattr(ohlcv, "empty", True):
+        return None
+
+    sections = [_format_pykrx_ohlcv_markdown(ohlcv, ticker, start_date, end_date)]
+
+    investor_notes = []
+    investor_fetchers = (
+        ("trading_value", "get_market_trading_value_by_date"),
+        ("trading_volume", "get_market_trading_volume_by_date"),
+    )
+    for kind, fn_name in investor_fetchers:
+        fetcher = getattr(krx_stock, fn_name, None)
+        if fetcher is None:
+            investor_notes.append(f"- pykrx supply/demand `{fn_name}` not available in this version.")
+            continue
+        try:
+            frame = fetcher(pkx_start, pkx_end, krx_ticker)
+        except Exception as exc:  # network / KRX schema drift / etc.
+            investor_notes.append(f"- pykrx {kind} fetch failed: {type(exc).__name__}: {exc}")
+            continue
+        if frame is None or getattr(frame, "empty", True):
+            investor_notes.append(f"- pykrx {kind}: no rows returned for this window.")
+            continue
+        sections.append(_format_investor_table(frame, kind))
+
+    if investor_notes:
+        sections.append("### Supply/demand notes\n" + "\n".join(investor_notes))
+
+    return "\n\n".join(sections)
+
+
+def get_stock_data(ticker: str, start_date: str, end_date: str) -> str:
+    """Return OHLCV data for Korean tickers, preferring pykrx with yfinance fallback."""
+    if is_korean_ticker(ticker):
+        pykrx_report = _fetch_pykrx_stock_data(ticker, start_date, end_date)
+        if pykrx_report is not None:
+            return _with_korea_context("Korean stock price data", ticker, pykrx_report)
+        data = get_YFin_data_online(ticker, start_date, end_date)
+        return _with_korea_context("Korean stock price data", ticker, data)
+    return get_YFin_data_online(ticker, start_date, end_date)
+
+
+def get_indicators(ticker: str, indicator: str, curr_date: str, look_back_days: int) -> str:
+    from .y_finance import get_stock_stats_indicators_window
+
+    data = get_stock_stats_indicators_window(ticker, indicator, curr_date, look_back_days)
+    if is_korean_ticker(ticker):
+        return _with_korea_context("Korean technical indicators", ticker, data)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# OpenDART helpers
+# ---------------------------------------------------------------------------
+
+
+def _dart_api_key() -> str | None:
+    """Return the configured OpenDART API key, if any."""
+    return os.environ.get("DART_API_KEY") or os.environ.get("OPENDART_API_KEY")
+
+
+def _dart_no_key_note() -> str:
+    return (
+        "### DART context\n"
+        "_DART API key not configured (set `DART_API_KEY` or `OPENDART_API_KEY` to enable "
+        "OpenDART filings and financial-statement augmentation)._"
+    )
+
+
+def _parse_corp_code_zip(content: bytes) -> dict[str, dict[str, str]]:
+    """Parse the ``corpCode.xml`` ZIP payload into a stock_code → record map.
+
+    Only entries with a non-empty ``stock_code`` (i.e. listed companies) are
+    kept since unlisted issuers are not addressable through Yahoo tickers.
+    """
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        xml_name = next((n for n in zf.namelist() if n.lower().endswith(".xml")), None)
+        if xml_name is None:
+            return {}
+        with zf.open(xml_name) as xml_file:
+            tree = ET.parse(xml_file)
+    root = tree.getroot()
+    mapping: dict[str, dict[str, str]] = {}
+    for node in root.findall("list"):
+        stock_code = (node.findtext("stock_code") or "").strip()
+        if not stock_code:
+            continue
+        mapping[stock_code] = {
+            "corp_code": (node.findtext("corp_code") or "").strip(),
+            "corp_name": (node.findtext("corp_name") or "").strip(),
+            "stock_code": stock_code,
+            "modify_date": (node.findtext("modify_date") or "").strip(),
+        }
+    return mapping
+
+
+@lru_cache(maxsize=1)
+def _load_corp_code_map() -> dict[str, dict[str, str]]:
+    """Fetch and cache the OpenDART corp-code ZIP. Returns ``{}`` on failure."""
+    api_key = _dart_api_key()
+    if not api_key:
+        return {}
+    try:
+        response = requests.get(
+            DART_CORPCODE_URL,
+            params={"crtfc_key": api_key},
+            timeout=DART_HTTP_TIMEOUT,
+        )
+        response.raise_for_status()
+        return _parse_corp_code_zip(response.content)
+    except Exception:
+        return {}
+
+
+def _resolve_corp_code(ticker: str) -> dict[str, str] | None:
+    """Map a Yahoo-style Korean ticker to its OpenDART corp record, or ``None``."""
+    stock_code = to_pykrx_ticker(ticker)
+    record = _load_corp_code_map().get(stock_code)
+    return record or None
+
+
+def _format_recent_filings(corp_code: str, curr_date: str) -> str:
+    """Return a markdown section of the latest disclosures, or a note on failure."""
+    try:
+        end_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    except ValueError:
+        return "### DART recent filings\n_Invalid curr_date; skipped._"
+    bgn_dt = end_dt - timedelta(days=365)
+    api_key = _dart_api_key()
+    if not api_key:
+        return "### DART recent filings\n_API key missing; skipped._"
+
+    try:
+        response = requests.get(
+            DART_LIST_URL,
+            params={
+                "crtfc_key": api_key,
+                "corp_code": corp_code,
+                "bgn_de": bgn_dt.strftime("%Y%m%d"),
+                "end_de": end_dt.strftime("%Y%m%d"),
+                "page_count": 10,
+            },
+            timeout=DART_HTTP_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return (
+            "### DART recent filings\n"
+            f"_DART list.json call failed: {type(exc).__name__}: {exc}._"
+        )
+
+    status = str(payload.get("status", ""))
+    rows = payload.get("list") or []
+    if status != "000" or not rows:
+        message = payload.get("message") or "no rows returned"
+        return f"### DART recent filings\n_No recent disclosures ({message})._"
+
+    lines = [
+        "### DART recent filings",
+        f"_Window: {bgn_dt.strftime('%Y-%m-%d')} → {end_dt.strftime('%Y-%m-%d')} (latest {len(rows)})_",
+        "",
+        "| Date | Report | Filer |",
+        "| --- | --- | --- |",
+    ]
+    pipe_escape = "\\|"
+    for row in rows:
+        rcept_no = (row.get("rcept_no") or "").strip()
+        report_nm = (row.get("report_nm") or "").strip()
+        rcept_dt = (row.get("rcept_dt") or "").strip()
+        flr_nm = (row.get("flr_nm") or "").strip()
+        title = report_nm.replace("|", pipe_escape) or "(untitled)"
+        if rcept_no:
+            link = DART_VIEWER_URL.format(rcept_no=rcept_no)
+            title_cell = f"[{title}]({link})"
+        else:
+            title_cell = title
+        filer_cell = flr_nm.replace("|", pipe_escape)
+        lines.append(f"| {rcept_dt} | {title_cell} | {filer_cell} |")
+    return "\n".join(lines)
+
+
+# OpenDART account-name normalization so the markdown summary is human-readable
+# regardless of whether a filing uses Korean-only or English-only labels.
+_FNLTT_ACCOUNT_LABELS = {
+    "ifrs-full_Revenue": "Revenue",
+    "ifrs-full_GrossProfit": "Gross profit",
+    "ifrs-full_ProfitLossFromOperatingActivities": "Operating profit",
+    "ifrs-full_ProfitLoss": "Net income",
+    "ifrs-full_Assets": "Total assets",
+    "ifrs-full_Liabilities": "Total liabilities",
+    "ifrs-full_Equity": "Total equity",
+    "ifrs-full_CashFlowsFromUsedInOperatingActivities": "Cash from operating",
+    "ifrs-full_CashFlowsFromUsedInInvestingActivities": "Cash from investing",
+    "ifrs-full_CashFlowsFromUsedInFinancingActivities": "Cash from financing",
+}
+
+
+def _format_financial_summary(corp_code: str, curr_date: str) -> str:
+    """Return a markdown summary of the latest annual report, or a note on failure."""
+    api_key = _dart_api_key()
+    if not api_key:
+        return "### DART financial summary\n_API key missing; skipped._"
+    try:
+        end_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    except ValueError:
+        return "### DART financial summary\n_Invalid curr_date; skipped._"
+    bsns_year = end_dt.year - 1
+
+    try:
+        response = requests.get(
+            DART_FNLTT_URL,
+            params={
+                "crtfc_key": api_key,
+                "corp_code": corp_code,
+                "bsns_year": str(bsns_year),
+                "reprt_code": "11011",
+                "fs_div": "CFS",
+            },
+            timeout=DART_HTTP_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return (
+            "### DART financial summary\n"
+            f"_DART fnlttSinglAcntAll.json call failed: {type(exc).__name__}: {exc}._"
+        )
+
+    status = str(payload.get("status", ""))
+    rows = payload.get("list") or []
+    if status != "000" or not rows:
+        message = payload.get("message") or "no rows returned"
+        return (
+            "### DART financial summary\n"
+            f"_No financial statement rows for FY{bsns_year} ({message})._"
+        )
+
+    summary: dict[str, dict[str, str]] = {}
+    for row in rows:
+        account_id = (row.get("account_id") or "").strip()
+        if account_id not in _FNLTT_ACCOUNT_LABELS:
+            continue
+        label = _FNLTT_ACCOUNT_LABELS[account_id]
+        entry = summary.setdefault(
+            label,
+            {
+                "current": (row.get("thstrm_amount") or "").strip(),
+                "prior": (row.get("frmtrm_amount") or "").strip(),
+                "sj_div": (row.get("sj_div") or "").strip(),
+            },
+        )
+        # Prefer the first occurrence but fill blanks from later rows when needed.
+        if not entry["current"]:
+            entry["current"] = (row.get("thstrm_amount") or "").strip()
+        if not entry["prior"]:
+            entry["prior"] = (row.get("frmtrm_amount") or "").strip()
+
+    if not summary:
+        return (
+            "### DART financial summary\n"
+            f"_FY{bsns_year} report fetched, but no recognized account_ids matched._"
+        )
+
+    lines = [
+        "### DART financial summary",
+        f"_FY{bsns_year} consolidated annual report (reprt_code=11011)._",
+        "",
+        "| Account | Current period | Prior period |",
+        "| --- | ---: | ---: |",
+    ]
+    for label in _FNLTT_ACCOUNT_LABELS.values():
+        if label not in summary:
+            continue
+        entry = summary[label]
+        lines.append(f"| {label} | {entry['current'] or '-'} | {entry['prior'] or '-'} |")
+    return "\n".join(lines)
+
+
+def _dart_context_sections(
+    ticker: str,
+    curr_date: str,
+    *,
+    include_filings: bool = True,
+    include_financials: bool = True,
+) -> str:
+    """Assemble the DART context block, never raising — failures become notes."""
+    try:
+        if not _dart_api_key():
+            return _dart_no_key_note()
+        record = _resolve_corp_code(ticker)
+        if not record:
+            return (
+                "### DART context\n"
+                f"_No corp_code mapping for stock_code `{to_pykrx_ticker(ticker)}` "
+                "(corp list fetch failed or ticker is unlisted on OpenDART)._"
+            )
+        corp_code = record["corp_code"]
+        corp_name = record.get("corp_name") or ""
+        header = (
+            "### DART context\n"
+            f"_Mapped {to_pykrx_ticker(ticker)} → corp_code `{corp_code}`"
+            f"{f' ({corp_name})' if corp_name else ''}._"
+        )
+        sections = [header]
+        if include_filings:
+            sections.append(_format_recent_filings(corp_code, curr_date))
+        if include_financials:
+            sections.append(_format_financial_summary(corp_code, curr_date))
+        return "\n\n".join(sections)
+    except Exception as exc:
+        return (
+            "### DART context\n"
+            f"_Unexpected DART pipeline error: {type(exc).__name__}: {exc}._"
+        )
+
+
+def get_fundamentals(ticker: str, curr_date: str) -> str:
+    data = get_yfinance_fundamentals(ticker, curr_date)
+    if is_korean_ticker(ticker):
+        dart_block = _dart_context_sections(ticker, curr_date)
+        body = f"{data}\n\n{dart_block}"
+        return _with_korea_context("Korean fundamentals baseline", ticker, body)
+    return data
+
+
+def get_balance_sheet(ticker: str, curr_date: str) -> str:
+    data = get_yfinance_balance_sheet(ticker, curr_date)
+    if is_korean_ticker(ticker):
+        dart_block = _dart_context_sections(ticker, curr_date, include_filings=False)
+        body = f"{data}\n\n{dart_block}"
+        return _with_korea_context("Korean balance sheet baseline", ticker, body)
+    return data
+
+
+def get_cashflow(ticker: str, curr_date: str) -> str:
+    data = get_yfinance_cashflow(ticker, curr_date)
+    if is_korean_ticker(ticker):
+        dart_block = _dart_context_sections(ticker, curr_date, include_filings=False)
+        body = f"{data}\n\n{dart_block}"
+        return _with_korea_context("Korean cash flow baseline", ticker, body)
+    return data
+
+
+def get_income_statement(ticker: str, curr_date: str) -> str:
+    data = get_yfinance_income_statement(ticker, curr_date)
+    if is_korean_ticker(ticker):
+        dart_block = _dart_context_sections(ticker, curr_date, include_filings=False)
+        body = f"{data}\n\n{dart_block}"
+        return _with_korea_context("Korean income statement baseline", ticker, body)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Korean-language news helpers (Naver Search API)
+# ---------------------------------------------------------------------------
+
+
+def _naver_news_credentials() -> tuple[str, str] | None:
+    """Return configured Naver Search API credentials, if any."""
+    client_id = os.environ.get("NAVER_NEWS_CLIENT_ID") or os.environ.get("NAVER_CLIENT_ID")
+    client_secret = os.environ.get("NAVER_NEWS_CLIENT_SECRET") or os.environ.get("NAVER_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        return None
+    return client_id, client_secret
+
+
+def _strip_html(text: str) -> str:
+    """Remove Naver's HTML highlights and decode entities."""
+    return re.sub(r"<[^>]+>", "", html.unescape(text or "")).strip()
+
+
+def _korean_news_query(ticker: str) -> str:
+    """Use DART corp_name when available, otherwise fall back to the bare stock code."""
+    corp_name = ""
+    if _dart_api_key():
+        try:
+            record = _resolve_corp_code(ticker)
+            corp_name = (record or {}).get("corp_name", "")
+        except Exception:
+            corp_name = ""
+    code = to_pykrx_ticker(ticker)
+    return f"{corp_name} {code} 주식".strip() if corp_name else f"{code} 주식"
+
+
+def _format_korean_news(ticker: str, start_date: str, end_date: str, *, display: int = 10) -> str:
+    """Return Naver Korean-news search results as markdown, never raising."""
+    creds = _naver_news_credentials()
+    if not creds:
+        return (
+            "### Korean-language news (Naver)\n"
+            "_Naver Search API credentials not configured (set `NAVER_CLIENT_ID`/`NAVER_CLIENT_SECRET` "
+            "or `NAVER_NEWS_CLIENT_ID`/`NAVER_NEWS_CLIENT_SECRET` to enable Korean-news augmentation)._"
+        )
+    client_id, client_secret = creds
+    query = _korean_news_query(ticker)
+    try:
+        response = requests.get(
+            NAVER_NEWS_URL,
+            params={"query": query, "display": display, "sort": "date"},
+            headers={
+                "X-Naver-Client-Id": client_id,
+                "X-Naver-Client-Secret": client_secret,
+            },
+            timeout=NAVER_HTTP_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return (
+            "### Korean-language news (Naver)\n"
+            f"_Naver news API call failed: {type(exc).__name__}: {exc}._"
+        )
+
+    items = payload.get("items") or []
+    lines = [
+        "### Korean-language news (Naver)",
+        f"_Query: `{query}`. Requested analysis window: {start_date} → {end_date}._",
+        "_Naver Search API does not provide strict date-range filtering here; results may fall outside the requested window._",
+        "",
+    ]
+    if not items:
+        lines.append("_No Korean-news search results returned._")
+        return "\n".join(lines)
+
+    for item in items[:display]:
+        title = _strip_html(item.get("title", "")) or "(untitled)"
+        description = _strip_html(item.get("description", ""))
+        pub_date = _strip_html(item.get("pubDate", "")) or "date unknown"
+        link = item.get("originallink") or item.get("link") or ""
+        if link:
+            headline = f"[{title}]({link})"
+        else:
+            headline = title
+        if description:
+            lines.append(f"- {pub_date}: {headline} — {description}")
+        else:
+            lines.append(f"- {pub_date}: {headline}")
+    return "\n".join(lines)
+
+
+def get_news(ticker: str, start_date: str, end_date: str) -> str:
+    data = get_news_yfinance(ticker, start_date, end_date)
+    if is_korean_ticker(ticker):
+        korean_news = _format_korean_news(ticker, start_date, end_date)
+        return _with_korea_context("Korean news baseline", ticker, f"{data}\n\n{korean_news}")
+    return data
+
+
+def get_global_news(curr_date: str, look_back_days: int | None = None, limit: int | None = None) -> str:
+    return get_global_news_yfinance(curr_date, look_back_days, limit)
+
+
+def get_insider_transactions(ticker: str) -> str:
+    data = get_yfinance_insider_transactions(ticker)
+    if is_korean_ticker(ticker):
+        return _with_korea_context("Korean insider-transactions baseline", ticker, data)
+    return data

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -114,6 +114,8 @@ DEFAULT_CONFIG = _apply_env_overrides({
         ".BO":  "^BSESN",   # BSE India (Sensex)
         ".T":   "^N225",    # Tokyo (Nikkei 225)
         ".HK":  "^HSI",     # Hong Kong (Hang Seng)
+        ".KS":  "^KS11",    # Korea KOSPI
+        ".KQ":  "^KQ11",    # Korea KOSDAQ
         ".L":   "^FTSE",    # London (FTSE 100)
         ".TO":  "^GSPTSE",  # Toronto (TSX Composite)
         ".AX":  "^AXJO",    # Australia (ASX 200)


### PR DESCRIPTION
## Summary
- Adds a Korea-specific data vendor for .KS/.KQ tickers with pykrx-first OHLCV and yfinance fallback
- Adds optional OpenDART disclosure/financial-statement context and Naver Korean-language news augmentation
- Maps Korean benchmarks to ^KS11/^KQ11 and updates CLI examples
- Documents the required user-supplied API keys in README and .env.example
- Adds a lightweight dashboard preview with a safe example status file

## API keys users can optionally add
- DART_API_KEY or OPENDART_API_KEY for OpenDART filings and financial summaries
- NAVER_CLIENT_ID/NAVER_CLIENT_SECRET or NAVER_NEWS_CLIENT_ID/NAVER_NEWS_CLIENT_SECRET for Korean-language news

## Test plan
- pytest -q
- 251 passed, 1 skipped, 7 warnings, 75 subtests passed

## Notes
- All Korean enrichments are fail-soft: missing credentials, empty upstream responses, or API failures produce analyst notes without breaking the baseline report.