### PR TITLE
fix: verify market data before analyst reports

### DIFF
--- a/tests/test_market_data_validator.py
+++ b/tests/test_market_data_validator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import tradingagents.dataflows.market_data_validator as validator
+
+
+def _sample_ohlcv() -> pd.DataFrame:
+    dates = pd.bdate_range("2026-04-01", "2026-05-20")
+    closes = [100 + i for i in range(len(dates))]
+
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": [value - 0.5 for value in closes],
+            "High": [value + 1.0 for value in closes],
+            "Low": [value - 1.0 for value in closes],
+            "Close": closes,
+            "Volume": [1_000_000 + i for i in range(len(dates))],
+        }
+    )
+
+
+def test_verified_market_snapshot_filters_future_rows(monkeypatch):
+    data = _sample_ohlcv()
+
+    future_row = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2026-06-01")],
+            "Open": [999.0],
+            "High": [999.0],
+            "Low": [999.0],
+            "Close": [999.0],
+            "Volume": [999],
+        }
+    )
+
+    data = pd.concat([data, future_row], ignore_index=True)
+
+    monkeypatch.setattr(
+        validator,
+        "load_ohlcv",
+        lambda symbol, curr_date: data,
+    )
+
+    snapshot = validator.build_verified_market_snapshot("COF", "2026-05-13")
+
+    assert "Verified market data snapshot for COF" in snapshot
+    assert "Requested analysis date: 2026-05-13" in snapshot
+    assert "Latest trading row used: 2026-05-13" in snapshot
+    assert "boll_lb" in snapshot
+    assert "999.00" not in snapshot
+
+
+def test_verified_market_snapshot_uses_previous_trading_day(monkeypatch):
+    data = _sample_ohlcv()
+
+    monkeypatch.setattr(
+        validator,
+        "load_ohlcv",
+        lambda symbol, curr_date: data,
+    )
+
+    snapshot = validator.build_verified_market_snapshot("COF", "2026-05-16")
+
+    assert "Requested analysis date: 2026-05-16" in snapshot
+    assert "Latest trading row used: 2026-05-15" in snapshot
+    assert "Recent verified closes" in snapshot

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,29 +1,35 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_indicators,
     get_language_instruction,
     get_stock_data,
+    get_verified_market_snapshot,
 )
 from tradingagents.dataflows.config import get_config
 
 
 def create_market_analyst(llm):
-
     def market_analyst_node(state):
         current_date = state["trade_date"]
         asset_type = state.get("asset_type", "stock")
         instrument_context = build_instrument_context(
-            state["company_of_interest"], asset_type
+            state["company_of_interest"],
+            asset_type,
         )
 
         tools = [
             get_stock_data,
             get_indicators,
+            get_verified_market_snapshot,
         ]
 
         system_message = (
-            """You are a trading assistant tasked with analyzing financial markets. Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy. Categories and each category's indicators are:
+            """You are a trading assistant tasked with analyzing financial markets.
+Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy.
+
+Categories and each category's indicators are:
 
 Moving Averages:
 - close_50_sma: 50 SMA: A medium-term trend indicator. Usage: Identify trend direction and serve as dynamic support/resistance. Tips: It lags price; combine with faster indicators for timely signals.
@@ -47,7 +53,16 @@ Volatility Indicators:
 Volume-Based Indicators:
 - vwma: VWMA: A moving average weighted by volume. Usage: Confirm trends by integrating price action with volume data. Tips: Watch for skewed results from volume spikes; use in combination with other volume analyses.
 
-- Select indicators that provide diverse and complementary information. Avoid redundancy (e.g., do not select both rsi and stochrsi). Also briefly explain why they are suitable for the given market context. When you tool call, please use the exact name of the indicators provided above as they are defined parameters, otherwise your call will fail. Please make sure to call get_stock_data first to retrieve the CSV that is needed to generate indicators. Then use get_indicators with the specific indicator names. Write a very detailed and nuanced report of the trends you observe. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."""
+- Select indicators that provide diverse and complementary information. Avoid redundancy (e.g., do not select both rsi and stochrsi). Also briefly explain why they are suitable for the given market context. When you tool call, please use the exact name of the indicators provided above as they are defined parameters, otherwise your call will fail.
+
+Please make sure to call get_stock_data first to retrieve the CSV that is needed to generate indicators. Then use get_indicators with the specific indicator names.
+
+Before writing the final market report, call get_verified_market_snapshot for the same ticker and current date. Treat the verified snapshot as the source of truth for exact OHLCV, price-level, and indicator-value claims. If another tool output conflicts with the verified snapshot, explicitly flag the discrepancy instead of inventing a reconciled number.
+
+Do not claim historical validation, support/resistance bounces, or exact percentage moves unless they are directly supported by tool output with concrete dates and prices.
+
+Write a very detailed and nuanced report of the trends you observe.
+Provide specific, actionable insights with supporting evidence to help traders make informed decisions."""
             + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
             + get_language_instruction()
         )
@@ -63,7 +78,7 @@ Volume-Based Indicators:
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     " You have access to the following tools: {tool_names}.\n{system_message}"
-                    "For your reference, the current date is {current_date}. {instrument_context}",
+                    "For your reference, the current date is {current_date}.\n{instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -1,49 +1,53 @@
 from langchain_core.messages import HumanMessage, RemoveMessage
 
-# Import tools from separate utility files
-from tradingagents.agents.utils.core_stock_tools import (
-    get_stock_data
-)
-from tradingagents.agents.utils.technical_indicators_tools import (
-    get_indicators
-)
+from tradingagents.agents.utils.core_stock_tools import get_stock_data
 from tradingagents.agents.utils.fundamental_data_tools import (
-    get_fundamentals,
     get_balance_sheet,
     get_cashflow,
-    get_income_statement
+    get_fundamentals,
+    get_income_statement,
+)
+from tradingagents.agents.utils.market_data_validation_tools import (
+    get_verified_market_snapshot,
 )
 from tradingagents.agents.utils.news_data_tools import (
-    get_news,
+    get_global_news,
     get_insider_transactions,
-    get_global_news
+    get_news,
 )
+from tradingagents.agents.utils.technical_indicators_tools import get_indicators
 
 
 def get_language_instruction() -> str:
-    """Return a prompt instruction for the configured output language.
+    """
+    Return a prompt instruction for the configured output language.
 
     Returns empty string when English (default), so no extra tokens are used.
-    Applied to every agent whose output reaches the saved report —
-    analysts, researchers, debaters, research manager, trader, and
-    portfolio manager — so a non-English run produces a fully localized
-    report rather than a mix of languages.
+    Applied to every agent whose output reaches the saved report — analysts,
+    researchers, debaters, research manager, trader, and portfolio manager —
+    so a non-English run produces a fully localized report rather than a mix
+    of languages.
     """
     from tradingagents.dataflows.config import get_config
+
     lang = get_config().get("output_language", "English")
+
     if lang.strip().lower() == "english":
         return ""
+
     return f" Write your entire response in {lang}."
 
 
 def build_instrument_context(ticker: str, asset_type: str = "stock") -> str:
     """Describe the exact instrument so agents preserve exchange-qualified tickers."""
     instrument_label = "asset" if asset_type == "crypto" else "instrument"
+
     extra_hint = (
         " Treat it as a crypto asset rather than a company, and do not assume company fundamentals are available."
         if asset_type == "crypto"
         else ""
     )
+
     return (
         f"The {instrument_label} to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
@@ -51,20 +55,16 @@ def build_instrument_context(ticker: str, asset_type: str = "stock") -> str:
         + extra_hint
     )
 
+
 def create_msg_delete():
     def delete_messages(state):
         """Clear messages and add placeholder for Anthropic compatibility"""
         messages = state["messages"]
 
-        # Remove all messages
         removal_operations = [RemoveMessage(id=m.id) for m in messages]
 
-        # Add a minimal placeholder message
         placeholder = HumanMessage(content="Continue")
 
         return {"messages": removal_operations + [placeholder]}
 
     return delete_messages
-
-
-        

--- a/tradingagents/agents/utils/market_data_validation_tools.py
+++ b/tradingagents/agents/utils/market_data_validation_tools.py
@@ -1,0 +1,25 @@
+from typing import Annotated
+
+from langchain_core.tools import tool
+
+from tradingagents.dataflows.market_data_validator import build_verified_market_snapshot
+
+
+@tool
+def get_verified_market_snapshot(
+    symbol: Annotated[str, "ticker symbol of the company"],
+    curr_date: Annotated[str, "The current trading date, YYYY-mm-dd"],
+    look_back_days: Annotated[
+        int,
+        "Number of recent trading rows to include for sanity checking",
+    ] = 30,
+) -> str:
+    """
+    Retrieve a deterministic verification snapshot for exact market data claims.
+
+    Returns the latest OHLCV row on or before curr_date, selected technical
+    indicators, and recent closing prices. Use this before making exact claims
+    about price levels, Bollinger bands, RSI, MACD, moving averages,
+    support/resistance, or historical comparisons.
+    """
+    return build_verified_market_snapshot(symbol, curr_date, look_back_days)

--- a/tradingagents/dataflows/market_data_validator.py
+++ b/tradingagents/dataflows/market_data_validator.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+from stockstats import wrap
+
+from tradingagents.dataflows.stockstats_utils import load_ohlcv
+
+
+DEFAULT_SNAPSHOT_INDICATORS: tuple[str, ...] = (
+    "close_10_ema",
+    "close_50_sma",
+    "close_200_sma",
+    "rsi",
+    "boll",
+    "boll_ub",
+    "boll_lb",
+    "macd",
+    "macds",
+    "macdh",
+    "atr",
+)
+
+
+def _normalize_ohlcv(data: pd.DataFrame, curr_date: str) -> pd.DataFrame:
+    if data is None or data.empty:
+        raise ValueError("No OHLCV data was returned for verification.")
+
+    df = data.copy()
+
+    if "Date" not in df.columns:
+        df = df.reset_index()
+        if "Date" not in df.columns:
+            df = df.rename(columns={df.columns[0]: "Date"})
+
+    df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+    df = df.dropna(subset=["Date"])
+
+    cutoff = pd.to_datetime(curr_date)
+    df = df[df["Date"] <= cutoff].sort_values("Date")
+
+    if df.empty:
+        raise ValueError(f"No OHLCV rows are available on or before {curr_date}.")
+
+    return df
+
+
+def _row_value(row: pd.Series, name: str):
+    candidates = (name, name.lower(), name.upper(), name.title())
+
+    for candidate in candidates:
+        if candidate in row.index and pd.notna(row[candidate]):
+            return row[candidate]
+
+    return None
+
+
+def _format_value(value) -> str:
+    if value is None or pd.isna(value):
+        return "N/A"
+
+    if isinstance(value, pd.Timestamp):
+        return value.strftime("%Y-%m-%d")
+
+    if isinstance(value, int):
+        return str(value)
+
+    if isinstance(value, float):
+        return f"{value:.2f}"
+
+    return str(value)
+
+
+def _latest_date(row: pd.Series) -> str:
+    value = _row_value(row, "Date")
+
+    if isinstance(value, pd.Timestamp):
+        return value.strftime("%Y-%m-%d")
+
+    parsed = pd.to_datetime(value, errors="coerce")
+    if pd.notna(parsed):
+        return parsed.strftime("%Y-%m-%d")
+
+    return str(value)
+
+
+def build_verified_market_snapshot(
+    symbol: str,
+    curr_date: str,
+    look_back_days: int = 30,
+    indicators: Iterable[str] | None = None,
+) -> str:
+    df = _normalize_ohlcv(load_ohlcv(symbol, curr_date), curr_date)
+
+    stock_df = wrap(df.copy())
+    stock_df["Date"] = pd.to_datetime(stock_df["Date"], errors="coerce")
+
+    selected_indicators = tuple(indicators or DEFAULT_SNAPSHOT_INDICATORS)
+
+    indicator_values: dict[str, str] = {}
+
+    for indicator in selected_indicators:
+        try:
+            stock_df[indicator]
+            value = stock_df.iloc[-1][indicator]
+            indicator_values[indicator] = _format_value(value)
+        except Exception as exc:
+            indicator_values[indicator] = f"N/A ({type(exc).__name__})"
+
+    latest = stock_df.iloc[-1]
+    latest_date = _latest_date(latest)
+
+    price_rows = [
+        ("Date", latest_date),
+        ("Open", _format_value(_row_value(latest, "Open"))),
+        ("High", _format_value(_row_value(latest, "High"))),
+        ("Low", _format_value(_row_value(latest, "Low"))),
+        ("Close", _format_value(_row_value(latest, "Close"))),
+        ("Volume", _format_value(_row_value(latest, "Volume"))),
+    ]
+
+    recent_window = max(1, min(int(look_back_days), 30))
+    recent = stock_df.tail(recent_window)
+
+    lines: list[str] = [
+        f"## Verified market data snapshot for {symbol.upper()}",
+        "",
+        f"- Requested analysis date: {curr_date}",
+        f"- Latest trading row used: {latest_date}",
+        "- Data rows after the requested analysis date are excluded before verification.",
+        "",
+        "### Latest verified OHLCV row",
+        "",
+        "| Field | Value |",
+        "|---|---:|",
+    ]
+
+    for field, value in price_rows:
+        lines.append(f"| {field} | {value} |")
+
+    lines.extend(
+        [
+            "",
+            "### Verified technical indicators on latest trading row",
+            "",
+            "| Indicator | Value |",
+            "|---|---:|",
+        ]
+    )
+
+    for indicator, value in indicator_values.items():
+        lines.append(f"| {indicator} | {value} |")
+
+    lines.extend(
+        [
+            "",
+            "### Recent verified closes",
+            "",
+            "| Date | Close |",
+            "|---|---:|",
+        ]
+    )
+
+    for _, row in recent.iterrows():
+        row_date = _latest_date(row)
+        close = _format_value(_row_value(row, "Close"))
+        lines.append(f"| {row_date} | {close} |")
+
+    lines.extend(
+        [
+            "",
+            "Verification instruction: use this snapshot as the source of truth for exact OHLCV, price-level, and indicator-value claims. If another tool output conflicts with this snapshot, explicitly flag the discrepancy instead of inventing a reconciled number. Do not claim historical validation, support/resistance bounces, or exact percentage moves unless they are directly supported by tool output with concrete dates and prices.",
+        ]
+    )
+
+    return "\n".join(lines)


### PR DESCRIPTION
Fixes #830

This PR adds a deterministic market data verification step for the Market Analyst.

The issue was that the generated report could mention exact technical levels, like Bollinger Band values or historical support/bounce claims, but sometimes those numbers were not matching the actual market data. So instead of only relying on the LLM's written reasoning, I added a seperate verification snapshot tool which gives the agent a more grounded source of truth before it writes the final market report.

### What changed

- Added a new `market_data_validator.py` dataflow helper.
- Added `get_verified_market_snapshot` as a LangChain tool.
- Wired the new tool into the Market Analyst.
- Updated the Market Analyst prompt so it must call this verification tool before writing exact OHLCV / price-level / indicator-value claims.
- Added tests for the new verified market snapshot logic.

### What the new tool returns

The new snapshot includes:

- latest OHLCV row on or before the analysis date
- selected technical indicators like:
  - Bollinger Bands
  - RSI
  - MACD
  - moving averages
  - ATR
- recent verified closing prices for sanity checking

It also makes sure data after the requested analysis date is excluded, so the report does not accidently use future rows.

### Why this helps

This should reduce cases where the agent says things like a Bollinger lower band or support level is at some exact price, when the actual indicator data does not support that claim.

The prompt now tells the Market Analyst to treat this verified snapshot as the source of truth for exact market data claims. If some other tool output conflicts with it, the agent should explicitly mention the mismatch instead of making up a reconciled number.

This does not completely solve all hallucinations, but it adds a deterministic check around the part that should be factual: price data, indicator values, dates, and recent closes.

### Validation

I ran:

```bash
python -m compileall tradingagents
python -m pytest tests/test_market_data_validator.py -q

Result :
2 passed
```