### PR TITLE
docs: add Indian market support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,6 @@ Please reference our work if you find *TradingAgents* provides you with some hel
       url={https://arxiv.org/abs/2412.20138}, 
 }
 ```
+## Indian Market Support
+
+TradingAgents can be used to analyze Indian stocks listed on NSE and BSE exchanges using their respective ticker symbols (e.g., RELIANCE.NS, TCS.NS).

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ We welcome contributions from the community! Whether it's fixing a bug, improvin
 
 Past contributions, including code, design feedback, and bug reports, are credited per release in [`CHANGELOG.md`](CHANGELOG.md).
 
+## Indian Market Support
+
+TradingAgents can be used to analyze Indian stocks listed on NSE and BSE exchanges using their respective ticker symbols (e.g., RELIANCE.NS for NSE and RELIANCE.BO for BSE).
+
 ## Citation
 
 Please reference our work if you find *TradingAgents* provides you with some help :)
@@ -274,6 +278,3 @@ Please reference our work if you find *TradingAgents* provides you with some hel
       url={https://arxiv.org/abs/2412.20138}, 
 }
 ```
-## Indian Market Support
-
-TradingAgents can be used to analyze Indian stocks listed on NSE and BSE exchanges using their respective ticker symbols (e.g., RELIANCE.NS, TCS.NS).


### PR DESCRIPTION
Added a section explaining Indian market support for NSE and BSE 
exchanges, helping Indian users understand how to use ticker 
symbols like RELIANCE.NS and TCS.NS with TradingAgents.