### PR TITLE
fix: ignore .env.enterprise and reports folder (#787)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ activemq-data/
 
 # Environments
 .env
+.env.enterprise
 .envrc
 .venv
 env/
@@ -217,3 +218,4 @@ __marimo__/
 
 # Cache
 **/data_cache/
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+reports/
 
 # Translations
 *.mo
@@ -148,8 +149,9 @@ activemq-data/
 *.sage.py
 
 # Environments
-.env
-.env.enterprise
+.env*
+!.env.example
+!.env.enterprise.example
 .envrc
 .venv
 env/
@@ -218,4 +220,3 @@ __marimo__/
 
 # Cache
 **/data_cache/
-reports/


### PR DESCRIPTION
Added .env.enterprise and reports/ to .gitignore as requested in #787. This prevents sensitive environment files and local analysis reports from being accidentally committed.