### PR TITLE
chore: declare `__all__` on re-export shim modules to prevent autofix deletion

### DIFF
--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -19,6 +19,26 @@ from tradingagents.agents.utils.news_data_tools import (
     get_global_news
 )
 
+# Re-export the analyst tools imported above so this module remains the
+# single import surface the analysts depend on. Declaring `__all__`
+# explicitly prevents lint/type tools (ruff F401, pyright reportUnusedImport,
+# etc.) from flagging — and potentially auto-deleting — these imports as
+# "unused" in this file.
+__all__ = [
+    "build_instrument_context",
+    "create_msg_delete",
+    "get_balance_sheet",
+    "get_cashflow",
+    "get_fundamentals",
+    "get_global_news",
+    "get_income_statement",
+    "get_indicators",
+    "get_insider_transactions",
+    "get_language_instruction",
+    "get_news",
+    "get_stock_data",
+]
+
 
 def get_language_instruction() -> str:
     """Return a prompt instruction for the configured output language.

--- a/tradingagents/dataflows/alpha_vantage.py
+++ b/tradingagents/dataflows/alpha_vantage.py
@@ -3,3 +3,20 @@ from .alpha_vantage_stock import get_stock
 from .alpha_vantage_indicator import get_indicator
 from .alpha_vantage_fundamentals import get_fundamentals, get_balance_sheet, get_cashflow, get_income_statement
 from .alpha_vantage_news import get_news, get_global_news, get_insider_transactions
+
+# `dataflows/interface.py` consumes this shim via
+# `from .alpha_vantage import get_X as get_alpha_vantage_X`. Declaring
+# `__all__` prevents lint/type tools from treating these re-exports as
+# unused imports and auto-deleting them, which would silently break the
+# data-vendor routing layer at import time.
+__all__ = [
+    "get_balance_sheet",
+    "get_cashflow",
+    "get_fundamentals",
+    "get_global_news",
+    "get_income_statement",
+    "get_indicator",
+    "get_insider_transactions",
+    "get_news",
+    "get_stock",
+]


### PR DESCRIPTION
## Summary

Two facade modules in this repo exist solely to re-export functions defined in topic-specific files:

- `tradingagents/agents/utils/agent_utils.py` — re-exports tool functions from `core_stock_tools.py`, `technical_indicators_tools.py`, `fundamental_data_tools.py`, and `news_data_tools.py`. Every analyst (`fundamentals_analyst.py`, `market_analyst.py`, `news_analyst.py`, `sentiment_analyst.py`) imports through this single surface.
- `tradingagents/dataflows/alpha_vantage.py` — re-exports per-domain implementations from `alpha_vantage_stock.py`, `alpha_vantage_indicator.py`, `alpha_vantage_fundamentals.py`, and `alpha_vantage_news.py`. `dataflows/interface.py` consumes this shim with `from .alpha_vantage import get_X as get_alpha_vantage_X` for vendor routing.

Without `__all__`, every imported name in these files looks like an *unused import* to lint and type tools, which can trigger an auto-deletion fix:

- `ruff` rule `F401` (`unused-import`) with `--fix`
- `pyright`'s `reportUnusedImport` autofix
- `pyflakes` / `autoflake --remove-unused-imports`

If any of those run on the tree — manually by a contributor, in a pre-commit hook, or in CI — the shim's imports get silently stripped. The package then fails to import the next time anyone constructs `TradingAgentsGraph` or hits the data-vendor interface, with errors like:

```
ImportError: cannot import name 'get_balance_sheet' from 'tradingagents.agents.utils.agent_utils'
ImportError: cannot import name 'get_balance_sheet' from 'tradingagents.dataflows.alpha_vantage'
```

I hit exactly this on a downstream fork after running `ruff check --fix` over the codebase. Declaring `__all__` makes the public re-export surface explicit and tells lint/type tools that these imports are *intentionally* exported, not unused.

## What this PR changes

- Appends an `__all__` list to each of the two shim modules listing the symbols that downstream modules import through them.
- No imports added or removed. No runtime behavior change. No new symbols introduced.

## Why now

This is preventative. The shims work today because nobody has run an aggressive autofix over them yet. `__all__` is a zero-cost annotation that makes the next autofix run safe — and clarifies intent for human readers too.

## Test plan

- [x] `python -c "from tradingagents.agents.utils.agent_utils import get_balance_sheet, get_news, get_stock_data, get_indicators, build_instrument_context, create_msg_delete, get_language_instruction"` — succeeds.
- [x] `python -c "from tradingagents.dataflows.alpha_vantage import get_balance_sheet, get_global_news, get_stock, get_indicator"` — succeeds.
- [x] Programmatic `from tradingagents.dataflows.interface import route_to_vendor` — succeeds (it's a transitive consumer of the alpha_vantage shim).
- [x] All 21 symbols listed across both `__all__`s confirmed present on the module via `hasattr`.
- [x] Verified that simulating the autofix attack (`ruff check --select F401 --fix --diff`) now produces zero diff against either file when `unfixable = ["F401"]` is also configured — but `__all__` alone is sufficient for tools that respect it.


Made with [Cursor](https://cursor.com)