### PR TITLE
feat(the-bazaar): castle UI pack — assemble theme + portraits (WIP)

### DIFF
--- a/web-ui/frontend/the-bazaar/README 2castle.md
+++ b/web-ui/frontend/the-bazaar/README 2castle.md
@@ -1,0 +1,43 @@
+# Traders of the Round Table - Castle UI Pack
+
+Drop-in front-end pack that transforms the TradingAgents "Bazaar" view
+into the castle-themed "Round Table" experience.
+
+## Files
+- castle.css            - full castle theme + scene + carousel + modal styles
+- castle-portraits.svg  - 8 inline SVG character portraits + castle crest
+- castle-council.js     - scene builder, debate playback engine, live SSE wiring
+- README.md             - this file
+
+## Install
+1. Copy this folder into your app (e.g. the-bazaar/assets/round-table/).
+2. In your index.html, just before </body>, AFTER the React app <script>:
+
+   <link rel="stylesheet" href="assets/round-table/castle.css">
+   <script defer src="assets/round-table/castle-council.js"></script>
+
+3. (Optional) Add Cinzel font in <head>:
+
+   <link rel="preconnect" href="https://fonts.googleapis.com">
+   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&display=swap" rel="stylesheet">
+
+The script auto-mounts on DOMContentLoaded, hides the original Bazaar
+verdict and report cards, and renders the council scene + carousel in
+their place. It expects the React app to expose window.AGENTS and
+that report bodies live in #root .detail-section with <h4> headings
+and .detail-content bodies.
+
+## Live mode (drive seats from real SSE)
+- fetch wrapper detects /analyze POSTs and flips the IDLE pill to LIVE.
+- EventSource wrapper routes SSE events to seats (thinking/speaking/done).
+- Edit AGENT_TO_SEAT and the regex matchers at the top of castle-council.js
+  if your backend uses different event names.
+
+## Customisation
+- Palette: edit :root in castle.css.
+- Characters: edit <symbol> ids in castle-portraits.svg.
+- Demo script: edit SCRIPT[] near the top of castle-council.js.
+
+## Remove
+Delete the two HTML tags. Nothing was written to disk.

--- a/web-ui/frontend/the-bazaar/README.md
+++ b/web-ui/frontend/the-bazaar/README.md
@@ -1,0 +1,75 @@
+# The Bazaar — TradingAgents Alternative UI Prototype
+
+A character-driven conversational trading interface. Summon your analyst team, watch them debate in real-time as distinct personas, and receive a dramatic verdict on your trade.
+
+## Quick Start
+
+```bash
+# Make sure the TradingAgents backend is running first:
+cd /Users/zachb/Desktop/TradingAgents/web-ui
+bash start.sh
+
+# Then open the prototype:
+open /path/to/the-bazaar/index.html
+# OR serve with any static file server:
+python3 -m http.server 8081
+# then visit http://localhost:8081
+```
+
+The prototype connects to the existing TradingAgents API at `http://localhost:8000` by default. Set `?api=http://other-host:8000` to change the backend URL.
+
+## Design System
+
+**The Bazaar** is the recommended primary UI concept from the TradingAgents redesign project. Key principles:
+
+- **Warm, inviting atmosphere** — amber/gold on dark earth tones
+- **Character-driven** — each analyst is a distinct persona with avatar, color, and voice
+- **Conversational** — analysis unfolds as a chat between agents and user
+- **Lively animations** — typing indicators, entrance animations, dramatic verdict reveals
+
+## Design Tokens
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Background | `#1A1410` | Page background |
+| Surface | `#241C14` | Cards, panels |
+| Elevated | `#2D241A` | Raised elements |
+| Primary | `#E8A840` | Actions, accents |
+| Border | `#3D3226` | Dividers |
+
+## Agent Personas
+
+| # | Character | Role | Color | Avatar |
+|---|-----------|------|-------|--------|
+| 1 | Flint | Market Analyst | `#8B6B4A` | 🐂 |
+| 2 | Vera | Sentiment Analyst | `#C44B4B` | 🔮 |
+| 3 | Reed | News Analyst | `#4B7A9E` | 📜 |
+| 4 | Sage | Fundamentals Analyst | `#5C8A6F` | 📊 |
+| 5 | Balthazar | Investment Debater | `#D4A030` | ⚖️ |
+| 6 | Morwen | Risk Debater | `#7B8B9A` | 🛡️ |
+| 7 | Kael | Trader | `#C07840` | 🏃 |
+| 8 | Elder Aldric | Judge | `#9B8BAA` | 👑 |
+
+## Flow
+
+```
+Bazaar Input → Debate Hall (SSE stream) → The Ledger (Verdict)
+```
+
+## Structure
+
+```
+the-bazaar/
+├── README.md          # This file
+└── index.html         # Self-contained React SPA (CDN deps)
+```
+
+## Integration
+
+To integrate into the existing TradingAgents repo:
+
+```bash
+cp -r the-bazaar /Users/zachb/Desktop/TradingAgents/web-ui/frontend/the-bazaar/
+```
+
+The existing backend (FastAPI at `web-ui/backend/main.py`) serves this prototype automatically if placed under the static files mount point.

--- a/web-ui/frontend/the-bazaar/castle-council.js
+++ b/web-ui/frontend/the-bazaar/castle-council.js
@@ -1,0 +1,501 @@
+/* Traders of the Round Table - drop-in castle UI */
+(function(){
+'use strict';
+
+function ready(fn){
+  if (document.readyState !== 'loading') fn();
+  else document.addEventListener('DOMContentLoaded', fn);
+}
+
+function getAssetURL(name){
+  const s = document.currentScript || Array.from(document.scripts).find(x => /castle-council\.js/.test(x.src));
+  if (!s) return name;
+  return s.src.replace(/castle-council\.js.*/, name);
+}
+
+function rebrandTextNodes(root){
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+  const replacements = [
+    [/\bThe Bazaar\b/g, 'The Round Table'],
+    [/\bBazaar\b/g, 'Round Table'],
+    [/\bMarket Square\b/g, 'The Keep'],
+    [/\bArchives\b/g, 'Chronicles'],
+    [/\bTHE CHAMBER CONVENES\b/g, 'THE COUNCIL CONVENES'],
+    [/\bThe chamber rules\b/g, 'The council rules'],
+  ];
+  const nodes = []; let n;
+  while ((n = walker.nextNode())) nodes.push(n);
+  nodes.forEach(node => {
+    let t = node.nodeValue, changed = false;
+    replacements.forEach(([re, to]) => { if (re.test(t)) { t = t.replace(re, to); changed = true; } });
+    if (changed) node.nodeValue = t;
+  });
+}
+
+const SCRIPT = [
+  { id:'market',       text:"Bearish divergence on the MACD histogram. Price made higher highs into $305, but momentum is fading.", sentiment:-2, reactions:[{to:'fundamentals', type:'thinking'},{to:'risk', type:'agree'}] },
+  { id:'social',       text:"Sentiment held strong through the week, but volume of mentions is cooling. Crowds are getting cautious.", sentiment:-1, reactions:[{to:'trader', type:'agree'},{to:'debater', type:'thinking'}] },
+  { id:'news',         text:"Services revenue narrative is intact. No catalysts to derail the long thesis in the next two weeks.", sentiment:+2, reactions:[{to:'fundamentals', type:'agree'},{to:'market', type:'disagree'}] },
+  { id:'fundamentals', text:"Margins are healthy and FCF is expanding. The fundamentals support a higher multiple from here.", sentiment:+3, reactions:[{to:'news', type:'agree'},{to:'debater', type:'disagree'}] },
+  { id:'debater',      text:"With respect - fundamentals are a 12-month story. Technicals say the next move is a pullback.", sentiment:-2, reactions:[{to:'market', type:'agree'},{to:'fundamentals', type:'disagree'}], rebuttal:true, target:'fundamentals' },
+  { id:'fundamentals', text:"A pullback would only improve the entry. The base case still ends materially higher.", sentiment:+1, reactions:[{to:'debater', type:'disagree'}], rebuttal:true, target:'debater' },
+  { id:'debater',      text:"Then we agree we wait. A tactical hold, not a fresh buy.", sentiment:0, reactions:[{to:'fundamentals', type:'thinking'},{to:'judge', type:'agree'}], rebuttal:true, target:'fundamentals' },
+  { id:'risk',         text:"Position sizing matters more than direction here. Volatility is creeping up; reduce exposure.", sentiment:-1, reactions:[{to:'trader', type:'agree'}] },
+  { id:'trader',       text:"I can defend the current position. I would not add until we see $295 hold.", sentiment:0, reactions:[{to:'risk', type:'agree'},{to:'debater', type:'agree'}] },
+  { id:'judge',        text:"Trend is up. Conviction is down. The council rules: HOLD.", sentiment:0, verdict:true },
+];
+
+const SEATS = [
+  { id:'judge',        angle: 270, name:'Elder Aldric',   role:'High Judge' },
+  { id:'market',       angle: 315, name:'Flint',          role:'Market Analyst' },
+  { id:'social',       angle: 0,   name:'Vera',           role:'Sentiment Seer' },
+  { id:'news',         angle: 45,  name:'Reed',           role:'News Herald' },
+  { id:'fundamentals', angle: 90,  name:'Sage',           role:'Fundamentals' },
+  { id:'debater',      angle: 135, name:'Balthazar',      role:'Adversary' },
+  { id:'risk',         angle: 180, name:'Morwen',         role:'Risk Warden' },
+  { id:'trader',       angle: 225, name:'Kael',           role:'Swift Trader' },
+];
+
+const AGENT_TO_SEAT = {
+  'market':'market','market_analyst':'market','flint':'market','Flint':'market',
+  'social':'social','social_analyst':'social','vera':'social','Vera':'social',
+  'news':'news','news_analyst':'news','reed':'news','Reed':'news',
+  'fundamentals':'fundamentals','fundamentals_analyst':'fundamentals','sage':'fundamentals','Sage':'fundamentals',
+  'bull':'fundamentals','bull_researcher':'fundamentals',
+  'bear':'debater','bear_researcher':'debater','debater':'debater','balthazar':'debater',
+  'risk':'risk','risk_manager':'risk','morwen':'risk',
+  'trader':'trader','kael':'trader',
+  'judge':'judge','aldric':'judge','researcher_judge':'judge','risk_judge':'judge',
+};
+
+const META = SEATS.reduce((a,s)=>{a[s.id]=s;return a;},{});
+let seatEls = {}, stage, speed=1, playing=false, stopFlag=false, currentIdx=0, tilt=0;
+let activeBubble=null, activeReactions=[];
+const liveBubbles = {};
+
+function injectPortraits(cb){
+  if (document.getElementById('debate-portrait-defs')) return cb();
+  fetch(getAssetURL('castle-portraits.svg')).then(r=>r.text()).then(svg=>{
+    const wrap = document.createElement('div');
+    wrap.id = 'debate-portrait-defs';
+    wrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden;';
+    // The SVG file already has an outer <svg>; we want symbol defs inside.
+    wrap.innerHTML = svg;
+    document.body.appendChild(wrap);
+    cb();
+  }).catch(e=>{ console.warn('[council] portraits failed', e); cb(); });
+}
+
+function buildScene(){
+  ['debate-scene-root','rt-verdict-card','rt-report-carousel'].forEach(id=>{
+    const el = document.getElementById(id); if (el) el.remove();
+  });
+
+  const root = document.createElement('div');
+  root.id = 'debate-scene-root';
+  root.innerHTML = ''
+    + '<div class="rt-chrome">'
+    +   '<div class="rt-header">'
+    +     '<div class="rt-title">'
+    +       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 21h18M5 21V10l7-5 7 5v11M10 21v-6h4v6"/></svg>'
+    +       '<span>The Council Convenes</span>'
+    +     '</div>'
+    +     '<div class="rt-controls">'
+    +       '<span id="rt-live-indicator" style="display:inline-flex;align-items:center;gap:6px;padding:6px 10px;background:linear-gradient(180deg,#2a3043,#1a1f2e);border:1px solid var(--castle-stone-light);color:var(--text-dim);border-radius:6px;font-family:inherit;font-size:10px;letter-spacing:.14em;text-transform:uppercase;">'
+    +         '<span id="rt-live-dot" style="width:8px;height:8px;border-radius:50%;background:#666;"></span>'
+    +         '<span id="rt-live-text">Idle</span>'
+    +       '</span>'
+    +       '<button class="rt-btn" id="rt-replay">Replay</button>'
+    +       '<button class="rt-btn" id="rt-speed">1x</button>'
+    +       '<button class="rt-btn primary" id="rt-play">Play</button>'
+    +       '<button class="rt-btn" id="rt-toggle-reports">Hide Chronicles</button>'
+    +     '</div>'
+    +   '</div>'
+    +   '<div class="rt-stage" id="rt-stage">'
+    +     '<div class="rt-banner left"></div>'
+    +     '<div class="rt-banner right"></div>'
+    +     '<div class="rt-table"></div>'
+    +     '<svg class="rt-crest"><use href="#castle-crest"/></svg>'
+    +     '<div class="rt-verdict-banner" id="rt-verdict-banner"></div>'
+    +     '<div class="rt-status" id="rt-status">The council awaits...</div>'
+    +   '</div>'
+    +   '<div class="rt-tilt">'
+    +     '<div class="rt-tilt-labels"><span>Bearish</span><span>Bullish</span></div>'
+    +     '<div class="rt-tilt-needle" id="rt-needle"></div>'
+    +   '</div>'
+    +   '<div class="rt-progress" id="rt-progress"></div>'
+    + '</div>';
+
+  const reactRoot = document.getElementById('root') || document.body.firstChild;
+  if (reactRoot && reactRoot.parentNode) reactRoot.parentNode.insertBefore(root, reactRoot);
+  else document.body.appendChild(root);
+
+  stage = document.getElementById('rt-stage');
+  const sw = stage.clientWidth, sh = stage.clientHeight;
+  const cx = sw/2, cy = sh/2, radius = Math.min(sw,sh)*0.40;
+  seatEls = {};
+  SEATS.forEach(seat=>{
+    const r = seat.angle * Math.PI / 180;
+    const x = cx + radius * Math.cos(r);
+    const y = cy + radius * Math.sin(r);
+    const el = document.createElement('div');
+    el.className = 'rt-seat';
+    el.dataset.id = seat.id;
+    el.dataset.angle = seat.angle;
+    el.style.left = x + 'px';
+    el.style.top = y + 'px';
+    el.innerHTML = '<div class="rt-portrait"><svg viewBox="0 0 100 100"><use href="#portrait-'+seat.id+'"/></svg></div>'
+      + '<div class="rt-name">'+seat.name+'</div>'
+      + '<div class="rt-role">'+seat.role+'</div>';
+    stage.appendChild(el);
+    seatEls[seat.id] = el;
+  });
+  for (let i=0; i<SEATS.length; i++){
+    const a1 = SEATS[i].angle, a2 = SEATS[(i+1)%SEATS.length].angle;
+    let mid = (i === SEATS.length-1) ? ((a1+a2+360)/2)%360 : (a1+a2)/2;
+    const r = (mid*Math.PI/180);
+    const rr = radius * 1.18;
+    const x = cx + rr*Math.cos(r), y = cy + rr*Math.sin(r);
+    const c = document.createElement('div');
+    c.className = 'rt-candle';
+    c.style.left = x+'px'; c.style.top = y+'px';
+    c.style.animationDelay = (i*0.2)+'s';
+    stage.appendChild(c);
+  }
+  const prog = document.getElementById('rt-progress');
+  SCRIPT.forEach(()=>{ const p=document.createElement('div'); p.className='rt-pip'; prog.appendChild(p); });
+}
+
+function setStatus(t){ const e=document.getElementById('rt-status'); if(e) e.textContent=t; }
+function setTilt(v){ tilt=Math.max(-10,Math.min(10,v)); const pct=((tilt+10)/20)*100; const n=document.getElementById('rt-needle'); if(n) n.style.left=pct+'%'; }
+function clearReactions(){ activeReactions.forEach(r=>r.remove()); activeReactions=[]; }
+function clearBubble(){ if(activeBubble){ activeBubble.classList.remove('visible'); const b=activeBubble; setTimeout(()=>b.remove(),300); activeBubble=null; } }
+function resetSeats(){ Object.values(seatEls).forEach(el=>el.classList.remove('speaking','thinking','done','dimmed')); }
+
+function placeBubble(bubble, seatId){
+  const seatEl = seatEls[seatId];
+  if (!seatEl) return;
+  const angle = parseFloat(seatEl.dataset.angle);
+  bubble.style.opacity='0';
+  bubble.style.left='0px'; bubble.style.top='0px';
+  requestAnimationFrame(()=>{
+    const sb = seatEl.getBoundingClientRect();
+    const stb = stage.getBoundingClientRect();
+    const bb = bubble.getBoundingClientRect();
+    const bw=bb.width, bh=bb.height;
+    const sx = sb.left - stb.left + sb.width/2;
+    const sy = sb.top - stb.top + sb.height/2;
+    let x=sx, y=sy;
+    if (angle===270){ x=sx-bw/2; y=sy-sb.height/2-bh-8; }
+    else if (angle===315){ x=sx-bw-8; y=sy-bh-4; }
+    else if (angle===0){ x=sx+sb.width/2+4; y=sy-bh/2; }
+    else if (angle===45){ x=sx+8; y=sy+4; }
+    else if (angle===90){ x=sx-bw/2; y=sy+sb.height/2+8; }
+    else if (angle===135){ x=sx-bw-8; y=sy+4; }
+    else if (angle===180){ x=sx-bw-sb.width/2-4; y=sy-bh/2; }
+    else if (angle===225){ x=sx-bw+8; y=sy-bh-4; }
+    x=Math.max(8,Math.min(stb.width-bw-8,x));
+    y=Math.max(8,Math.min(stb.height-bh-8,y));
+    bubble.style.left=x+'px'; bubble.style.top=y+'px';
+    bubble.style.opacity=''; bubble.classList.add('visible');
+  });
+}
+
+function showBubble(line){
+  clearBubble();
+  const meta = META[line.id];
+  const b = document.createElement('div');
+  b.className = 'rt-bubble' + (line.rebuttal?' rebuttal':'');
+  b.innerHTML = '<div class="rt-bubble-name"><span class="dot"></span>'+meta.name+' &mdash; '+meta.role+'</div><div>'+line.text+'</div>';
+  stage.appendChild(b);
+  activeBubble = b;
+  placeBubble(b, line.id);
+  if (line.rebuttal){
+    setTimeout(()=>b.classList.add('shake'),200);
+    setTimeout(()=>b.classList.remove('shake'),700);
+  }
+}
+
+function showReactions(reactions){
+  clearReactions();
+  if (!reactions) return;
+  reactions.forEach((r,i)=>{
+    const seatEl = seatEls[r.to]; if (!seatEl) return;
+    const sb = seatEl.getBoundingClientRect();
+    const stb = stage.getBoundingClientRect();
+    const sx = sb.left - stb.left + sb.width/2;
+    const sy = sb.top - stb.top;
+    const el = document.createElement('div');
+    el.className = 'rt-reaction ' + r.type;
+    const label = { agree:'Aye', disagree:'Nay', thinking:'Pondering' }[r.type] || r.type;
+    el.innerHTML = '<span class="chip"><svg viewBox="0 0 100 100"><use href="#portrait-'+r.to+'"/></svg></span><span>'+label+'</span>';
+    el.style.left = sx+'px'; el.style.top = sy+'px';
+    stage.appendChild(el);
+    activeReactions.push(el);
+    setTimeout(()=>el.classList.add('visible'), 80 + i*120);
+  });
+}
+
+function setActiveSeat(id){ Object.entries(seatEls).forEach(([k,el])=>{ el.classList.remove('speaking','thinking'); if(k===id) el.classList.add('speaking'); }); }
+function markDone(id){ if(seatEls[id]) seatEls[id].classList.add('done'); }
+function updateProgress(i){ document.querySelectorAll('#rt-progress .rt-pip').forEach((p,idx)=>{ p.classList.remove('active'); if(idx<i) p.classList.add('done'); if(idx===i) p.classList.add('active'); }); }
+async function wait(ms){ const step=50; let e=0; while(e<ms/speed){ if(stopFlag) throw new Error('stop'); await new Promise(r=>setTimeout(r,step)); e+=step; } }
+
+async function freezeFrame(){
+  Object.entries(seatEls).forEach(([k,el])=>{ if(k!=='judge') el.classList.add('dimmed'); });
+  if (seatEls.judge){ seatEls.judge.classList.remove('done','dimmed'); seatEls.judge.classList.add('speaking'); }
+  const banner = document.getElementById('rt-verdict-banner');
+  if (banner){
+    banner.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#1a1408" stroke-width="1.8"><path d="M12 2 L 19 6 L 19 11 Q 19 19 12 22 Q 5 19 5 11 L 5 6 Z"/><path d="M9 12 L 12 9 L 15 12 M 12 9 L 12 15"/></svg><span>Final Verdict</span>';
+    banner.classList.add('show');
+  }
+}
+
+async function playFrom(idx){
+  playing=true; stopFlag=false;
+  const pb = document.getElementById('rt-play'); if (pb) pb.textContent='Pause';
+  if (idx===0){
+    resetSeats(); clearBubble(); clearReactions(); setTilt(0);
+    const vb = document.getElementById('rt-verdict-banner'); if (vb) vb.classList.remove('show');
+    updateProgress(-1);
+  }
+  try {
+    for (let i=idx; i<SCRIPT.length; i++){
+      if (stopFlag) break;
+      currentIdx=i;
+      const line = SCRIPT[i];
+      updateProgress(i);
+      setActiveSeat(line.id);
+      setStatus(line.rebuttal?'Rebuttal in progress...':(line.verdict?'The council renders its verdict...':META[line.id].name+' speaks'));
+      showBubble(line);
+      showReactions(line.reactions);
+      setTilt(tilt + (line.sentiment||0));
+      await wait(line.verdict?3800:3000);
+      markDone(line.id);
+      clearReactions();
+    }
+    if (!stopFlag){
+      clearBubble();
+      await freezeFrame();
+      setStatus('Verdict rendered. Long may the council reign.');
+      updateProgress(SCRIPT.length);
+    }
+  } catch(e){}
+  playing=false;
+  const pb2 = document.getElementById('rt-play'); if (pb2) pb2.textContent='Play';
+}
+
+function wireControls(){
+  document.getElementById('rt-play').addEventListener('click', ()=>{
+    if (playing) stopFlag=true;
+    else {
+      if (currentIdx >= SCRIPT.length-1) currentIdx=0;
+      playFrom(currentIdx===0?0:currentIdx+1);
+    }
+  });
+  document.getElementById('rt-replay').addEventListener('click', ()=>{
+    stopFlag=true;
+    setTimeout(()=>{ currentIdx=0; playFrom(0); }, 200);
+  });
+  document.getElementById('rt-speed').addEventListener('click', (e)=>{
+    const speeds=[1,1.5,2,0.75];
+    const idx = speeds.indexOf(speed);
+    speed = speeds[(idx+1)%speeds.length];
+    e.target.textContent = speed+'x';
+  });
+  document.getElementById('rt-toggle-reports').addEventListener('click', (e)=>{
+    const c = document.getElementById('rt-report-carousel');
+    const r = document.getElementById('root');
+    if (e.target.textContent.startsWith('Hide')){
+      if (c) c.style.display='none';
+      if (r) r.style.display='none';
+      e.target.textContent='Show Chronicles';
+    } else {
+      if (c) c.style.display='';
+      if (r) r.style.display='';
+      e.target.textContent='Hide Chronicles';
+    }
+  });
+}
+
+function analystFromTitle(title){
+  const t = (title||'').toLowerCase();
+  if (t.includes('flint') || t.includes('market')) return { id:'market', name:'Flint', role:'Market Analyst' };
+  if (t.includes('vera') || t.includes('sentiment') || t.includes('social')) return { id:'social', name:'Vera', role:'Sentiment Seer' };
+  if (t.includes('reed') || t.includes('news')) return { id:'news', name:'Reed', role:'News Herald' };
+  if (t.includes('sage') || t.includes('fundamentals')) return { id:'fundamentals', name:'Sage', role:'Fundamentals Scholar' };
+  if (t.includes('balthazar') || t.includes('debater')) return { id:'debater', name:'Balthazar', role:'Adversary' };
+  if (t.includes('morwen') || t.includes('risk')) return { id:'risk', name:'Morwen', role:'Risk Warden' };
+  if (t.includes('kael') || t.includes('trader')) return { id:'trader', name:'Kael', role:'Swift Trader' };
+  if (t.includes('aldric') || t.includes('judge')) return { id:'judge', name:'Elder Aldric', role:'High Judge' };
+  return { id:'market', name:'Analyst', role:'Council' };
+}
+
+function buildVerdictAndCarousel(){
+  const sections = Array.from(document.querySelectorAll('#root .detail-section'));
+  const reports = sections.map(sec=>{
+    const t = sec.querySelector('h4,h3,h2');
+    const b = sec.querySelector('.detail-content') || sec;
+    return { title:(t&&t.textContent.trim())||'', html:b.innerHTML };
+  }).filter(r=>r.title && r.html.length>50);
+
+  // Find verdict value (HOLD/BUY/SELL)
+  let verdict = 'HOLD';
+  const verdictEl = Array.from(document.querySelectorAll('#root *')).find(el=>{
+    if (el.children.length>30) return false;
+    const t=(el.textContent||'').trim();
+    return /^HOLD$|^BUY$|^SELL$/i.test(t);
+  });
+  if (verdictEl) verdict = verdictEl.textContent.trim().toUpperCase();
+
+  const vc = document.createElement('div');
+  vc.id = 'rt-verdict-card'; vc.className = 'rt-verdict-card';
+  vc.innerHTML = ''
+    + '<svg class="rt-crest-large" viewBox="0 0 100 100"><use href="#castle-crest"/></svg>'
+    + '<div class="rt-verdict-label">By Decree of the Round Table</div>'
+    + '<div class="rt-verdict-value">'+verdict+'</div>'
+    + '<div class="rt-verdict-meta"><span id="rt-verdict-ticker">&mdash;</span><span class="sep">&middot;</span><span>Unanimous Council</span></div>';
+  document.getElementById('debate-scene-root').insertAdjacentElement('afterend', vc);
+
+  const car = document.createElement('div');
+  car.id = 'rt-report-carousel'; car.className = 'rt-report-carousel';
+  car.innerHTML = ''
+    + '<div class="rt-carousel-controls">'
+    +   '<div class="rt-carousel-title">Council Chronicles &middot; Analyst Reports</div>'
+    +   '<div style="display:flex;gap:8px;"><button class="rt-arrow" id="rt-prev">&lsaquo;</button><button class="rt-arrow" id="rt-next">&rsaquo;</button></div>'
+    + '</div>'
+    + '<div class="rt-report-track" id="rt-report-track"></div>';
+  vc.insertAdjacentElement('afterend', car);
+
+  const track = document.getElementById('rt-report-track');
+  reports.forEach(src=>{
+    const a = analystFromTitle(src.title);
+    const card = document.createElement('div');
+    card.className = 'rt-report-card';
+    card.innerHTML = ''
+      + '<div class="rt-report-head">'
+      +   '<div class="rt-mini-portrait"><svg viewBox="0 0 100 100"><use href="#portrait-'+a.id+'"/></svg></div>'
+      +   '<div><h3>'+a.name+'</h3><div class="rt-report-role">'+a.role+' &middot; '+src.title+'</div></div>'
+      + '</div>'
+      + '<div class="rt-report-body">'+src.html+'</div>';
+    const btn = document.createElement('button');
+    btn.className = 'rt-read-full';
+    btn.innerHTML = 'Read Full Scroll';
+    btn.addEventListener('click', ()=>openModal(card));
+    card.appendChild(btn);
+    track.appendChild(card);
+  });
+  document.getElementById('rt-prev').addEventListener('click', ()=>{ const c=track.querySelector('.rt-report-card'); if(c) track.scrollBy({left:-(c.clientWidth+16),behavior:'smooth'}); });
+  document.getElementById('rt-next').addEventListener('click', ()=>{ const c=track.querySelector('.rt-report-card'); if(c) track.scrollBy({left:(c.clientWidth+16),behavior:'smooth'}); });
+}
+
+function openModal(card){
+  const portrait = card.querySelector('.rt-mini-portrait').innerHTML;
+  const name = card.querySelector('h3').textContent;
+  const role = card.querySelector('.rt-report-role').textContent;
+  const body = card.querySelector('.rt-report-body').innerHTML;
+  const back = document.createElement('div');
+  back.className='rt-modal-backdrop';
+  back.innerHTML = '<div class="rt-modal"><div class="rt-modal-head"><div class="rt-modal-portrait">'+portrait+'</div><div class="rt-modal-title-block"><div class="rt-modal-title">'+name+'</div><div class="rt-modal-sub">'+role+'</div></div><button class="rt-modal-close">&times;</button></div><div class="rt-modal-body">'+body+'</div></div>';
+  document.body.appendChild(back);
+  requestAnimationFrame(()=>back.classList.add('visible'));
+  function close(){ back.classList.remove('visible'); setTimeout(()=>back.remove(),300); document.removeEventListener('keydown',onKey); }
+  function onKey(e){ if(e.key==='Escape') close(); }
+  back.addEventListener('click', e=>{ if (e.target===back) close(); });
+  back.querySelector('.rt-modal-close').addEventListener('click', close);
+  document.addEventListener('keydown', onKey);
+}
+
+function installLiveWiring(){
+  if (window.__sseHookInstalled) return;
+  window.__sseHookInstalled = true;
+  window.__sseListeners = [];
+  const RealES = window.EventSource;
+  window.EventSource = function HookedES(url, opts){
+    const es = new RealES(url, opts);
+    const safe = (url||'').toString().replace(/token=[a-zA-Z0-9_\-]+/g,'TOK');
+    console.log('[live] EventSource:', safe);
+    const origAdd = es.addEventListener.bind(es);
+    es.addEventListener = function(type, fn, opts2){
+      const wrapped = function(ev){
+        try { window.__sseListeners.forEach(l=>{ try{ l(type, ev); }catch(e){} }); } catch(e){}
+        return fn.apply(this, arguments);
+      };
+      return origAdd(type, wrapped, opts2);
+    };
+    return es;
+  };
+  Object.keys(RealES).forEach(k=>{ try{ window.EventSource[k]=RealES[k]; }catch(e){} });
+  window.EventSource.prototype = RealES.prototype;
+
+  window.__sseListeners.push((type, ev)=>{
+    let data;
+    try { data = ev.data ? JSON.parse(ev.data) : null; } catch(e){ data = ev.data; }
+    if (!data) return;
+    const agent = data.agent || data.analyst || data.author || (data.payload && data.payload.agent);
+    const status = data.status || data.event || data.state || type;
+    const text = data.message || data.text || data.content || (data.payload && data.payload.text);
+    const seatId = AGENT_TO_SEAT[agent] || AGENT_TO_SEAT[(agent||'').toLowerCase().replace(/[^a-z_]/g,'')];
+    if (!seatId) return;
+    const seatEl = seatEls[seatId]; if (!seatEl) return;
+    if (/think|start|begin|working/i.test(status)){
+      Object.values(seatEls).forEach(el=>el.classList.remove('speaking'));
+      seatEl.classList.remove('done'); seatEl.classList.add('thinking');
+    } else if (/speak|message|delta|chunk|update/i.test(status)){
+      Object.values(seatEls).forEach(el=>el.classList.remove('speaking','thinking'));
+      seatEl.classList.add('speaking');
+      if (text) showLiveBubble(seatId, text);
+    } else if (/done|complete|finish|end/i.test(status)){
+      seatEl.classList.remove('speaking','thinking');
+      seatEl.classList.add('done');
+    }
+  });
+
+  const _fetch = window.fetch;
+  window.fetch = function(){
+    const url = (arguments[0]||'').toString();
+    if (/\/analyze/.test(url)){
+      const dot = document.getElementById('rt-live-dot');
+      const txt = document.getElementById('rt-live-text');
+      const ind = document.getElementById('rt-live-indicator');
+      if (dot){ dot.style.background='#c43f54'; dot.style.boxShadow='0 0 8px #c43f54'; }
+      if (txt) txt.textContent='Live - Council in session';
+      if (ind){ ind.style.borderColor='var(--castle-crimson-bright)'; ind.style.color='#f5b8c2'; }
+      Object.values(seatEls).forEach(el=>el.classList.remove('done','speaking','thinking','dimmed'));
+    }
+    return _fetch.apply(this, arguments);
+  };
+}
+
+function showLiveBubble(seatId, text){
+  let disp = (typeof text === 'string' && text.length > 220) ? text.slice(0,217)+'...' : text;
+  if (liveBubbles[seatId]){ liveBubbles[seatId].remove(); delete liveBubbles[seatId]; }
+  const meta = META[seatId]; if (!meta) return;
+  const b = document.createElement('div');
+  b.className = 'rt-bubble';
+  b.innerHTML = '<div class="rt-bubble-name"><span class="dot"></span>'+meta.name+' &mdash; '+meta.role+'</div><div>'+disp+'</div>';
+  stage.appendChild(b);
+  liveBubbles[seatId] = b;
+  placeBubble(b, seatId);
+  setTimeout(()=>{ if (liveBubbles[seatId]===b){ b.classList.remove('visible'); setTimeout(()=>b.remove(),300); delete liveBubbles[seatId]; } }, 6000);
+}
+
+function mount(){
+  document.title = 'Traders of the Round Table';
+  rebrandTextNodes(document.body);
+  if (window.__brandObserver) window.__brandObserver.disconnect();
+  window.__brandObserver = new MutationObserver(()=>rebrandTextNodes(document.body));
+  window.__brandObserver.observe(document.body, { childList:true, subtree:true, characterData:true });
+
+  injectPortraits(()=>{
+    buildScene();
+    wireControls();
+    buildVerdictAndCarousel();
+    installLiveWiring();
+    setTimeout(()=>{ try { playFrom(0); } catch(e){} }, 500);
+  });
+}
+
+ready(mount);
+
+})();

--- a/web-ui/frontend/the-bazaar/castle-portraits.svg
+++ b/web-ui/frontend/the-bazaar/castle-portraits.svg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="position:absolute;width:0;height:0;overflow:hidden;" aria-hidden="true">
+  <defs>
+    <radialGradient id="rt-skin" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0" stop-color="#f5d4a7"/>
+      <stop offset="1" stop-color="#b6885a"/>
+    </radialGradient>
+    <radialGradient id="rt-skin-dark" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0" stop-color="#c69770"/>
+      <stop offset="1" stop-color="#6f4a2a"/>
+    </radialGradient>
+    <radialGradient id="rt-skin-pale" cx="0.4" cy="0.35" r="0.7">
+      <stop offset="0" stop-color="#f8e1c8"/>
+      <stop offset="1" stop-color="#b69479"/>
+    </radialGradient>
+    <linearGradient id="rt-bg-court" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2a3043"/>
+      <stop offset="1" stop-color="#10131e"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-crimson" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3a1620"/>
+      <stop offset="1" stop-color="#170811"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-violet" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2a1a3a"/>
+      <stop offset="1" stop-color="#0f0820"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-emerald" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#15302a"/>
+      <stop offset="1" stop-color="#06140f"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-sand" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3a2e1a"/>
+      <stop offset="1" stop-color="#1a1305"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-steel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2e3445"/>
+      <stop offset="1" stop-color="#0a0d18"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-gold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5a3f12"/>
+      <stop offset="1" stop-color="#231809"/>
+    </linearGradient>
+    <linearGradient id="rt-bg-ash" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#27262d"/>
+      <stop offset="1" stop-color="#0c0b10"/>
+    </linearGradient>
+    <linearGradient id="rt-gold-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f2c761"/>
+      <stop offset="1" stop-color="#9c7424"/>
+    </linearGradient>
+  </defs>
+
+  <symbol id="portrait-market" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-court)"/>
+    <g opacity="0.45" stroke="#5b6379" stroke-width="1" fill="none">
+      <path d="M14 70 L14 80 M14 72 h6 v6 h-6z" fill="#3fa055" stroke="#3fa055"/>
+      <path d="M28 64 L28 78 M28 66 h6 v8 h-6z" fill="#c43f54" stroke="#c43f54"/>
+      <path d="M82 60 L82 76 M82 62 h6 v8 h-6z" fill="#3fa055" stroke="#3fa055"/>
+    </g>
+    <path d="M10 100 Q 50 60 90 100 Z" fill="#3a2516"/>
+    <path d="M22 100 Q 50 78 78 100 Z" fill="#5a3a22"/>
+    <circle cx="50" cy="86" r="3" fill="#f2c761" stroke="#1a1408" stroke-width="0.5"/>
+    <ellipse cx="50" cy="48" rx="22" ry="26" fill="url(#rt-skin)"/>
+    <path d="M28 42 Q 32 22 50 22 Q 70 22 72 40 Q 64 32 50 32 Q 36 32 28 42Z" fill="#5a3014"/>
+    <path d="M34 60 Q 50 70 66 60 Q 60 66 50 66 Q 40 66 34 60Z" fill="#3a200a" opacity="0.5"/>
+    <ellipse cx="42" cy="50" rx="2" ry="2.4" fill="#1c1408"/>
+    <ellipse cx="58" cy="50" rx="2" ry="2.4" fill="#1c1408"/>
+    <circle cx="58" cy="50" r="6" fill="none" stroke="#f2c761" stroke-width="1"/>
+    <path d="M64 50 L78 38" stroke="#f2c761" stroke-width="0.8"/>
+    <path d="M37 44 L 47 42" stroke="#1c1408" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M63 42 L 53 44" stroke="#1c1408" stroke-width="1.2" stroke-linecap="round"/>
+    <path d="M44 60 Q 50 62 56 60" stroke="#5a1818" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="portrait-social" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-violet)"/>
+    <circle cx="76" cy="22" r="8" fill="#d9b35a" opacity="0.5"/>
+    <circle cx="73" cy="20" r="7" fill="url(#rt-bg-violet)"/>
+    <g fill="#f2c761" opacity="0.8">
+      <circle cx="18" cy="16" r="0.8"/>
+      <circle cx="30" cy="10" r="0.6"/>
+      <circle cx="14" cy="32" r="0.7"/>
+      <circle cx="90" cy="42" r="0.8"/>
+    </g>
+    <path d="M6 100 Q 50 58 94 100 Z" fill="#2a1450"/>
+    <path d="M14 100 Q 50 70 86 100 Z" fill="#3d1c70"/>
+    <circle cx="50" cy="86" r="3.5" fill="#cfd2db" stroke="#1c1408" stroke-width="0.4"/>
+    <circle cx="50" cy="86" r="1.2" fill="#2a1450"/>
+    <path d="M22 56 Q 30 22 50 20 Q 70 22 78 56 L 78 70 Q 50 60 22 70 Z" fill="#1f0a36"/>
+    <path d="M30 56 Q 36 30 50 28 Q 64 30 70 56 L 68 60 Q 50 52 32 60 Z" fill="#160628"/>
+    <ellipse cx="50" cy="52" rx="18" ry="22" fill="url(#rt-skin-pale)"/>
+    <path d="M34 38 Q 40 32 50 33 Q 60 32 66 38 Q 58 36 50 38 Q 42 36 34 38 Z" fill="#5a3a82"/>
+    <path d="M40 50 Q 44 53 48 50" stroke="#1c1408" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+    <path d="M52 50 Q 56 53 60 50" stroke="#1c1408" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+    <circle cx="50" cy="44" r="1.4" fill="#c43f54"/>
+    <path d="M44 64 Q 50 67 56 64" stroke="#8e2a3a" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="portrait-news" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-emerald)"/>
+    <g opacity="0.6">
+      <rect x="6" y="58" width="22" height="10" rx="2" fill="#efe2c4" transform="rotate(-12 17 63)"/>
+      <line x1="9" y1="61" x2="22" y2="61" stroke="#3a2814" stroke-width="0.5" transform="rotate(-12 17 63)"/>
+      <line x1="9" y1="64" x2="22" y2="64" stroke="#3a2814" stroke-width="0.5" transform="rotate(-12 17 63)"/>
+    </g>
+    <path d="M8 100 Q 50 58 92 100 Z" fill="#143a26"/>
+    <path d="M18 100 Q 50 72 82 100 Z" fill="#1e5a3a"/>
+    <path d="M30 92 Q 50 82 70 92" stroke="#d9b35a" stroke-width="1.5" fill="none"/>
+    <ellipse cx="50" cy="48" rx="20" ry="24" fill="url(#rt-skin)"/>
+    <path d="M30 40 Q 34 24 50 22 Q 66 24 70 40 Q 64 30 50 30 Q 36 30 30 40 Z" fill="#3a2a14"/>
+    <path d="M50 22 Q 60 26 66 36" stroke="#5a4424" stroke-width="1" fill="none"/>
+    <ellipse cx="42" cy="50" rx="2" ry="2.6" fill="#1c1408"/>
+    <ellipse cx="58" cy="50" rx="2" ry="2.6" fill="#1c1408"/>
+    <path d="M37 44 L 47 43" stroke="#1c1408" stroke-width="1" stroke-linecap="round"/>
+    <path d="M63 43 L 53 44" stroke="#1c1408" stroke-width="1" stroke-linecap="round"/>
+    <ellipse cx="50" cy="62" rx="3.5" ry="2.5" fill="#3a0a10"/>
+    <g transform="translate(72 64) rotate(28)">
+      <path d="M0 0 L0 24 Q -1 26 -3 24 Z" fill="#efe2c4" stroke="#3a2814" stroke-width="0.4"/>
+      <path d="M0 14 L0 24" stroke="#3a2814" stroke-width="0.6"/>
+    </g>
+  </symbol>
+
+  <symbol id="portrait-fundamentals" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-sand)"/>
+    <g opacity="0.35" stroke="#d9b35a" stroke-width="0.4">
+      <line x1="6" y1="20" x2="94" y2="20"/>
+      <line x1="6" y1="28" x2="94" y2="28"/>
+      <line x1="6" y1="36" x2="94" y2="36"/>
+    </g>
+    <path d="M6 100 Q 50 58 94 100 Z" fill="#3a2e1a"/>
+    <path d="M16 100 Q 50 72 84 100 Z" fill="#5a4424"/>
+    <path d="M28 92 Q 50 82 72 92" stroke="#f2c761" stroke-width="1.6" fill="none"/>
+    <circle cx="50" cy="90" r="3" fill="#f2c761" stroke="#1c1408" stroke-width="0.5"/>
+    <ellipse cx="50" cy="46" rx="20" ry="24" fill="url(#rt-skin)"/>
+    <path d="M30 38 Q 34 28 44 26 Q 54 28 56 30 Q 64 30 70 40 Q 70 32 60 26 Q 50 22 40 26 Q 32 30 30 38 Z" fill="#a89a82"/>
+    <path d="M28 50 Q 28 40 34 38 L 32 60 Z" fill="#a89a82"/>
+    <path d="M72 50 Q 72 40 66 38 L 68 60 Z" fill="#a89a82"/>
+    <path d="M30 60 Q 32 78 50 82 Q 68 78 70 60 Q 66 68 58 70 Q 50 72 42 70 Q 34 68 30 60 Z" fill="#cfc6b4"/>
+    <path d="M40 70 Q 50 76 60 70" stroke="#a89a82" stroke-width="1" fill="none"/>
+    <path d="M36 44 Q 42 40 48 44" stroke="#a89a82" stroke-width="2.4" fill="none" stroke-linecap="round"/>
+    <path d="M52 44 Q 58 40 64 44" stroke="#a89a82" stroke-width="2.4" fill="none" stroke-linecap="round"/>
+    <ellipse cx="42" cy="50" rx="1.8" ry="2.2" fill="#1c1408"/>
+    <ellipse cx="58" cy="50" rx="1.8" ry="2.2" fill="#1c1408"/>
+    <circle cx="42" cy="50" r="5" fill="none" stroke="#d9b35a" stroke-width="0.8"/>
+    <circle cx="58" cy="50" r="5" fill="none" stroke="#d9b35a" stroke-width="0.8"/>
+    <line x1="47" y1="50" x2="53" y2="50" stroke="#d9b35a" stroke-width="0.8"/>
+    <path d="M46 60 Q 50 61 54 60" stroke="#5a3018" stroke-width="0.8" fill="none"/>
+  </symbol>
+
+  <symbol id="portrait-debater" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-crimson)"/>
+    <ellipse cx="50" cy="44" rx="36" ry="32" fill="#5a1830" opacity="0.4"/>
+    <path d="M6 100 Q 50 56 94 100 Z" fill="#1a0a14"/>
+    <path d="M18 100 Q 50 70 82 100 Z" fill="#3a0a18"/>
+    <g fill="#c43f54">
+      <circle cx="34" cy="92" r="1.2"/>
+      <circle cx="44" cy="86" r="1.2"/>
+      <circle cx="56" cy="86" r="1.2"/>
+      <circle cx="66" cy="92" r="1.2"/>
+    </g>
+    <path d="M28 44 Q 28 22 50 22 Q 72 22 72 44 Q 72 64 64 70 L 50 76 L 36 70 Q 28 64 28 44 Z" fill="url(#rt-skin-dark)"/>
+    <path d="M28 40 Q 32 18 50 18 Q 68 18 72 40 Q 64 24 50 24 Q 36 24 28 40 Z" fill="#1a1408"/>
+    <path d="M50 18 Q 60 22 68 38" stroke="#3a2010" stroke-width="0.8" fill="none"/>
+    <path d="M36 44 L 47 41" stroke="#1a1408" stroke-width="1.8" stroke-linecap="round"/>
+    <path d="M64 41 L 53 44" stroke="#1a1408" stroke-width="1.8" stroke-linecap="round"/>
+    <ellipse cx="42" cy="50" rx="2.2" ry="2.6" fill="#1c1408"/>
+    <ellipse cx="58" cy="50" rx="2.2" ry="2.6" fill="#1c1408"/>
+    <path d="M40 49 L 44 49" stroke="#c43f54" stroke-width="0.4" opacity="0.7"/>
+    <path d="M56 49 L 60 49" stroke="#c43f54" stroke-width="0.4" opacity="0.7"/>
+    <path d="M44 66 Q 50 72 56 66 Q 54 70 50 71 Q 46 70 44 66 Z" fill="#1a1408"/>
+    <path d="M43 62 Q 50 60 57 62" stroke="#1a1408" stroke-width="1.4" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="portrait-risk" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-steel)"/>
+    <g opacity="0.4" stroke="#5b6379" stroke-width="1" stroke-linecap="round">
+      <line x1="14" y1="10" x2="36" y2="42"/>
+      <line x1="86" y1="10" x2="64" y2="42"/>
+    </g>
+    <path d="M4 100 Q 50 58 96 100 Z" fill="#2a3043"/>
+    <path d="M14 100 Q 50 68 86 100 Z" fill="#3d4459"/>
+    <path d="M50 78 L 50 100" stroke="#5b6379" stroke-width="1.4"/>
+    <path d="M34 84 Q 50 78 66 84 L 66 90 Q 50 86 34 90 Z" fill="#5b6379" stroke="#1a1f2e" stroke-width="0.5"/>
+    <path d="M28 30 Q 30 18 50 16 Q 70 18 72 30 L 72 38 L 28 38 Z" fill="#5b6379" stroke="#1a1f2e" stroke-width="0.6"/>
+    <rect x="28" y="34" width="44" height="3" fill="#d9b35a"/>
+    <path d="M50 24 L 53 30 L 50 32 L 47 30 Z" fill="#c43f54" stroke="#1c1408" stroke-width="0.4"/>
+    <ellipse cx="50" cy="50" rx="18" ry="22" fill="url(#rt-skin)"/>
+    <path d="M34 38 Q 38 38 42 40 L 40 50 Z" fill="#5a3a14"/>
+    <path d="M66 38 Q 62 38 58 40 L 60 50 Z" fill="#5a3a14"/>
+    <path d="M38 46 L 46 46" stroke="#1c1408" stroke-width="1.4" stroke-linecap="round"/>
+    <path d="M54 46 L 62 46" stroke="#1c1408" stroke-width="1.4" stroke-linecap="round"/>
+    <ellipse cx="42" cy="52" rx="2" ry="2.4" fill="#1c1408"/>
+    <ellipse cx="58" cy="52" rx="2" ry="2.4" fill="#1c1408"/>
+    <path d="M44 64 L 56 64" stroke="#5a1818" stroke-width="1.4" stroke-linecap="round"/>
+    <path d="M34 60 Q 50 70 66 60" stroke="#2a3043" stroke-width="1" fill="none"/>
+  </symbol>
+
+  <symbol id="portrait-trader" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-ash)"/>
+    <g opacity="0.35" stroke="#cfd2db" stroke-width="1" stroke-linecap="round">
+      <line x1="14" y1="86" x2="26" y2="42"/>
+      <line x1="86" y1="86" x2="74" y2="42"/>
+    </g>
+    <path d="M8 100 Q 50 58 92 100 Z" fill="#1a1d2a"/>
+    <path d="M18 100 Q 50 70 82 100 Z" fill="#2b2f40"/>
+    <circle cx="50" cy="86" r="3" fill="#cfd2db" stroke="#1c1408" stroke-width="0.4"/>
+    <path d="M22 56 Q 28 22 50 20 Q 72 22 78 56 L 76 68 Q 50 58 24 68 Z" fill="#13151c"/>
+    <path d="M30 56 Q 36 30 50 28 Q 64 30 70 56 L 68 60 Q 50 52 32 60 Z" fill="#0a0c12"/>
+    <rect x="30" y="44" width="40" height="10" fill="#1c1408" opacity="0.45"/>
+    <ellipse cx="50" cy="52" rx="17" ry="20" fill="url(#rt-skin)"/>
+    <rect x="30" y="56" width="40" height="8" fill="#2a3043"/>
+    <ellipse cx="42" cy="48" rx="2.2" ry="2.4" fill="#1c1408"/>
+    <ellipse cx="58" cy="48" rx="2.2" ry="2.4" fill="#1c1408"/>
+    <circle cx="42.6" cy="47.4" r="0.6" fill="#f2c761"/>
+    <circle cx="58.6" cy="47.4" r="0.6" fill="#f2c761"/>
+    <path d="M37 43 L 46 42" stroke="#1c1408" stroke-width="1.4" stroke-linecap="round"/>
+    <path d="M62 41 L 54 44" stroke="#1c1408" stroke-width="1.4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="portrait-judge" viewBox="0 0 100 100">
+    <rect width="100" height="100" fill="url(#rt-bg-gold)"/>
+    <circle cx="50" cy="46" r="38" fill="#d9b35a" opacity="0.18"/>
+    <path d="M2 100 Q 50 54 98 100 Z" fill="#3a0a18"/>
+    <path d="M14 100 Q 50 66 86 100 Z" fill="#5a1828"/>
+    <path d="M22 92 Q 50 80 78 92" stroke="#f2c761" stroke-width="2" fill="none"/>
+    <path d="M22 95 Q 50 84 78 95" stroke="#d9b35a" stroke-width="0.8" fill="none"/>
+    <path d="M26 80 Q 50 68 74 80 L 74 86 Q 50 76 26 86 Z" fill="#f5f1e6" stroke="#1c1408" stroke-width="0.4"/>
+    <g fill="#1c1408">
+      <circle cx="36" cy="80" r="0.8"/>
+      <circle cx="46" cy="78" r="0.8"/>
+      <circle cx="54" cy="78" r="0.8"/>
+      <circle cx="64" cy="80" r="0.8"/>
+    </g>
+    <ellipse cx="50" cy="46" rx="19" ry="23" fill="url(#rt-skin)"/>
+    <path d="M30 42 Q 30 24 50 22 Q 70 24 70 42 Q 78 58 70 70 L 64 66 L 50 68 L 36 66 L 30 70 Q 22 58 30 42 Z" fill="#e8e3d4"/>
+    <path d="M32 56 Q 34 88 50 92 Q 66 88 68 56 Q 64 70 56 76 Q 50 80 44 76 Q 36 70 32 56 Z" fill="#f5f1e6"/>
+    <path d="M40 78 Q 50 86 60 78" stroke="#cfc6b4" stroke-width="0.8" fill="none"/>
+    <g>
+      <path d="M28 30 L 32 18 L 38 26 L 44 14 L 50 24 L 56 14 L 62 26 L 68 18 L 72 30 Z" fill="url(#rt-gold-grad)" stroke="#5a3f12" stroke-width="0.6" stroke-linejoin="round"/>
+      <circle cx="44" cy="14" r="1.4" fill="#c43f54"/>
+      <circle cx="56" cy="14" r="1.4" fill="#3fa055"/>
+      <circle cx="50" cy="24" r="1.6" fill="#cfd2db"/>
+      <rect x="28" y="28" width="44" height="4" fill="#d9b35a" stroke="#5a3f12" stroke-width="0.4"/>
+    </g>
+    <path d="M36 44 Q 42 40 48 44" stroke="#cfc6b4" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M52 44 Q 58 40 64 44" stroke="#cfc6b4" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <ellipse cx="42" cy="50" rx="1.8" ry="2.2" fill="#1c1408"/>
+    <ellipse cx="58" cy="50" rx="1.8" ry="2.2" fill="#1c1408"/>
+    <path d="M44 60 Q 50 62 56 60" stroke="#5a3018" stroke-width="0.8" fill="none"/>
+  </symbol>
+
+  <symbol id="castle-crest" viewBox="0 0 100 100">
+    <path d="M50 6 L 88 18 L 88 48 Q 88 82 50 96 Q 12 82 12 48 L 12 18 Z"
+          fill="url(#rt-gold-grad)" stroke="#5a3f12" stroke-width="1.2" stroke-linejoin="round"/>
+    <path d="M50 12 L 82 22 L 82 48 Q 82 78 50 90 Q 18 78 18 48 L 18 22 Z"
+          fill="#3a0a18" stroke="#8e2a3a" stroke-width="0.8"/>
+    <g stroke="#cfd2db" stroke-width="2.2" stroke-linecap="round">
+      <line x1="30" y1="34" x2="70" y2="74"/>
+      <line x1="70" y1="34" x2="30" y2="74"/>
+    </g>
+    <g stroke="#5b6379" stroke-width="0.6">
+      <line x1="30" y1="34" x2="70" y2="74"/>
+      <line x1="70" y1="34" x2="30" y2="74"/>
+    </g>
+    <circle cx="30" cy="34" r="2.4" fill="#f2c761" stroke="#5a3f12" stroke-width="0.4"/>
+    <circle cx="70" cy="34" r="2.4" fill="#f2c761" stroke="#5a3f12" stroke-width="0.4"/>
+    <path d="M34 18 L 38 10 L 44 16 L 50 8 L 56 16 L 62 10 L 66 18 Z"
+          fill="url(#rt-gold-grad)" stroke="#5a3f12" stroke-width="0.6" stroke-linejoin="round"/>
+    <rect x="34" y="16" width="32" height="4" fill="#d9b35a" stroke="#5a3f12" stroke-width="0.4"/>
+    <circle cx="50" cy="54" r="6" fill="#c43f54" stroke="#1c1408" stroke-width="0.6"/>
+    <circle cx="48" cy="52" r="2" fill="#f5b8c2" opacity="0.7"/>
+    <path d="M14 78 Q 50 84 86 78 L 80 86 Q 50 90 20 86 Z" fill="#f2c761" stroke="#5a3f12" stroke-width="0.4"/>
+  </symbol>
+</svg>

--- a/web-ui/frontend/the-bazaar/castle.css
+++ b/web-ui/frontend/the-bazaar/castle.css
@@ -1,0 +1,682 @@
+/* ============================================================
+   TRADERS OF THE ROUND TABLE — Castle Theme
+   ============================================================ */
+
+:root {
+  --castle-night: #0e1320;
+  --castle-night-2: #161b2c;
+  --castle-stone-dark: #2a3043;
+  --castle-stone: #3d4459;
+  --castle-stone-light: #5b6379;
+  --castle-mortar: #1a1f2e;
+  --castle-gold: #d9b35a;
+  --castle-gold-bright: #f2c761;
+  --castle-gold-soft: #b89243;
+  --castle-crimson: #8e2a3a;
+  --castle-crimson-bright: #c43f54;
+  --castle-parchment: #efe2c4;
+  --castle-parchment-warm: #e8d6a8;
+  --castle-parchment-dark: #c9b485;
+  --castle-ink: #1c1408;
+  --castle-candle: #ffc869;
+  --castle-candle-glow: rgba(255, 200, 105, 0.45);
+
+  --bg: var(--castle-night);
+  --bg-2: var(--castle-night-2);
+  --surface: var(--castle-stone-dark);
+  --surface-2: var(--castle-stone);
+  --border: var(--castle-stone-light);
+  --text: #ece6d4;
+  --text-dim: #a8a89e;
+  --accent: var(--castle-gold);
+  --accent-2: var(--castle-gold-bright);
+  --warm: var(--castle-crimson);
+}
+
+body {
+  background: radial-gradient(ellipse at top, #1a2138 0%, #0e1320 50%, #07090f 100%) !important;
+  color: var(--text);
+}
+
+header, .app-header, [class*=AppHeader], [class*=appHeader] {
+  background: linear-gradient(180deg, #1a2138 0%, #0e1320 100%) !important;
+  border-bottom: 1px solid var(--castle-gold-soft) !important;
+  box-shadow: 0 2px 0 rgba(217,179,90,0.12), 0 8px 30px rgba(0,0,0,0.6) !important;
+}
+
+button.primary, [class*=primary] button, button[class*=Primary] {
+  background: linear-gradient(180deg, var(--castle-gold-bright) 0%, var(--castle-gold-soft) 100%) !important;
+  color: var(--castle-ink) !important;
+  border: 1px solid var(--castle-gold-soft) !important;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.2);
+}
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: var(--castle-night-2); }
+::-webkit-scrollbar-thumb { background: var(--castle-stone-light); border-radius: 6px; border: 2px solid var(--castle-night-2); }
+::-webkit-scrollbar-thumb:hover { background: var(--castle-gold-soft); }
+
+/* Hide React's old verdict + report cards (the council replaces them) */
+#root .detail-section,
+#root .detail-card,
+#root .verdict-card,
+#root [class*=verdict-card] { display: none !important; }
+#root .app-header, #root [class*=AppHeader] { display: none !important; }
+
+/* ============================================================
+   THE COUNCIL SCENE
+   ============================================================ */
+
+#debate-scene-root {
+  margin: 20px auto 28px;
+  max-width: 1200px;
+  padding: 0 20px;
+  font-family: 'Cinzel', Georgia, serif;
+  color: var(--text);
+}
+.rt-chrome {
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(217,179,90,0.04) 0%, rgba(0,0,0,0) 30%),
+    linear-gradient(180deg, #1a2138 0%, #0e1320 60%, #07090f 100%);
+  border: 1px solid var(--castle-stone-light);
+  border-radius: 14px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.04),
+    inset 0 0 80px rgba(0,0,0,0.6),
+    0 12px 40px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+.rt-chrome::before {
+  content:''; position:absolute; inset:10px;
+  border: 1px solid rgba(217,179,90,0.18);
+  border-radius: 10px; pointer-events:none; z-index: 2;
+}
+.rt-chrome::after {
+  content:''; position:absolute; inset:0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(255,200,105,0.10) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 100%, rgba(196,63,84,0.06) 0%, transparent 50%);
+  pointer-events:none; z-index: 1;
+}
+
+.rt-header {
+  position: relative; z-index: 3;
+  display:flex; align-items:center; justify-content:space-between;
+  padding: 14px 22px 12px;
+  border-bottom: 1px solid rgba(217,179,90,0.18);
+  background: linear-gradient(180deg, rgba(217,179,90,0.05), transparent);
+}
+.rt-title {
+  display:flex; align-items:center; gap:14px;
+  font-family: 'Cinzel', Georgia, serif;
+  letter-spacing: 0.22em; font-size: 13px;
+  color: var(--castle-gold-bright); text-transform: uppercase;
+}
+.rt-title svg { width:22px; height:22px; }
+.rt-controls { display:flex; align-items:center; gap:8px; }
+.rt-btn {
+  background: linear-gradient(180deg, #2a3043 0%, #1a1f2e 100%);
+  border: 1px solid var(--castle-stone-light);
+  color: var(--castle-parchment);
+  padding: 6px 12px; border-radius: 6px;
+  font-family: inherit; font-size: 11px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  cursor: pointer; transition: all 0.15s;
+}
+.rt-btn:hover { border-color: var(--castle-gold-soft); color: var(--castle-gold-bright); }
+.rt-btn.primary {
+  background: linear-gradient(180deg, var(--castle-gold-bright), var(--castle-gold-soft));
+  color: var(--castle-ink); border-color: var(--castle-gold-soft);
+  font-weight: 700; text-shadow: 0 1px 0 rgba(255,255,255,0.2);
+}
+.rt-btn.primary:hover { filter: brightness(1.08); }
+
+.rt-stage {
+  position: relative; height: 560px; z-index: 1;
+  padding-top: 30px; padding-bottom: 30px; box-sizing: border-box;
+}
+
+.rt-banner {
+  position: absolute; top: 0;
+  width: 60px; height: 110px;
+  background: linear-gradient(180deg, var(--castle-crimson) 0%, #5a1822 100%);
+  border-radius: 4px 4px 30px 30px / 4px 4px 18px 18px;
+  box-shadow:
+    inset 0 2px 0 rgba(255,255,255,0.1),
+    inset 0 -20px 30px rgba(0,0,0,0.3),
+    0 4px 12px rgba(0,0,0,0.5);
+  z-index: 2;
+}
+.rt-banner::before {
+  content:''; position:absolute; top: 18px; left:50%; transform:translateX(-50%);
+  width: 24px; height: 24px;
+  background: radial-gradient(circle, var(--castle-gold-bright) 30%, var(--castle-gold-soft) 60%, transparent 70%);
+  border-radius:50%;
+}
+.rt-banner.left { left: 40px; border-left: 2px solid #4a141d; }
+.rt-banner.right { right: 40px; border-right: 2px solid #4a141d; }
+
+.rt-table {
+  position: absolute; left: 50%; top: 50%;
+  width: 380px; height: 380px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 38% 32%, rgba(255,255,255,0.06) 0%, transparent 30%),
+    radial-gradient(circle at 50% 50%, #4a5067 0%, #353b50 35%, #252a3c 65%, #1a1f2e 100%);
+  box-shadow:
+    inset 0 0 60px rgba(0,0,0,0.6),
+    inset 0 2px 0 rgba(255,255,255,0.08),
+    0 30px 80px rgba(0,0,0,0.8),
+    0 0 60px rgba(217,179,90,0.05);
+  border: 3px solid #1a1f2e;
+  z-index: 3;
+}
+.rt-table::before {
+  content:''; position:absolute; inset: 18px; border-radius: 50%;
+  border: 1px solid rgba(217,179,90,0.22);
+  box-shadow: inset 0 0 30px rgba(217,179,90,0.05);
+}
+.rt-table::after {
+  content:''; position:absolute; inset: 40px; border-radius: 50%;
+  border: 1px dashed rgba(217,179,90,0.15);
+}
+.rt-crest {
+  position: absolute; left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 90px; height: 90px; z-index: 4;
+  pointer-events: none; opacity: 0.6;
+}
+
+.rt-seat {
+  position: absolute; width: 110px;
+  transform: translate(-50%, -50%);
+  display: flex; flex-direction: column; align-items: center;
+  z-index: 5;
+  transition: transform 0.3s ease, filter 0.3s ease;
+}
+.rt-portrait {
+  width: 72px; height: 72px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 25%, #2a3043, #161b2c);
+  border: 3px solid var(--castle-stone-light);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.6), inset 0 0 0 1px rgba(0,0,0,0.4);
+  overflow: hidden; position: relative;
+  transition: all 0.25s ease;
+}
+.rt-portrait svg { width:100%; height:100%; display:block; }
+.rt-seat.speaking .rt-portrait {
+  transform: scale(1.12);
+  border-color: var(--castle-gold-bright);
+  box-shadow:
+    0 0 0 3px rgba(242,199,97,0.25),
+    0 0 24px rgba(242,199,97,0.5),
+    0 4px 16px rgba(0,0,0,0.6);
+}
+.rt-seat.thinking .rt-portrait {
+  border-color: var(--castle-gold-soft);
+  box-shadow: 0 0 0 2px rgba(217,179,90,0.18), 0 4px 12px rgba(0,0,0,0.6);
+  animation: thinkPulse 1.4s ease-in-out infinite;
+}
+@keyframes thinkPulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(217,179,90,0.18), 0 4px 12px rgba(0,0,0,0.6); }
+  50%      { box-shadow: 0 0 0 4px rgba(217,179,90,0.32), 0 0 16px rgba(217,179,90,0.35), 0 4px 12px rgba(0,0,0,0.6); }
+}
+.rt-seat.done .rt-portrait { filter: saturate(0.6) brightness(0.85); }
+.rt-seat.dimmed { filter: grayscale(0.7) brightness(0.55); }
+
+.rt-name {
+  margin-top: 8px;
+  font-family: 'Cinzel', serif;
+  font-size: 10px; letter-spacing: 0.18em;
+  color: var(--castle-parchment-dark);
+  text-transform: uppercase; text-align: center;
+  line-height: 1.2;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.8);
+}
+.rt-role {
+  font-size: 8.5px; letter-spacing: 0.1em;
+  color: var(--text-dim); text-transform: uppercase;
+  margin-top: 2px; text-align:center;
+}
+.rt-seat.speaking .rt-name { color: var(--castle-gold-bright); }
+
+.rt-candle {
+  position: absolute; width: 12px; height: 28px;
+  transform: translate(-50%, -50%); z-index: 4;
+  pointer-events: none;
+}
+.rt-candle::before {
+  content:''; position:absolute; bottom: 0; left: 50%;
+  transform:translateX(-50%);
+  width: 6px; height: 18px;
+  background: linear-gradient(180deg, var(--castle-parchment-dark), #8a7544);
+  border-radius: 2px; box-shadow: 0 2px 4px rgba(0,0,0,0.6);
+}
+.rt-candle::after {
+  content:''; position:absolute; bottom: 14px; left: 50%;
+  transform:translateX(-50%);
+  width: 10px; height: 16px;
+  background: radial-gradient(ellipse at 50% 60%, #fff5c0 0%, var(--castle-candle) 35%, #ff8a3a 70%, transparent 80%);
+  border-radius: 50% 50% 50% 50% / 70% 70% 30% 30%;
+  box-shadow: 0 0 12px var(--castle-candle-glow), 0 0 24px rgba(255,200,105,0.25);
+  animation: flicker 1.6s ease-in-out infinite alternate;
+}
+@keyframes flicker {
+  0%   { transform: translateX(-50%) scale(1, 1); opacity: 0.95; }
+  35%  { transform: translateX(-50%) scale(0.95, 1.06); opacity: 1; }
+  65%  { transform: translateX(-50%) scale(1.05, 0.95); opacity: 0.85; }
+  100% { transform: translateX(-50%) scale(0.98, 1.04); opacity: 0.98; }
+}
+
+.rt-bubble {
+  position: absolute; z-index: 20;
+  max-width: 240px;
+  background: linear-gradient(180deg, var(--castle-parchment) 0%, var(--castle-parchment-warm) 100%);
+  color: var(--castle-ink);
+  padding: 10px 14px 11px; border-radius: 12px;
+  border: 1px solid var(--castle-parchment-dark);
+  box-shadow:
+    0 12px 24px rgba(0,0,0,0.6),
+    0 0 0 1px rgba(0,0,0,0.15),
+    inset 0 1px 0 rgba(255,255,255,0.5);
+  font-family: 'Georgia', serif; font-size: 12px; line-height: 1.45;
+  opacity: 0; transform: scale(0.85);
+  transition: opacity 0.25s, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+}
+.rt-bubble.visible { opacity: 1; transform: scale(1); }
+.rt-bubble.rebuttal {
+  border-color: var(--castle-crimson);
+  background: linear-gradient(180deg, #f5dcd0, #ecc4b2);
+}
+.rt-bubble.rebuttal.shake { animation: shake 0.4s ease-in-out; }
+@keyframes shake {
+  0%,100% { transform: scale(1) translateX(0); }
+  25% { transform: scale(1) translateX(-4px); }
+  75% { transform: scale(1) translateX(4px); }
+}
+.rt-bubble-name {
+  font-family: 'Cinzel', serif;
+  font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--castle-crimson);
+  margin-bottom: 4px;
+  display:flex; align-items:center; gap:6px;
+}
+.rt-bubble-name .dot {
+  width:6px; height:6px; border-radius:50%; background: currentColor;
+}
+
+.rt-reaction {
+  position: absolute; z-index: 8;
+  transform: translate(-50%, -210%);
+  display: inline-flex; align-items:center; gap: 6px;
+  padding: 4px 9px 4px 4px; border-radius: 999px;
+  font-family: 'Cinzel', serif;
+  font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase;
+  background: linear-gradient(180deg, #1e2438, #0e1320);
+  color: var(--castle-parchment);
+  border: 1px solid var(--castle-stone-light);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.5);
+  opacity: 0; transition: opacity 0.25s, transform 0.25s;
+}
+.rt-reaction.visible { opacity: 1; transform: translate(-50%, -240%); }
+.rt-reaction .chip {
+  width: 18px; height: 18px; border-radius: 50%; overflow: hidden;
+  background: var(--castle-stone-dark);
+  border: 1px solid var(--castle-stone-light);
+  flex-shrink: 0;
+}
+.rt-reaction .chip svg { width:100%; height:100%; display:block; }
+.rt-reaction.agree { border-color: #5fbf6f; color: #b8f0c0; }
+.rt-reaction.disagree { border-color: var(--castle-crimson-bright); color: #f5b8c2; }
+.rt-reaction.thinking { border-color: var(--castle-gold-soft); color: var(--castle-gold-bright); }
+
+.rt-tilt {
+  position: relative; z-index: 3;
+  margin: 0 22px 14px; height: 26px;
+  background: linear-gradient(90deg,
+    var(--castle-crimson) 0%, #6e2530 30%,
+    #2a3043 50%, #2d5d3a 70%, #3fa055 100%);
+  border-radius: 13px;
+  border: 1px solid var(--castle-stone-light);
+  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5);
+  overflow: visible;
+}
+.rt-tilt-labels {
+  position:absolute; inset:0;
+  display:flex; align-items:center; justify-content:space-between;
+  padding: 0 14px;
+  font-family:'Cinzel',serif; font-size:10px; letter-spacing:0.22em;
+  color: rgba(255,255,255,0.85);
+  text-shadow: 0 1px 2px rgba(0,0,0,0.8);
+  pointer-events:none;
+}
+.rt-tilt-needle {
+  position: absolute; top: -7px; bottom: -7px;
+  width: 4px; left: 50%; transform: translateX(-50%);
+  background: linear-gradient(180deg, #fff, var(--castle-gold-bright));
+  border-radius: 4px;
+  box-shadow: 0 0 12px rgba(255,255,255,0.7), 0 0 24px rgba(242,199,97,0.5);
+  transition: left 0.8s cubic-bezier(0.4, 0.0, 0.2, 1);
+}
+.rt-tilt-needle::before, .rt-tilt-needle::after {
+  content:''; position:absolute; left:50%; transform:translateX(-50%);
+  width: 0; height:0;
+  border-left: 6px solid transparent; border-right:6px solid transparent;
+}
+.rt-tilt-needle::before { top: -6px; border-bottom: 7px solid var(--castle-gold-bright); }
+.rt-tilt-needle::after  { bottom: -6px; border-top: 7px solid var(--castle-gold-bright); }
+
+.rt-progress {
+  display:flex; gap: 6px;
+  margin: 0 22px 16px;
+  position: relative; z-index: 3;
+}
+.rt-pip {
+  flex: 1; height: 6px;
+  background: var(--castle-mortar); border-radius: 3px;
+  border: 1px solid var(--castle-stone-dark);
+  transition: background 0.3s, box-shadow 0.3s;
+}
+.rt-pip.active {
+  background: linear-gradient(90deg, var(--castle-gold-bright), var(--castle-gold-soft));
+  box-shadow: 0 0 8px rgba(242,199,97,0.5);
+}
+.rt-pip.done { background: var(--castle-gold-soft); }
+
+.rt-verdict-banner {
+  position: absolute;
+  top: 32px; left: 50%; transform: translateX(-50%);
+  z-index: 12;
+  display: none;
+  align-items: center; gap: 12px;
+  padding: 11px 22px;
+  background: linear-gradient(180deg, #f4e4c2 0%, #e8d09a 100%);
+  color: #1a1408;
+  border: 2px solid var(--castle-gold-soft);
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 1px rgba(0,0,0,0.25),
+    0 2px 0 rgba(255,255,255,0.4) inset,
+    0 16px 38px rgba(0,0,0,0.85),
+    0 0 70px rgba(242,199,97,0.55),
+    0 0 140px rgba(242,199,97,0.18);
+  font-family: 'Cinzel', serif;
+  font-size: 13px; letter-spacing: 0.28em;
+  text-transform: uppercase; font-weight: 900;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.5);
+}
+.rt-verdict-banner svg { stroke: #1a1408; flex-shrink: 0; }
+.rt-verdict-banner::before {
+  content:''; position:absolute; inset: 3px;
+  border-radius: 5px; border: 1px solid rgba(0,0,0,0.18);
+  pointer-events: none;
+}
+.rt-verdict-banner.show {
+  display: inline-flex;
+  animation: verdictBannerFloat 0.7s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes verdictBannerFloat {
+  0%   { transform: translate(-50%, -10px); opacity: 0; }
+  60%  { transform: translate(-50%, 4px);   opacity: 1; }
+  100% { transform: translate(-50%, 0);     opacity: 1; }
+}
+/* per-verdict palettes */
+.rt-verdict-banner.buy  { background: linear-gradient(180deg, #d4f0d2 0%, #a6d6a1 100%); border-color: #3fa055; }
+.rt-verdict-banner.sell { background: linear-gradient(180deg, #f5d0d6 0%, #e8a4ad 100%); border-color: var(--castle-crimson-bright); }
+.rt-verdict-banner.hold { /* default gold palette */ }
+
+.rt-status {
+  position:absolute; bottom: 12px; left: 50%;
+  transform: translateX(-50%); z-index: 10;
+  font-family:'Cinzel',serif; font-size: 10px;
+  letter-spacing: 0.3em; color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ============================================================
+   VERDICT CARD (castle seal)
+   ============================================================ */
+
+.rt-verdict-card {
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(217,179,90,0.12) 0%, transparent 60%),
+    linear-gradient(180deg, #1e2438 0%, #0e1320 100%);
+  border: 1px solid var(--castle-gold-soft);
+  border-radius: 16px;
+  padding: 28px 28px 26px;
+  margin: 16px auto 22px;
+  max-width: 1200px;
+  text-align: center; position: relative; overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(217,179,90,0.18) inset,
+    0 0 60px rgba(217,179,90,0.06) inset,
+    0 24px 70px rgba(0,0,0,0.7);
+}
+.rt-verdict-card::before {
+  content:''; position:absolute; inset: 12px;
+  border: 1px solid rgba(217,179,90,0.25);
+  border-radius: 12px; pointer-events:none;
+}
+.rt-verdict-card::after {
+  content:''; position:absolute; top: 0; left: 0; right:0;
+  height: 4px;
+  background: linear-gradient(90deg, transparent, var(--castle-gold-bright), transparent);
+  opacity: 0.7;
+}
+.rt-crest-large { margin: 0 auto 14px; width: 88px; height: 88px; position: relative; }
+.rt-verdict-label {
+  font-family: 'Cinzel', serif; font-size: 11px;
+  letter-spacing: 0.4em; color: var(--castle-gold-soft);
+  text-transform: uppercase; margin-bottom: 8px;
+}
+.rt-verdict-value {
+  font-family: 'Cinzel', serif; font-size: 56px;
+  font-weight: 900; letter-spacing: 0.3em;
+  color: var(--castle-gold-bright);
+  text-shadow: 0 0 30px rgba(242,199,97,0.3);
+  margin: 4px 0 10px;
+}
+.rt-verdict-meta {
+  display: inline-flex; align-items: center; gap: 14px;
+  padding: 8px 18px;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid var(--castle-stone-light);
+  border-radius: 999px;
+  font-family: 'Cinzel', serif; font-size: 11px;
+  letter-spacing: 0.24em; color: var(--castle-parchment-dark);
+  text-transform: uppercase;
+}
+.rt-verdict-meta .sep { color: var(--castle-gold-soft); }
+
+/* ============================================================
+   REPORT CAROUSEL
+   ============================================================ */
+
+.rt-report-carousel {
+  margin: 20px auto; max-width: 1200px;
+  padding: 0 20px; position: relative;
+}
+.rt-report-track {
+  display: grid;
+  grid-auto-flow: column; grid-auto-columns: 88%;
+  gap: 16px;
+  overflow-x: auto; overflow-y: hidden;
+  scroll-snap-type: x mandatory; scroll-behavior: smooth;
+  padding: 4px 4px 18px; scrollbar-width: thin;
+}
+@media (min-width: 900px)  { .rt-report-track { grid-auto-columns: 60%; } }
+@media (min-width: 1200px) { .rt-report-track { grid-auto-columns: 46%; } }
+
+.rt-report-card {
+  position: relative;
+  scroll-snap-align: start;
+  background:
+    linear-gradient(180deg, rgba(217,179,90,0.02), transparent 30%),
+    linear-gradient(180deg, var(--castle-parchment) 0%, var(--castle-parchment-warm) 100%);
+  color: var(--castle-ink);
+  border-radius: 12px;
+  border: 1px solid var(--castle-parchment-dark);
+  box-shadow:
+    0 12px 32px rgba(0,0,0,0.5),
+    0 0 0 1px rgba(0,0,0,0.15),
+    inset 0 1px 0 rgba(255,255,255,0.4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  min-height: 480px; max-height: 580px;
+}
+.rt-report-head {
+  display:flex; align-items:center; gap: 14px;
+  padding: 14px 18px;
+  background: linear-gradient(180deg, rgba(0,0,0,0.08), transparent);
+  border-bottom: 1px solid rgba(0,0,0,0.12);
+}
+.rt-mini-portrait {
+  width: 48px; height: 48px; border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid var(--castle-gold-soft);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  background: var(--castle-stone-dark);
+  flex-shrink: 0;
+}
+.rt-mini-portrait svg { width:100%; height:100%; display:block; }
+.rt-report-head h3 {
+  font-family: 'Cinzel', serif;
+  font-size: 14px; letter-spacing: 0.2em;
+  margin: 0; color: var(--castle-ink);
+  text-transform: uppercase;
+}
+.rt-report-role {
+  font-size: 10px; letter-spacing: 0.16em;
+  color: var(--castle-crimson);
+  text-transform: uppercase; margin-top: 2px;
+}
+.rt-report-body {
+  padding: 16px 22px 22px;
+  overflow-y: auto;
+  font-family: 'Georgia', serif;
+  font-size: 13px; line-height: 1.6; color: #2c2516;
+  white-space: pre-wrap;
+  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 85%, transparent 100%);
+          mask-image: linear-gradient(180deg, #000 0%, #000 85%, transparent 100%);
+}
+.rt-report-body strong { color: var(--castle-crimson); }
+.rt-report-body table, .rt-modal-body table { white-space: normal; }
+.rt-report-body table {
+  font-size: 11px; border-collapse: collapse; margin: 10px 0;
+}
+.rt-report-body th, .rt-report-body td {
+  border: 1px solid rgba(0,0,0,0.2); padding: 4px 8px;
+}
+
+/* carousel arrow controls */
+.rt-carousel-controls {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.rt-carousel-title {
+  font-family: 'Cinzel', serif;
+  font-size: 13px; letter-spacing: 0.22em;
+  color: var(--castle-gold-bright);
+  text-transform: uppercase;
+}
+.rt-arrow {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: linear-gradient(180deg, #2a3043, #1a1f2e);
+  border: 1px solid var(--castle-stone-light);
+  color: var(--castle-gold-bright);
+  cursor: pointer; font-size: 16px;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.rt-arrow:hover { border-color: var(--castle-gold-bright); transform: scale(1.05); }
+
+.rt-read-full {
+  position: absolute; bottom: 14px; right: 18px; z-index: 3;
+  padding: 8px 14px;
+  background: linear-gradient(180deg, var(--castle-gold-bright), var(--castle-gold-soft));
+  color: var(--castle-ink);
+  border: 1px solid var(--castle-gold-soft);
+  border-radius: 6px;
+  font-family: 'Cinzel', serif;
+  font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; font-weight: 700;
+  cursor: pointer; box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+}
+.rt-read-full:hover { filter: brightness(1.08); }
+
+/* ============================================================
+   READ-FULL MODAL
+   ============================================================ */
+
+.rt-modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(7,9,15,0.85);
+  backdrop-filter: blur(6px);
+  z-index: 9999;
+  display: flex; align-items: center; justify-content: center;
+  padding: 40px 24px;
+  opacity: 0; transition: opacity 0.25s;
+}
+.rt-modal-backdrop.visible { opacity: 1; }
+.rt-modal {
+  background: linear-gradient(180deg, var(--castle-parchment) 0%, var(--castle-parchment-warm) 100%);
+  color: var(--castle-ink);
+  border: 2px solid var(--castle-gold-soft);
+  border-radius: 14px;
+  width: min(1100px, 100%); max-height: 90vh;
+  display: flex; flex-direction: column;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.7);
+  overflow: hidden;
+  transform: scale(0.94); transition: transform 0.3s;
+}
+.rt-modal-backdrop.visible .rt-modal { transform: scale(1); }
+.rt-modal-head {
+  display: flex; align-items: center; gap: 16px;
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+}
+.rt-modal-portrait {
+  width: 64px; height: 64px; border-radius: 50%;
+  overflow: hidden; border: 3px solid var(--castle-gold-soft);
+  flex-shrink: 0;
+}
+.rt-modal-portrait svg { width:100%; height:100%; display:block; }
+.rt-modal-title-block { flex: 1; }
+.rt-modal-title {
+  font-family: 'Cinzel', serif;
+  font-size: 22px; letter-spacing: 0.18em;
+  margin: 0; text-transform: uppercase;
+  color: var(--castle-ink);
+}
+.rt-modal-sub {
+  font-family: 'Cinzel', serif;
+  font-size: 11px; letter-spacing: 0.2em;
+  color: var(--castle-crimson);
+  text-transform: uppercase; margin-top: 4px;
+}
+.rt-modal-close {
+  width: 38px; height: 38px; border-radius: 50%;
+  background: linear-gradient(180deg, #2a3043, #1a1f2e);
+  border: 1px solid var(--castle-stone-light);
+  color: var(--castle-gold-bright);
+  cursor: pointer; font-size: 18px;
+}
+.rt-modal-close:hover { border-color: var(--castle-gold-bright); }
+.rt-modal-body {
+  overflow-y: auto; padding: 24px 32px 32px;
+  font-family: 'Georgia', serif; font-size: 14px;
+  line-height: 1.7; color: #2c2516;
+  flex: 1; white-space: pre-wrap;
+}
+.rt-modal-body table {
+  font-size: 12px; border-collapse: collapse; margin: 12px 0;
+}
+.rt-modal-body th, .rt-modal-body td {
+  border: 1px solid rgba(0,0,0,0.2); padding: 6px 10px;
+}
+.rt-modal-body strong { color: var(--castle-crimson); }
+
+/* lock background scroll while modal is open */
+body:has(.rt-modal-backdrop.visible) { overflow: hidden; }

--- a/web-ui/frontend/the-bazaar/index.html
+++ b/web-ui/frontend/the-bazaar/index.html
@@ -8,10 +8,10 @@
 <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 <style>
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      THE BAZAAR — Design Tokens & Global Styles
      Warm, conversational, character-driven trading interface
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   :root {
     --bg-root:       #1A1410;
     --bg-surface:    #241C14;
@@ -54,15 +54,14 @@
     overflow-x: hidden;
   }
 
-  /* ── Scrollbar ────────────────────────────────── */
   ::-webkit-scrollbar { width: 5px; }
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      ANIMATIONS
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(16px); }
     to   { opacity: 1; transform: translateY(0); }
@@ -72,11 +71,11 @@
     to   { opacity: 1; }
   }
   @keyframes slideInLeft {
-    from { opacity: 0; transform: translateX(-24px); }
+    from { opacity: 0; transform: translateX(-32px); }
     to   { opacity: 1; transform: translateX(0); }
   }
   @keyframes slideInRight {
-    from { opacity: 0; transform: translateX(24px); }
+    from { opacity: 0; transform: translateX(32px); }
     to   { opacity: 1; transform: translateX(0); }
   }
   @keyframes pulseGlow {
@@ -105,12 +104,31 @@
     60% { opacity: 0.7; }
     100% { opacity: 0; transform: translateY(-40px) scale(1.2); }
   }
+  @keyframes speakerPulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(232,168,64,0.4); }
+    50%      { box-shadow: 0 0 0 8px rgba(232,168,64,0); }
+  }
+  @keyframes clashShake {
+    0%, 100% { transform: translateX(0); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(-3px); }
+    20%, 40%, 60%, 80% { transform: translateX(3px); }
+  }
+  @keyframes scrollUnfurl {
+    from { max-height: 0; opacity: 0; transform: scaleY(0.9); transform-origin: top; }
+    to   { max-height: 500px; opacity: 1; transform: scaleY(1); }
+  }
+  @keyframes gavelStrike {
+    0% { transform: rotate(-20deg) scale(0.5); opacity: 0; }
+    50% { transform: rotate(5deg) scale(1.2); opacity: 1; }
+    70% { transform: rotate(-3deg) scale(0.95); }
+    100% { transform: rotate(0) scale(1); }
+  }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      LAYOUT
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   .app-container {
-    max-width: 800px;
+    max-width: 860px;
     margin: 0 auto;
     min-height: 100vh;
     display: flex;
@@ -120,18 +138,22 @@
   /* ── Top Bar ─────────────────────────────────── */
   .topbar {
     display: flex; align-items: center; justify-content: space-between;
-    padding: 12px 20px;
+    padding: 10px 20px;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-default);
     position: sticky; top: 0; z-index: 100;
+    gap: 12px;
   }
   .topbar-brand {
-    font-size: 18px; font-weight: bold;
+    font-size: 17px; font-weight: bold;
     color: var(--accent-amber);
     letter-spacing: 0.02em;
     display: flex; align-items: center; gap: 8px;
+    cursor: pointer;
+    transition: opacity 150ms;
   }
-  .topbar-brand .icon { font-size: 22px; }
+  .topbar-brand:hover { opacity: 0.8; }
+  .topbar-brand .icon { font-size: 20px; }
   .topbar-status {
     font-size: 12px; color: var(--text-muted);
     display: flex; align-items: center; gap: 6px;
@@ -142,6 +164,25 @@
     animation: pulseGlow 1.5s ease-in-out infinite;
   }
   .live-indicator.inactive { background: var(--text-muted); animation: none; }
+
+  .topbar-nav {
+    display: flex; gap: 4px;
+  }
+  .topbar-nav button {
+    background: transparent; border: 1px solid var(--border-default);
+    border-radius: 8px; padding: 4px 12px;
+    color: var(--text-secondary); font-size: 12px;
+    font-family: var(--font-sans); cursor: pointer;
+    transition: all 150ms;
+  }
+  .topbar-nav button:hover {
+    border-color: var(--accent-amber); color: var(--accent-amber);
+  }
+  .topbar-nav button.active {
+    border-color: var(--accent-amber);
+    background: rgba(232,168,64,0.08);
+    color: var(--accent-amber);
+  }
 
   /* ── Token Gate ──────────────────────────────── */
   .token-overlay {
@@ -177,18 +218,16 @@
   .token-card button:hover { background: var(--accent-glow); transform: translateY(-1px); }
   .token-error { color: var(--signal-bearish); font-size: 13px; margin-top: 8px; }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      SCREEN: BAZAAR INPUT
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   .bazaar-input {
     flex: 1; display: flex; flex-direction: column;
     align-items: center; justify-content: center;
     padding: 40px 20px;
     animation: fadeInUp 0.6s ease;
   }
-  .bazaar-input .welcome-text {
-    text-align: center; margin-bottom: 32px;
-  }
+  .bazaar-input .welcome-text { text-align: center; margin-bottom: 32px; }
   .bazaar-input .welcome-text h1 {
     font-size: 32px; color: var(--accent-amber); margin-bottom: 6px;
     letter-spacing: 0.01em;
@@ -219,9 +258,7 @@
     width: 100%; max-width: 480px;
     animation: fadeInUp 0.6s ease 0.15s both;
   }
-  .bazaar-input .form-row {
-    display: flex; gap: 12px; margin-bottom: 16px;
-  }
+  .bazaar-input .form-row { display: flex; gap: 12px; margin-bottom: 16px; }
   .bazaar-input .form-group { flex: 1; }
   .bazaar-input .form-label {
     display: block; font-size: 11px; font-weight: 600;
@@ -279,92 +316,175 @@
     transform: translateY(-1px);
     box-shadow: 0 6px 24px rgba(232,168,64,0.25);
   }
-  .bazaar-input .btn-summon:disabled {
-    opacity: 0.5; cursor: not-allowed; transform: none;
-  }
-  .bazaar-input .btn-summon .sparkle {
-    position: absolute;
-    width: 4px; height: 4px; background: #fff;
-    border-radius: 50%;
-    animation: sparkle 1.5s ease-in-out infinite;
-  }
+  .bazaar-input .btn-summon:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
 
-  /* ═══════════════════════════════════════════════════════════════
-     SCREEN: DEBATE HALL
-     ═══════════════════════════════════════════════════════════════ */
-  .debate-hall {
+  /* ═══════════════════════════════════════════════════
+     SCREEN: COUNCIL ARENA (DEBATE)
+     ═══════════════════════════════════════════════════ */
+  .arena {
     flex: 1; display: flex; flex-direction: column;
     overflow: hidden;
   }
-  .debate-header {
-    padding: 12px 20px;
+
+  /* ── Council Table ────────────────────────────── */
+  .council-table {
+    background: var(--bg-surface);
+    border-bottom: 2px solid var(--border-default);
+    padding: 14px 20px;
+    display: flex; align-items: center; gap: 6px;
+    overflow-x: auto;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .council-table .councilor {
+    display: flex; flex-direction: column; align-items: center;
+    gap: 4px; min-width: 52px;
+    padding: 6px 4px; border-radius: 10px;
+    border: 2px solid transparent;
+    transition: all 300ms;
+    opacity: 0.5;
+    cursor: default;
+  }
+  .council-table .councilor.spoken {
+    opacity: 0.85;
+  }
+  .council-table .councilor.speaking {
+    opacity: 1;
+    border-color: var(--accent-amber);
+    background: rgba(232,168,64,0.08);
+    animation: speakerPulse 2s ease-in-out infinite;
+  }
+  .council-table .councilor .counc-avatar {
+    width: 32px; height: 32px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 16px;
+    border: 1.5px solid;
+  }
+  .council-table .councilor .counc-initial {
+    font-size: 9px; font-weight: 700; color: var(--text-muted);
+    text-transform: uppercase; letter-spacing: 0.06em;
+    margin-top: 2px;
+  }
+
+  /* ── Arena Header ─────────────────────────────── */
+  .arena-header {
+    padding: 10px 20px;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-default);
     display: flex; align-items: center; gap: 12px;
     font-size: 13px;
   }
-  .debate-header .ticker-badge {
+  .arena-header .ticker-badge {
     background: rgba(232,168,64,0.12);
     color: var(--accent-amber); font-weight: 700;
     padding: 3px 12px; border-radius: 20px;
     font-family: var(--font-mono); font-size: 14px;
   }
-  .debate-header .date-label { color: var(--text-secondary); }
+  .arena-header .date-label { color: var(--text-secondary); }
+  .arena-header .clash-counter {
+    margin-left: auto;
+    font-size: 11px; color: var(--text-muted);
+    font-style: italic;
+  }
 
-  .debate-chat {
+  /* ── Arena Scroll ─────────────────────────────── */
+  .arena-scroll {
     flex: 1; overflow-y: auto; padding: 16px 20px;
     display: flex; flex-direction: column; gap: 10px;
   }
 
-  /* ── Character Message ────────────────────────── */
-  .char-msg {
-    display: flex; gap: 12px;
-    animation: fadeInUp 0.35s ease both;
+  /* ── Testimony Cards ──────────────────────────── */
+  .testimony-card {
+    animation: slideInLeft 0.4s ease both;
+    max-width: 88%;
+    align-self: flex-start;
+  }
+  .testimony-card.clash-card {
+    animation: slideInRight 0.4s ease both;
+    align-self: flex-end;
     max-width: 90%;
   }
-  .char-msg.agent-msg { align-self: flex-start; }
-  .char-msg.system-msg {
-    align-self: center; max-width: 70%;
-    font-style: italic; color: var(--text-muted);
-    text-align: center; font-size: 13px;
-    animation: fadeIn 0.5s ease both;
+  .testimony-card .testimony-banner {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 6px;
   }
-  .char-msg .avatar-ring {
-    width: 40px; height: 40px; min-width: 40px;
-    border-radius: 50%;
+  .testimony-card .testimony-banner .test-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;
     font-size: 18px;
     border: 2px solid;
     background: var(--bg-elevated);
   }
-  .char-msg .msg-bubble {
+  .testimony-card .testimony-banner .test-name {
+    font-size: 13px; font-weight: 700; letter-spacing: 0.03em;
+  }
+  .testimony-card .testimony-banner .test-role {
+    font-size: 10px; color: var(--text-muted); font-weight: 400;
+  }
+  .testimony-card .testimony-body {
     background: var(--bg-elevated);
     border: 1px solid var(--border-default);
-    border-radius: 14px; border-top-left-radius: 4px;
-    padding: 10px 14px;
-  }
-  .char-msg .msg-sender {
-    font-size: 12px; font-weight: 700; margin-bottom: 3px;
-    letter-spacing: 0.03em;
-  }
-  .char-msg .msg-content {
-    font-size: 14px; line-height: 1.55;
-    color: var(--text-primary);
+    border-radius: 12px; padding: 12px 16px;
+    font-size: 14px; line-height: 1.6;
     white-space: pre-wrap; word-break: break-word;
   }
-  .char-msg .msg-content.report-content {
-    font-size: 13px; max-height: 180px; overflow-y: auto;
+  .testimony-card:not(.clash-card) .testimony-body {
+    border-left: 3px solid;
+  }
+  .testimony-card.clash-card .testimony-body {
+    border-right: 3px solid;
+    text-align: right;
+  }
+  .testimony-card .testimony-meta {
+    font-size: 10px; color: var(--text-muted);
+    margin-top: 4px; padding: 0 4px;
+  }
+  .testimony-card.clash-card .testimony-meta {
+    text-align: right;
+  }
+  /* Report testimony — collapsible */
+  .testimony-card.report-card .testimony-body {
+    max-height: 120px; overflow-y: auto; font-size: 12px;
     color: var(--text-secondary);
-    border-left: 2px solid var(--border-default);
-    padding-left: 10px; margin-top: 4px;
+    border-left: 3px solid var(--border-default);
   }
-  .char-msg .msg-content.decision-content {
-    font-size: 18px; font-weight: 700; text-align: center;
-    padding: 8px 0;
+
+  /* ── Herald (System) Message ──────────────────── */
+  .herald-msg {
+    align-self: center; text-align: center;
+    padding: 8px 20px; max-width: 80%;
+    animation: fadeIn 0.5s ease both;
   }
-  .char-msg .msg-time {
-    font-size: 10px; color: var(--text-muted); margin-top: 4px;
+  .herald-msg .herald-divider {
+    display: flex; align-items: center; gap: 12px;
+    margin-bottom: 4px;
   }
+  .herald-msg .herald-divider::before,
+  .herald-msg .herald-divider::after {
+    content: ''; flex: 1; height: 1px;
+    background: var(--border-default);
+  }
+  .herald-msg .herald-divider span {
+    font-size: 13px; color: var(--text-muted);
+    font-style: italic;
+  }
+  .herald-msg .herald-text {
+    font-size: 11px; color: var(--text-muted);
+    font-style: italic;
+  }
+
+  /* ── Gavel (Verdict Preview) ──────────────────── */
+  .gavel-preview {
+    align-self: center; text-align: center;
+    padding: 16px; animation: gavelStrike 0.6s ease both;
+  }
+  .gavel-preview .gavel-icon { font-size: 36px; }
+  .gavel-preview .gavel-text {
+    font-size: 20px; font-weight: 900; margin-top: 4px;
+    animation: pulseGlow 3s ease-in-out infinite;
+  }
+  .gavel-preview .gavel-text.buy  { color: var(--signal-bullish); }
+  .gavel-preview .gavel-text.sell { color: var(--signal-bearish); }
+  .gavel-preview .gavel-text.hold { color: var(--signal-neutral); }
 
   /* ── Typing Indicator ─────────────────────────── */
   .typing-indicator {
@@ -403,9 +523,9 @@
     border-color: var(--accent-amber); color: var(--accent-amber);
   }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      SCREEN: THE LEDGER (VERDICT)
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   .ledger {
     flex: 1; display: flex; flex-direction: column;
     align-items: center; justify-content: center;
@@ -466,21 +586,121 @@
     z-index: 999;
   }
 
-  /* ═══════════════════════════════════════════════════════════════
-     ERROR BANNER
-     ═══════════════════════════════════════════════════════════════ */
-  .error-banner {
-    margin: 8px 20px; padding: 10px 16px;
-    background: rgba(229,115,115,0.12);
-    border: 1px solid var(--signal-bearish);
-    border-radius: 10px; color: var(--signal-bearish);
-    font-size: 13px; display: flex; align-items: center; gap: 8px;
-    animation: fadeInUp 0.3s ease;
+  /* ═══════════════════════════════════════════════════
+     SCREEN: HISTORY ARCHIVES
+     ═══════════════════════════════════════════════════ */
+  .archives {
+    flex: 1; display: flex; flex-direction: column;
+    padding: 32px 20px;
+    animation: fadeInUp 0.5s ease;
+    gap: 24px;
+  }
+  .archives-hero {
+    text-align: center; padding: 12px 0;
+  }
+  .archives-hero h2 {
+    font-size: 24px; color: var(--accent-amber);
+    letter-spacing: 0.02em; margin-bottom: 4px;
+  }
+  .archives-hero p {
+    color: var(--text-secondary); font-size: 14px; font-style: italic;
+  }
+  .archives-grid {
+    display: grid; gap: 12px;
+  }
+  .archive-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 12px; padding: 18px;
+    cursor: pointer;
+    transition: all 200ms;
+    animation: fadeInUp 0.4s ease both;
+    display: flex; align-items: center; gap: 16px;
+  }
+  .archive-card:hover {
+    border-color: var(--border-active);
+    transform: translateX(4px);
+    box-shadow: 0 2px 12px rgba(232,168,64,0.1);
+  }
+  .archive-card .arc-verdict {
+    font-size: 36px; flex-shrink: 0;
+  }
+  .archive-card .arc-info { flex: 1; min-width: 0; }
+  .archive-card .arc-ticker {
+    font-weight: 700; font-size: 20px;
+    font-family: var(--font-mono); color: var(--text-primary);
+  }
+  .archive-card .arc-date {
+    font-size: 12px; color: var(--text-muted);
+  }
+  .archive-card .arc-preview {
+    font-size: 12px; color: var(--text-secondary);
+    margin-top: 4px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    max-width: 400px;
+  }
+  .archive-card .arc-badge {
+    font-size: 10px; font-weight: 700;
+    padding: 3px 10px; border-radius: 16px;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    flex-shrink: 0;
+  }
+  .archive-card .arc-badge.buy  { background: rgba(76,175,80,0.12); color: var(--signal-bullish); }
+  .archive-card .arc-badge.sell { background: rgba(229,115,115,0.12); color: var(--signal-bearish); }
+  .archive-card .arc-badge.hold { background: rgba(255,183,77,0.12); color: var(--signal-neutral); }
+  .archive-card .arc-badge.unknown { background: rgba(107,95,78,0.12); color: var(--text-muted); }
+
+  /* ── Archive Detail View ──────────────────────── */
+  .archive-detail {
+    flex: 1; display: flex; flex-direction: column;
+    padding: 24px 20px; gap: 20px;
+    animation: fadeInUp 0.4s ease;
+  }
+  .archive-detail .detail-verdict {
+    text-align: center; padding: 20px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 14px;
+  }
+  .archive-detail .detail-verdict .dv-icon { font-size: 48px; }
+  .archive-detail .detail-verdict .dv-decision {
+    font-size: 28px; font-weight: 900; margin-top: 4px;
+  }
+  .archive-detail .detail-verdict .dv-decision.buy  { color: var(--signal-bullish); }
+  .archive-detail .detail-verdict .dv-decision.sell { color: var(--signal-bearish); }
+  .archive-detail .detail-verdict .dv-decision.hold { color: var(--signal-neutral); }
+  .archive-detail .detail-verdict .dv-meta {
+    font-size: 13px; color: var(--text-muted); margin-top: 2px;
+  }
+  .archive-detail .detail-section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 12px; padding: 16px;
+  }
+  .archive-detail .detail-section h4 {
+    font-size: 12px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-muted); margin-bottom: 10px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .archive-detail .detail-content {
+    font-size: 13px; line-height: 1.7;
+    color: var(--text-secondary);
+    white-space: pre-wrap; word-break: break-word;
+    max-height: 300px; overflow-y: auto;
+  }
+  .archive-detail .detail-loading {
+    text-align: center; color: var(--text-muted);
+    padding: 48px; font-style: italic;
+  }
+  .archive-detail .detail-error {
+    text-align: center; color: var(--signal-bearish);
+    padding: 24px;
   }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      SCREEN: DASHBOARD
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   .dashboard {
     flex: 1; display: flex; flex-direction: column;
     padding: 32px 20px;
@@ -558,17 +778,13 @@
     transform: translateY(-2px);
     box-shadow: 0 4px 16px rgba(232,168,64,0.12);
   }
-  .recent-card .rc-icon {
-    font-size: 28px; flex-shrink: 0;
-  }
+  .recent-card .rc-icon { font-size: 28px; flex-shrink: 0; }
   .recent-card .rc-info { flex: 1; min-width: 0; }
   .recent-card .rc-ticker {
     font-weight: 700; font-size: 18px;
     font-family: var(--font-mono); color: var(--text-primary);
   }
-  .recent-card .rc-date {
-    font-size: 12px; color: var(--text-muted);
-  }
+  .recent-card .rc-date { font-size: 12px; color: var(--text-muted); }
   .recent-card .rc-arrow {
     color: var(--text-muted); font-size: 14px;
     transition: all 200ms;
@@ -615,16 +831,24 @@
     display: flex; align-items: center; justify-content: center;
     font-size: 14px;
   }
-  .agent-showcase .sc-name {
-    font-size: 13px; font-weight: 600;
-  }
-  .agent-showcase .sc-role {
-    font-size: 10px; color: var(--text-muted);
+  .agent-showcase .sc-name { font-size: 13px; font-weight: 600; }
+  .agent-showcase .sc-role { font-size: 10px; color: var(--text-muted); }
+
+  /* ═══════════════════════════════════════════════════
+     ERROR BANNER
+     ═══════════════════════════════════════════════════ */
+  .error-banner {
+    margin: 8px 20px; padding: 10px 16px;
+    background: rgba(229,115,115,0.12);
+    border: 1px solid var(--signal-bearish);
+    border-radius: 10px; color: var(--signal-bearish);
+    font-size: 13px; display: flex; align-items: center; gap: 8px;
+    animation: fadeInUp 0.3s ease;
   }
 
-  /* ═══════════════════════════════════════════════════════════════
+  /* ═══════════════════════════════════════════════════
      RESPONSIVE
-     ═══════════════════════════════════════════════════════════════ */
+     ═══════════════════════════════════════════════════ */
   @media (max-width: 600px) {
     .bazaar-input .analyst-grid { grid-template-columns: 1fr; }
     .ledger-card { padding: 28px 20px; }
@@ -636,15 +860,14 @@
     .recent-grid { grid-template-columns: 1fr; }
     .agent-showcase { gap: 6px; }
     .agent-showcase .showcase-chip { padding: 6px 12px; font-size: 11px; }
+    .council-table { gap: 2px; padding: 10px 8px; }
+    .council-table .councilor { min-width: 40px; }
+    .council-table .councilor .counc-avatar { width: 24px; height: 24px; font-size: 12px; }
   }
 
   /* ── Page Transitions ─────────────────────────── */
-  .screen-enter {
-    animation: fadeInUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
-  }
-  .screen-exit {
-    animation: fadeOut 0.2s ease forwards;
-  }
+  .screen-enter { animation: fadeInUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) both; }
+  .screen-exit { animation: fadeOut 0.2s ease forwards; }
   @keyframes fadeOut {
     from { opacity: 1; }
     to   { opacity: 0; }
@@ -655,11 +878,11 @@
 <div id="root"></div>
 
 <script type="text/babel">
-const { useState, useEffect, useRef, useCallback } = React;
+const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
-/* ═══════════════════════════════════════════════════════════════════
+/* ═══════════════════════════════════════════════════
    AGENT PERSONAS
-   ═══════════════════════════════════════════════════════════════════ */
+   ═══════════════════════════════════════════════════ */
 const AGENTS = {
   market:     { id:'market', name:'Flint', role:'Market Analyst', avatar:'🐂', color:'#8B6B4A', accent:'#A07654' },
   social:     { id:'social', name:'Vera', role:'Sentiment Seer', avatar:'🔮', color:'#C44B4B', accent:'#D46060' },
@@ -671,11 +894,11 @@ const AGENTS = {
   judge:      { id:'judge', name:'Elder Aldric', role:'High Judge', avatar:'👑', color:'#9B8BAA', accent:'#AD9DBC' },
 };
 
-const NARRATOR = { id:'system', name:'The Bazaar', avatar:'🏛️', color:'#E8A840', accent:'#F0C060' };
+const NARRATOR = { id:'system', name:'The Herald', avatar:'🏛️', color:'#E8A840', accent:'#F0C060' };
+const ALL_AGENTS = Object.values(AGENTS);
 
 /* Map SSE node names to agent personas */
 function resolveAgent(eventType, nodeName, sectionName) {
-  // Direct analyst reports
   if (eventType === 'report') {
     if (sectionName === 'market_report') return AGENTS.market;
     if (sectionName === 'sentiment_report') return AGENTS.social;
@@ -683,16 +906,12 @@ function resolveAgent(eventType, nodeName, sectionName) {
     if (sectionName === 'fundamentals_report') return AGENTS.fundamentals;
     if (sectionName === 'trader_plan') return AGENTS.trader;
   }
-  // Debates
   if (eventType === 'debate') {
-    if (nodeName && nodeName.includes('risk')) return AGENTS.risk;
+    if (nodeName && nodeName.toLowerCase().includes('risk')) return AGENTS.risk;
     return AGENTS.debater;
   }
-  // Decision
   if (eventType === 'decision') return AGENTS.judge;
-  // Status messages
   if (eventType === 'status') return NARRATOR;
-  // Chunks — try to map by node name
   if (nodeName) {
     const n = nodeName.toLowerCase();
     if (n.includes('market')) return AGENTS.market;
@@ -707,11 +926,9 @@ function resolveAgent(eventType, nodeName, sectionName) {
   return NARRATOR;
 }
 
-/* ═══════════════════════════════════════════════════════════════════
+/* ═══════════════════════════════════════════════════
    HOOKS
-   ═══════════════════════════════════════════════════════════════════ */
-
-// Read ?api= and ?token= from URL
+   ═══════════════════════════════════════════════════ */
 function useQueryParams() {
   if (typeof window === 'undefined') return {};
   const params = new URLSearchParams(window.location.search);
@@ -721,87 +938,38 @@ function useQueryParams() {
   };
 }
 
-/* ═══════════════════════════════════════════════════════════════════
+/* ═══════════════════════════════════════════════════
    COMPONENTS
-   ═══════════════════════════════════════════════════════════════════ */
+   ═══════════════════════════════════════════════════ */
 
-/* ── Character Message ───────────────────────────────────────────── */
-function CharacterMessage({ msg, index }) {
-  const isSystem = msg.agent.id === 'system';
-  if (isSystem) {
-    return (
-      <div className="char-msg system-msg" style={{animationDelay: `${index * 0.05}s`}}>
-        <div className="msg-content">{msg.content}</div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="char-msg agent-msg" style={{animationDelay: `${index * 0.05}s`}}>
-      <div className="avatar-ring" style={{borderColor: msg.agent.color}}>
-        {msg.agent.avatar}
-      </div>
-      <div className="msg-bubble" style={{borderLeftColor: msg.agent.color, borderLeftWidth: 2}}>
-        <div className="msg-sender" style={{color: msg.agent.color}}>
-          {msg.agent.name} <span style={{fontWeight:400, fontSize:11, color:'var(--text-muted)'}}>· {msg.agent.role}</span>
-        </div>
-        <div className={`msg-content ${msg.kind === 'report' ? 'report-content' : ''} ${msg.kind === 'decision' ? 'decision-content' : ''}`}>
-          {msg.content}
-        </div>
-        {msg.timestamp && <div className="msg-time">{msg.timestamp}</div>}
-      </div>
-    </div>
-  );
-}
-
-/* ── Typing Indicator ────────────────────────────────────────────── */
-function TypingIndicator({ agentName }) {
-  return (
-    <div className="typing-indicator">
-      <div className="dots">
-        <span></span><span></span><span></span>
-      </div>
-      <span className="typing-label">{agentName || 'The Council'} deliberates...</span>
-    </div>
-  );
-}
-
-/* ── Token Gate ──────────────────────────────────────────────────── */
+/* ── Token Gate ─────────────────────────────────── */
 function TokenGate({ onUnlock, apiBase }) {
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
   const [validating, setValidating] = useState(false);
   const { urlToken } = useQueryParams();
 
-  useEffect(() => {
-    if (urlToken) {
-      verifyAndUnlock(urlToken);
-    }
-  }, []);
+  useEffect(() => { if (urlToken) verifyAndUnlock(urlToken); }, []);
 
   async function verifyAndUnlock(token) {
-    setValidating(true);
-    setError('');
+    setValidating(true); setError('');
     try {
       const resp = await fetch(`${apiBase}/auth/verify?token=${encodeURIComponent(token)}`, {
         headers: { 'Authorization': `Bearer ${token}` },
       });
-      if (resp.ok) {
-        onUnlock(token);
-      } else {
+      if (resp.ok) { onUnlock(token); }
+      else {
         const data = await resp.json().catch(() => ({}));
-        setError(data.detail || `Invalid token (HTTP ${resp.status}). Check your API token and try again.`);
+        setError(data.detail || `Invalid token (HTTP ${resp.status}).`);
       }
     } catch (err) {
-      setError(`Cannot reach the backend at ${apiBase}. Is the server running?`);
-    } finally {
-      setValidating(false);
-    }
+      setError(`Cannot reach backend at ${apiBase}. Is the server running?`);
+    } finally { setValidating(false); }
   }
 
   function handleSubmit(e) {
     e.preventDefault();
-    if (!input.trim()) { setError('A token is required to enter The Bazaar.'); return; }
+    if (!input.trim()) { setError('A token is required.'); return; }
     verifyAndUnlock(input.trim());
   }
 
@@ -811,14 +979,9 @@ function TokenGate({ onUnlock, apiBase }) {
         <div style={{fontSize:48, marginBottom:12}}>🏛️</div>
         <h2>Enter The Bazaar</h2>
         <p>The gates are sealed. Speak the passphrase to summon the Council of Analysts.</p>
-        <input
-          type="password"
-          placeholder="API token..."
-          value={input}
-          onChange={e => { setInput(e.target.value); setError(''); }}
-          autoFocus
-          disabled={validating}
-        />
+        <input type="password" placeholder="API token..." value={input}
+               onChange={e => { setInput(e.target.value); setError(''); }}
+               autoFocus disabled={validating} />
         <button type="submit" disabled={validating}>
           {validating ? 'Verifying...' : 'Enter the Marketplace'}
         </button>
@@ -828,7 +991,7 @@ function TokenGate({ onUnlock, apiBase }) {
   );
 }
 
-/* ── DeepSeek Model Presets ─────────────────────────────────────── */
+/* ── DeepSeek Model Presets ────────────────────── */
 const DEEPSEEK_PRESETS = [
   { id: 'v4pro', label: 'V4 Pro + Flash', desc: 'Best quality, fast aux',
     llm_provider: 'deepseek', deep_think_llm: 'deepseek-v4-pro', quick_think_llm: 'deepseek-v4-flash' },
@@ -840,25 +1003,18 @@ const DEEPSEEK_PRESETS = [
     llm_provider: 'deepseek', deep_think_llm: 'deepseek-r1', quick_think_llm: 'deepseek-v4-flash' },
 ];
 
-/* ── Bazaar Input Screen ─────────────────────────────────────────── */
+/* ── Bazaar Input Screen ────────────────────────── */
 function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
   const [ticker, setTicker] = useState(prefillTicker || '');
-  const [date, setDate] = useState(() => {
-    const d = new Date();
-    return d.toISOString().split('T')[0];
-  });
+  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
   const [analysts, setAnalysts] = useState(['market','social','news','fundamentals']);
   const [depth, setDepth] = useState('standard');
   const [modelPreset, setModelPreset] = useState('v4pro');
 
-  useEffect(() => {
-    if (prefillTicker) setTicker(prefillTicker);
-  }, [prefillTicker]);
+  useEffect(() => { if (prefillTicker) setTicker(prefillTicker); }, [prefillTicker]);
 
   function toggleAnalyst(id) {
-    setAnalysts(prev =>
-      prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]
-    );
+    setAnalysts(prev => prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]);
   }
 
   function handleSummon(e) {
@@ -867,16 +1023,14 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
     const preset = DEEPSEEK_PRESETS.find(p => p.id === modelPreset) || DEEPSEEK_PRESETS[0];
     onSubmit({
       ticker: ticker.trim().toUpperCase(),
-      date,
-      analysts,
-      depth,
+      date, analysts, depth,
       llm_provider: preset.llm_provider,
       deep_think_llm: preset.deep_think_llm,
       quick_think_llm: preset.quick_think_llm,
     });
   }
 
-  const agentEntries = Object.values(AGENTS).slice(0, 4); // core 4 analysts
+  const agentEntries = ALL_AGENTS.slice(0, 4);
 
   return (
     <div className="bazaar-input">
@@ -884,23 +1038,18 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
         <h1>🏛️ The Bazaar</h1>
         <p className="tagline">Where the finest analytical minds gather to debate your trade.</p>
       </div>
-
       <div className="agent-roster">
-        {Object.values(AGENTS).map(a => (
+        {ALL_AGENTS.map(a => (
           <div key={a.id} className="agent-chip" title={`${a.name} — ${a.role}`}
-               style={{borderColor: a.color + '44'}}>
-            {a.avatar}
-          </div>
+               style={{borderColor: a.color + '44'}}>{a.avatar}</div>
         ))}
       </div>
-
       <form className="form-card" onSubmit={handleSummon}>
         <div className="form-row">
           <div className="form-group">
             <label className="form-label">Ticker Symbol</label>
             <input type="text" className="form-input" placeholder="AAPL"
-                   value={ticker}
-                   onChange={e => setTicker(e.target.value.toUpperCase())}
+                   value={ticker} onChange={e => setTicker(e.target.value.toUpperCase())}
                    maxLength={10} autoFocus />
           </div>
           <div className="form-group">
@@ -909,17 +1058,13 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
                    onChange={e => setDate(e.target.value)} />
           </div>
         </div>
-
         <div className="form-group">
           <label className="form-label">The Council</label>
           <div className="analyst-grid">
             {agentEntries.map(a => (
-              <div key={a.id}
-                   className={`analyst-check ${analysts.includes(a.id) ? 'checked' : ''}`}
+              <div key={a.id} className={`analyst-check ${analysts.includes(a.id) ? 'checked' : ''}`}
                    onClick={() => toggleAnalyst(a.id)}>
-                <div className="avatar" style={{background: a.color+'22', color: a.color}}>
-                  {a.avatar}
-                </div>
+                <div className="avatar" style={{background: a.color+'22', color: a.color}}>{a.avatar}</div>
                 <div>
                   <div style={{fontWeight:600, fontSize:13}}>{a.name}</div>
                   <div style={{fontSize:10, color:'var(--text-muted)'}}>{a.role}</div>
@@ -928,7 +1073,6 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
             ))}
           </div>
         </div>
-
         <div className="form-row">
           <div className="form-group">
             <label className="form-label">LLM Model (DeepSeek only)</label>
@@ -940,88 +1084,147 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
             </select>
           </div>
         </div>
-
         <div className="form-row">
           <div className="form-group">
             <label className="form-label">Research Depth</label>
-            <select className="form-input" value={depth}
-                    onChange={e => setDepth(e.target.value)}>
+            <select className="form-input" value={depth} onChange={e => setDepth(e.target.value)}>
               <option value="standard">Standard</option>
               <option value="deep">Deep</option>
             </select>
           </div>
         </div>
-
         <button className="btn-summon" type="submit" disabled={isSubmitting || !ticker.trim()}>
-          {isSubmitting ? (
-            <span>Summoning the Council...</span>
-          ) : (
-            <span>Summon the Council ⚡</span>
-          )}
+          {isSubmitting ? 'Summoning the Council...' : 'Summon the Council ⚡'}
         </button>
       </form>
     </div>
   );
 }
 
-/* ── Debate Hall ─────────────────────────────────────────────────── */
-function DebateHall({ messages, isStreaming, streamingAgent, ticker, date, error }) {
-  const chatEndRef = useRef(null);
-  const chatContainerRef = useRef(null);
+/* ── Council Table ──────────────────────────────── */
+function CouncilTable({ activeAgentId, spokenAgents }) {
+  return (
+    <div className="council-table">
+      {ALL_AGENTS.map(a => {
+        const isSpeaking = activeAgentId === a.id;
+        const hasSpoken = spokenAgents.has(a.id);
+        let cls = 'councilor';
+        if (isSpeaking) cls += ' speaking';
+        else if (hasSpoken) cls += ' spoken';
+        return (
+          <div key={a.id} className={cls}>
+            <div className="counc-avatar" style={{borderColor: a.color, background: isSpeaking ? a.color+'22' : 'transparent'}}>
+              {a.avatar}
+            </div>
+            <div className="counc-initial">{a.name.slice(0,3)}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ── Testimony Card ─────────────────────────────── */
+function TestimonyCard({ msg, isClash, index }) {
+  const agent = msg.agent;
+  const isReport = msg.kind === 'report';
+
+  return (
+    <div className={`testimony-card ${isClash ? 'clash-card' : ''} ${isReport ? 'report-card' : ''}`}
+         style={{animationDelay: `${index * 0.06}s`}}>
+      <div className="testimony-banner" style={{flexDirection: isClash ? 'row-reverse' : 'row'}}>
+        <div className="test-avatar" style={{borderColor: agent.color}}>{agent.avatar}</div>
+        <div style={{textAlign: isClash ? 'right' : 'left'}}>
+          <div className="test-name" style={{color: agent.color}}>{agent.name}</div>
+          <div className="test-role">{agent.role}</div>
+        </div>
+      </div>
+      <div className="testimony-body" style={isClash ? {borderRightColor: agent.color} : {borderLeftColor: agent.color}}>
+        {msg.content}
+      </div>
+      {msg.timestamp && (
+        <div className="testimony-meta">{msg.timestamp}</div>
+      )}
+    </div>
+  );
+}
+
+/* ── Herald Message ─────────────────────────────── */
+function HeraldMsg({ text, subtext }) {
+  return (
+    <div className="herald-msg">
+      <div className="herald-divider"><span>🏛️ {text}</span></div>
+      {subtext && <div className="herald-text">{subtext}</div>}
+    </div>
+  );
+}
+
+/* ── Typing Indicator ───────────────────────────── */
+function TypingIndicator({ agentName }) {
+  return (
+    <div className="typing-indicator">
+      <div className="dots"><span></span><span></span><span></span></div>
+      <span className="typing-label">{agentName || 'The Council'} deliberates...</span>
+    </div>
+  );
+}
+
+/* ── Council Arena (Debate Hall) ────────────────── */
+function CouncilArena({ messages, isStreaming, streamingAgent, ticker, date, error, activeAgentId, spokenAgents, clashCount }) {
+  const scrollEndRef = useRef(null);
+  const scrollContainerRef = useRef(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
   useEffect(() => {
-    if (autoScroll && chatEndRef.current) {
-      chatEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    if (autoScroll && scrollEndRef.current) {
+      scrollEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [messages, autoScroll]);
 
   function handleScroll() {
-    if (!chatContainerRef.current) return;
-    const el = chatContainerRef.current;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-    setAutoScroll(atBottom);
+    if (!scrollContainerRef.current) return;
+    const el = scrollContainerRef.current;
+    setAutoScroll(el.scrollHeight - el.scrollTop - el.clientHeight < 80);
   }
 
   return (
-    <div className="debate-hall">
-      <div className="debate-header">
-        <span className="live-indicator"></span>
+    <div className="arena">
+      <CouncilTable activeAgentId={activeAgentId} spokenAgents={spokenAgents} />
+      <div className="arena-header">
         <span className="ticker-badge">{ticker}</span>
         <span className="date-label">{date}</span>
-        <span style={{flex:1}}></span>
-        <span style={{fontSize:11, color:'var(--text-muted)'}}>
-          {messages.length} messages
+        <span className="clash-counter">
+          {clashCount > 0 ? `⚔️ ${clashCount} argument${clashCount !== 1 ? 's' : ''} exchanged` : 'Council assembles...'}
         </span>
       </div>
 
       {error && (
-        <div className="error-banner">
-          <span>⚠️</span> {error}
-        </div>
+        <div className="error-banner"><span>⚠️</span> {error}</div>
       )}
 
-      <div className="debate-chat" ref={chatContainerRef} onScroll={handleScroll}>
+      <div className="arena-scroll" ref={scrollContainerRef} onScroll={handleScroll}>
         {messages.length === 0 && !isStreaming && (
-          <div style={{textAlign:'center', color:'var(--text-muted)', padding:40}}>
-            <div style={{fontSize:40, marginBottom:12}}>🏛️</div>
-            <p>The Council assembles. Their debate will appear here.</p>
+          <div style={{textAlign:'center', color:'var(--text-muted)', padding:60}}>
+            <div style={{fontSize:48, marginBottom:12}}>🏛️</div>
+            <p>The Council assembles in the Great Hall.</p>
+            <p style={{fontSize:13, marginTop:6}}>Their debate will appear here as testimony scrolls.</p>
           </div>
         )}
 
-        {messages.map((msg, i) => (
-          <CharacterMessage key={i} msg={msg} index={i} />
-        ))}
+        {messages.map((msg, i) => {
+          if (msg.agent.id === 'system') {
+            return <HeraldMsg key={msg.id || i} text={msg.content} subtext={msg.subtext} />;
+          }
+          const isClash = msg.agent.id === 'debater' || msg.agent.id === 'risk';
+          return <TestimonyCard key={msg.id || i} msg={msg} isClash={isClash} index={i} />;
+        })}
 
-        {isStreaming && (
-          <TypingIndicator agentName={streamingAgent} />
-        )}
-
-        <div ref={chatEndRef} />
+        {isStreaming && <TypingIndicator agentName={streamingAgent} />}
+        <div ref={scrollEndRef} />
 
         {!autoScroll && messages.length > 5 && (
-          <button className="jump-bottom" onClick={() => { setAutoScroll(true); chatEndRef.current?.scrollIntoView({behavior:'smooth'}); }}>
-            ↓ Latest messages
+          <button className="jump-bottom" onClick={() => { setAutoScroll(true); scrollEndRef.current?.scrollIntoView({behavior:'smooth'}); }}>
+            ↓ Latest testimony
           </button>
         )}
       </div>
@@ -1029,26 +1232,20 @@ function DebateHall({ messages, isStreaming, streamingAgent, ticker, date, error
   );
 }
 
-/* ── Ledger (Verdict) ────────────────────────────────────────────── */
-function Ledger({ decision, ticker, date, onNewAnalysis }) {
+/* ── Ledger (Verdict) ───────────────────────────── */
+function Ledger({ decision, ticker, date, onNewAnalysis, onViewHistory }) {
   const [particles, setParticles] = useState([]);
 
   useEffect(() => {
-    // Spawn celebration particles
     const emojis = decision === 'BUY' ? ['💰','📈','✨','🚀','💎'] :
                    decision === 'SELL' ? ['📉','💸','⚠️','🔻','🏃'] :
                    ['🤝','⚖️','🧘','⏳','📊'];
-    const newParticles = [];
-    for (let i = 0; i < 12; i++) {
-      newParticles.push({
-        id: i,
-        emoji: emojis[i % emojis.length],
-        left: 20 + Math.random() * 60,
-        delay: Math.random() * 0.8,
-        duration: 1.5 + Math.random() * 1.5,
-      });
-    }
-    setParticles(newParticles);
+    setParticles(Array.from({length: 12}, (_, i) => ({
+      id: i, emoji: emojis[i % emojis.length],
+      left: 20 + Math.random() * 60,
+      delay: Math.random() * 0.8,
+      duration: 1.5 + Math.random() * 1.5,
+    })));
   }, [decision]);
 
   const decisionClass = decision === 'BUY' ? 'buy' : decision === 'SELL' ? 'sell' : 'hold';
@@ -1057,17 +1254,11 @@ function Ledger({ decision, ticker, date, onNewAnalysis }) {
   return (
     <div className="ledger">
       {particles.map(p => (
-        <div key={p.id} className="particle"
-             style={{
-               left: `${p.left}%`,
-               bottom: '40%',
-               animationDelay: `${p.delay}s`,
-               animationDuration: `${p.duration}s`,
-             }}>
-          {p.emoji}
-        </div>
+        <div key={p.id} className="particle" style={{
+          left: `${p.left}%`, bottom: '40%',
+          animationDelay: `${p.delay}s`, animationDuration: `${p.duration}s`,
+        }}>{p.emoji}</div>
       ))}
-
       <div className="ledger-card" style={{animationDelay: '0.2s'}}>
         <div className="verdict-icon">{verdictEmoji}</div>
         <div className="verdict-label">The Council Has Spoken</div>
@@ -1078,24 +1269,23 @@ function Ledger({ decision, ticker, date, onNewAnalysis }) {
           {decision === 'SELL' && 'The Council urges caution. The bears have won the argument — headwinds are too strong, and the risks outweigh the potential rewards.'}
           {decision === 'HOLD' && 'The Council is divided. Neither bulls nor bears carried enough conviction — patience is the prudent course.'}
         </div>
-        <button className="btn-new" onClick={onNewAnalysis}>
-          Summon a New Council →
-        </button>
+        <div style={{display:'flex', gap:10, justifyContent:'center'}}>
+          <button className="btn-new" onClick={onNewAnalysis}>Summon a New Council →</button>
+          <button className="btn-new" onClick={onViewHistory}>Browse Archives →</button>
+        </div>
       </div>
     </div>
   );
 }
 
-/* ── Agent Showcase ─────────────────────────────────────────────────── */
+/* ── Agent Showcase ─────────────────────────────── */
 function AgentShowcase() {
   return (
     <div className="agent-showcase">
-      {Object.values(AGENTS).map((a, i) => (
-        <div key={a.id} className="showcase-chip" 
+      {ALL_AGENTS.map((a, i) => (
+        <div key={a.id} className="showcase-chip"
              style={{animationDelay: `${i * 0.08}s`, borderLeft: `2px solid ${a.color}`}}>
-          <div className="sc-avatar" style={{background: a.color + '22', color: a.color}}>
-            {a.avatar}
-          </div>
+          <div className="sc-avatar" style={{background: a.color + '22', color: a.color}}>{a.avatar}</div>
           <div>
             <div className="sc-name" style={{color: a.color}}>{a.name}</div>
             <div className="sc-role">{a.role}</div>
@@ -1106,8 +1296,8 @@ function AgentShowcase() {
   );
 }
 
-/* ── Dashboard ──────────────────────────────────────────────────────── */
-function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
+/* ── Dashboard ──────────────────────────────────── */
+function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token, onNavHistory }) {
   const [reports, setReports] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -1122,14 +1312,9 @@ function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
         });
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
-        if (!cancelled) {
-          setReports((data.reports || []).slice(0, 8));
-        }
-      } catch (err) {
-        if (!cancelled) setError(err.message);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+        if (!cancelled) setReports((data.reports || []).slice(0, 6));
+      } catch (err) { if (!cancelled) setError(err.message); }
+      finally { if (!cancelled) setLoading(false); }
     }
     fetchReports();
     return () => { cancelled = true; };
@@ -1141,11 +1326,6 @@ function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
     if (ticker) onQuickAnalyze(ticker);
   }
 
-  function mapDecisionIcon(report) {
-    // We don't know decision from list — use ticker as icon hint
-    return '📊';
-  }
-
   return (
     <div className="dashboard">
       <div className="dashboard-hero">
@@ -1153,11 +1333,8 @@ function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
         <p className="subtitle">Where the finest analytical minds gather to debate your trade.</p>
         <form className="quickstart" onSubmit={handleQuickSubmit}>
           <input type="text" placeholder="AAPL" maxLength={10}
-                 value={quickTicker}
-                 onChange={e => setQuickTicker(e.target.value.toUpperCase())} />
-          <button className="btn-go" type="submit" disabled={!quickTicker.trim()}>
-            Analyze →
-          </button>
+                 value={quickTicker} onChange={e => setQuickTicker(e.target.value.toUpperCase())} />
+          <button className="btn-go" type="submit" disabled={!quickTicker.trim()}>Analyze →</button>
         </form>
       </div>
 
@@ -1169,10 +1346,7 @@ function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
       <div>
         <div className="section-title">Recent Analyses</div>
         {loading && (
-          <div className="dashboard-loading">
-            <div className="spinner"></div>
-            Consulting the archives...
-          </div>
+          <div className="dashboard-loading"><div className="spinner"></div> Consulting the archives...</div>
         )}
         {error && (
           <div className="dashboard-empty">
@@ -1206,12 +1380,195 @@ function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════
+/* ── History Archives Screen ────────────────────── */
+function HistoryArchives({ apiBase, token, onViewDetail, onBack }) {
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchAll() {
+      try {
+        const resp = await fetch(`${apiBase}/reports?token=${encodeURIComponent(token || '')}`, {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) setReports(data.reports || []);
+      } catch (err) { if (!cancelled) setError(err.message); }
+      finally { if (!cancelled) setLoading(false); }
+    }
+    fetchAll();
+    return () => { cancelled = true; };
+  }, [apiBase, token]);
+
+  // Try to detect verdict from report data if available
+  function detectVerdict(report) {
+    if (report.signal) {
+      const s = report.signal.toUpperCase();
+      if (s === 'BUY' || s === 'BULLISH') return { emoji: '🐂', cls: 'buy', label: 'BUY' };
+      if (s === 'SELL' || s === 'BEARISH') return { emoji: '🐻', cls: 'sell', label: 'SELL' };
+    }
+    if (report.decision) {
+      const d = report.decision.toUpperCase();
+      if (d === 'BUY') return { emoji: '🐂', cls: 'buy', label: 'BUY' };
+      if (d === 'SELL') return { emoji: '🐻', cls: 'sell', label: 'SELL' };
+      if (d === 'HOLD') return { emoji: '🦉', cls: 'hold', label: 'HOLD' };
+    }
+    return { emoji: '📊', cls: 'unknown', label: 'View' };
+  }
+
+  return (
+    <div className="archives">
+      <div className="archives-hero">
+        <h2>📜 The Council Archives</h2>
+        <p>Past deliberations and verdicts of the trading council.</p>
+      </div>
+
+      {loading && (
+        <div className="dashboard-loading"><div className="spinner"></div> Searching the archives...</div>
+      )}
+      {error && (
+        <div className="dashboard-empty">⚠️ Could not load archives: {error}</div>
+      )}
+      {!loading && !error && reports.length === 0 && (
+        <div className="dashboard-empty">
+          📭 The archives are empty. No councils have been summoned yet.
+        </div>
+      )}
+      {!loading && reports.length > 0 && (
+        <div className="archives-grid">
+          {reports.map((r, i) => {
+            const v = detectVerdict(r);
+            return (
+              <div key={`${r.ticker}-${r.date}-${i}`} className="archive-card"
+                   style={{animationDelay: `${i * 0.05}s`}}
+                   onClick={() => onViewDetail(r)}>
+                <div className="arc-verdict">{v.emoji}</div>
+                <div className="arc-info">
+                  <div className="arc-ticker">{r.ticker}</div>
+                  <div className="arc-date">{r.date}</div>
+                  {r.summary && <div className="arc-preview">{r.summary}</div>}
+                </div>
+                <div className={`arc-badge ${v.cls}`}>{v.label}</div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── History Detail Screen ──────────────────────── */
+function HistoryDetail({ report, apiBase, token, onBack, onReanalyze }) {
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchDetail() {
+      try {
+        const resp = await fetch(`${apiBase}/reports/${encodeURIComponent(report.ticker)}/${encodeURIComponent(report.date)}?token=${encodeURIComponent(token || '')}`, {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) setDetail(data);
+      } catch (err) { if (!cancelled) setError(err.message); }
+      finally { if (!cancelled) setLoading(false); }
+    }
+    fetchDetail();
+    return () => { cancelled = true; };
+  }, [report.ticker, report.date, apiBase, token]);
+
+  if (loading) {
+    return (
+      <div className="archive-detail">
+        <div className="detail-loading">Loading analysis for {report.ticker}...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="archive-detail">
+        <div className="detail-error">⚠️ Could not load analysis: {error}</div>
+        <button className="btn-new" onClick={onBack} style={{alignSelf:'center'}}>← Back to Archives</button>
+      </div>
+    );
+  }
+
+  const decision = detail?.signal || detail?.final_decision || detail?.decision || 'HOLD';
+  const decisionClass = decision.toUpperCase() === 'BUY' ? 'buy' : decision.toUpperCase() === 'SELL' ? 'sell' : 'hold';
+  const verdictEmoji = decision.toUpperCase() === 'BUY' ? '🐂' : decision.toUpperCase() === 'SELL' ? '🐻' : '🦉';
+
+  return (
+    <div className="archive-detail">
+      <div className="detail-verdict">
+        <div className="dv-icon">{verdictEmoji}</div>
+        <div className={`dv-decision ${decisionClass}`}>{String(decision).toUpperCase()}</div>
+        <div className="dv-meta">{report.ticker} · {report.date}</div>
+      </div>
+
+      {detail?.summary && (
+        <div className="detail-section">
+          <h4>📋 Summary</h4>
+          <div className="detail-content">{detail.summary}</div>
+        </div>
+      )}
+
+      {detail?.market_report && (
+        <div className="detail-section">
+          <h4><span style={{color:AGENTS.market.color}}>{AGENTS.market.avatar} {AGENTS.market.name}</span> · Market Report</h4>
+          <div className="detail-content">{String(detail.market_report)}</div>
+        </div>
+      )}
+
+      {detail?.sentiment_report && (
+        <div className="detail-section">
+          <h4><span style={{color:AGENTS.social.color}}>{AGENTS.social.avatar} {AGENTS.social.name}</span> · Sentiment Report</h4>
+          <div className="detail-content">{String(detail.sentiment_report)}</div>
+        </div>
+      )}
+
+      {detail?.news_report && (
+        <div className="detail-section">
+          <h4><span style={{color:AGENTS.news.color}}>{AGENTS.news.avatar} {AGENTS.news.name}</span> · News Report</h4>
+          <div className="detail-content">{String(detail.news_report)}</div>
+        </div>
+      )}
+
+      {detail?.fundamentals_report && (
+        <div className="detail-section">
+          <h4><span style={{color:AGENTS.fundamentals.color}}>{AGENTS.fundamentals.avatar} {AGENTS.fundamentals.name}</span> · Fundamentals Report</h4>
+          <div className="detail-content">{String(detail.fundamentals_report)}</div>
+        </div>
+      )}
+
+      {detail?.debate && (
+        <div className="detail-section">
+          <h4>⚖️ Council Debate</h4>
+          <div className="detail-content">{String(detail.debate)}</div>
+        </div>
+      )}
+
+      <div style={{display:'flex', gap:10, justifyContent:'center', paddingBottom:20}}>
+        <button className="btn-new" onClick={onBack}>← Back to Archives</button>
+        <button className="btn-new" onClick={() => onReanalyze(report)}>Re-Analyze →</button>
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════
    APP
-   ═══════════════════════════════════════════════════════════════════ */
+   ═══════════════════════════════════════════════════ */
 function App() {
   const { apiBase, urlToken } = useQueryParams();
-  const [screen, setScreen] = useState('dashboard'); // dashboard | input | debate | ledger
+  const [screen, setScreen] = useState('dashboard');
   const [token, setToken] = useState(() => localStorage.getItem('bazaar_token') || '');
   const [showTokenGate, setShowTokenGate] = useState(!localStorage.getItem('bazaar_token'));
   const [messages, setMessages] = useState([]);
@@ -1222,11 +1579,14 @@ function App() {
   const [verdict, setVerdict] = useState(null);
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [prefillTicker, setPrefillTicker] = useState('');
+  const [activeAgentId, setActiveAgentId] = useState(null);
+  const [spokenAgents, setSpokenAgents] = useState(new Set());
+  const [clashCount, setClashCount] = useState(0);
+  const [historyDetailReport, setHistoryDetailReport] = useState(null);
   const eventSourceRef = useRef(null);
   const messagesRef = useRef([]);
-  const [prefillTicker, setPrefillTicker] = useState('');
 
-  // Keep messagesRef in sync
   useEffect(() => { messagesRef.current = messages; }, [messages]);
 
   function handleTokenUnlock(t) {
@@ -1235,10 +1595,19 @@ function App() {
     setShowTokenGate(false);
   }
 
-  function addMessage(agent, content, kind='text') {
+  function addMessage(agent, content, kind='text', subtext) {
     const now = new Date();
     const timestamp = now.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
-    setMessages(prev => [...prev, { agent, content, kind, timestamp, id: Date.now() + Math.random() }]);
+    setMessages(prev => [...prev, { agent, content, kind, timestamp, subtext, id: Date.now() + Math.random() }]);
+
+    // Track spoken agents & clash count
+    if (agent.id !== 'system') {
+      setSpokenAgents(prev => new Set([...prev, agent.id]));
+      setActiveAgentId(agent.id);
+    }
+    if (agent.id === 'debater' || agent.id === 'risk') {
+      setClashCount(prev => prev + 1);
+    }
   }
 
   async function handleSubmit({ ticker, date, analysts, depth, llm_provider, deep_think_llm, quick_think_llm }) {
@@ -1248,25 +1617,18 @@ function App() {
     setMessages([]);
     setError('');
     setIsStreaming(true);
+    setActiveAgentId(null);
+    setSpokenAgents(new Set());
+    setClashCount(0);
 
-    // Opening narration
-    addMessage(NARRATOR, `The Council assembles to deliberate on ${ticker} for the date of ${date}.`);
+    addMessage(NARRATOR, `The Council Convenes`, 'system', `Ticker: ${ticker} · Date: ${date}`);
     setStreamingAgent('The Council');
 
     try {
-      // POST /analyze
       const resp = await fetch(`${apiBase}/analyze?token=${encodeURIComponent(token)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({
-          ticker,
-          date,
-          analysts,
-          research_depth: depth,
-          llm_provider,
-          deep_think_llm,
-          quick_think_llm,
-        }),
+        body: JSON.stringify({ ticker, date, analysts, research_depth: depth, llm_provider, deep_think_llm, quick_think_llm }),
       });
 
       if (!resp.ok) {
@@ -1275,9 +1637,8 @@ function App() {
       }
 
       const { job_id } = await resp.json();
-      addMessage(NARRATOR, `The Council has been summoned. Job ${job_id.slice(0,8)}... The debate begins.`);
+      addMessage(NARRATOR, 'The Council is seated. Testimonies begin.', 'system');
 
-      // Connect SSE
       const sseUrl = `${apiBase}/stream/${job_id}?token=${encodeURIComponent(token)}`;
       const es = new EventSource(sseUrl);
       eventSourceRef.current = es;
@@ -1297,9 +1658,8 @@ function App() {
             case 'report': {
               const agent = resolveAgent('report', eventData.node, eventData.section);
               const reportText = eventData.report || '';
-              // Truncate long reports for the chat
-              const displayText = reportText.length > 600
-                ? reportText.slice(0, 600) + '\n\n... (report continues in full analysis)'
+              const displayText = reportText.length > 400
+                ? reportText.slice(0, 400) + '\n\n... (report continues in full analysis)'
                 : reportText;
               addMessage(agent, displayText, 'report');
               setStreamingAgent(agent.name);
@@ -1321,33 +1681,28 @@ function App() {
               const displayDecision = sig || rawDecision;
               addMessage(agent, `⚡ ${displayDecision}`, 'decision');
 
-              // Close SSE and transition to ledger
               es.close();
               eventSourceRef.current = null;
               setIsStreaming(false);
               setStreamingAgent('');
+              setActiveAgentId('judge');
 
-              // Brief pause for dramatic effect, then show verdict
               setTimeout(() => {
                 setVerdict(sig || rawDecision || 'HOLD');
                 setScreen('ledger');
-              }, 2000);
+              }, 2500);
               break;
             }
             case 'complete': {
-              addMessage(NARRATOR, 'The Council has concluded its deliberation.');
+              addMessage(NARRATOR, 'The Council has spoken. The verdict is recorded.', 'system');
               es.close();
               eventSourceRef.current = null;
               setIsStreaming(false);
               setStreamingAgent('');
 
-              // If we didn't get a decision event, check result
-              if (!verdict && eventData.result) {
+              if (eventData.result) {
                 const sig = (eventData.result.signal || '').toUpperCase() || 'HOLD';
-                setTimeout(() => {
-                  setVerdict(sig);
-                  setScreen('ledger');
-                }, 1500);
+                setTimeout(() => { setVerdict(sig); setScreen('ledger'); }, 2000);
               }
               break;
             }
@@ -1361,7 +1716,7 @@ function App() {
               break;
             }
             case 'error': {
-              addMessage(NARRATOR, `❌ ${eventData.message || 'An error occurred during analysis.'}`);
+              addMessage(NARRATOR, `❌ ${eventData.message || 'An error occurred during analysis.'}`, 'system');
               setError(eventData.message || 'Analysis failed');
               setIsStreaming(false);
               setStreamingAgent('');
@@ -1369,14 +1724,9 @@ function App() {
               eventSourceRef.current = null;
               break;
             }
-            default: {
-              // 'chunk' events — show as brief status
-              break;
-            }
+            default: break;
           }
-        } catch (parseErr) {
-          // Ignore malformed events
-        }
+        } catch (parseErr) { /* ignore malformed */ }
       };
 
       es.onerror = () => {
@@ -1388,7 +1738,7 @@ function App() {
       };
 
     } catch (err) {
-      addMessage(NARRATOR, `❌ Failed to summon the Council: ${err.message}`);
+      addMessage(NARRATOR, `❌ Failed to summon the Council: ${err.message}`, 'system');
       setError(err.message);
       setIsStreaming(false);
       setStreamingAgent('');
@@ -1396,16 +1746,10 @@ function App() {
   }
 
   function handleNewAnalysis() {
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
+    if (eventSourceRef.current) { eventSourceRef.current.close(); eventSourceRef.current = null; }
     setScreen('dashboard');
-    setMessages([]);
-    setVerdict(null);
-    setError('');
-    setIsStreaming(false);
-    setStreamingAgent('');
+    setMessages([]); setVerdict(null); setError('');
+    setIsStreaming(false); setStreamingAgent('');
     setPrefillTicker('');
   }
 
@@ -1415,26 +1759,39 @@ function App() {
   }
 
   function handleViewReport(report) {
-    // Navigate to input with the ticker pre-filled for re-analysis
     setPrefillTicker(report.ticker);
     setScreen('input');
   }
 
-  function handleBackToDashboard() {
-    if (eventSourceRef.current) {
+  function navigateTo(s) {
+    if (eventSourceRef.current && s !== 'debate') {
       eventSourceRef.current.close();
       eventSourceRef.current = null;
+      setIsStreaming(false);
+      setStreamingAgent('');
     }
-    setIsStreaming(false);
-    setStreamingAgent('');
-    setScreen('dashboard');
+    setScreen(s);
+    if (s === 'dashboard') { setMessages([]); setVerdict(null); setError(''); }
+  }
+
+  function handleViewDetail(report) {
+    setHistoryDetailReport(report);
+    setScreen('history-detail');
+  }
+
+  function handleReanalyze(report) {
+    setPrefillTicker(report.ticker);
+    setScreen('input');
+  }
+
+  function handleBackFromDetail() {
+    setScreen('history');
+    setHistoryDetailReport(null);
   }
 
   // Cleanup on unmount
   useEffect(() => {
-    return () => {
-      if (eventSourceRef.current) eventSourceRef.current.close();
-    };
+    return () => { if (eventSourceRef.current) eventSourceRef.current.close(); };
   }, []);
 
   if (showTokenGate) {
@@ -1444,29 +1801,21 @@ function App() {
   return (
     <div className="app-container">
       <div className="topbar">
-        <div className="topbar-brand">
+        <div className="topbar-brand" onClick={() => navigateTo('dashboard')}>
           <span className="icon">🏛️</span> The Bazaar
         </div>
+        <div className="topbar-nav">
+          <button className={screen === 'dashboard' ? 'active' : ''}
+                  onClick={() => navigateTo('dashboard')}>Market Square</button>
+          <button className={screen === 'history' || screen === 'history-detail' ? 'active' : ''}
+                  onClick={() => { setScreen('history'); setHistoryDetailReport(null); }}>
+            📜 Archives
+          </button>
+        </div>
         <div className="topbar-status">
-          {screen === 'dashboard' && <span style={{color:'var(--text-muted)'}}>Market Square</span>}
-          {screen === 'input' && (
-            <button onClick={handleBackToDashboard}
-                    style={{
-                      background:'transparent', border:'1px solid var(--border-default)',
-                      borderRadius:8, padding:'4px 14px', color:'var(--text-secondary)',
-                      cursor:'pointer', fontFamily:'var(--font-sans)', fontSize:12,
-                      transition:'all 150ms'
-                    }}
-                    onMouseEnter={e => { e.target.style.borderColor='var(--accent-amber)'; e.target.style.color='var(--accent-amber)'; }}
-                    onMouseLeave={e => { e.target.style.borderColor='var(--border-default)'; e.target.style.color='var(--text-secondary)'; }}>
-              ← Market Square
-            </button>
-          )}
           {screen === 'debate' && (
-            <>
-              <span className={`live-indicator ${isStreaming ? '' : 'inactive'}`}></span>
-              <span>{isStreaming ? 'Live' : 'Concluded'}</span>
-            </>
+            <><span className={`live-indicator ${isStreaming ? '' : 'inactive'}`}></span>
+            <span>{isStreaming ? 'Live' : 'Concluded'}</span></>
           )}
           {screen === 'ledger' && <span style={{color:'var(--accent-amber)'}}>Verdict Rendered</span>}
         </div>
@@ -1474,40 +1823,45 @@ function App() {
 
       {screen === 'dashboard' && (
         <Dashboard onQuickAnalyze={handleQuickAnalyze} onViewReport={handleViewReport}
-                   apiBase={apiBase} token={token} />
+                   apiBase={apiBase} token={token} onNavHistory={() => setScreen('history')} />
       )}
 
       {screen === 'input' && (
-        <BazaarInput onSubmit={handleSubmit} isSubmitting={isSubmitting}
-                     prefillTicker={prefillTicker} />
+        <BazaarInput onSubmit={handleSubmit} isSubmitting={isSubmitting} prefillTicker={prefillTicker} />
       )}
 
       {screen === 'debate' && (
-        <DebateHall
-          messages={messages}
-          isStreaming={isStreaming}
-          streamingAgent={streamingAgent}
-          ticker={currentTicker}
-          date={currentDate}
-          error={error}
+        <CouncilArena
+          messages={messages} isStreaming={isStreaming} streamingAgent={streamingAgent}
+          ticker={currentTicker} date={currentDate} error={error}
+          activeAgentId={activeAgentId} spokenAgents={spokenAgents} clashCount={clashCount}
         />
       )}
 
       {screen === 'ledger' && verdict && (
-        <Ledger
-          decision={verdict}
-          ticker={currentTicker}
-          date={currentDate}
-          onNewAnalysis={handleNewAnalysis}
-        />
+        <Ledger decision={verdict} ticker={currentTicker} date={currentDate}
+                onNewAnalysis={handleNewAnalysis}
+                onViewHistory={() => setScreen('history')} />
+      )}
+
+      {screen === 'history' && (
+        <HistoryArchives apiBase={apiBase} token={token}
+                         onViewDetail={handleViewDetail}
+                         onBack={() => navigateTo('dashboard')} />
+      )}
+
+      {screen === 'history-detail' && historyDetailReport && (
+        <HistoryDetail report={historyDetailReport} apiBase={apiBase} token={token}
+                       onBack={handleBackFromDetail}
+                       onReanalyze={handleReanalyze} />
       )}
     </div>
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════
+/* ═══════════════════════════════════════════════════
    MOUNT
-   ═══════════════════════════════════════════════════════════════════ */
+   ═══════════════════════════════════════════════════ */
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 </script>
 </body>

--- a/web-ui/frontend/the-bazaar/index.html
+++ b/web-ui/frontend/the-bazaar/index.html
@@ -767,21 +767,42 @@ function TypingIndicator({ agentName }) {
 }
 
 /* ── Token Gate ──────────────────────────────────────────────────── */
-function TokenGate({ onUnlock }) {
+function TokenGate({ onUnlock, apiBase }) {
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
+  const [validating, setValidating] = useState(false);
   const { urlToken } = useQueryParams();
 
   useEffect(() => {
     if (urlToken) {
-      onUnlock(urlToken);
+      verifyAndUnlock(urlToken);
     }
   }, []);
+
+  async function verifyAndUnlock(token) {
+    setValidating(true);
+    setError('');
+    try {
+      const resp = await fetch(`${apiBase}/auth/verify?token=${encodeURIComponent(token)}`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (resp.ok) {
+        onUnlock(token);
+      } else {
+        const data = await resp.json().catch(() => ({}));
+        setError(data.detail || `Invalid token (HTTP ${resp.status}). Check your API token and try again.`);
+      }
+    } catch (err) {
+      setError(`Cannot reach the backend at ${apiBase}. Is the server running?`);
+    } finally {
+      setValidating(false);
+    }
+  }
 
   function handleSubmit(e) {
     e.preventDefault();
     if (!input.trim()) { setError('A token is required to enter The Bazaar.'); return; }
-    onUnlock(input.trim());
+    verifyAndUnlock(input.trim());
   }
 
   return (
@@ -796,13 +817,28 @@ function TokenGate({ onUnlock }) {
           value={input}
           onChange={e => { setInput(e.target.value); setError(''); }}
           autoFocus
+          disabled={validating}
         />
-        <button type="submit">Enter the Marketplace</button>
+        <button type="submit" disabled={validating}>
+          {validating ? 'Verifying...' : 'Enter the Marketplace'}
+        </button>
         {error && <div className="token-error">{error}</div>}
       </form>
     </div>
   );
 }
+
+/* ── DeepSeek Model Presets ─────────────────────────────────────── */
+const DEEPSEEK_PRESETS = [
+  { id: 'v4pro', label: 'V4 Pro + Flash', desc: 'Best quality, fast aux',
+    llm_provider: 'deepseek', deep_think_llm: 'deepseek-v4-pro', quick_think_llm: 'deepseek-v4-flash' },
+  { id: 'v4pro-chat', label: 'V4 Pro + Chat', desc: 'Best quality, balanced aux',
+    llm_provider: 'deepseek', deep_think_llm: 'deepseek-v4-pro', quick_think_llm: 'deepseek-chat' },
+  { id: 'chat', label: 'Chat (Balanced)', desc: 'Good quality, lower cost',
+    llm_provider: 'deepseek', deep_think_llm: 'deepseek-chat', quick_think_llm: 'deepseek-chat' },
+  { id: 'r1', label: 'R1 Reasoning', desc: 'Deep reasoning, slower',
+    llm_provider: 'deepseek', deep_think_llm: 'deepseek-r1', quick_think_llm: 'deepseek-v4-flash' },
+];
 
 /* ── Bazaar Input Screen ─────────────────────────────────────────── */
 function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
@@ -813,6 +849,7 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
   });
   const [analysts, setAnalysts] = useState(['market','social','news','fundamentals']);
   const [depth, setDepth] = useState('standard');
+  const [modelPreset, setModelPreset] = useState('v4pro');
 
   useEffect(() => {
     if (prefillTicker) setTicker(prefillTicker);
@@ -827,7 +864,16 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
   function handleSummon(e) {
     e.preventDefault();
     if (!ticker.trim()) return;
-    onSubmit({ ticker: ticker.trim().toUpperCase(), date, analysts, depth });
+    const preset = DEEPSEEK_PRESETS.find(p => p.id === modelPreset) || DEEPSEEK_PRESETS[0];
+    onSubmit({
+      ticker: ticker.trim().toUpperCase(),
+      date,
+      analysts,
+      depth,
+      llm_provider: preset.llm_provider,
+      deep_think_llm: preset.deep_think_llm,
+      quick_think_llm: preset.quick_think_llm,
+    });
   }
 
   const agentEntries = Object.values(AGENTS).slice(0, 4); // core 4 analysts
@@ -880,6 +926,18 @@ function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="form-group">
+            <label className="form-label">LLM Model (DeepSeek only)</label>
+            <select className="form-input" value={modelPreset}
+                    onChange={e => setModelPreset(e.target.value)}>
+              {DEEPSEEK_PRESETS.map(p => (
+                <option key={p.id} value={p.id}>{p.label} — {p.desc}</option>
+              ))}
+            </select>
           </div>
         </div>
 
@@ -1155,7 +1213,7 @@ function App() {
   const { apiBase, urlToken } = useQueryParams();
   const [screen, setScreen] = useState('dashboard'); // dashboard | input | debate | ledger
   const [token, setToken] = useState(() => localStorage.getItem('bazaar_token') || '');
-  const [showTokenGate, setShowTokenGate] = useState(!urlToken && !localStorage.getItem('bazaar_token'));
+  const [showTokenGate, setShowTokenGate] = useState(!localStorage.getItem('bazaar_token'));
   const [messages, setMessages] = useState([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingAgent, setStreamingAgent] = useState('');
@@ -1183,7 +1241,7 @@ function App() {
     setMessages(prev => [...prev, { agent, content, kind, timestamp, id: Date.now() + Math.random() }]);
   }
 
-  async function handleSubmit({ ticker, date, analysts, depth }) {
+  async function handleSubmit({ ticker, date, analysts, depth, llm_provider, deep_think_llm, quick_think_llm }) {
     setScreen('debate');
     setCurrentTicker(ticker);
     setCurrentDate(date);
@@ -1205,6 +1263,9 @@ function App() {
           date,
           analysts,
           research_depth: depth,
+          llm_provider,
+          deep_think_llm,
+          quick_think_llm,
         }),
       });
 
@@ -1377,7 +1438,7 @@ function App() {
   }, []);
 
   if (showTokenGate) {
-    return <TokenGate onUnlock={handleTokenUnlock} />;
+    return <TokenGate onUnlock={handleTokenUnlock} apiBase={apiBase} />;
   }
 
   return (

--- a/web-ui/frontend/the-bazaar/index.html
+++ b/web-ui/frontend/the-bazaar/index.html
@@ -1,0 +1,1453 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Bazaar — TradingAgents</title>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style>
+  /* ═══════════════════════════════════════════════════════════════
+     THE BAZAAR — Design Tokens & Global Styles
+     Warm, conversational, character-driven trading interface
+     ═══════════════════════════════════════════════════════════════ */
+  :root {
+    --bg-root:       #1A1410;
+    --bg-surface:    #241C14;
+    --bg-elevated:   #2D241A;
+    --bg-input:      #1E1812;
+    --border-default:#3D3226;
+    --border-active: #8B6B3A;
+    --text-primary:  #F0E6D3;
+    --text-secondary:#A89B85;
+    --text-muted:    #6B5F4E;
+    --accent-amber:  #E8A840;
+    --accent-glow:   #F0C060;
+    --signal-bullish:#4CAF50;
+    --signal-bearish:#E57373;
+    --signal-neutral:#FFB74D;
+
+    /* Character colors */
+    --char-flint:    #8B6B4A;
+    --char-vera:     #C44B4B;
+    --char-reed:     #4B7A9E;
+    --char-sage:     #5C8A6F;
+    --char-balthazar:#D4A030;
+    --char-morwen:   #7B8B9A;
+    --char-kael:     #C07840;
+    --char-aldric:   #9B8BAA;
+
+    --font-sans: 'Georgia', 'Times New Roman', serif;
+    --font-chat: 'Georgia', 'Times New Roman', serif;
+    --font-mono: 'Courier New', monospace;
+  }
+
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body {
+    background: var(--bg-root);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: 15px;
+    line-height: 1.6;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  /* ── Scrollbar ────────────────────────────────── */
+  ::-webkit-scrollbar { width: 5px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+  /* ═══════════════════════════════════════════════════════════════
+     ANIMATIONS
+     ═══════════════════════════════════════════════════════════════ */
+  @keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes slideInLeft {
+    from { opacity: 0; transform: translateX(-24px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+  @keyframes slideInRight {
+    from { opacity: 0; transform: translateX(24px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+  @keyframes pulseGlow {
+    0%, 100% { box-shadow: 0 0 8px rgba(232,168,64,0.3); }
+    50%      { box-shadow: 0 0 20px rgba(232,168,64,0.6); }
+  }
+  @keyframes typingBounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+    30% { transform: translateY(-6px); opacity: 1; }
+  }
+  @keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+  @keyframes verdictReveal {
+    0% { transform: scale(0.3); opacity: 0; filter: blur(12px); }
+    50% { transform: scale(1.05); opacity: 0.8; filter: blur(0); }
+    100% { transform: scale(1); opacity: 1; filter: blur(0); }
+  }
+  @keyframes sparkle {
+    0%, 100% { opacity: 0; transform: scale(0); }
+    50% { opacity: 1; transform: scale(1); }
+  }
+  @keyframes floatUp {
+    0% { opacity: 0; transform: translateY(40px) scale(0.8); }
+    60% { opacity: 0.7; }
+    100% { opacity: 0; transform: translateY(-40px) scale(1.2); }
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     LAYOUT
+     ═══════════════════════════════════════════════════════════════ */
+  .app-container {
+    max-width: 800px;
+    margin: 0 auto;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Top Bar ─────────────────────────────────── */
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 20px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-default);
+    position: sticky; top: 0; z-index: 100;
+  }
+  .topbar-brand {
+    font-size: 18px; font-weight: bold;
+    color: var(--accent-amber);
+    letter-spacing: 0.02em;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .topbar-brand .icon { font-size: 22px; }
+  .topbar-status {
+    font-size: 12px; color: var(--text-muted);
+    display: flex; align-items: center; gap: 6px;
+  }
+  .live-indicator {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--signal-bullish);
+    animation: pulseGlow 1.5s ease-in-out infinite;
+  }
+  .live-indicator.inactive { background: var(--text-muted); animation: none; }
+
+  /* ── Token Gate ──────────────────────────────── */
+  .token-overlay {
+    position: fixed; inset: 0;
+    background: rgba(26,20,16,0.94);
+    display: flex; align-items: center; justify-content: center;
+    z-index: 9999;
+  }
+  .token-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 14px; padding: 36px;
+    max-width: 400px; width: 90%;
+    text-align: center;
+    animation: fadeInUp 0.5s ease;
+  }
+  .token-card h2 { color: var(--accent-amber); font-size: 22px; margin-bottom: 8px; }
+  .token-card p { color: var(--text-secondary); font-size: 14px; margin-bottom: 20px; }
+  .token-card input {
+    width: 100%; padding: 12px 16px;
+    background: var(--bg-input); border: 1px solid var(--border-default);
+    border-radius: 10px; color: var(--text-primary); font-size: 14px;
+    font-family: var(--font-mono); text-align: center; margin-bottom: 12px;
+    transition: border-color 200ms;
+  }
+  .token-card input:focus { outline: none; border-color: var(--accent-amber); }
+  .token-card button {
+    width: 100%; padding: 12px; border: none; border-radius: 10px;
+    background: var(--accent-amber); color: #1A1410; font-weight: 700;
+    font-size: 15px; cursor: pointer; font-family: var(--font-sans);
+    transition: all 150ms;
+  }
+  .token-card button:hover { background: var(--accent-glow); transform: translateY(-1px); }
+  .token-error { color: var(--signal-bearish); font-size: 13px; margin-top: 8px; }
+
+  /* ═══════════════════════════════════════════════════════════════
+     SCREEN: BAZAAR INPUT
+     ═══════════════════════════════════════════════════════════════ */
+  .bazaar-input {
+    flex: 1; display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    padding: 40px 20px;
+    animation: fadeInUp 0.6s ease;
+  }
+  .bazaar-input .welcome-text {
+    text-align: center; margin-bottom: 32px;
+  }
+  .bazaar-input .welcome-text h1 {
+    font-size: 32px; color: var(--accent-amber); margin-bottom: 6px;
+    letter-spacing: 0.01em;
+  }
+  .bazaar-input .welcome-text .tagline {
+    color: var(--text-secondary); font-size: 15px; font-style: italic;
+  }
+  .bazaar-input .agent-roster {
+    display: flex; gap: 4px; justify-content: center;
+    margin-bottom: 28px; flex-wrap: wrap;
+  }
+  .bazaar-input .agent-chip {
+    width: 44px; height: 44px; border-radius: 50%;
+    border: 2px solid var(--border-default);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px; cursor: default;
+    transition: all 200ms;
+  }
+  .bazaar-input .agent-chip:hover {
+    border-color: var(--accent-amber);
+    transform: translateY(-3px);
+    box-shadow: 0 4px 12px rgba(232,168,64,0.2);
+  }
+  .bazaar-input .form-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 14px; padding: 28px;
+    width: 100%; max-width: 480px;
+    animation: fadeInUp 0.6s ease 0.15s both;
+  }
+  .bazaar-input .form-row {
+    display: flex; gap: 12px; margin-bottom: 16px;
+  }
+  .bazaar-input .form-group { flex: 1; }
+  .bazaar-input .form-label {
+    display: block; font-size: 11px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.07em;
+    color: var(--text-muted); margin-bottom: 6px;
+  }
+  .bazaar-input .form-input {
+    width: 100%; padding: 10px 14px;
+    background: var(--bg-input); border: 1px solid var(--border-default);
+    border-radius: 10px; color: var(--text-primary); font-size: 15px;
+    font-family: var(--font-sans); transition: border-color 200ms;
+    outline: none;
+  }
+  .bazaar-input .form-input:focus { border-color: var(--border-active); }
+  .bazaar-input select.form-input {
+    cursor: pointer; appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' fill='%23A89B85'%3E%3Cpath d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 12px center;
+    padding-right: 36px;
+  }
+
+  .bazaar-input .analyst-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+    margin-bottom: 20px;
+  }
+  .bazaar-input .analyst-check {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 12px; background: var(--bg-input);
+    border: 1px solid var(--border-default); border-radius: 8px;
+    cursor: pointer; transition: all 150ms; font-size: 13px;
+    user-select: none;
+  }
+  .bazaar-input .analyst-check:hover { border-color: var(--border-active); }
+  .bazaar-input .analyst-check.checked {
+    border-color: var(--accent-amber);
+    background: rgba(232,168,64,0.08);
+  }
+  .bazaar-input .analyst-check .avatar {
+    width: 26px; height: 26px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px; flex-shrink: 0;
+  }
+
+  .bazaar-input .btn-summon {
+    width: 100%; padding: 14px; border: none; border-radius: 12px;
+    background: linear-gradient(135deg, var(--accent-amber), #D49520);
+    color: #1A1410; font-size: 16px; font-weight: 700;
+    cursor: pointer; font-family: var(--font-sans);
+    letter-spacing: 0.02em;
+    transition: all 200ms;
+    position: relative; overflow: hidden;
+  }
+  .bazaar-input .btn-summon:hover {
+    background: linear-gradient(135deg, var(--accent-glow), #E8A840);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 24px rgba(232,168,64,0.25);
+  }
+  .bazaar-input .btn-summon:disabled {
+    opacity: 0.5; cursor: not-allowed; transform: none;
+  }
+  .bazaar-input .btn-summon .sparkle {
+    position: absolute;
+    width: 4px; height: 4px; background: #fff;
+    border-radius: 50%;
+    animation: sparkle 1.5s ease-in-out infinite;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     SCREEN: DEBATE HALL
+     ═══════════════════════════════════════════════════════════════ */
+  .debate-hall {
+    flex: 1; display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+  .debate-header {
+    padding: 12px 20px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-default);
+    display: flex; align-items: center; gap: 12px;
+    font-size: 13px;
+  }
+  .debate-header .ticker-badge {
+    background: rgba(232,168,64,0.12);
+    color: var(--accent-amber); font-weight: 700;
+    padding: 3px 12px; border-radius: 20px;
+    font-family: var(--font-mono); font-size: 14px;
+  }
+  .debate-header .date-label { color: var(--text-secondary); }
+
+  .debate-chat {
+    flex: 1; overflow-y: auto; padding: 16px 20px;
+    display: flex; flex-direction: column; gap: 10px;
+  }
+
+  /* ── Character Message ────────────────────────── */
+  .char-msg {
+    display: flex; gap: 12px;
+    animation: fadeInUp 0.35s ease both;
+    max-width: 90%;
+  }
+  .char-msg.agent-msg { align-self: flex-start; }
+  .char-msg.system-msg {
+    align-self: center; max-width: 70%;
+    font-style: italic; color: var(--text-muted);
+    text-align: center; font-size: 13px;
+    animation: fadeIn 0.5s ease both;
+  }
+  .char-msg .avatar-ring {
+    width: 40px; height: 40px; min-width: 40px;
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px;
+    border: 2px solid;
+    background: var(--bg-elevated);
+  }
+  .char-msg .msg-bubble {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 14px; border-top-left-radius: 4px;
+    padding: 10px 14px;
+  }
+  .char-msg .msg-sender {
+    font-size: 12px; font-weight: 700; margin-bottom: 3px;
+    letter-spacing: 0.03em;
+  }
+  .char-msg .msg-content {
+    font-size: 14px; line-height: 1.55;
+    color: var(--text-primary);
+    white-space: pre-wrap; word-break: break-word;
+  }
+  .char-msg .msg-content.report-content {
+    font-size: 13px; max-height: 180px; overflow-y: auto;
+    color: var(--text-secondary);
+    border-left: 2px solid var(--border-default);
+    padding-left: 10px; margin-top: 4px;
+  }
+  .char-msg .msg-content.decision-content {
+    font-size: 18px; font-weight: 700; text-align: center;
+    padding: 8px 0;
+  }
+  .char-msg .msg-time {
+    font-size: 10px; color: var(--text-muted); margin-top: 4px;
+  }
+
+  /* ── Typing Indicator ─────────────────────────── */
+  .typing-indicator {
+    display: flex; gap: 12px; align-items: center;
+    padding: 4px 0;
+    animation: fadeIn 0.3s ease;
+  }
+  .typing-indicator .dots {
+    display: flex; gap: 4px; padding: 8px 14px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 14px;
+  }
+  .typing-indicator .dots span {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--accent-amber);
+    animation: typingBounce 1.2s ease-in-out infinite;
+  }
+  .typing-indicator .dots span:nth-child(2) { animation-delay: 0.15s; }
+  .typing-indicator .dots span:nth-child(3) { animation-delay: 0.3s; }
+  .typing-indicator .typing-label {
+    font-size: 11px; color: var(--text-muted);
+    font-style: italic;
+  }
+
+  /* ── Jump to bottom button ───────────────────── */
+  .jump-bottom {
+    position: sticky; bottom: 12px; align-self: center;
+    padding: 6px 16px; background: var(--bg-elevated);
+    border: 1px solid var(--border-default); border-radius: 20px;
+    color: var(--text-secondary); font-size: 12px;
+    cursor: pointer; transition: all 150ms;
+    animation: fadeIn 0.3s ease;
+  }
+  .jump-bottom:hover {
+    border-color: var(--accent-amber); color: var(--accent-amber);
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     SCREEN: THE LEDGER (VERDICT)
+     ═══════════════════════════════════════════════════════════════ */
+  .ledger {
+    flex: 1; display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    padding: 40px 20px;
+    animation: fadeIn 0.6s ease;
+  }
+  .ledger-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 18px; padding: 40px 36px;
+    max-width: 500px; width: 100%;
+    text-align: center;
+    animation: verdictReveal 0.7s ease both;
+  }
+  .ledger-card .verdict-icon {
+    font-size: 64px; margin-bottom: 12px;
+    animation: pulseGlow 2s ease-in-out infinite;
+  }
+  .ledger-card .verdict-label {
+    font-size: 11px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.1em;
+    color: var(--text-muted); margin-bottom: 4px;
+  }
+  .ledger-card .verdict-decision {
+    font-size: 36px; font-weight: 900;
+    letter-spacing: 0.03em; margin-bottom: 8px;
+  }
+  .ledger-card .verdict-decision.buy  { color: var(--signal-bullish); }
+  .ledger-card .verdict-decision.sell { color: var(--signal-bearish); }
+  .ledger-card .verdict-decision.hold { color: var(--signal-neutral); }
+  .ledger-card .verdict-ticker {
+    font-family: var(--font-mono); font-size: 14px;
+    color: var(--text-secondary); margin-bottom: 20px;
+  }
+  .ledger-card .verdict-summary {
+    color: var(--text-secondary); font-size: 14px;
+    line-height: 1.6; margin-bottom: 24px;
+    border-top: 1px solid var(--border-default);
+    border-bottom: 1px solid var(--border-default);
+    padding: 16px 0;
+  }
+  .ledger-card .btn-new {
+    padding: 12px 32px; border: 1px solid var(--border-default);
+    border-radius: 10px; background: transparent;
+    color: var(--accent-amber); font-size: 14px;
+    font-family: var(--font-sans); cursor: pointer;
+    transition: all 150ms;
+  }
+  .ledger-card .btn-new:hover {
+    border-color: var(--accent-amber);
+    background: rgba(232,168,64,0.06);
+  }
+
+  /* ── Floating particles for verdict ──────────── */
+  .particle {
+    position: fixed; pointer-events: none;
+    font-size: 20px; animation: floatUp 2s ease-out forwards;
+    z-index: 999;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     ERROR BANNER
+     ═══════════════════════════════════════════════════════════════ */
+  .error-banner {
+    margin: 8px 20px; padding: 10px 16px;
+    background: rgba(229,115,115,0.12);
+    border: 1px solid var(--signal-bearish);
+    border-radius: 10px; color: var(--signal-bearish);
+    font-size: 13px; display: flex; align-items: center; gap: 8px;
+    animation: fadeInUp 0.3s ease;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     SCREEN: DASHBOARD
+     ═══════════════════════════════════════════════════════════════ */
+  .dashboard {
+    flex: 1; display: flex; flex-direction: column;
+    padding: 32px 20px;
+    animation: fadeInUp 0.5s ease;
+    gap: 28px;
+  }
+  .dashboard-hero {
+    text-align: center; padding: 20px 0;
+    animation: fadeIn 0.6s ease;
+  }
+  .dashboard-hero h1 {
+    font-size: 36px; color: var(--accent-amber);
+    letter-spacing: 0.01em; margin-bottom: 6px;
+  }
+  .dashboard-hero .subtitle {
+    color: var(--text-secondary); font-size: 15px;
+    font-style: italic;
+  }
+  .dashboard-hero .quickstart {
+    display: inline-flex; align-items: center; gap: 12px;
+    margin-top: 20px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-default);
+    border-radius: 14px; padding: 12px 20px;
+    animation: fadeInUp 0.6s ease 0.2s both;
+  }
+  .dashboard-hero .quickstart input {
+    background: var(--bg-input); border: 1px solid var(--border-default);
+    border-radius: 10px; padding: 10px 16px;
+    color: var(--text-primary); font-size: 16px;
+    font-family: var(--font-sans); width: 120px;
+    text-align: center; text-transform: uppercase;
+    transition: border-color 200ms;
+  }
+  .dashboard-hero .quickstart input:focus { outline: none; border-color: var(--accent-amber); }
+  .dashboard-hero .quickstart .btn-go {
+    padding: 10px 24px; border: none; border-radius: 10px;
+    background: linear-gradient(135deg, var(--accent-amber), #D49520);
+    color: #1A1410; font-weight: 700; font-size: 15px;
+    cursor: pointer; font-family: var(--font-sans);
+    transition: all 200ms;
+  }
+  .dashboard-hero .quickstart .btn-go:hover {
+    background: linear-gradient(135deg, var(--accent-glow), #E8A840);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(232,168,64,0.25);
+  }
+  .dashboard-hero .quickstart .btn-go:disabled { opacity: 0.5; cursor: not-allowed; }
+  
+  .dashboard .section-title {
+    font-size: 13px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-muted); margin-bottom: 12px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .dashboard .section-title::after {
+    content: ''; flex: 1; height: 1px;
+    background: var(--border-default);
+  }
+  
+  .recent-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+  }
+  .recent-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 12px; padding: 16px;
+    cursor: pointer; transition: all 200ms;
+    animation: fadeInUp 0.4s ease both;
+    display: flex; align-items: center; gap: 14px;
+  }
+  .recent-card:hover {
+    border-color: var(--accent-amber);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(232,168,64,0.12);
+  }
+  .recent-card .rc-icon {
+    font-size: 28px; flex-shrink: 0;
+  }
+  .recent-card .rc-info { flex: 1; min-width: 0; }
+  .recent-card .rc-ticker {
+    font-weight: 700; font-size: 18px;
+    font-family: var(--font-mono); color: var(--text-primary);
+  }
+  .recent-card .rc-date {
+    font-size: 12px; color: var(--text-muted);
+  }
+  .recent-card .rc-arrow {
+    color: var(--text-muted); font-size: 14px;
+    transition: all 200ms;
+  }
+  .recent-card:hover .rc-arrow { color: var(--accent-amber); transform: translateX(2px); }
+  
+  .dashboard-empty {
+    text-align: center; color: var(--text-muted);
+    padding: 40px; font-style: italic;
+  }
+  .dashboard-loading {
+    display: flex; align-items: center; gap: 8px;
+    color: var(--text-muted); font-size: 13px;
+    padding: 12px 0;
+  }
+  .dashboard-loading .spinner {
+    width: 14px; height: 14px; border: 2px solid var(--border-default);
+    border-top-color: var(--accent-amber); border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  
+  .agent-showcase {
+    display: flex; gap: 8px; justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .agent-showcase .showcase-chip {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 16px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: 24px;
+    transition: all 200ms;
+    cursor: default;
+    animation: fadeInUp 0.4s ease both;
+  }
+  .agent-showcase .showcase-chip:hover {
+    border-color: var(--accent-amber);
+    background: var(--bg-elevated);
+  }
+  .agent-showcase .sc-avatar {
+    width: 28px; height: 28px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+  }
+  .agent-showcase .sc-name {
+    font-size: 13px; font-weight: 600;
+  }
+  .agent-showcase .sc-role {
+    font-size: 10px; color: var(--text-muted);
+  }
+
+  /* ═══════════════════════════════════════════════════════════════
+     RESPONSIVE
+     ═══════════════════════════════════════════════════════════════ */
+  @media (max-width: 600px) {
+    .bazaar-input .analyst-grid { grid-template-columns: 1fr; }
+    .ledger-card { padding: 28px 20px; }
+    .ledger-card .verdict-decision { font-size: 28px; }
+    .dashboard-hero h1 { font-size: 28px; }
+    .dashboard-hero .quickstart { flex-direction: column; width: 100%; }
+    .dashboard-hero .quickstart input { width: 100%; }
+    .dashboard-hero .quickstart .btn-go { width: 100%; }
+    .recent-grid { grid-template-columns: 1fr; }
+    .agent-showcase { gap: 6px; }
+    .agent-showcase .showcase-chip { padding: 6px 12px; font-size: 11px; }
+  }
+
+  /* ── Page Transitions ─────────────────────────── */
+  .screen-enter {
+    animation: fadeInUp 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .screen-exit {
+    animation: fadeOut 0.2s ease forwards;
+  }
+  @keyframes fadeOut {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel">
+const { useState, useEffect, useRef, useCallback } = React;
+
+/* ═══════════════════════════════════════════════════════════════════
+   AGENT PERSONAS
+   ═══════════════════════════════════════════════════════════════════ */
+const AGENTS = {
+  market:     { id:'market', name:'Flint', role:'Market Analyst', avatar:'🐂', color:'#8B6B4A', accent:'#A07654' },
+  social:     { id:'social', name:'Vera', role:'Sentiment Seer', avatar:'🔮', color:'#C44B4B', accent:'#D46060' },
+  news:       { id:'news', name:'Reed', role:'News Herald', avatar:'📜', color:'#4B7A9E', accent:'#5D8DB5' },
+  fundamentals:{ id:'fundamentals', name:'Sage', role:'Fundamentals Scholar', avatar:'📊', color:'#5C8A6F', accent:'#6D9E80' },
+  debater:    { id:'debater', name:'Balthazar', role:'Investment Debater', avatar:'⚖️', color:'#D4A030', accent:'#E8B840' },
+  risk:       { id:'risk', name:'Morwen', role:'Risk Guardian', avatar:'🛡️', color:'#7B8B9A', accent:'#8D9DAC' },
+  trader:     { id:'trader', name:'Kael', role:'Swift Trader', avatar:'🏃', color:'#C07840', accent:'#D48850' },
+  judge:      { id:'judge', name:'Elder Aldric', role:'High Judge', avatar:'👑', color:'#9B8BAA', accent:'#AD9DBC' },
+};
+
+const NARRATOR = { id:'system', name:'The Bazaar', avatar:'🏛️', color:'#E8A840', accent:'#F0C060' };
+
+/* Map SSE node names to agent personas */
+function resolveAgent(eventType, nodeName, sectionName) {
+  // Direct analyst reports
+  if (eventType === 'report') {
+    if (sectionName === 'market_report') return AGENTS.market;
+    if (sectionName === 'sentiment_report') return AGENTS.social;
+    if (sectionName === 'news_report') return AGENTS.news;
+    if (sectionName === 'fundamentals_report') return AGENTS.fundamentals;
+    if (sectionName === 'trader_plan') return AGENTS.trader;
+  }
+  // Debates
+  if (eventType === 'debate') {
+    if (nodeName && nodeName.includes('risk')) return AGENTS.risk;
+    return AGENTS.debater;
+  }
+  // Decision
+  if (eventType === 'decision') return AGENTS.judge;
+  // Status messages
+  if (eventType === 'status') return NARRATOR;
+  // Chunks — try to map by node name
+  if (nodeName) {
+    const n = nodeName.toLowerCase();
+    if (n.includes('market')) return AGENTS.market;
+    if (n.includes('social') || n.includes('sentiment')) return AGENTS.social;
+    if (n.includes('news')) return AGENTS.news;
+    if (n.includes('fundamentals')) return AGENTS.fundamentals;
+    if (n.includes('risk')) return AGENTS.risk;
+    if (n.includes('debate')) return AGENTS.debater;
+    if (n.includes('trader') || n.includes('invest')) return AGENTS.trader;
+    if (n.includes('judge') || n.includes('final') || n.includes('decision')) return AGENTS.judge;
+  }
+  return NARRATOR;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   HOOKS
+   ═══════════════════════════════════════════════════════════════════ */
+
+// Read ?api= and ?token= from URL
+function useQueryParams() {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  return {
+    apiBase: params.get('api') || 'http://localhost:8000',
+    urlToken: params.get('token') || '',
+  };
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   COMPONENTS
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Character Message ───────────────────────────────────────────── */
+function CharacterMessage({ msg, index }) {
+  const isSystem = msg.agent.id === 'system';
+  if (isSystem) {
+    return (
+      <div className="char-msg system-msg" style={{animationDelay: `${index * 0.05}s`}}>
+        <div className="msg-content">{msg.content}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="char-msg agent-msg" style={{animationDelay: `${index * 0.05}s`}}>
+      <div className="avatar-ring" style={{borderColor: msg.agent.color}}>
+        {msg.agent.avatar}
+      </div>
+      <div className="msg-bubble" style={{borderLeftColor: msg.agent.color, borderLeftWidth: 2}}>
+        <div className="msg-sender" style={{color: msg.agent.color}}>
+          {msg.agent.name} <span style={{fontWeight:400, fontSize:11, color:'var(--text-muted)'}}>· {msg.agent.role}</span>
+        </div>
+        <div className={`msg-content ${msg.kind === 'report' ? 'report-content' : ''} ${msg.kind === 'decision' ? 'decision-content' : ''}`}>
+          {msg.content}
+        </div>
+        {msg.timestamp && <div className="msg-time">{msg.timestamp}</div>}
+      </div>
+    </div>
+  );
+}
+
+/* ── Typing Indicator ────────────────────────────────────────────── */
+function TypingIndicator({ agentName }) {
+  return (
+    <div className="typing-indicator">
+      <div className="dots">
+        <span></span><span></span><span></span>
+      </div>
+      <span className="typing-label">{agentName || 'The Council'} deliberates...</span>
+    </div>
+  );
+}
+
+/* ── Token Gate ──────────────────────────────────────────────────── */
+function TokenGate({ onUnlock }) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+  const { urlToken } = useQueryParams();
+
+  useEffect(() => {
+    if (urlToken) {
+      onUnlock(urlToken);
+    }
+  }, []);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (!input.trim()) { setError('A token is required to enter The Bazaar.'); return; }
+    onUnlock(input.trim());
+  }
+
+  return (
+    <div className="token-overlay">
+      <form className="token-card" onSubmit={handleSubmit}>
+        <div style={{fontSize:48, marginBottom:12}}>🏛️</div>
+        <h2>Enter The Bazaar</h2>
+        <p>The gates are sealed. Speak the passphrase to summon the Council of Analysts.</p>
+        <input
+          type="password"
+          placeholder="API token..."
+          value={input}
+          onChange={e => { setInput(e.target.value); setError(''); }}
+          autoFocus
+        />
+        <button type="submit">Enter the Marketplace</button>
+        {error && <div className="token-error">{error}</div>}
+      </form>
+    </div>
+  );
+}
+
+/* ── Bazaar Input Screen ─────────────────────────────────────────── */
+function BazaarInput({ onSubmit, isSubmitting, prefillTicker }) {
+  const [ticker, setTicker] = useState(prefillTicker || '');
+  const [date, setDate] = useState(() => {
+    const d = new Date();
+    return d.toISOString().split('T')[0];
+  });
+  const [analysts, setAnalysts] = useState(['market','social','news','fundamentals']);
+  const [depth, setDepth] = useState('standard');
+
+  useEffect(() => {
+    if (prefillTicker) setTicker(prefillTicker);
+  }, [prefillTicker]);
+
+  function toggleAnalyst(id) {
+    setAnalysts(prev =>
+      prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]
+    );
+  }
+
+  function handleSummon(e) {
+    e.preventDefault();
+    if (!ticker.trim()) return;
+    onSubmit({ ticker: ticker.trim().toUpperCase(), date, analysts, depth });
+  }
+
+  const agentEntries = Object.values(AGENTS).slice(0, 4); // core 4 analysts
+
+  return (
+    <div className="bazaar-input">
+      <div className="welcome-text">
+        <h1>🏛️ The Bazaar</h1>
+        <p className="tagline">Where the finest analytical minds gather to debate your trade.</p>
+      </div>
+
+      <div className="agent-roster">
+        {Object.values(AGENTS).map(a => (
+          <div key={a.id} className="agent-chip" title={`${a.name} — ${a.role}`}
+               style={{borderColor: a.color + '44'}}>
+            {a.avatar}
+          </div>
+        ))}
+      </div>
+
+      <form className="form-card" onSubmit={handleSummon}>
+        <div className="form-row">
+          <div className="form-group">
+            <label className="form-label">Ticker Symbol</label>
+            <input type="text" className="form-input" placeholder="AAPL"
+                   value={ticker}
+                   onChange={e => setTicker(e.target.value.toUpperCase())}
+                   maxLength={10} autoFocus />
+          </div>
+          <div className="form-group">
+            <label className="form-label">Analysis Date</label>
+            <input type="date" className="form-input" value={date}
+                   onChange={e => setDate(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">The Council</label>
+          <div className="analyst-grid">
+            {agentEntries.map(a => (
+              <div key={a.id}
+                   className={`analyst-check ${analysts.includes(a.id) ? 'checked' : ''}`}
+                   onClick={() => toggleAnalyst(a.id)}>
+                <div className="avatar" style={{background: a.color+'22', color: a.color}}>
+                  {a.avatar}
+                </div>
+                <div>
+                  <div style={{fontWeight:600, fontSize:13}}>{a.name}</div>
+                  <div style={{fontSize:10, color:'var(--text-muted)'}}>{a.role}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="form-group">
+            <label className="form-label">Research Depth</label>
+            <select className="form-input" value={depth}
+                    onChange={e => setDepth(e.target.value)}>
+              <option value="standard">Standard</option>
+              <option value="deep">Deep</option>
+            </select>
+          </div>
+        </div>
+
+        <button className="btn-summon" type="submit" disabled={isSubmitting || !ticker.trim()}>
+          {isSubmitting ? (
+            <span>Summoning the Council...</span>
+          ) : (
+            <span>Summon the Council ⚡</span>
+          )}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+/* ── Debate Hall ─────────────────────────────────────────────────── */
+function DebateHall({ messages, isStreaming, streamingAgent, ticker, date, error }) {
+  const chatEndRef = useRef(null);
+  const chatContainerRef = useRef(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  useEffect(() => {
+    if (autoScroll && chatEndRef.current) {
+      chatEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages, autoScroll]);
+
+  function handleScroll() {
+    if (!chatContainerRef.current) return;
+    const el = chatContainerRef.current;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    setAutoScroll(atBottom);
+  }
+
+  return (
+    <div className="debate-hall">
+      <div className="debate-header">
+        <span className="live-indicator"></span>
+        <span className="ticker-badge">{ticker}</span>
+        <span className="date-label">{date}</span>
+        <span style={{flex:1}}></span>
+        <span style={{fontSize:11, color:'var(--text-muted)'}}>
+          {messages.length} messages
+        </span>
+      </div>
+
+      {error && (
+        <div className="error-banner">
+          <span>⚠️</span> {error}
+        </div>
+      )}
+
+      <div className="debate-chat" ref={chatContainerRef} onScroll={handleScroll}>
+        {messages.length === 0 && !isStreaming && (
+          <div style={{textAlign:'center', color:'var(--text-muted)', padding:40}}>
+            <div style={{fontSize:40, marginBottom:12}}>🏛️</div>
+            <p>The Council assembles. Their debate will appear here.</p>
+          </div>
+        )}
+
+        {messages.map((msg, i) => (
+          <CharacterMessage key={i} msg={msg} index={i} />
+        ))}
+
+        {isStreaming && (
+          <TypingIndicator agentName={streamingAgent} />
+        )}
+
+        <div ref={chatEndRef} />
+
+        {!autoScroll && messages.length > 5 && (
+          <button className="jump-bottom" onClick={() => { setAutoScroll(true); chatEndRef.current?.scrollIntoView({behavior:'smooth'}); }}>
+            ↓ Latest messages
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Ledger (Verdict) ────────────────────────────────────────────── */
+function Ledger({ decision, ticker, date, onNewAnalysis }) {
+  const [particles, setParticles] = useState([]);
+
+  useEffect(() => {
+    // Spawn celebration particles
+    const emojis = decision === 'BUY' ? ['💰','📈','✨','🚀','💎'] :
+                   decision === 'SELL' ? ['📉','💸','⚠️','🔻','🏃'] :
+                   ['🤝','⚖️','🧘','⏳','📊'];
+    const newParticles = [];
+    for (let i = 0; i < 12; i++) {
+      newParticles.push({
+        id: i,
+        emoji: emojis[i % emojis.length],
+        left: 20 + Math.random() * 60,
+        delay: Math.random() * 0.8,
+        duration: 1.5 + Math.random() * 1.5,
+      });
+    }
+    setParticles(newParticles);
+  }, [decision]);
+
+  const decisionClass = decision === 'BUY' ? 'buy' : decision === 'SELL' ? 'sell' : 'hold';
+  const verdictEmoji = decision === 'BUY' ? '🐂' : decision === 'SELL' ? '🐻' : '🦉';
+
+  return (
+    <div className="ledger">
+      {particles.map(p => (
+        <div key={p.id} className="particle"
+             style={{
+               left: `${p.left}%`,
+               bottom: '40%',
+               animationDelay: `${p.delay}s`,
+               animationDuration: `${p.duration}s`,
+             }}>
+          {p.emoji}
+        </div>
+      ))}
+
+      <div className="ledger-card" style={{animationDelay: '0.2s'}}>
+        <div className="verdict-icon">{verdictEmoji}</div>
+        <div className="verdict-label">The Council Has Spoken</div>
+        <div className={`verdict-decision ${decisionClass}`}>{decision}</div>
+        <div className="verdict-ticker">{ticker} · {date}</div>
+        <div className="verdict-summary">
+          {decision === 'BUY' && 'The Council sees opportunity. The bulls have carried the day — favorable winds, strong fundamentals, and rising sentiment converge.'}
+          {decision === 'SELL' && 'The Council urges caution. The bears have won the argument — headwinds are too strong, and the risks outweigh the potential rewards.'}
+          {decision === 'HOLD' && 'The Council is divided. Neither bulls nor bears carried enough conviction — patience is the prudent course.'}
+        </div>
+        <button className="btn-new" onClick={onNewAnalysis}>
+          Summon a New Council →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Agent Showcase ─────────────────────────────────────────────────── */
+function AgentShowcase() {
+  return (
+    <div className="agent-showcase">
+      {Object.values(AGENTS).map((a, i) => (
+        <div key={a.id} className="showcase-chip" 
+             style={{animationDelay: `${i * 0.08}s`, borderLeft: `2px solid ${a.color}`}}>
+          <div className="sc-avatar" style={{background: a.color + '22', color: a.color}}>
+            {a.avatar}
+          </div>
+          <div>
+            <div className="sc-name" style={{color: a.color}}>{a.name}</div>
+            <div className="sc-role">{a.role}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Dashboard ──────────────────────────────────────────────────────── */
+function Dashboard({ onQuickAnalyze, onViewReport, apiBase, token }) {
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [quickTicker, setQuickTicker] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchReports() {
+      try {
+        const resp = await fetch(`${apiBase}/reports?token=${encodeURIComponent(token || '')}`, {
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setReports((data.reports || []).slice(0, 8));
+        }
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchReports();
+    return () => { cancelled = true; };
+  }, [apiBase, token]);
+
+  function handleQuickSubmit(e) {
+    e.preventDefault();
+    const ticker = quickTicker.trim().toUpperCase();
+    if (ticker) onQuickAnalyze(ticker);
+  }
+
+  function mapDecisionIcon(report) {
+    // We don't know decision from list — use ticker as icon hint
+    return '📊';
+  }
+
+  return (
+    <div className="dashboard">
+      <div className="dashboard-hero">
+        <h1>🏛️ The Bazaar</h1>
+        <p className="subtitle">Where the finest analytical minds gather to debate your trade.</p>
+        <form className="quickstart" onSubmit={handleQuickSubmit}>
+          <input type="text" placeholder="AAPL" maxLength={10}
+                 value={quickTicker}
+                 onChange={e => setQuickTicker(e.target.value.toUpperCase())} />
+          <button className="btn-go" type="submit" disabled={!quickTicker.trim()}>
+            Analyze →
+          </button>
+        </form>
+      </div>
+
+      <div>
+        <div className="section-title">The Council</div>
+        <AgentShowcase />
+      </div>
+
+      <div>
+        <div className="section-title">Recent Analyses</div>
+        {loading && (
+          <div className="dashboard-loading">
+            <div className="spinner"></div>
+            Consulting the archives...
+          </div>
+        )}
+        {error && (
+          <div className="dashboard-empty">
+            ⚠️ Could not load reports: {error}
+            <br/><span style={{fontSize:12}}>(Is the backend running at {apiBase}?)</span>
+          </div>
+        )}
+        {!loading && !error && reports.length === 0 && (
+          <div className="dashboard-empty">
+            📭 No analyses yet. Summon the Council above to create your first.
+          </div>
+        )}
+        {!loading && reports.length > 0 && (
+          <div className="recent-grid">
+            {reports.map((r, i) => (
+              <div key={`${r.ticker}-${r.date}`} className="recent-card"
+                   style={{animationDelay: `${i * 0.06}s`}}
+                   onClick={() => onViewReport(r)}>
+                <div className="rc-icon">📈</div>
+                <div className="rc-info">
+                  <div className="rc-ticker">{r.ticker}</div>
+                  <div className="rc-date">{r.date}</div>
+                </div>
+                <div className="rc-arrow">→</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   APP
+   ═══════════════════════════════════════════════════════════════════ */
+function App() {
+  const { apiBase, urlToken } = useQueryParams();
+  const [screen, setScreen] = useState('dashboard'); // dashboard | input | debate | ledger
+  const [token, setToken] = useState(() => localStorage.getItem('bazaar_token') || '');
+  const [showTokenGate, setShowTokenGate] = useState(!urlToken && !localStorage.getItem('bazaar_token'));
+  const [messages, setMessages] = useState([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingAgent, setStreamingAgent] = useState('');
+  const [currentTicker, setCurrentTicker] = useState('');
+  const [currentDate, setCurrentDate] = useState('');
+  const [verdict, setVerdict] = useState(null);
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const eventSourceRef = useRef(null);
+  const messagesRef = useRef([]);
+  const [prefillTicker, setPrefillTicker] = useState('');
+
+  // Keep messagesRef in sync
+  useEffect(() => { messagesRef.current = messages; }, [messages]);
+
+  function handleTokenUnlock(t) {
+    localStorage.setItem('bazaar_token', t);
+    setToken(t);
+    setShowTokenGate(false);
+  }
+
+  function addMessage(agent, content, kind='text') {
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+    setMessages(prev => [...prev, { agent, content, kind, timestamp, id: Date.now() + Math.random() }]);
+  }
+
+  async function handleSubmit({ ticker, date, analysts, depth }) {
+    setScreen('debate');
+    setCurrentTicker(ticker);
+    setCurrentDate(date);
+    setMessages([]);
+    setError('');
+    setIsStreaming(true);
+
+    // Opening narration
+    addMessage(NARRATOR, `The Council assembles to deliberate on ${ticker} for the date of ${date}.`);
+    setStreamingAgent('The Council');
+
+    try {
+      // POST /analyze
+      const resp = await fetch(`${apiBase}/analyze?token=${encodeURIComponent(token)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({
+          ticker,
+          date,
+          analysts,
+          research_depth: depth,
+        }),
+      });
+
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err.detail || `API returned ${resp.status}`);
+      }
+
+      const { job_id } = await resp.json();
+      addMessage(NARRATOR, `The Council has been summoned. Job ${job_id.slice(0,8)}... The debate begins.`);
+
+      // Connect SSE
+      const sseUrl = `${apiBase}/stream/${job_id}?token=${encodeURIComponent(token)}`;
+      const es = new EventSource(sseUrl);
+      eventSourceRef.current = es;
+
+      es.onmessage = (e) => {
+        try {
+          const payload = JSON.parse(e.data);
+          const { type, data: eventData } = payload;
+
+          switch (type) {
+            case 'status': {
+              const agent = resolveAgent('status');
+              addMessage(agent, eventData.message || 'Processing...');
+              setStreamingAgent(agent.role);
+              break;
+            }
+            case 'report': {
+              const agent = resolveAgent('report', eventData.node, eventData.section);
+              const reportText = eventData.report || '';
+              // Truncate long reports for the chat
+              const displayText = reportText.length > 600
+                ? reportText.slice(0, 600) + '\n\n... (report continues in full analysis)'
+                : reportText;
+              addMessage(agent, displayText, 'report');
+              setStreamingAgent(agent.name);
+              break;
+            }
+            case 'debate': {
+              const agent = resolveAgent('debate', eventData.node);
+              const debateText = eventData.current_response || eventData.judge_decision || '';
+              if (debateText && debateText.length > 10) {
+                addMessage(agent, debateText);
+                setStreamingAgent(agent.name);
+              }
+              break;
+            }
+            case 'decision': {
+              const agent = resolveAgent('decision', eventData.node);
+              const sig = (eventData.signal || '').toUpperCase();
+              const rawDecision = eventData.final_decision || '';
+              const displayDecision = sig || rawDecision;
+              addMessage(agent, `⚡ ${displayDecision}`, 'decision');
+
+              // Close SSE and transition to ledger
+              es.close();
+              eventSourceRef.current = null;
+              setIsStreaming(false);
+              setStreamingAgent('');
+
+              // Brief pause for dramatic effect, then show verdict
+              setTimeout(() => {
+                setVerdict(sig || rawDecision || 'HOLD');
+                setScreen('ledger');
+              }, 2000);
+              break;
+            }
+            case 'complete': {
+              addMessage(NARRATOR, 'The Council has concluded its deliberation.');
+              es.close();
+              eventSourceRef.current = null;
+              setIsStreaming(false);
+              setStreamingAgent('');
+
+              // If we didn't get a decision event, check result
+              if (!verdict && eventData.result) {
+                const sig = (eventData.result.signal || '').toUpperCase() || 'HOLD';
+                setTimeout(() => {
+                  setVerdict(sig);
+                  setScreen('ledger');
+                }, 1500);
+              }
+              break;
+            }
+            case 'message': {
+              const agent = resolveAgent('message', eventData.node);
+              const text = eventData.content || '';
+              if (text && text.length > 5) {
+                addMessage(agent, text);
+                setStreamingAgent(agent.name);
+              }
+              break;
+            }
+            case 'error': {
+              addMessage(NARRATOR, `❌ ${eventData.message || 'An error occurred during analysis.'}`);
+              setError(eventData.message || 'Analysis failed');
+              setIsStreaming(false);
+              setStreamingAgent('');
+              es.close();
+              eventSourceRef.current = null;
+              break;
+            }
+            default: {
+              // 'chunk' events — show as brief status
+              break;
+            }
+          }
+        } catch (parseErr) {
+          // Ignore malformed events
+        }
+      };
+
+      es.onerror = () => {
+        if (es.readyState === EventSource.CLOSED) {
+          setIsStreaming(false);
+          setStreamingAgent('');
+          eventSourceRef.current = null;
+        }
+      };
+
+    } catch (err) {
+      addMessage(NARRATOR, `❌ Failed to summon the Council: ${err.message}`);
+      setError(err.message);
+      setIsStreaming(false);
+      setStreamingAgent('');
+    }
+  }
+
+  function handleNewAnalysis() {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    setScreen('dashboard');
+    setMessages([]);
+    setVerdict(null);
+    setError('');
+    setIsStreaming(false);
+    setStreamingAgent('');
+    setPrefillTicker('');
+  }
+
+  function handleQuickAnalyze(ticker) {
+    setPrefillTicker(ticker);
+    setScreen('input');
+  }
+
+  function handleViewReport(report) {
+    // Navigate to input with the ticker pre-filled for re-analysis
+    setPrefillTicker(report.ticker);
+    setScreen('input');
+  }
+
+  function handleBackToDashboard() {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    setIsStreaming(false);
+    setStreamingAgent('');
+    setScreen('dashboard');
+  }
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (eventSourceRef.current) eventSourceRef.current.close();
+    };
+  }, []);
+
+  if (showTokenGate) {
+    return <TokenGate onUnlock={handleTokenUnlock} />;
+  }
+
+  return (
+    <div className="app-container">
+      <div className="topbar">
+        <div className="topbar-brand">
+          <span className="icon">🏛️</span> The Bazaar
+        </div>
+        <div className="topbar-status">
+          {screen === 'dashboard' && <span style={{color:'var(--text-muted)'}}>Market Square</span>}
+          {screen === 'input' && (
+            <button onClick={handleBackToDashboard}
+                    style={{
+                      background:'transparent', border:'1px solid var(--border-default)',
+                      borderRadius:8, padding:'4px 14px', color:'var(--text-secondary)',
+                      cursor:'pointer', fontFamily:'var(--font-sans)', fontSize:12,
+                      transition:'all 150ms'
+                    }}
+                    onMouseEnter={e => { e.target.style.borderColor='var(--accent-amber)'; e.target.style.color='var(--accent-amber)'; }}
+                    onMouseLeave={e => { e.target.style.borderColor='var(--border-default)'; e.target.style.color='var(--text-secondary)'; }}>
+              ← Market Square
+            </button>
+          )}
+          {screen === 'debate' && (
+            <>
+              <span className={`live-indicator ${isStreaming ? '' : 'inactive'}`}></span>
+              <span>{isStreaming ? 'Live' : 'Concluded'}</span>
+            </>
+          )}
+          {screen === 'ledger' && <span style={{color:'var(--accent-amber)'}}>Verdict Rendered</span>}
+        </div>
+      </div>
+
+      {screen === 'dashboard' && (
+        <Dashboard onQuickAnalyze={handleQuickAnalyze} onViewReport={handleViewReport}
+                   apiBase={apiBase} token={token} />
+      )}
+
+      {screen === 'input' && (
+        <BazaarInput onSubmit={handleSubmit} isSubmitting={isSubmitting}
+                     prefillTicker={prefillTicker} />
+      )}
+
+      {screen === 'debate' && (
+        <DebateHall
+          messages={messages}
+          isStreaming={isStreaming}
+          streamingAgent={streamingAgent}
+          ticker={currentTicker}
+          date={currentDate}
+          error={error}
+        />
+      )}
+
+      {screen === 'ledger' && verdict && (
+        <Ledger
+          decision={verdict}
+          ticker={currentTicker}
+          date={currentDate}
+          onNewAnalysis={handleNewAnalysis}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   MOUNT
+   ═══════════════════════════════════════════════════════════════════ */
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

First-pass assembly of the "Traders of the Round Table" drop-in front-end pack that replaces the Bazaar view with a castle-themed round-table council scene. **Draft — substantial wiring work still pending. See "Not done" below.**

The pack was delivered as a zip with effectively three artifacts:
- `castle-council.js` (~25 KB) — complete: scene builder, scripted-debate playback, SSE hook, report carousel, read-full modal.
- `castle.css` — shipped as a 20-line stub (~3 KB) missing every theme variable and every scene/seat/bubble/table style the JS references.
- `castle-portraits.svg` — shipped as a 167-byte empty `<svg>` wrapper with zero `<symbol>` definitions.

This PR fills in the two stubs so the pack can actually render once it gets wired in, and vendors the JS / pack readme so the next PR can build on a known baseline.

## What's in this PR (1 commit on top of the bazaar branch)

`8448c68` feat(the-bazaar): castle UI pack — assemble theme + portraits (WIP)

- **`castle.css` (682 lines)** — written from scratch around the theme tokens supplied in the pack design notes. Defines:
  - `:root` castle palette (night / stone / gold / crimson / parchment / candle tokens).
  - Scene chrome — `.rt-chrome` with inset frame, `.rt-stage`, `.rt-banner` (left/right crimson banners), `.rt-table` (radial-gradient round table with double inner rings), `.rt-crest` watermark, `.rt-candle` with `flicker` keyframes.
  - Seats with `speaking` / `thinking` / `done` / `dimmed` states. Added a `thinkPulse` keyframe so a seat actively thinking pulses gold (helps when many `message` events fire back-to-back during LLM iteration).
  - Parchment `.rt-bubble` with rebuttal `shake`, sentiment `.rt-tilt` needle, progress pips.
  - Freeze-frame `.rt-verdict-banner` with `verdictBannerFloat` keyframes and three palette variants — `.buy` (green), `.sell` (crimson), `.hold` (gold, default). The JS isn't wired to apply these yet — see "Not done."
  - `.rt-verdict-card`, `.rt-report-carousel`, `.rt-report-card`, `.rt-mini-portrait`, full `.rt-modal-*` (head, portrait, title, body, table styles), `.rt-arrow`, `.rt-read-full`.
  - `#root .detail-section`, `#root .detail-card`, `#root .verdict-card`, `#root .app-header` overrides with `!important` so the original Bazaar widgets stay hidden after React re-renders.
  - `body:has(.rt-modal-backdrop.visible) { overflow: hidden }` to prevent background scroll while the read-full modal is open.

- **`castle-portraits.svg` (275 lines)** — 8 stylized circular character symbols + a heraldic crest, replacing the empty stub:
  - `#portrait-market` (Flint, monocle + candlestick backdrop)
  - `#portrait-social` (Vera, hooded mystic with moon halo and stars)
  - `#portrait-news` (Reed, scholar with quill and scroll)
  - `#portrait-fundamentals` (Sage, bearded with spectacles and ledger lines)
  - `#portrait-debater` (Balthazar, intense crimson antagonist)
  - `#portrait-risk` (Morwen, helmeted guardian with crossed spears)
  - `#portrait-trader` (Kael, hooded scout with twin daggers)
  - `#portrait-judge` (Elder Aldric, crowned with white beard)
  - `#castle-crest` — gold shield with crossed swords, ruby gem, crown atop, ribbon banner
  - Shared skin/background gradient defs at the top to keep the file compact.

- **`castle-council.js`** — vendored as-shipped from the pack zip, **no edits in this PR**. See "Not done" for the rewrites it needs.

- **`README 2castle.md`** — pack-author readme, vendored as-shipped. Filename keeps the space + number to avoid colliding with the bazaar's existing `README.md`; will be renamed once the rest of the wiring lands.

## What is NOT done (deliberately deferred)

These are all called out in the task spec and explicitly out of scope for this draft:

- **`index.html` not wired.** No `<link>` for the CSS, no deferred `<script>` for the JS, no Cinzel font preload. Nothing renders for users yet — the pack is dormant.
- **Files not relocated.** Spec calls for `assets/traders-round-table/` but they're still at the bazaar root. Holding off until the JS rewrite to avoid two churn commits.
- **SSE dispatcher is wrong.** The backend (`web-ui/backend/main.py` L407–487, L228–236) emits unnamed `data:`-only frames shaped `{type, data, timestamp}` with `type` ∈ {`report`, `debate`, `decision`, `message`, `chunk`, `complete`, `error`, `heartbeat`, `status`}. Per-seat identity lives in `data.section` (for reports) or `data.node` (for everything else). The existing hook reads `data.agent` / `data.status` / `data.text` — none of which exist — so **zero seats will animate live**.
- **`onmessage` is never intercepted.** The React app (`index.html` L1646) does `es.onmessage = (e) => {...}`, but the SSE hook only patches `addEventListener`. Setter assignments slip past it. Fix is to attach our own `es.addEventListener('message', ...)` inside the constructor wrapper so both paths fire.
- **Verdict freeze-frame hardcoded.** `freezeFrame()` writes "Final Verdict" with no plumbing from the `decision` event's `signal` field. CSS already supports `.rt-verdict-banner.buy` / `.sell` / `.hold` — JS just needs to set the class + innerText.
- **`AGENT_TO_SEAT` missing real LangGraph node names.** The map keys are lower/snake_case guesses; real node names from `tradingagents/graph/setup.py` and `analyst_execution.py` are Title Case with spaces: `Market Analyst`, `Sentiment Analyst`, `News Analyst`, `Fundamentals Analyst`, `Bull Researcher`, `Bear Researcher`, `Research Manager`, `Trader`, `Aggressive Analyst`, `Neutral Analyst`, `Conservative Analyst`, `Portfolio Manager`. Three risk-debate nodes (`Aggressive` / `Neutral` / `Conservative Analyst`) all collapse onto the single Morwen seat — needs to be documented in the JS comment.
- **No `live-run` verification.** No screenshots, no DevTools SSE capture, no Lighthouse delta. The next PR runs `/analyze` against a real ticker via Chrome MCP and attaches screenshots showing the IDLE → LIVE flip and seat animation.
- **No project README pointer.** The bazaar README still references only the original Bazaar UI.

## Why open a draft now

The CSS + SVG work is heavy (~950 lines of authored content combined) and stands on its own as a reviewable unit. Splitting it from the JS/wiring keeps each PR's diff scoped. Reviewers can sanity-check the theme tokens, scene structure, portrait silhouettes, and `#root` hide-rules in isolation before the live-mode rewrite arrives.

## Branch scope note

This branch is 4 commits ahead of `main`. Three are pre-existing bazaar work (`f3512d5`, `66dc69a`, `9352bc5`) carried over from earlier sessions; the new content is just `8448c68`. If TauricResearch wants those three reviewed separately, the branch can be rebased into a stack — flag it and I'll restructure.

## Test plan (for follow-up PR)

- [ ] Wire `index.html` with the three include tags (CSS / JS / optional Cinzel font preload).
- [ ] Move files into `assets/traders-round-table/`.
- [ ] Rewrite `installLiveWiring()` to switch on `data.type` and unwrap `data.data`.
- [ ] Intercept `onmessage` via `addEventListener('message', ...)` inside the EventSource wrapper.
- [ ] Plumb `decision.signal` into `freezeFrame()` banner text + class.
- [ ] Add real LangGraph node names to `AGENT_TO_SEAT` (Title Case + sanitized variants).
- [ ] Smoke-test scripted mode locally — castle chrome, 8 portraits, candles flicker, scripted debate, freeze-frame, carousel populates.
- [ ] Live-run `/analyze` against one ticker — verify IDLE→LIVE, seat animations, bubble text matches model output, verdict banner shows BUY/HOLD/SELL.
- [ ] Confirm modal ESC + click-outside, no background scroll bleed.
- [ ] Confirm Lighthouse perf does not regress by >5 points.
- [ ] Confirm removing the two tags from `index.html` cleanly reverts to the original Bazaar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)