### PR TITLE
fix(dataflows): handle yfinance >=1.4 unnamed-index column in stockstats path

### DIFF
--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -34,6 +34,11 @@ def yf_retry(func, max_retries=3, base_delay=2.0):
 
 def _clean_dataframe(data: pd.DataFrame) -> pd.DataFrame:
     """Normalize a stock DataFrame for stockstats: parse dates, drop invalid rows, fill price gaps."""
+    if "Date" not in data.columns:
+        for candidate in ("index", "Datetime", "date"):
+            if candidate in data.columns:
+                data = data.rename(columns={candidate: "Date"})
+                break
     data["Date"] = pd.to_datetime(data["Date"], errors="coerce")
     data = data.dropna(subset=["Date"])
 
@@ -83,6 +88,14 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
             auto_adjust=True,
         ))
         data = data.reset_index()
+        # yfinance >=1.4 leaves the index unnamed, so reset_index() produces
+        # a column called "index" instead of "Date". Rename so downstream
+        # _clean_dataframe (which expects "Date") keeps working.
+        if "Date" not in data.columns:
+            for candidate in ("index", "Datetime", "date"):
+                if candidate in data.columns:
+                    data = data.rename(columns={candidate: "Date"})
+                    break
         data.to_csv(data_file, index=False, encoding="utf-8")
 
     data = _clean_dataframe(data)


### PR DESCRIPTION
## Problem

With `yfinance>=1.4`, every Market Analyst run silently degrades to no technical indicators. The agent's final report ends up without any 50/200 SMA, MACD, RSI, Bollinger Bands or ATR data — visible as hundreds of:

```
Error getting bulk stockstats data: 'Date'
Error getting stockstats indicator data for indicator close_50_sma on 2026-05-22: 'Date'
... (repeats for every indicator × every date in the lookback window)
```

## Root cause

`yf.download(..., multi_level_index=False)` in yfinance 1.4+ now returns a DataFrame whose index is **unnamed**. The subsequent `data.reset_index()` in `load_ohlcv` therefore produces a column called `index`, not `Date`. Two downstream consumers break:

1. `_clean_dataframe` calls `data["Date"]` → `KeyError: 'Date'` when reading a cache file written under the new schema.
2. `_get_stock_stats_bulk` calls `wrap(data)` and then `df["Date"]` → same `KeyError`.

The error is caught and logged as a warning per indicator, then fallback to `get_stockstats_indicator` (which calls `StockstatsUtils.get_stock_stats` — same broken path) also fails. The Market Analyst proceeds without any technical signal at all, and the downstream Trader / Risk team / Portfolio Manager continue from a degraded mosaic without realising the technical column is empty.

## Fix

Rename the unnamed-index column to `Date` in two places:

1. **Download path** (`load_ohlcv`): right after `data.reset_index()`, before writing the cache CSV. This makes fresh downloads write the canonical schema.
2. **Clean path** (`_clean_dataframe`): handles pre-existing cache files that were written under the broken schema, so users don't need to manually clear `~/.tradingagents/cache/`.

The candidate-name loop also handles `Datetime` (older yfinance behavior) and lowercase `date`.

## Verified

Locally on Python 3.12, `yfinance==1.4.0`, `stockstats==0.6.8`:

```python
from tradingagents.dataflows.stockstats_utils import StockstatsUtils
StockstatsUtils.get_stock_stats('WDC', 'close_50_sma',  '2026-05-22')  # → 379.37
StockstatsUtils.get_stock_stats('WDC', 'close_200_sma', '2026-05-22')  # → 221.32
StockstatsUtils.get_stock_stats('WDC', 'macds',         '2026-05-22')  # → 33.63
```

End-to-end agent run on WDC 2026-05-22 (DeepSeek provider): **0** `Error getting bulk` lines (vs ~940 before the patch). The Market Analyst's report now contains real golden-cross / MACD divergence / RSI levels, and the Trader's entry/stop reflect actual support levels (50 SMA at $379 used as `Stop Loss` reference) instead of guessing.

## Scope

One file, ~13 lines added, no behavior change for users on older yfinance. Backward-compatible with both broken-schema caches and well-formed caches.