### PR TITLE
fix: make analyst placeholder context-aware

### DIFF
--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -1,0 +1,53 @@
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
+
+from tradingagents.agents.utils.agent_utils import create_msg_delete
+
+
+def test_create_msg_delete_uses_context_aware_placeholder():
+    delete_messages = create_msg_delete()
+
+    result = delete_messages(
+        {
+            "messages": [
+                HumanMessage(content="old user message", id="human-1"),
+                AIMessage(content="old ai message", id="ai-1"),
+            ],
+            "company_of_interest": "EC",
+            "trade_date": "2026-05-13",
+            "asset_type": "stock",
+        }
+    )
+
+    messages = result["messages"]
+    placeholder = messages[-1]
+
+    assert len(messages) == 3
+    assert all(isinstance(message, RemoveMessage) for message in messages[:-1])
+    assert isinstance(placeholder, HumanMessage)
+
+    assert placeholder.content != "Continue"
+    assert "`EC`" in placeholder.content
+    assert "stock" in placeholder.content
+    assert "2026-05-13" in placeholder.content
+    assert "assigned analysis" in placeholder.content
+    assert "standalone user request" in placeholder.content
+
+
+def test_create_msg_delete_placeholder_has_safe_defaults():
+    delete_messages = create_msg_delete()
+
+    result = delete_messages(
+        {
+            "messages": [
+                HumanMessage(content="old user message", id="human-1"),
+            ],
+        }
+    )
+
+    placeholder = result["messages"][-1]
+
+    assert isinstance(placeholder, HumanMessage)
+    assert placeholder.content != "Continue"
+    assert "the requested instrument" in placeholder.content
+    assert "the requested date" in placeholder.content
+    assert "stock" in placeholder.content

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -1,49 +1,50 @@
 from langchain_core.messages import HumanMessage, RemoveMessage
 
-# Import tools from separate utility files
-from tradingagents.agents.utils.core_stock_tools import (
-    get_stock_data
-)
-from tradingagents.agents.utils.technical_indicators_tools import (
-    get_indicators
-)
+from tradingagents.agents.utils.core_stock_tools import get_stock_data
 from tradingagents.agents.utils.fundamental_data_tools import (
-    get_fundamentals,
     get_balance_sheet,
     get_cashflow,
-    get_income_statement
+    get_fundamentals,
+    get_income_statement,
 )
 from tradingagents.agents.utils.news_data_tools import (
-    get_news,
+    get_global_news,
     get_insider_transactions,
-    get_global_news
+    get_news,
 )
+from tradingagents.agents.utils.technical_indicators_tools import get_indicators
 
 
 def get_language_instruction() -> str:
-    """Return a prompt instruction for the configured output language.
+    """
+    Return a prompt instruction for the configured output language.
 
     Returns empty string when English (default), so no extra tokens are used.
-    Applied to every agent whose output reaches the saved report —
-    analysts, researchers, debaters, research manager, trader, and
-    portfolio manager — so a non-English run produces a fully localized
-    report rather than a mix of languages.
+    Applied to every agent whose output reaches the saved report — analysts,
+    researchers, debaters, research manager, trader, and portfolio manager —
+    so a non-English run produces a fully localized report rather than a mix
+    of languages.
     """
     from tradingagents.dataflows.config import get_config
+
     lang = get_config().get("output_language", "English")
+
     if lang.strip().lower() == "english":
         return ""
+
     return f" Write your entire response in {lang}."
 
 
 def build_instrument_context(ticker: str, asset_type: str = "stock") -> str:
     """Describe the exact instrument so agents preserve exchange-qualified tickers."""
     instrument_label = "asset" if asset_type == "crypto" else "instrument"
+
     extra_hint = (
         " Treat it as a crypto asset rather than a company, and do not assume company fundamentals are available."
         if asset_type == "crypto"
         else ""
     )
+
     return (
         f"The {instrument_label} to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
@@ -51,20 +52,33 @@ def build_instrument_context(ticker: str, asset_type: str = "stock") -> str:
         + extra_hint
     )
 
+
+def _build_workflow_placeholder(state) -> HumanMessage:
+    ticker = state.get("company_of_interest", "the requested instrument")
+    trade_date = state.get("trade_date", "the requested date")
+    asset_type = state.get("asset_type", "stock")
+
+    return HumanMessage(
+        content=(
+            "Proceed with your assigned analysis for this TradingAgents workflow. "
+            f"The instrument to analyze is `{ticker}`. "
+            "Use this exact ticker in every tool call, report, and recommendation. "
+            f"The asset type is {asset_type}. "
+            f"The analysis date is {trade_date}. "
+            "Do not treat this placeholder as a standalone user request."
+        )
+    )
+
+
 def create_msg_delete():
     def delete_messages(state):
-        """Clear messages and add placeholder for Anthropic compatibility"""
+        """Clear messages and add a context-aware placeholder for compatibility."""
         messages = state["messages"]
 
-        # Remove all messages
         removal_operations = [RemoveMessage(id=m.id) for m in messages]
 
-        # Add a minimal placeholder message
-        placeholder = HumanMessage(content="Continue")
+        placeholder = _build_workflow_placeholder(state)
 
         return {"messages": removal_operations + [placeholder]}
 
     return delete_messages
-
-
-        


### PR DESCRIPTION
Fixes #888

This PR fixes the issue where the analyst workflow could pass a bare `Continue` message to the next analyst after clearing the previous messages.

Earlier, `create_msg_delete()` was deleting the old messages and then adding this placeholder:

```python
HumanMessage(content="Continue")
```

This can be a problem for some OpenAI-compatible providers or proxy providers because they may treat `Continue` as the actual user prompt. Because of that, some later analyst reports can end up explaining the word "continue" or replying like the user only said continue, instead of doing the financial analysis for the selected ticker.

So I changed the placeholder to be more context-aware. It now keeps the next analyst anchored to the actual workflow context.

The new placeholder includes:

- the ticker / instrument
- the asset type
- the analysis date
- instruction to use the exact ticker in tool calls, reports and recommendations
- a note that this placeholder should not be treated as a standalone user request

This keeps the compatibility reason for having a HumanMessage after clearing history, but avoids sending a vague natural language command like `Continue`.

### What changed

- Updated `create_msg_delete()` in `agent_utils.py`
- Added a helper to build a safer workflow placeholder message
- Added tests for the placeholder behavior
- Verified that the placeholder is no longer just `Continue`
- Verified that ticker, asset type and trade date are included in the new placeholder

### Why this helps

This should prevent later analysts from losing the actual task context after message cleanup. It also makes the workflow safer for OpenAI-compatible providers that are more likely to interpret the last human message very literally.

It does not change the overall graph flow, only makes the placeholder message less ambiguous and more tied to the current TradingAgents workflow.

### Validation

I ran:

```bash
python -m compileall tradingagents/agents/utils/agent_utils.py
python -m pytest tests/test_agent_utils.py -q
```

Result:

```bash
2 passed
```