### PR TITLE
feat: add AWS Bedrock provider support

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -3,3 +3,8 @@ AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
 AZURE_OPENAI_DEPLOYMENT_NAME=
 # OPENAI_API_VERSION=2024-10-21  # optional, required for non-v1 API
+
+# AWS Bedrock
+# Uses standard AWS credential chain: env vars, ~/.aws/credentials, IAM role.
+# AWS_PROFILE=
+# AWS_DEFAULT_REGION=us-west-2

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 
+For AWS Bedrock, set `llm_provider: "bedrock"` and ensure your AWS credentials are configured (via `~/.aws/credentials`, environment variables, or IAM role). Set `AWS_DEFAULT_REGION` and optionally `AWS_PROFILE`. Install the extra dependency with `pip install .[bedrock]`. Use cross-region inference profile IDs (e.g. `us.anthropic.claude-opus-4-6-v1`) as model names.
+
 Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash
 cp .env.example .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 [project.scripts]
 tradingagents = "cli.main:app"
 
+[project.optional-dependencies]
+bedrock = ["langchain-aws>=1.5.0"]
+
 [tool.setuptools.packages.find]
 include = ["tradingagents*", "cli*"]
 

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -32,6 +32,8 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "openrouter": "OPENROUTER_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
+    # AWS Bedrock uses AWS credential chain (env vars, ~/.aws/credentials, IAM role).
+    "bedrock":    None,
 }
 
 

--- a/tradingagents/llm_clients/bedrock_client.py
+++ b/tradingagents/llm_clients/bedrock_client.py
@@ -1,0 +1,79 @@
+import os
+from typing import Any, Optional
+
+try:
+    from langchain_aws import ChatBedrockConverse
+except ImportError:
+    raise ImportError(
+        "Could not import langchain-aws. Please install it using 'pip install .[bedrock]' "
+        "to use the AWS Bedrock provider."
+    )
+
+from .base_client import BaseLLMClient, normalize_content
+
+_PASSTHROUGH_KWARGS = ("timeout", "max_retries", "callbacks")
+
+
+class NormalizedChatBedrockConverse(ChatBedrockConverse):
+    """ChatBedrockConverse with normalized content output."""
+
+    def invoke(self, input, config=None, **kwargs):
+        return normalize_content(super().invoke(input, config, **kwargs))
+
+    async def ainvoke(self, input, config=None, **kwargs):
+        return normalize_content(await super().ainvoke(input, config, **kwargs))
+
+    def with_structured_output(self, schema, *, method=None, **kwargs):
+        method = method or "function_calling"
+        return super().with_structured_output(schema, method=method, **kwargs)
+
+
+class BedrockClient(BaseLLMClient):
+    """Client for AWS Bedrock via the Converse API.
+
+    Uses the standard AWS credential chain for authentication:
+        - Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+        - Shared credentials file (~/.aws/credentials)
+        - IAM role (EC2, ECS, Lambda)
+
+    Optional environment variables:
+        AWS_PROFILE: Named profile in ~/.aws/credentials
+        AWS_REGION / AWS_DEFAULT_REGION: AWS region (default: us-west-2)
+    """
+
+    def __init__(self, model: str, base_url: Optional[str] = None, **kwargs):
+        super().__init__(model, base_url, **kwargs)
+
+    def get_llm(self) -> Any:
+        """Return configured ChatBedrockConverse instance."""
+        import boto3
+        from botocore.config import Config
+
+        region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-west-2"
+        profile = os.environ.get("AWS_PROFILE")
+
+        session = boto3.Session(profile_name=profile, region_name=region)
+        client = session.client(
+            "bedrock-runtime",
+            config=Config(
+                read_timeout=300,
+                connect_timeout=10,
+                retries={"max_attempts": 3},
+            ),
+        )
+
+        llm_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "region_name": region,
+            "client": client,
+        }
+
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs:
+                llm_kwargs[key] = self.kwargs[key]
+
+        return NormalizedChatBedrockConverse(**llm_kwargs)
+
+    def validate_model(self) -> bool:
+        """Bedrock accepts any model/inference-profile ID."""
+        return True

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -54,4 +54,8 @@ def create_llm_client(
         from .azure_client import AzureOpenAIClient
         return AzureOpenAIClient(model, base_url, **kwargs)
 
+    if provider_lower == "bedrock":
+        from .bedrock_client import BedrockClient
+        return BedrockClient(model, base_url, **kwargs)
+
     raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -153,6 +153,20 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # so the two provider keys share one model list.
     "minimax": _MINIMAX_MODELS,
     "minimax-cn": _MINIMAX_MODELS,
+    "bedrock": {
+        "quick": [
+            ("Claude Sonnet 4.6 (cross-region)", "us.anthropic.claude-sonnet-4-6-v1"),
+            ("Claude Haiku 4.5 (cross-region)", "us.anthropic.claude-haiku-4-5-v1"),
+            ("Claude Sonnet 4.5 (cross-region)", "us.anthropic.claude-sonnet-4-5-v1"),
+            ("Custom model/inference profile ID", "custom"),
+        ],
+        "deep": [
+            ("Claude Opus 4.7 (cross-region)", "us.anthropic.claude-opus-4-7"),
+            ("Claude Opus 4.6 (cross-region)", "us.anthropic.claude-opus-4-6-v1"),
+            ("Claude Sonnet 4.6 (cross-region)", "us.anthropic.claude-sonnet-4-6-v1"),
+            ("Custom model/inference profile ID", "custom"),
+        ],
+    },
     # OpenRouter: fetched dynamically. Azure: any deployed model name.
     # Ollama display labels intentionally omit a "local" marker — the
     # endpoint is now configurable via OLLAMA_BASE_URL, so the same labels


### PR DESCRIPTION
## Summary

Add AWS Bedrock as a supported LLM provider, enabling users to run TradingAgents with Claude models via their existing AWS credentials without needing separate API keys.

## Changes

- **New**: `tradingagents/llm_clients/bedrock_client.py` — Bedrock client using `ChatBedrockConverse` with standard AWS credential chain support
- **Modified**: `factory.py` — Register bedrock provider
- **Modified**: `api_key_env.py` — Mark bedrock as not requiring an API key
- **Modified**: `model_catalog.py` — Add Bedrock model options (Claude cross-region inference profiles)
- **Modified**: `pyproject.toml` — Add `langchain-aws` as optional dependency (`pip install .[bedrock]`)
- **Modified**: `.env.enterprise.example` — Add Bedrock configuration example
- **Modified**: `README.md` — Add Bedrock usage instructions

## Features

- Uses standard AWS credential chain (env vars, `~/.aws/credentials`, IAM role)
- Supports `AWS_PROFILE` and `AWS_DEFAULT_REGION` environment variables
- 300s read timeout for large model responses (Opus)
- `with_structured_output` support for structured agent outputs
- Cross-region inference profile IDs as model names

## Testing

Tested end-to-end with Claude Opus 4.6 (`us.anthropic.claude-opus-4-6-v1`) running full multi-agent analysis pipeline (fundamentals, technicals, sentiment, debate, risk, portfolio manager).