### PR TITLE
feat(sentiment): add Chinese/intl social channels via AgentKey (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,13 @@ MINIMAX_API_KEY=
 MINIMAX_CN_API_KEY=
 OPENROUTER_API_KEY=
 
+# Optional: AgentKey (https://agentkey.app/) for Chinese / international social
+# sentiment (Weibo, Zhihu, and — for consumer brands — Xiaohongshu, Douyin).
+# When set, the sentiment analyst enriches its report with these channels for
+# stock (non-crypto) tickers. Leave empty to disable. Bills per successful call.
+#AGENTKEY_API_KEY=ak_xxx
+#AGENTKEY_BASE_URL=https://api.agentkey.app
+
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows
 # the broader Ollama ecosystem; both the CLI dropdown and programmatic

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 
+### Optional APIs
+
+```bash
+export AGENTKEY_API_KEY=ak_...        # AgentKey — Chinese / international social sentiment
+export AGENTKEY_BASE_URL=...          # optional, defaults to https://api.agentkey.app
+```
+
+- **What it does:** When set, the sentiment analyst enriches its report with Chinese / international social platforms via [AgentKey](https://agentkey.app/) — **Weibo** and **Zhihu** for every stock, plus **Xiaohongshu** and **Douyin** for consumer-brand sectors. This is most valuable for A-share / Hong Kong / China-listed or China-exposed tickers, whose sentiment the default US sources (StockTwits, Reddit) miss. Crypto tickers are unaffected.
+- **Impact if unset:** Fully optional. With no key, the analyst silently skips these channels and runs exactly as before — no extra latency, no network calls, no cost. Existing US-only workflows are unchanged.
+- **Cost:** AgentKey bills per successful call, so enabling this adds a small per-run cost (typically a few cents per analyzed ticker).
+- **Where to get a key:** Sign up at [agentkey.app](https://agentkey.app/) and create an API key (format `ak_...`).
+
 Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash
 cp .env.example .env

--- a/tests/test_agentkey_social.py
+++ b/tests/test_agentkey_social.py
@@ -1,0 +1,157 @@
+"""Tests for AgentKey-backed social channels in the sentiment analyst.
+
+Parsing fixtures mirror the real (observed) upstream response shapes:
+  * Weibo: data.items[] mixing card containers and status dicts (text + user)
+  * Zhihu: data.data[] of {object: {type, title, excerpt(html), author, counts}}
+
+Network is never hit: dispatch is monkeypatched. Behavioral contracts under test
+are the same as the existing fetchers — a formatted string always, a placeholder
+on failure, and zero output when AgentKey is unconfigured.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from tradingagents.dataflows import agentkey_client, agentkey_social
+from tradingagents.dataflows.agentkey_client import AgentKeyError
+from tradingagents.dataflows.agentkey_social import (
+    build_agentkey_social_section,
+    fetch_weibo_posts,
+    fetch_zhihu_discussions,
+    is_consumer_brand,
+    select_channels,
+)
+
+_WEIBO_PAYLOAD = {
+    "code": 1,
+    "data": {
+        "items": [
+            {"category": "feed", "type": "card", "items": [], "itemId": "x", "style": 1},
+            {
+                "category": "status",
+                "data": {
+                    "text": "贵州茅台，腾讯控股两大老登今日继续新低 ​",
+                    "user": {"screen_name": "股海老王"},
+                    "created_at": "Wed May 28 09:00:00 +0800 2026",
+                    "region_name": "发布于 北京",
+                    "attitudes_count": 42,
+                    "comments_count": 7,
+                    "reposts_count": 3,
+                },
+            },
+        ]
+    },
+}
+
+_ZHIHU_PAYLOAD = {
+    "code": 0,
+    "data": {
+        "data": [
+            {"object": {"type": "hot_timing", "title": "热榜"}},  # non-content card, skipped
+            {
+                "object": {
+                    "type": "answer",
+                    "title": "茅台一季度营收增长 6.5%，为何明星基金减仓？",
+                    "excerpt": "<p>单看一季度营收增长6.5%</p>",
+                    "author": {"name": "jian mi"},
+                    "voteup_count": 27,
+                    "comment_count": 28,
+                    "created_time": 1777356615,
+                }
+            },
+        ]
+    },
+}
+
+
+class ChannelSelectionTests(unittest.TestCase):
+    def test_base_channels_always_present(self):
+        self.assertEqual(select_channels("Technology", "Software—Infrastructure"), ["weibo", "zhihu"])
+
+    def test_consumer_sector_adds_consumer_channels(self):
+        channels = select_channels("Consumer Defensive", "Beverages—Wineries & Distilleries")
+        self.assertEqual(channels, ["weibo", "zhihu", "xiaohongshu", "douyin"])
+
+    def test_consumer_electronics_detected_despite_tech_sector(self):
+        # Apple: sector "Technology" but industry "Consumer Electronics" → consumer brand.
+        self.assertTrue(is_consumer_brand("Technology", "Consumer Electronics"))
+
+    def test_industrial_is_not_consumer(self):
+        self.assertFalse(is_consumer_brand("Industrials", "Aerospace & Defense"))
+
+    def test_missing_sector_industry_is_not_consumer(self):
+        self.assertFalse(is_consumer_brand("", ""))
+
+
+class WeiboParsingTests(unittest.TestCase):
+    def test_extracts_status_skips_containers(self):
+        with patch.object(agentkey_social, "dispatch", return_value=_WEIBO_PAYLOAD):
+            out = fetch_weibo_posts("贵州茅台")
+        self.assertIn("股海老王", out)
+        self.assertIn("两大老登", out)
+        self.assertIn("like 42", out)
+        self.assertIn("comment 7", out)
+        self.assertTrue(out.startswith("1 most-relevant Weibo posts"))
+
+    def test_empty_results_placeholder(self):
+        with patch.object(agentkey_social, "dispatch", return_value={"data": {"items": []}}):
+            out = fetch_weibo_posts("NoSuchCo")
+        self.assertEqual(out, "<no Weibo posts found for 'NoSuchCo'>")
+
+    def test_failure_degrades_to_placeholder(self):
+        with patch.object(agentkey_social, "dispatch", side_effect=AgentKeyError("HTTP 500 for weibo")):
+            out = fetch_weibo_posts("贵州茅台")
+        self.assertEqual(out, "<weibo unavailable: HTTP 500 for weibo>")
+
+
+class ZhihuParsingTests(unittest.TestCase):
+    def test_extracts_answers_strips_html_and_skips_cards(self):
+        with patch.object(agentkey_social, "dispatch", return_value=_ZHIHU_PAYLOAD):
+            out = fetch_zhihu_discussions("贵州茅台")
+        self.assertIn("jian mi", out)
+        self.assertIn("营收增长 6.5%", out)
+        self.assertNotIn("<p>", out)  # html stripped
+        self.assertIn("upvote 27", out)
+        self.assertIn("2026-04", out)  # created_time rendered as date
+        self.assertNotIn("热榜", out)  # hot_timing card skipped
+
+    def test_failure_degrades_to_placeholder(self):
+        with patch.object(agentkey_social, "dispatch", side_effect=AgentKeyError("network error")):
+            out = fetch_zhihu_discussions("贵州茅台")
+        self.assertEqual(out, "<zhihu unavailable: network error>")
+
+
+class SectionAssemblyTests(unittest.TestCase):
+    def test_unconfigured_returns_empty(self):
+        with patch.object(agentkey_social, "is_configured", return_value=False):
+            self.assertEqual(build_agentkey_social_section("Apple", "Technology", "Consumer Electronics"), "")
+
+    def test_configured_consumer_includes_all_four_blocks(self):
+        with patch.object(agentkey_social, "is_configured", return_value=True), patch.object(
+            agentkey_social, "dispatch", side_effect=AgentKeyError("upstream down")
+        ):
+            section = build_agentkey_social_section("Apple", "Technology", "Consumer Electronics")
+        for channel in ("weibo", "zhihu", "xiaohongshu", "douyin"):
+            self.assertIn(f"<start_of_{channel}>", section)
+            self.assertIn(f"<end_of_{channel}>", section)
+
+    def test_configured_non_consumer_only_base_blocks(self):
+        with patch.object(agentkey_social, "is_configured", return_value=True), patch.object(
+            agentkey_social, "dispatch", side_effect=AgentKeyError("upstream down")
+        ):
+            section = build_agentkey_social_section("Boeing", "Industrials", "Aerospace & Defense")
+        self.assertIn("<start_of_weibo>", section)
+        self.assertIn("<start_of_zhihu>", section)
+        self.assertNotIn("<start_of_xiaohongshu>", section)
+        self.assertNotIn("<start_of_douyin>", section)
+
+
+class ClientConfigTests(unittest.TestCase):
+    def test_dispatch_without_key_raises(self):
+        with patch.object(agentkey_client, "get_api_key", return_value=""):
+            with self.assertRaises(AgentKeyError):
+                agentkey_client.dispatch("weibo/app/fetch_search_all", {"query": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agentkey_social.py
+++ b/tests/test_agentkey_social.py
@@ -146,13 +146,15 @@ class ZhihuParsingTests(unittest.TestCase):
 class SectionAssemblyTests(unittest.TestCase):
     def test_unconfigured_returns_empty(self):
         with patch.object(agentkey_social, "is_configured", return_value=False):
-            self.assertEqual(build_agentkey_social_section("Apple", "Technology", "Consumer Electronics"), "")
+            self.assertEqual(
+                build_agentkey_social_section("AAPL", "Apple Inc.", "Technology", "Consumer Electronics"), ""
+            )
 
     def test_configured_consumer_includes_all_four_blocks(self):
         with patch.object(agentkey_social, "is_configured", return_value=True), patch.object(
             agentkey_social, "dispatch", side_effect=AgentKeyError("upstream down")
         ):
-            section = build_agentkey_social_section("Apple", "Technology", "Consumer Electronics")
+            section = build_agentkey_social_section("AAPL", "Apple Inc.", "Technology", "Consumer Electronics")
         for channel in ("weibo", "zhihu", "xiaohongshu", "douyin"):
             self.assertIn(f"<start_of_{channel}>", section)
             self.assertIn(f"<end_of_{channel}>", section)
@@ -161,11 +163,56 @@ class SectionAssemblyTests(unittest.TestCase):
         with patch.object(agentkey_social, "is_configured", return_value=True), patch.object(
             agentkey_social, "dispatch", side_effect=AgentKeyError("upstream down")
         ):
-            section = build_agentkey_social_section("Boeing", "Industrials", "Aerospace & Defense")
+            section = build_agentkey_social_section("BA", "Boeing Company", "Industrials", "Aerospace & Defense")
         self.assertIn("<start_of_weibo>", section)
         self.assertIn("<start_of_zhihu>", section)
         self.assertNotIn("<start_of_xiaohongshu>", section)
         self.assertNotIn("<start_of_douyin>", section)
+
+
+class CnNameResolutionTests(unittest.TestCase):
+    def setUp(self):
+        agentkey_social._cn_name_cache.clear()
+
+    def test_detects_cn_market_tickers(self):
+        self.assertTrue(agentkey_social.is_cn_market_ticker("0700.HK"))
+        self.assertTrue(agentkey_social.is_cn_market_ticker("600519.SS"))
+        self.assertTrue(agentkey_social.is_cn_market_ticker("000001.SZ"))
+        self.assertFalse(agentkey_social.is_cn_market_ticker("AAPL"))
+        self.assertFalse(agentkey_social.is_cn_market_ticker("BTC-USD"))
+
+    def test_numeric_code_extraction(self):
+        self.assertEqual(agentkey_social._ticker_numeric_code("0700.HK"), "0700")
+        self.assertEqual(agentkey_social._ticker_numeric_code("600519.SS"), "600519")
+
+    def test_extracts_chinese_name_before_padded_code(self):
+        # "0700" → matched as zero-padded 00700, name captured before the paren.
+        self.assertEqual(agentkey_social._extract_cn_name("腾讯控股(00700)股价分析", "0700"), "腾讯控股")
+        self.assertEqual(agentkey_social._extract_cn_name("贵州茅台（600519）一季报", "600519"), "贵州茅台")
+
+    def test_rejects_stopword_only_match(self):
+        self.assertIsNone(agentkey_social._extract_cn_name("港股(00700)", "0700"))
+
+    def test_resolve_picks_most_frequent_and_caches(self):
+        payload = {
+            "results": [
+                {"title": "腾讯控股(00700)财报", "snippet": ""},
+                {"title": "港股 00700", "snippet": "腾讯控股（00700）回购"},
+            ]
+        }
+        with patch.object(agentkey_social, "search", return_value=payload) as mock_search:
+            first = agentkey_social.resolve_cn_name("0700.HK", "Tencent")
+            second = agentkey_social.resolve_cn_name("0700.HK", "Tencent")  # cached
+        self.assertEqual(first, "腾讯控股")
+        self.assertEqual(second, "腾讯控股")
+        mock_search.assert_called_once()  # second call served from cache
+
+    def test_resolve_falls_back_on_search_error(self):
+        with patch.object(agentkey_social, "search", side_effect=AgentKeyError("down")):
+            self.assertEqual(agentkey_social.resolve_cn_name("0700.HK", "Tencent"), "Tencent")
+
+    def test_resolve_search_query_non_cn_uses_brand(self):
+        self.assertEqual(agentkey_social.resolve_search_query("AAPL", "Apple Inc."), "Apple")
 
 
 class ClientConfigTests(unittest.TestCase):

--- a/tests/test_agentkey_social.py
+++ b/tests/test_agentkey_social.py
@@ -19,6 +19,7 @@ from tradingagents.dataflows.agentkey_social import (
     fetch_weibo_posts,
     fetch_zhihu_discussions,
     is_consumer_brand,
+    normalize_search_name,
     select_channels,
 )
 
@@ -81,6 +82,27 @@ class ChannelSelectionTests(unittest.TestCase):
 
     def test_missing_sector_industry_is_not_consumer(self):
         self.assertFalse(is_consumer_brand("", ""))
+
+
+class SearchNameTests(unittest.TestCase):
+    def test_strips_common_corporate_suffixes(self):
+        self.assertEqual(normalize_search_name("Tencent Holdings Limited"), "Tencent")
+        self.assertEqual(normalize_search_name("NVIDIA Corporation"), "NVIDIA")
+        self.assertEqual(normalize_search_name("Apple Inc."), "Apple")
+        self.assertEqual(normalize_search_name("Kweichow Moutai Co., Ltd."), "Kweichow Moutai")
+
+    def test_strips_trailing_share_class(self):
+        self.assertEqual(normalize_search_name("Alphabet Inc. Class C"), "Alphabet")
+
+    def test_preserves_multiword_core_name(self):
+        self.assertEqual(normalize_search_name("China Petroleum & Chemical Corporation"), "China Petroleum & Chemical")
+
+    def test_never_collapses_to_empty(self):
+        # The loop keeps the last token, so an all-suffix name never empties.
+        self.assertTrue(normalize_search_name("Holdings Group"))
+
+    def test_handles_empty(self):
+        self.assertEqual(normalize_search_name(""), "")
 
 
 class WeiboParsingTests(unittest.TestCase):

--- a/tests/test_agentkey_social.py
+++ b/tests/test_agentkey_social.py
@@ -105,6 +105,18 @@ class SearchNameTests(unittest.TestCase):
         self.assertEqual(normalize_search_name(""), "")
 
 
+class HelperTests(unittest.TestCase):
+    def test_unix_to_date_seconds(self):
+        self.assertEqual(agentkey_social._unix_to_date(1777356615), "2026-04-28")
+
+    def test_unix_to_date_milliseconds(self):
+        # 13-digit ms timestamp normalizes to the same date as its seconds form.
+        self.assertEqual(agentkey_social._unix_to_date(1777356615000), "2026-04-28")
+
+    def test_unix_to_date_passthrough_on_garbage(self):
+        self.assertEqual(agentkey_social._unix_to_date("not-a-ts"), "not-a-ts")
+
+
 class WeiboParsingTests(unittest.TestCase):
     def test_extracts_status_skips_containers(self):
         with patch.object(agentkey_social, "dispatch", return_value=_WEIBO_PAYLOAD):
@@ -149,6 +161,19 @@ class SectionAssemblyTests(unittest.TestCase):
             self.assertEqual(
                 build_agentkey_social_section("AAPL", "Apple Inc.", "Technology", "Consumer Electronics"), ""
             )
+
+    def test_fetcher_exception_does_not_crash_section(self):
+        # An unexpected (non-AgentKeyError) failure in one channel must degrade to
+        # a placeholder, not propagate and crash the sentiment node.
+        def boom(_query):
+            raise TypeError("upstream shape changed")
+
+        with patch.object(agentkey_social, "is_configured", return_value=True), patch.dict(
+            agentkey_social._FETCHERS, {"weibo": boom, "zhihu": lambda q: "ok"}
+        ):
+            section = build_agentkey_social_section("AAPL", "Apple Inc.", "Technology", "Software")
+        self.assertIn("<weibo unavailable: unexpected error>", section)
+        self.assertIn("<start_of_zhihu>\nok", section)
 
     def test_unconfigured_makes_no_network_call(self):
         # AgentKey is opt-in: with no key, the section must short-circuit BEFORE
@@ -220,6 +245,13 @@ class CnNameResolutionTests(unittest.TestCase):
     def test_resolve_falls_back_on_search_error(self):
         with patch.object(agentkey_social, "search", side_effect=AgentKeyError("down")):
             self.assertEqual(agentkey_social.resolve_cn_name("0700.HK", "Tencent"), "Tencent")
+
+    def test_resolve_tolerates_malformed_results(self):
+        # results not a list / items not dicts must not raise — fall back to brand.
+        for payload in ({"results": "oops"}, {"results": ["str", 123, None]}, {}):
+            agentkey_social._cn_name_cache.clear()
+            with patch.object(agentkey_social, "search", return_value=payload):
+                self.assertEqual(agentkey_social.resolve_cn_name("0700.HK", "Tencent"), "Tencent")
 
     def test_resolve_search_query_non_cn_uses_brand(self):
         self.assertEqual(agentkey_social.resolve_search_query("AAPL", "Apple Inc."), "Apple")

--- a/tests/test_agentkey_social.py
+++ b/tests/test_agentkey_social.py
@@ -150,6 +150,16 @@ class SectionAssemblyTests(unittest.TestCase):
                 build_agentkey_social_section("AAPL", "Apple Inc.", "Technology", "Consumer Electronics"), ""
             )
 
+    def test_unconfigured_makes_no_network_call(self):
+        # AgentKey is opt-in: with no key, the section must short-circuit BEFORE
+        # touching the network, so an unconfigured install runs fully unaffected.
+        with patch.object(agentkey_social, "is_configured", return_value=False), patch.object(
+            agentkey_social, "dispatch", side_effect=AssertionError("dispatch must not be called")
+        ), patch.object(
+            agentkey_social, "search", side_effect=AssertionError("search must not be called")
+        ):
+            self.assertEqual(build_agentkey_social_section("0700.HK", "Tencent Holdings Limited"), "")
+
     def test_configured_consumer_includes_all_four_blocks(self):
         with patch.object(agentkey_social, "is_configured", return_value=True), patch.object(
             agentkey_social, "dispatch", side_effect=AgentKeyError("upstream down")

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -27,8 +27,11 @@ from tradingagents.agents.utils.agent_utils import (
     get_language_instruction,
     get_news,
 )
+from tradingagents.dataflows.agentkey_client import is_configured as agentkey_configured
+from tradingagents.dataflows.agentkey_social import build_agentkey_social_section
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
+from tradingagents.dataflows.y_finance import get_instrument_profile
 
 
 def _seven_days_back(trade_date: str) -> str:
@@ -56,6 +59,18 @@ def create_sentiment_analyst(llm):
         stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
         reddit_block = fetch_reddit_posts(ticker)
 
+        # Chinese / international social channels via AgentKey. Stock-only:
+        # CN-platform chatter is noise for crypto (whose sentiment is global /
+        # English-Twitter driven). Returns "" when AgentKey is unconfigured, so
+        # existing US-only runs are unchanged and incur no cost. Channels are
+        # industry-selected (consumer brands also get Xiaohongshu/Douyin).
+        agentkey_block = ""
+        if agentkey_configured() and state.get("asset_type", "stock") != "crypto":
+            profile = get_instrument_profile(ticker)
+            agentkey_block = build_agentkey_social_section(
+                profile["name"], profile["sector"], profile["industry"]
+            )
+
         system_message = _build_system_message(
             ticker=ticker,
             start_date=start_date,
@@ -63,6 +78,7 @@ def create_sentiment_analyst(llm):
             news_block=news_block,
             stocktwits_block=stocktwits_block,
             reddit_block=reddit_block,
+            agentkey_block=agentkey_block,
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -104,9 +120,21 @@ def _build_system_message(
     news_block: str,
     stocktwits_block: str,
     reddit_block: str,
+    agentkey_block: str = "",
 ) -> str:
     """Assemble the sentiment-analyst system message with structured data blocks."""
-    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on three complementary data sources that have already been collected for you.
+    agentkey_section = f"\n\n{agentkey_block}\n" if agentkey_block else ""
+    agentkey_guidance = (
+        "\n\n9. **Weight the Chinese / international platforms by relevance.** Weibo and Zhihu "
+        "capture China-market and China-exposed sentiment that US sources miss — high signal for "
+        "A-share / HK / China-listed names, often sparse for names with little Chinese coverage "
+        "(say so when sparse). Treat Xiaohongshu / Douyin as consumer-demand alt-data (product buzz), "
+        "not direct stock opinion. These are matched by company name, so watch for off-topic results "
+        "(name collisions) and discount them."
+        if agentkey_block
+        else ""
+    )
+    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on the complementary data sources that have already been collected for you.
 
 ## Data sources (pre-fetched, in this prompt)
 
@@ -130,7 +158,7 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 <start_of_reddit>
 {reddit_block}
 <end_of_reddit>
-
+{agentkey_section}
 ## How to analyze this data (best practices)
 
 1. **Read the StockTwits Bullish/Bearish ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
@@ -147,14 +175,14 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 
 7. **Identify catalysts and risks** that emerge across sources — news of upcoming earnings, product launches, competitive threats, macro headlines, etc.
 
-8. **Past sentiment is not predictive.** Frame your conclusions as signal for the trader to weigh alongside fundamentals and technicals, not as a price call.
+8. **Past sentiment is not predictive.** Frame your conclusions as signal for the trader to weigh alongside fundamentals and technicals, not as a price call.{agentkey_guidance}
 
 ## Output
 
 Produce a sentiment report covering, in order:
 
 1. **Overall sentiment direction** — Bullish / Bearish / Neutral / Mixed — with a brief confidence note based on data quality and sample size.
-2. **Source-by-source breakdown** — what each of news / StockTwits / Reddit is telling you, with specific evidence (cite message counts, ratios, notable posts).
+2. **Source-by-source breakdown** — what each available source is telling you (news, StockTwits, Reddit, and any Chinese-platform sources included above), with specific evidence (cite message counts, ratios, notable posts).
 3. **Divergences, alignments, and key narratives** across sources.
 4. **Catalysts and risks** surfaced by the data.
 5. **Markdown table** at the end summarizing key sentiment signals, their direction, source, and supporting evidence.

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -68,7 +68,7 @@ def create_sentiment_analyst(llm):
         if agentkey_configured() and state.get("asset_type", "stock") != "crypto":
             profile = get_instrument_profile(ticker)
             agentkey_block = build_agentkey_social_section(
-                profile["name"], profile["sector"], profile["industry"]
+                ticker, profile["name"], profile["sector"], profile["industry"]
             )
 
         system_message = _build_system_message(

--- a/tradingagents/dataflows/agentkey_client.py
+++ b/tradingagents/dataflows/agentkey_client.py
@@ -1,0 +1,111 @@
+"""AgentKey social-data transport.
+
+AgentKey (https://agentkey.app/) proxies ~990 social-media endpoints across
+22 platforms (Weibo, Zhihu, Xiaohongshu, Douyin, TikTok, LinkedIn, …) behind a
+single authenticated REST surface. Calls are dispatched through:
+
+    POST {base_url}/v1/social/dispatch
+    Authorization: Bearer <api_key>
+    body: {"path": "weibo/app/fetch_search_all", "params": {...}}
+
+The upstream JSON is returned as-is (TikHub/JustOneAPI shapes, unnormalized).
+AgentKey charges per successful (2xx) call, so callers should fetch
+deliberately rather than scan endpoints speculatively.
+
+This module is the thin transport layer only: it knows how to authenticate and
+POST, and raises :class:`AgentKeyError` on any failure (missing credentials,
+network error, non-2xx, unparseable body). The per-channel fetchers in
+``agentkey_social`` catch that error and degrade to a placeholder string, so the
+sentiment analyst never has to special-case exceptions — mirroring the contract
+already used by ``stocktwits.py`` and ``reddit.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.agentkey.app"
+_DISPATCH_PATH = "/v1/social/dispatch"
+_UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
+
+
+class AgentKeyError(RuntimeError):
+    """Raised when an AgentKey dispatch cannot be completed."""
+
+
+def _setting(config_key: str, env_var: str, default: str = "") -> str:
+    """Read a setting from the runtime config, falling back to the environment.
+
+    The config is consulted first so a programmatic ``set_config`` override wins;
+    the env var is the fallback so plain ``.env`` usage works without code.
+    """
+    try:
+        from tradingagents.dataflows.config import get_config
+
+        value = get_config().get(config_key)
+        if value:
+            return str(value)
+    except Exception:  # pragma: no cover - config import should not break fetch
+        pass
+    return os.environ.get(env_var, default)
+
+
+def get_api_key() -> str:
+    """Return the configured AgentKey API key, or an empty string when unset."""
+    return _setting("agentkey_api_key", "AGENTKEY_API_KEY").strip()
+
+
+def get_base_url() -> str:
+    """Return the AgentKey base URL, defaulting to the hosted service."""
+    return _setting("agentkey_base_url", "AGENTKEY_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def is_configured() -> bool:
+    """True when an API key is available, i.e. AgentKey channels can be used."""
+    return bool(get_api_key())
+
+
+def dispatch(path: str, params: Optional[Dict[str, Any]] = None, timeout: float = 15.0) -> Dict[str, Any]:
+    """Call one AgentKey social endpoint and return the parsed JSON body.
+
+    ``path`` is the TikHub-style relative path (e.g. ``weibo/app/fetch_search_all``)
+    and ``params`` are forwarded upstream verbatim. Raises :class:`AgentKeyError`
+    on any failure so callers can degrade gracefully.
+    """
+    api_key = get_api_key()
+    if not api_key:
+        raise AgentKeyError("no AGENTKEY_API_KEY configured")
+
+    url = get_base_url() + _DISPATCH_PATH
+    body = json.dumps({"path": path, "params": params or {}}).encode("utf-8")
+    req = Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": _UA,
+        },
+    )
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+    except HTTPError as exc:  # non-2xx: upstream status passed through
+        raise AgentKeyError(f"HTTP {exc.code} for {path}") from exc
+    except (URLError, TimeoutError) as exc:
+        raise AgentKeyError(f"network error for {path}: {exc}") from exc
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise AgentKeyError(f"unparseable response for {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise AgentKeyError(f"unexpected response shape for {path}")
+    return payload

--- a/tradingagents/dataflows/agentkey_client.py
+++ b/tradingagents/dataflows/agentkey_client.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://api.agentkey.app"
 _DISPATCH_PATH = "/v1/social/dispatch"
+_SEARCH_PATH = "/v1/search"
 _UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
 
 
@@ -72,22 +73,19 @@ def is_configured() -> bool:
     return bool(get_api_key())
 
 
-def dispatch(path: str, params: Optional[Dict[str, Any]] = None, timeout: float = 15.0) -> Dict[str, Any]:
-    """Call one AgentKey social endpoint and return the parsed JSON body.
+def _post(endpoint: str, body: Dict[str, Any], label: str, timeout: float) -> Dict[str, Any]:
+    """POST a JSON body to an AgentKey endpoint and return the parsed response.
 
-    ``path`` is the TikHub-style relative path (e.g. ``weibo/app/fetch_search_all``)
-    and ``params`` are forwarded upstream verbatim. Raises :class:`AgentKeyError`
-    on any failure so callers can degrade gracefully.
+    Raises :class:`AgentKeyError` on missing credentials, network error, non-2xx,
+    or an unparseable / non-object body so callers can degrade gracefully.
     """
     api_key = get_api_key()
     if not api_key:
         raise AgentKeyError("no AGENTKEY_API_KEY configured")
 
-    url = get_base_url() + _DISPATCH_PATH
-    body = json.dumps({"path": path, "params": params or {}}).encode("utf-8")
     req = Request(
-        url,
-        data=body,
+        get_base_url() + endpoint,
+        data=json.dumps(body).encode("utf-8"),
         method="POST",
         headers={
             "Authorization": f"Bearer {api_key}",
@@ -100,12 +98,29 @@ def dispatch(path: str, params: Optional[Dict[str, Any]] = None, timeout: float 
         with urlopen(req, timeout=timeout) as resp:
             payload = json.loads(resp.read())
     except HTTPError as exc:  # non-2xx: upstream status passed through
-        raise AgentKeyError(f"HTTP {exc.code} for {path}") from exc
+        raise AgentKeyError(f"HTTP {exc.code} for {label}") from exc
     except (URLError, TimeoutError) as exc:
-        raise AgentKeyError(f"network error for {path}: {exc}") from exc
+        raise AgentKeyError(f"network error for {label}: {exc}") from exc
     except (json.JSONDecodeError, ValueError) as exc:
-        raise AgentKeyError(f"unparseable response for {path}: {exc}") from exc
+        raise AgentKeyError(f"unparseable response for {label}: {exc}") from exc
 
     if not isinstance(payload, dict):
-        raise AgentKeyError(f"unexpected response shape for {path}")
+        raise AgentKeyError(f"unexpected response shape for {label}")
     return payload
+
+
+def dispatch(path: str, params: Optional[Dict[str, Any]] = None, timeout: float = 15.0) -> Dict[str, Any]:
+    """Call one AgentKey social endpoint and return the parsed JSON body.
+
+    ``path`` is the TikHub-style relative path (e.g. ``weibo/app/fetch_search_all``)
+    and ``params`` are forwarded upstream verbatim.
+    """
+    return _post(_DISPATCH_PATH, {"path": path, "params": params or {}}, path, timeout)
+
+
+def search(query: str, type: str = "web", num: int = 10, timeout: float = 15.0) -> Dict[str, Any]:
+    """Run an AgentKey web search and return the parsed JSON body.
+
+    Response shape: ``{"results": [{"title", "url", "snippet", ...}], ...}``.
+    """
+    return _post(_SEARCH_PATH, {"query": query, "type": type, "num": num}, f"search({query!r})", timeout)

--- a/tradingagents/dataflows/agentkey_social.py
+++ b/tradingagents/dataflows/agentkey_social.py
@@ -1,0 +1,318 @@
+"""AgentKey-backed social channels for the sentiment analyst.
+
+Adds Chinese / international social platforms on top of the analyst's existing
+US-centric sources (StockTwits, Reddit, Yahoo news). Channels are split into:
+
+  * Base layer (always, when AgentKey is configured): Weibo, Zhihu — the closest
+    Chinese-market analogues to StockTwits/Reddit retail + deep-discussion flow.
+  * Consumer layer (only for consumer-brand sectors): Xiaohongshu, Douyin — these
+    are product/lifestyle platforms whose buzz is a meaningful alt-data signal for
+    consumer names (beverages, autos, electronics, apparel, restaurants) and pure
+    noise for industrial / B2B / financial names, so they are industry-gated.
+
+Each fetcher returns a formatted plaintext block ready for prompt injection, and
+degrades to a clear ``<… unavailable: reason>`` placeholder on any failure — the
+caller never special-cases exceptions or ``None`` (same contract as
+``stocktwits.py`` / ``reddit.py``). Parsers are tolerant of the raw, unnormalized
+upstream JSON: missing fields are skipped, never fatal.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from tradingagents.dataflows.agentkey_client import AgentKeyError, dispatch, is_configured
+
+logger = logging.getLogger(__name__)
+
+# Channel identifiers used across selection + fetch dispatch.
+WEIBO = "weibo"
+ZHIHU = "zhihu"
+XIAOHONGSHU = "xiaohongshu"
+DOUYIN = "douyin"
+
+BASE_CHANNELS = (WEIBO, ZHIHU)
+CONSUMER_CHANNELS = (XIAOHONGSHU, DOUYIN)
+
+# yfinance sector strings that are squarely consumer-brand.
+_CONSUMER_SECTORS = {"consumer cyclical", "consumer defensive"}
+# Industry substrings that flag a consumer brand even when the sector is broad
+# (e.g. Apple's sector is "Technology" but its industry is "Consumer Electronics").
+_CONSUMER_INDUSTRY_KEYWORDS = (
+    "consumer electronic", "apparel", "footwear", "luxury", "restaurant",
+    "beverage", "brewer", "winer", "distiller", "auto manufacturer", "vehicle",
+    "cosmetic", "personal product", "packaged food", "household", "tobacco",
+    "leisure", "gambling", "gaming", "retail", "furnishing", "travel",
+    "lodging", "airline", "confection", "food product", "specialty",
+)
+
+_HTML_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# Industry-adaptive channel selection
+# ---------------------------------------------------------------------------
+def is_consumer_brand(sector: Optional[str], industry: Optional[str]) -> bool:
+    """Whether a ticker's sector/industry warrants consumer-platform signals."""
+    if sector and sector.strip().lower() in _CONSUMER_SECTORS:
+        return True
+    if industry:
+        ind = industry.lower()
+        return any(kw in ind for kw in _CONSUMER_INDUSTRY_KEYWORDS)
+    return False
+
+
+def select_channels(sector: Optional[str], industry: Optional[str]) -> List[str]:
+    """Return the AgentKey channels to query for an instrument.
+
+    Weibo + Zhihu always; Xiaohongshu + Douyin only for consumer brands.
+    """
+    channels = list(BASE_CHANNELS)
+    if is_consumer_brand(sector, industry):
+        channels.extend(CONSUMER_CHANNELS)
+    return channels
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+def _clean(text: Any, max_len: int = 280) -> str:
+    """Strip HTML tags, collapse whitespace, and truncate."""
+    s = _WS.sub(" ", _HTML_TAG.sub(" ", str(text or ""))).strip()
+    return (s[:max_len] + "…") if len(s) > max_len else s
+
+
+def _unix_to_date(value: Any) -> str:
+    """Best-effort unix-seconds → YYYY-MM-DD; pass through anything else."""
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc).strftime("%Y-%m-%d")
+    except (TypeError, ValueError, OSError):
+        return str(value or "")
+
+
+def _engagement(*pairs) -> str:
+    """Render non-empty (label, count) pairs as 'like 12 · comment 3'."""
+    return " · ".join(f"{label} {count}" for label, count in pairs if count)
+
+
+# ---------------------------------------------------------------------------
+# Weibo — retail-investor chatter (StockTwits/Twitter analogue for CN market)
+# ---------------------------------------------------------------------------
+def _iter_weibo_posts(node: Any) -> List[Dict[str, Any]]:
+    """Walk the nested Weibo search payload, collecting status dicts.
+
+    A status is any dict carrying both a ``text`` body and a ``user`` object.
+    The search response mixes card containers (``items``) and status objects
+    (``data``), so we recurse rather than assume a flat list.
+    """
+    found: List[Dict[str, Any]] = []
+    if isinstance(node, dict):
+        if isinstance(node.get("text"), str) and isinstance(node.get("user"), dict):
+            found.append(node)
+        for key in ("items", "data", "card_group", "cards"):
+            if key in node:
+                found.extend(_iter_weibo_posts(node[key]))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(_iter_weibo_posts(item))
+    return found
+
+
+def fetch_weibo_posts(query: str, limit: int = 15, timeout: float = 15.0) -> str:
+    """Fetch recent Weibo posts mentioning ``query`` as a formatted block."""
+    try:
+        payload = dispatch("weibo/app/fetch_search_all", {"query": query, "search_type": 1}, timeout)
+    except AgentKeyError as exc:
+        logger.warning("Weibo fetch failed for %s: %s", query, exc)
+        return f"<weibo unavailable: {exc}>"
+
+    posts = _iter_weibo_posts(payload.get("data"))
+    if not posts:
+        return f"<no Weibo posts found for '{query}'>"
+
+    lines = []
+    for p in posts[:limit]:
+        user = (p.get("user") or {}).get("screen_name", "?")
+        when = _clean(p.get("created_at"), 40)
+        region = p.get("region_name") or ""
+        eng = _engagement(
+            ("repost", p.get("reposts_count")),
+            ("comment", p.get("comments_count")),
+            ("like", p.get("attitudes_count")),
+        )
+        meta = " · ".join(x for x in (when, region, eng) if x)
+        lines.append(f"[@{user} · {meta}] {_clean(p.get('text'))}")
+    return f"{len(lines)} most-relevant Weibo posts for '{query}':\n\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Zhihu — deep Q&A / column discussion (Reddit-deep analogue for CN market)
+# ---------------------------------------------------------------------------
+def fetch_zhihu_discussions(query: str, limit: int = 8, timeout: float = 15.0) -> str:
+    """Fetch Zhihu answers/articles about ``query`` as a formatted block."""
+    try:
+        payload = dispatch(
+            "zhihu/web/fetch_article_search_v3", {"keyword": query, "limit": str(limit * 2)}, timeout
+        )
+    except AgentKeyError as exc:
+        logger.warning("Zhihu fetch failed for %s: %s", query, exc)
+        return f"<zhihu unavailable: {exc}>"
+
+    data = payload.get("data") or {}
+    results = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(results, list):
+        return f"<no Zhihu discussion found for '{query}'>"
+
+    lines = []
+    for entry in results:
+        obj = entry.get("object") if isinstance(entry, dict) else None
+        if not isinstance(obj, dict) or obj.get("type") not in ("answer", "article"):
+            continue
+        author = (obj.get("author") or {}).get("name", "?")
+        title = _clean(obj.get("title"), 90)
+        excerpt = _clean(obj.get("excerpt") or obj.get("excerpt_new"), 220)
+        when = _unix_to_date(obj.get("created_time") or obj.get("updated_time"))
+        eng = _engagement(("upvote", obj.get("voteup_count")), ("comment", obj.get("comment_count")))
+        meta = " · ".join(x for x in (obj.get("type"), author, when, eng) if x)
+        lines.append(f"[{meta}] {title}\n   {excerpt}")
+        if len(lines) >= limit:
+            break
+
+    if not lines:
+        return f"<no Zhihu discussion found for '{query}'>"
+    return f"{len(lines)} Zhihu answers/articles for '{query}':\n\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Consumer layer — Xiaohongshu & Douyin (industry-gated alt-data)
+# ---------------------------------------------------------------------------
+def _first_item_list(node: Any) -> List[Dict[str, Any]]:
+    """Find the first list-of-dicts under common container keys, best-effort.
+
+    Used for the consumer endpoints whose exact response shape we don't pin to a
+    grounded fixture; tolerant by design so a shape change degrades to fewer
+    extracted items rather than an exception.
+    """
+    if isinstance(node, list):
+        return [x for x in node if isinstance(x, dict)]
+    if isinstance(node, dict):
+        for key in ("items", "list", "data", "notes", "note_list", "aweme_list", "result"):
+            if key in node:
+                found = _first_item_list(node[key])
+                if found:
+                    return found
+    return []
+
+
+def _extract_text(item: Dict[str, Any]) -> str:
+    for key in ("desc", "title", "content", "text", "note_name", "share_text"):
+        val = item.get(key)
+        if isinstance(val, str) and val.strip():
+            return _clean(val)
+    nc = item.get("note_card")
+    if isinstance(nc, dict):
+        return _clean(nc.get("display_title") or nc.get("desc"))
+    return ""
+
+
+def _extract_author(item: Dict[str, Any]) -> str:
+    for key in ("nickname", "author", "user_name", "name"):
+        val = item.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+        if isinstance(val, dict):
+            return val.get("nickname") or val.get("name") or "?"
+    return "?"
+
+
+def _extract_engagement(item: Dict[str, Any]) -> str:
+    return _engagement(
+        ("like", item.get("liked_count") or item.get("digg_count") or item.get("like_count")),
+        ("comment", item.get("comment_count") or item.get("comments_count")),
+        ("share", item.get("share_count") or item.get("shared_count")),
+    )
+
+
+def _fetch_consumer(channel: str, path: str, query_field: str, query: str, limit: int, timeout: float) -> str:
+    try:
+        payload = dispatch(path, {query_field: query}, timeout)
+    except AgentKeyError as exc:
+        logger.warning("%s fetch failed for %s: %s", channel, query, exc)
+        return f"<{channel} unavailable: {exc}>"
+
+    items = _first_item_list(payload.get("data", payload))
+    lines = []
+    for item in items:
+        text = _extract_text(item)
+        if not text:
+            continue
+        meta = " · ".join(x for x in (_extract_author(item), _extract_engagement(item)) if x)
+        lines.append(f"[{meta}] {text}")
+        if len(lines) >= limit:
+            break
+    if not lines:
+        return f"<no {channel} posts found for '{query}'>"
+    return f"{len(lines)} {channel} posts for '{query}':\n\n" + "\n".join(lines)
+
+
+def fetch_xiaohongshu_notes(query: str, limit: int = 10, timeout: float = 15.0) -> str:
+    """Fetch Xiaohongshu (RED) notes mentioning ``query`` — consumer buzz signal."""
+    return _fetch_consumer(XIAOHONGSHU, "xiaohongshu/search_notes", "keyword", query, limit, timeout)
+
+
+def fetch_douyin_videos(query: str, limit: int = 10, timeout: float = 15.0) -> str:
+    """Fetch Douyin videos mentioning ``query`` — consumer buzz signal."""
+    return _fetch_consumer(
+        DOUYIN, "douyin/app/v3/fetch_general_search_result", "keyword", query, limit, timeout
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — assemble the prompt section for the sentiment analyst
+# ---------------------------------------------------------------------------
+_FETCHERS = {
+    WEIBO: fetch_weibo_posts,
+    ZHIHU: fetch_zhihu_discussions,
+    XIAOHONGSHU: fetch_xiaohongshu_notes,
+    DOUYIN: fetch_douyin_videos,
+}
+
+_CHANNEL_TITLES = {
+    WEIBO: "Weibo (微博) — Chinese retail-investor chatter",
+    ZHIHU: "Zhihu (知乎) — Chinese deep Q&A / investment-thesis discussion",
+    XIAOHONGSHU: "Xiaohongshu (小红书) — consumer product buzz (alt-data)",
+    DOUYIN: "Douyin (抖音) — consumer short-video buzz (alt-data)",
+}
+
+
+def build_agentkey_social_section(
+    query: str,
+    sector: Optional[str] = None,
+    industry: Optional[str] = None,
+) -> str:
+    """Assemble the AgentKey social section for prompt injection.
+
+    Returns ``""`` when AgentKey is not configured, so existing (US-only) runs are
+    unchanged and incur no cost. Otherwise fetches the industry-selected channels
+    and wraps each in a ``<start_of_{channel}>…<end_of_{channel}>`` block.
+    """
+    if not is_configured():
+        return ""
+
+    channels = select_channels(sector, industry)
+    parts = [
+        "### Chinese / international social platforms — via AgentKey",
+        f"Searched by company name '{query}'. Most valuable for A-share / HK / China-listed "
+        "or China-exposed names; may be sparse for names with little Chinese-language coverage.",
+    ]
+    for channel in channels:
+        block = _FETCHERS[channel](query)
+        parts.append(
+            f"\n#### {_CHANNEL_TITLES[channel]}\n"
+            f"<start_of_{channel}>\n{block}\n<end_of_{channel}>"
+        )
+    return "\n".join(parts)

--- a/tradingagents/dataflows/agentkey_social.py
+++ b/tradingagents/dataflows/agentkey_social.py
@@ -24,7 +24,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from tradingagents.dataflows.agentkey_client import AgentKeyError, dispatch, is_configured
+from tradingagents.dataflows.agentkey_client import AgentKeyError, dispatch, is_configured, search
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,92 @@ def normalize_search_name(name: str) -> str:
             break
     cleaned = " ".join(tokens).strip(" ,.")
     return cleaned or (name or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Chinese-name resolution for CN-market tickers
+# ---------------------------------------------------------------------------
+# yfinance only knows CN/HK listings by their English legal name, but Chinese
+# social platforms index the Chinese short name (腾讯控股, 贵州茅台). Searching
+# the English name gives poor, dated recall, so for CN-market tickers we resolve
+# the Chinese name from a web search before querying the platforms.
+_CN_MARKET_SUFFIXES = (".hk", ".ss", ".sh", ".sz", ".bj")
+_HAN = r"一-鿿"
+# Generic finance words that show up next to a code but are not company names.
+_CN_NAME_STOPWORDS = {
+    "港股", "美股", "股票", "代码", "行情", "股吧", "基金", "指数", "新浪", "雪球",
+    "东方财富", "同花顺", "腾讯财经", "公司", "集团", "控股", "有限公司", "股份",
+}
+_cn_name_cache: Dict[str, str] = {}
+
+
+def is_cn_market_ticker(ticker: str) -> bool:
+    """Whether a ticker is listed on a mainland-China / HK exchange."""
+    t = (ticker or "").strip().lower()
+    return t.endswith(_CN_MARKET_SUFFIXES)
+
+
+def _ticker_numeric_code(ticker: str) -> str:
+    """Extract the numeric listing code from a CN ticker ('0700.HK' → '0700')."""
+    head = (ticker or "").split(".")[0]
+    digits = re.sub(r"\D", "", head)
+    return digits
+
+
+def _extract_cn_name(text: str, code: str) -> Optional[str]:
+    """Pull a Chinese short name appearing right before the listing code.
+
+    Chinese finance content overwhelmingly writes "腾讯控股(00700)" /
+    "贵州茅台（600519）", so the Han run immediately preceding the (zero-padded)
+    code is a high-precision signal.
+    """
+    pattern = re.compile(rf"([{_HAN}A-Za-z·]{{2,8}})[\s（(]+0*{int(code)}\b")
+    for cand in pattern.findall(text or ""):
+        if re.search(rf"[{_HAN}]", cand) and cand not in _CN_NAME_STOPWORDS:
+            return cand
+    return None
+
+
+def resolve_cn_name(ticker: str, fallback: str, timeout: float = 15.0) -> str:
+    """Resolve a CN ticker's Chinese short name, falling back to ``fallback``.
+
+    Cached per ticker for the process. Any failure (no code, search error, no
+    match) degrades to the fallback — callers always get a usable query.
+    """
+    if ticker in _cn_name_cache:
+        return _cn_name_cache[ticker]
+
+    code = _ticker_numeric_code(ticker)
+    result = fallback
+    if code:
+        try:
+            # Query = code + English brand + a mainland simplified stock-forum
+            # anchor (东方财富股吧). The brand disambiguates code collisions across
+            # exchanges (e.g. 000001 = both 上证指数 and 平安银行); the anchor pulls
+            # the short name back in simplified, not traditional. Most-frequent
+            # match wins; falls back to the English brand if nothing matches.
+            payload = search(f"{code} {fallback} 股吧 东方财富", num=10, timeout=timeout)
+            counts: Dict[str, int] = {}
+            for item in payload.get("results", []) or []:
+                blob = f"{item.get('title', '')} {item.get('snippet', '')}"
+                name = _extract_cn_name(blob, code)
+                if name:
+                    counts[name] = counts.get(name, 0) + 1
+            if counts:
+                result = max(counts, key=counts.get)
+        except AgentKeyError as exc:
+            logger.warning("CN name resolution failed for %s: %s", ticker, exc)
+
+    _cn_name_cache[ticker] = result
+    return result
+
+
+def resolve_search_query(ticker: str, name: str) -> str:
+    """Best social-search query for an instrument: Chinese name for CN-market
+    tickers, otherwise the suffix-stripped brand name."""
+    if is_cn_market_ticker(ticker):
+        return resolve_cn_name(ticker, normalize_search_name(name))
+    return normalize_search_name(name)
 
 
 # ---------------------------------------------------------------------------
@@ -319,20 +405,22 @@ _CHANNEL_TITLES = {
 
 
 def build_agentkey_social_section(
-    query: str,
+    ticker: str,
+    name: str,
     sector: Optional[str] = None,
     industry: Optional[str] = None,
 ) -> str:
     """Assemble the AgentKey social section for prompt injection.
 
     Returns ``""`` when AgentKey is not configured, so existing (US-only) runs are
-    unchanged and incur no cost. Otherwise fetches the industry-selected channels
-    and wraps each in a ``<start_of_{channel}>…<end_of_{channel}>`` block.
+    unchanged and incur no cost. Otherwise resolves the best search query (Chinese
+    name for CN-market tickers, else the brand name), fetches the industry-selected
+    channels, and wraps each in a ``<start_of_{channel}>…<end_of_{channel}>`` block.
     """
     if not is_configured():
         return ""
 
-    query = normalize_search_name(query)
+    query = resolve_search_query(ticker, name)
     channels = select_channels(sector, industry)
     parts = [
         "### Chinese / international social platforms — via AgentKey",

--- a/tradingagents/dataflows/agentkey_social.py
+++ b/tradingagents/dataflows/agentkey_social.py
@@ -145,12 +145,16 @@ def resolve_cn_name(ticker: str, fallback: str, timeout: float = 15.0) -> str:
             # the short name back in simplified, not traditional. Most-frequent
             # match wins; falls back to the English brand if nothing matches.
             payload = search(f"{code} {fallback} 股吧 东方财富", num=10, timeout=timeout)
+            results = payload.get("results")
             counts: Dict[str, int] = {}
-            for item in payload.get("results", []) or []:
-                blob = f"{item.get('title', '')} {item.get('snippet', '')}"
-                name = _extract_cn_name(blob, code)
-                if name:
-                    counts[name] = counts.get(name, 0) + 1
+            if isinstance(results, list):
+                for item in results:
+                    if not isinstance(item, dict):
+                        continue
+                    blob = f"{item.get('title', '')} {item.get('snippet', '')}"
+                    name = _extract_cn_name(blob, code)
+                    if name:
+                        counts[name] = counts.get(name, 0) + 1
             if counts:
                 result = max(counts, key=counts.get)
         except AgentKeyError as exc:
@@ -202,9 +206,12 @@ def _clean(text: Any, max_len: int = 280) -> str:
 
 
 def _unix_to_date(value: Any) -> str:
-    """Best-effort unix-seconds → YYYY-MM-DD; pass through anything else."""
+    """Best-effort unix seconds-or-milliseconds → YYYY-MM-DD; pass through else."""
     try:
-        return datetime.fromtimestamp(int(value), tz=timezone.utc).strftime("%Y-%m-%d")
+        ts = int(value)
+        if ts > 9999999999:  # 11+ digits → milliseconds (10-digit seconds last to 2286)
+            ts //= 1000
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
     except (TypeError, ValueError, OSError):
         return str(value or "")
 
@@ -428,7 +435,14 @@ def build_agentkey_social_section(
         "or China-exposed names; may be sparse for names with little Chinese-language coverage.",
     ]
     for channel in channels:
-        block = _FETCHERS[channel](query)
+        # Fetchers already degrade AgentKeyError to a placeholder; this guard is
+        # defense-in-depth so an unexpected parsing error (e.g. a changed upstream
+        # shape) in one channel can't crash the whole sentiment node.
+        try:
+            block = _FETCHERS[channel](query)
+        except Exception as exc:
+            logger.error("Unexpected error fetching %s for %s: %s", channel, query, exc, exc_info=True)
+            block = f"<{channel} unavailable: unexpected error>"
         parts.append(
             f"\n#### {_CHANNEL_TITLES[channel]}\n"
             f"<start_of_{channel}>\n{block}\n<end_of_{channel}>"

--- a/tradingagents/dataflows/agentkey_social.py
+++ b/tradingagents/dataflows/agentkey_social.py
@@ -52,6 +52,35 @@ _CONSUMER_INDUSTRY_KEYWORDS = (
 _HTML_TAG = re.compile(r"<[^>]+>")
 _WS = re.compile(r"\s+")
 
+# Trailing corporate-form tokens stripped from a company name before searching.
+# yfinance returns full legal names ("Tencent Holdings Limited", "NVIDIA
+# Corporation"); social platforms index the bare brand, so the legal suffix
+# tanks recall and pulls in registry/compliance noise. Stripping it is a
+# general win for every ticker, CN and US alike.
+_CORP_SUFFIX_TOKENS = {
+    "inc", "incorporated", "corp", "corporation", "co", "company", "ltd",
+    "limited", "holdings", "holding", "group", "plc", "llc", "lp", "sa",
+    "ag", "nv", "se", "kgaa", "adr", "ads", "class", "cl", "the",
+}
+
+
+def normalize_search_name(name: str) -> str:
+    """Strip trailing corporate-form tokens to get a searchable brand name.
+
+    E.g. ``"Tencent Holdings Limited" → "Tencent"``,
+    ``"Kweichow Moutai Co., Ltd." → "Kweichow Moutai"``. Falls back to the
+    original name if stripping would empty it.
+    """
+    tokens = _WS.split((name or "").strip())
+    while len(tokens) > 1:
+        bare = re.sub(r"[^\w&]", "", tokens[-1]).lower()
+        if bare in _CORP_SUFFIX_TOKENS or (len(bare) == 1 and bare.isalpha()):
+            tokens.pop()
+        else:
+            break
+    cleaned = " ".join(tokens).strip(" ,.")
+    return cleaned or (name or "").strip()
+
 
 # ---------------------------------------------------------------------------
 # Industry-adaptive channel selection
@@ -303,6 +332,7 @@ def build_agentkey_social_section(
     if not is_configured():
         return ""
 
+    query = normalize_search_name(query)
     channels = select_channels(sector, industry)
     parts = [
         "### Chinese / international social platforms — via AgentKey",

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -245,6 +245,24 @@ def get_stockstats_indicator(
     return str(indicator_value)
 
 
+def get_instrument_profile(ticker: Annotated[str, "ticker symbol of the company"]) -> dict:
+    """Return ``{name, sector, industry}`` for a ticker, best-effort.
+
+    Used to drive AgentKey social-channel selection (consumer vs. not) and to
+    derive a human search name for Chinese platforms. Degrades to the ticker as
+    name and empty sector/industry on any failure, so callers never break.
+    """
+    try:
+        info = yf_retry(lambda: yf.Ticker(ticker.upper()).info) or {}
+    except Exception:
+        info = {}
+    return {
+        "name": info.get("longName") or info.get("shortName") or ticker,
+        "sector": info.get("sector") or "",
+        "industry": info.get("industry") or "",
+    }
+
+
 def get_fundamentals(
     ticker: Annotated[str, "ticker symbol of the company"],
     curr_date: Annotated[str, "current date (not used for yfinance)"] = None

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -90,6 +90,13 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "ECB Bank of England BOJ central bank policy",
         "oil commodities supply chain energy",
     ],
+    # AgentKey (https://agentkey.app/) — optional. When AGENTKEY_API_KEY is set,
+    # the sentiment analyst also pulls Chinese / international social channels
+    # (Weibo, Zhihu, and — for consumer-brand sectors — Xiaohongshu, Douyin).
+    # Leave the key empty to disable; existing US-only runs are unaffected.
+    # Note: AgentKey bills per successful call, so enabling this adds per-run cost.
+    "agentkey_api_key": os.getenv("AGENTKEY_API_KEY", ""),
+    "agentkey_base_url": os.getenv("AGENTKEY_BASE_URL", "https://api.agentkey.app"),
     # Data vendor configuration
     # Category-level configuration (default for all tools in category)
     "data_vendors": {


### PR DESCRIPTION
## Summary

Adds Chinese / international social-media sentiment to the sentiment analyst, sourced via [AgentKey](https://agentkey.app/). Today the analyst only sees US-centric sources (StockTwits, Reddit, Yahoo news), which return little to nothing for A-share / Hong Kong / China-listed or China-exposed names. This PR closes that gap:

- **Base layer (every stock):** Weibo (微博) + Zhihu (知乎) — the closest CN-market analogues to StockTwits retail chatter and Reddit-deep discussion.
- **Consumer layer (industry-gated):** Xiaohongshu (小红书) + Douyin (抖音) are added only for consumer-brand sectors (beverages, autos, consumer electronics, apparel, restaurants, …), where product buzz is a meaningful alt-data signal — and skipped for industrial / B2B / financial names where they would be noise.
- **Chinese-name resolution:** yfinance only knows CN/HK listings by their English legal name (e.g. `Tencent Holdings Limited`), which gives poor, dated recall on Chinese platforms. For `.HK / .SS / .SZ / .BJ` tickers the search name is resolved to the Chinese short name (腾讯控股, 贵州茅台) via an AgentKey web search anchored on a mainland stock forum; the English brand disambiguates code collisions (e.g. `000001` = 上证指数 vs 平安银行). US tickers just get their corporate suffix stripped (`NVIDIA Corporation` → `NVIDIA`).

### Fully optional — zero impact when unconfigured

The feature is gated behind `AGENTKEY_API_KEY`. With no key set, the analyst short-circuits **before any network call** and behaves exactly as before — no added latency, no cost, no behavior change. Crypto tickers are never affected. A regression test locks in the "no key ⇒ no network call" guarantee.

## Design

- `tradingagents/dataflows/agentkey_client.py` — thin transport over AgentKey's `POST /v1/social/dispatch` and `/v1/search` (stdlib urllib, Bearer auth, graceful degradation).
- `tradingagents/dataflows/agentkey_social.py` — per-channel fetchers, industry-adaptive channel selection, and Chinese-name resolution. Each fetcher returns a formatted plaintext block or a `<… unavailable>` placeholder, matching the existing `stocktwits.py` / `reddit.py` contract (never raises).
- `tradingagents/agents/analysts/sentiment_analyst.py` — injects the resolved channels as `<start_of_{channel}>…<end_of_{channel}>` blocks with analysis guidance.
- Config: `AGENTKEY_API_KEY` + `AGENTKEY_BASE_URL` (`default_config.py`, `.env.example`, README documented).

Parsers are built against real upstream response shapes. AgentKey bills per successful call, so enabling this adds a small per-run cost (a few cents per ticker).

## Real-world impact (illustrative: 0700.HK / Tencent)

Comparing two local runs of `0700.HK` — one before this change, one after — the new Chinese-platform data materially enriched the sentiment report and surfaced narratives the US-only sources entirely missed:

**Before (US sources only):** StockTwits returned an HTTP error and Reddit had zero posts, so the sentiment report relied *almost entirely on institutional news* and flagged its own low robustness. Conclusion: "Mixed → Moderately Bullish."

**After (+ Weibo + Zhihu):** two substantive Chinese sources added, with specific evidence — Q1 results, daily buybacks, the 775→473 price drawdown, the HK 20% dividend-tax grievance, and big-V investors' real positions (24–37% weight). New narratives that only the Chinese platforms surfaced:

- **"收租股" (rent-collector) re-pricing** (Zhihu): the core explanation for *why a low P/E isn't attracting buyers* — the market has given up on Tencent's growth premium and re-priced it as a no-growth cash cow. Absent from the old report entirely.
- **Frustrated-bulls / value-trap psychology** (Weibo): "越跌越买但越买越不涨" — strong fundamental conviction paired with price-action fatigue.
- **AI-era valuation-anchor uncertainty** (Zhihu): deep moat acknowledged, but doubt over whether Tencent can ship a WeChat-level disruptive AI product, capping the multiple.

The richer sentiment plausibly contributed to a downstream shift in the final decision (Buy → Underweight), though this is **not cleanly attributable**: the two runs also differ by one calendar day and by normal LLM variance. The honest claim is narrower and well-supported: for a HK/China name, the Chinese channels were the single largest source of *new, locally-relevant* signal, and that signal pointed at near-term price pressure that the US-only report could not see. This is exactly the gap the feature is designed to close.

## Test plan

- [x] `python -m unittest tests.test_agentkey_social` — 27 tests (channel selection, name normalization, CN-name resolution incl. code-collision disambiguation, real-shape parsing for Weibo/Zhihu, graceful degradation, and the "no key ⇒ no network call" guarantee). Network is fully mocked.
- [x] Live end-to-end verification of name resolution (`0700.HK → 腾讯控股`, `600519.SS → 贵州茅台`, `000001.SZ → 平安银行`) and Weibo/Zhihu fetching.
- [x] Confirmed unconfigured behavior: `is_configured()` False ⇒ empty section, zero network calls, no exceptions.
