### PR TITLE
fix: anchor analyst placeholder to workflow context instead of bare "Continue"

### DIFF
--- a/tests/test_agent_utils.py
+++ b/tests/test_agent_utils.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import MagicMock
+
+from langchain_core.messages import HumanMessage, RemoveMessage
+
+from tradingagents.agents.utils.agent_utils import create_msg_delete
+
+
+class CreateMsgDeleteTests(unittest.TestCase):
+    def _make_state(self, ticker="AAPL", asset_type="stock", trade_date="2026-01-15"):
+        msg = MagicMock()
+        msg.id = "msg-1"
+        return {
+            "messages": [msg],
+            "company_of_interest": ticker,
+            "asset_type": asset_type,
+            "trade_date": trade_date,
+        }
+
+    def test_placeholder_contains_ticker(self):
+        state = self._make_state(ticker="EC")
+        result = create_msg_delete()(state)
+        human_messages = [m for m in result["messages"] if hasattr(m, "content")]
+        self.assertTrue(any("`EC`" in m.content for m in human_messages))
+
+    def test_placeholder_contains_trade_date(self):
+        state = self._make_state(trade_date="2026-05-28")
+        result = create_msg_delete()(state)
+        human_messages = [m for m in result["messages"] if hasattr(m, "content")]
+        self.assertTrue(any("2026-05-28" in m.content for m in human_messages))
+
+    def test_placeholder_contains_asset_type(self):
+        state = self._make_state(asset_type="crypto")
+        result = create_msg_delete()(state)
+        human_messages = [m for m in result["messages"] if hasattr(m, "content")]
+        self.assertTrue(any("crypto" in m.content for m in human_messages))
+
+    def test_placeholder_is_not_bare_continue(self):
+        state = self._make_state()
+        result = create_msg_delete()(state)
+        human_messages = [m for m in result["messages"] if hasattr(m, "content")]
+        self.assertFalse(
+            any(m.content.strip() == "Continue" for m in human_messages),
+            "Placeholder must not be the bare word 'Continue'",
+        )
+
+    def test_removes_existing_messages(self):
+        state = self._make_state()
+        result = create_msg_delete()(state)
+        remove_ops = [m for m in result["messages"] if isinstance(m, RemoveMessage)]
+        human_ops = [m for m in result["messages"] if isinstance(m, HumanMessage)]
+        self.assertEqual(len(remove_ops), 1)
+        self.assertEqual(len(human_ops), 1)

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -66,12 +66,11 @@ def create_msg_delete():
         trade_date = state.get("trade_date", "the requested date")
         asset_type = state.get("asset_type", "stock")
 
+        instrument_context = build_instrument_context(ticker, asset_type)
         placeholder = HumanMessage(
             content=(
-                "Proceed with your assigned analysis for this workflow. "
-                f"The instrument to analyze is `{ticker}`. "
-                "Use this exact ticker in every tool call, report, and recommendation. "
-                f"The asset type is {asset_type}. "
+                f"Proceed with your assigned analysis for this workflow. "
+                f"{instrument_context} "
                 f"The analysis date is {trade_date}."
             )
         )

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -59,8 +59,22 @@ def create_msg_delete():
         # Remove all messages
         removal_operations = [RemoveMessage(id=m.id) for m in messages]
 
-        # Add a minimal placeholder message
-        placeholder = HumanMessage(content="Continue")
+        # Anchor the next analyst to the actual workflow context so that
+        # providers which interpret the placeholder literally still produce
+        # relevant output instead of reacting to the bare word "Continue".
+        ticker = state.get("company_of_interest", "the requested instrument")
+        trade_date = state.get("trade_date", "the requested date")
+        asset_type = state.get("asset_type", "stock")
+
+        placeholder = HumanMessage(
+            content=(
+                "Proceed with your assigned analysis for this workflow. "
+                f"The instrument to analyze is `{ticker}`. "
+                "Use this exact ticker in every tool call, report, and recommendation. "
+                f"The asset type is {asset_type}. "
+                f"The analysis date is {trade_date}."
+            )
+        )
 
         return {"messages": removal_operations + [placeholder]}
 


### PR DESCRIPTION
## Summary

- Replaces the static `HumanMessage(content=\"Continue\")` placeholder in `create_msg_delete` with a context-aware message built via the existing `build_instrument_context()` helper.
- Adds `tests/test_agent_utils.py` with 5 tests covering the new behaviour.

## Root cause (from #888)

After each analyst finishes, `create_msg_delete` clears the message history and inserts a bare `HumanMessage(content=\"Continue\")`. Some LLM providers — especially OpenAI-compatible proxies and models running in non-English mode — interpret this literally as the full user request, producing outputs about the word \"continue\" instead of the assigned financial analysis.

## Fix

```python
# Before
placeholder = HumanMessage(content="Continue")

# After — delegates to the existing helper, picking up the crypto hint automatically
instrument_context = build_instrument_context(ticker, asset_type)
placeholder = HumanMessage(
    content=(
        f"Proceed with your assigned analysis for this workflow. "
        f"{instrument_context} "
        f"The analysis date is {trade_date}."
    )
)
```

`build_instrument_context` already handles the crypto-specific wording (`asset` instead of `instrument`, with the \"do not assume company fundamentals\" hint), so both call sites stay in sync if the function wording ever changes.

The fields (`company_of_interest`, `asset_type`, `trade_date`) are already present in `AgentState`. A `.get()` with a safe default is used to avoid `KeyError` on any edge-case state.

## Test plan

- [x] `tests/test_agent_utils.py` — 5 unit tests pass (`pytest tests/test_agent_utils.py -v`)
  - placeholder contains ticker
  - placeholder contains trade date
  - placeholder contains asset type
  - placeholder is not the bare word \"Continue\"
  - original messages are removed and exactly one HumanMessage is returned

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)