### PR TITLE
feat: add Kimi (Moonshot AI) LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=
 XAI_API_KEY=
 DEEPSEEK_API_KEY=
+# Kimi (Moonshot AI). Keys from different consoles (moonshot.ai, kimi.com, etc.)
+# are not interchangeable. The provider defaults to https://api.moonshot.ai/v1.
+# If your key only works with a different endpoint, set KIMI_BASE_URL.
+MOONSHOT_API_KEY=
+#KIMI_BASE_URL=https://api.moonshot.cn/v1   # override if needed
 DASHSCOPE_API_KEY=
 DASHSCOPE_CN_API_KEY=
 ZHIPU_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# Git worktrees (isolated development for features like Kimi provider)
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- Native Kimi (Moonshot AI) provider support (`kimi`) with correct reasoning_content round-tripping for K2 models.
+
+### Fixed
+
+- **MiniMax M2.x reasoning models**: `reasoning_split` is now placed under
+  `extra_body` in the request payload instead of as a top-level key. This
+  prevents `TypeError: Completions.create() got an unexpected keyword
+  argument 'reasoning_split'` (and the "did you mean reasoning_effort?"
+  suggestion) when using any `MiniMax-M2.*` model. The capability guard added
+  in #826 only prevented the parameter for non-reasoning MiniMax models; the
+  actual payload construction for reasoning models was still broken because
+  langchain_openai unpacks the dict from `_get_request_payload` directly
+  into the OpenAI SDK client. Follow-up to #826.
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ export GOOGLE_API_KEY=...          # Google (Gemini)
 export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
 export XAI_API_KEY=...             # xAI (Grok)
 export DEEPSEEK_API_KEY=...        # DeepSeek
+export MOONSHOT_API_KEY=...        # Kimi (Moonshot AI) — https://platform.kimi.com/console/api-keys
 export DASHSCOPE_API_KEY=...       # Qwen — International (dashscope-intl.aliyuncs.com)
 export DASHSCOPE_CN_API_KEY=...    # Qwen — China (dashscope.aliyuncs.com)
 export ZHIPU_API_KEY=...           # GLM via Z.AI (international)
@@ -153,9 +154,17 @@ export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```
 
+> **Important for Kimi users**:
+> - Keys from different Moonshot/Kimi consoles (e.g. `platform.moonshot.ai`, `platform.kimi.com`) are **not interchangeable**.
+> - The provider defaults to `https://api.moonshot.ai/v1`.
+> - If your key only works with a different endpoint (e.g. `https://api.moonshot.cn/v1`), set the `KIMI_BASE_URL` environment variable.
+> - Generate your key from the console that matches your account.
+
 For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
+
+For Kimi (Moonshot AI), the provider defaults to `https://api.moonshot.ai/v1`. If your API key only works with a different endpoint (e.g. the China portal), set `KIMI_BASE_URL=https://api.moonshot.cn/v1`. Keys from different Moonshot/Kimi consoles are not interchangeable.
 
 Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash
@@ -213,7 +222,7 @@ from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"        # openai, google, anthropic, xai, deepseek, qwen, qwen-cn, glm, glm-cn, minimax, minimax-cn, openrouter, ollama, azure
+config["llm_provider"] = "openai"        # openai, google, anthropic, xai, deepseek, kimi, qwen, qwen-cn, glm, glm-cn, minimax, minimax-cn, openrouter, ollama, azure
 config["deep_think_llm"] = "gpt-5.4"     # Model for complex reasoning
 config["quick_think_llm"] = "gpt-5.4-mini" # Model for quick tasks
 config["max_debate_rounds"] = 2

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -274,6 +274,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("DeepSeek", "deepseek", "https://api.deepseek.com"),
         ("Qwen", "qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
+        ("Kimi", "kimi", os.environ.get("KIMI_BASE_URL") or "https://api.moonshot.ai/v1"),
         ("MiniMax", "minimax", "https://api.minimax.io/v1"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),

--- a/tests/test_kimi_reasoning.py
+++ b/tests/test_kimi_reasoning.py
@@ -1,0 +1,116 @@
+"""Tests for KimiChatOpenAI reasoning_content roundtrip behaviour.
+
+Kimi K2 models (kimi-k2.6, kimi-k2.5, ...) emit ``reasoning_content`` by default.
+This must be captured on receive and re-attached on send, or multi-turn
+tool-calling agent workflows will receive 400 errors from the API.
+"""
+
+import os
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompt_values import ChatPromptValue
+
+from tradingagents.llm_clients.openai_client import (
+    KimiChatOpenAI,
+    NormalizedChatOpenAI,
+    _input_to_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# _input_to_messages helper (same contract as DeepSeek)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestInputToMessages:
+    def test_list_input_returned_as_is(self):
+        msgs = [HumanMessage(content="hi")]
+        assert _input_to_messages(msgs) is msgs
+
+    def test_chat_prompt_value_unwrapped(self):
+        msgs = [HumanMessage(content="hi")]
+        prompt_value = ChatPromptValue(messages=msgs)
+        assert _input_to_messages(prompt_value) == msgs
+
+    def test_string_input_yields_empty_list(self):
+        assert _input_to_messages("hello") == []
+
+
+# ---------------------------------------------------------------------------
+# Reasoning content propagation (the critical Kimi requirement)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestKimiReasoningContent:
+    def _client(self):
+        os.environ.setdefault("MOONSHOT_API_KEY", "placeholder")
+        return KimiChatOpenAI(
+            model="kimi-k2.6",
+            api_key="placeholder",
+            base_url="https://api.moonshot.ai/v1",
+        )
+
+    def test_capture_on_receive(self):
+        """When the response carries reasoning_content, it lands on the
+        AIMessage's additional_kwargs so the next turn can echo it back."""
+        client = self._client()
+        result = client._create_chat_result(
+            {
+                "model": "kimi-k2.6",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Plan: buy NVDA.",
+                            "reasoning_content": "Step 1: trend is up. Step 2: ...",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            }
+        )
+        ai = result.generations[0].message
+        assert ai.additional_kwargs["reasoning_content"] == "Step 1: trend is up. Step 2: ..."
+
+    def test_propagate_on_send(self):
+        """When an outgoing AIMessage carries reasoning_content, the request
+        payload echoes it on the corresponding message dict."""
+        client = self._client()
+        prior = AIMessage(
+            content="Plan",
+            additional_kwargs={"reasoning_content": "weighed bull case"},
+        )
+        new_user = HumanMessage(content="Refine.")
+        payload = client._get_request_payload([prior, new_user])
+        assistant_dicts = [m for m in payload["messages"] if m.get("role") == "assistant"]
+        assert assistant_dicts, "assistant message missing from outgoing payload"
+        assert assistant_dicts[0]["reasoning_content"] == "weighed bull case"
+
+    def test_propagate_through_chat_prompt_value(self):
+        """Non-list inputs (ChatPromptValue) must also propagate reasoning_content."""
+        client = self._client()
+        prior = AIMessage(
+            content="Plan",
+            additional_kwargs={"reasoning_content": "weighed bull case"},
+        )
+        prompt_value = ChatPromptValue(messages=[prior, HumanMessage(content="Refine.")])
+        payload = client._get_request_payload(prompt_value)
+        assistant_dicts = [m for m in payload["messages"] if m.get("role") == "assistant"]
+        assert assistant_dicts[0]["reasoning_content"] == "weighed bull case"
+
+
+# ---------------------------------------------------------------------------
+# Base class isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBaseClassIsolation:
+    def test_normalized_does_not_propagate_reasoning_content(self):
+        """NormalizedChatOpenAI must not carry Kimi-specific behaviour."""
+        assert not hasattr(NormalizedChatOpenAI, "_get_request_payload") or (
+            NormalizedChatOpenAI._get_request_payload
+            is NormalizedChatOpenAI.__bases__[0]._get_request_payload
+        )

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,8 +1,9 @@
 """Tests for MinimaxChatOpenAI quirks.
 
-Verifies the subclass injects ``reasoning_split=True`` into outgoing
-requests so M2.x reasoning models put their <think> block into
-``reasoning_details`` instead of polluting ``message.content``.
+Verifies the subclass injects ``reasoning_split=True`` under ``extra_body``
+in the request payload for M2.x reasoning models. This ensures the
+parameter reaches the MiniMax API without triggering the OpenAI SDK's
+strict kwarg validation on ``Completions.create()`` (see #826).
 """
 
 import os
@@ -25,22 +26,28 @@ def _client(model: str = "MiniMax-M2.7"):
 
 @pytest.mark.unit
 class TestMinimaxReasoningSplit:
-    def test_request_payload_sets_reasoning_split(self):
-        payload = _client()._get_request_payload([HumanMessage(content="hi")])
-        assert payload.get("reasoning_split") is True
+    def test_request_payload_sets_reasoning_split_under_extra_body(self):
+        """reasoning_split must be nested under extra_body.
 
-    def test_caller_supplied_reasoning_split_is_preserved(self):
-        """If the user explicitly sets reasoning_split, don't override it
-        (setdefault semantics — caller wins)."""
+        Top-level keys are unpacked as kwargs to the OpenAI SDK's
+        Completions.create(), which rejects unknown parameters with
+        TypeError. Only extra_body is forwarded into the request body.
+        """
+        payload = _client()._get_request_payload([HumanMessage(content="hi")])
+        assert payload.get("reasoning_split") is None  # never at top level
+        extra_body = payload.get("extra_body") or {}
+        assert extra_body.get("reasoning_split") is True
+
+    def test_caller_supplied_reasoning_split_in_extra_body_is_preserved(self):
+        """Caller-provided value inside extra_body is left untouched."""
         client = _client()
         payload = client._get_request_payload(
             [HumanMessage(content="hi")],
-            reasoning_split=False,
+            extra_body={"reasoning_split": False, "other": 1},
         )
-        # langchain may or may not surface that kwarg into the payload;
-        # what matters is we don't blindly overwrite a non-default value
-        # the caller passed. setdefault leaves an existing value alone.
-        assert payload.get("reasoning_split") in (False, True)
+        extra_body = payload.get("extra_body") or {}
+        assert extra_body.get("reasoning_split") is False
+        assert extra_body.get("other") == 1  # other keys preserved
 
     def test_non_reasoning_minimax_does_not_inject_reasoning_split(self):
         """Coding Plan / MiniMax-Text-01 / any non-M2-prefixed model must NOT
@@ -50,9 +57,32 @@ class TestMinimaxReasoningSplit:
             payload = _client(model)._get_request_payload(
                 [HumanMessage(content="hi")]
             )
+            # Must not appear at top level
             assert "reasoning_split" not in payload, (
-                f"{model!r} payload unexpectedly contains reasoning_split"
+                f"{model!r} payload unexpectedly contains top-level reasoning_split"
             )
+            # Must not appear under extra_body either
+            eb = payload.get("extra_body") or {}
+            assert eb.get("reasoning_split") is None, (
+                f"{model!r} extra_body unexpectedly contains reasoning_split"
+            )
+
+    def test_merges_into_existing_extra_body_without_clobber(self):
+        """When extra_body already exists (e.g. from model_kwargs), we add
+        our key without removing other entries."""
+        # Simulate a client that was constructed with extra_body already set
+        # (users can do this via model_kwargs or direct kwarg in some paths).
+        os.environ.setdefault("MINIMAX_API_KEY", "placeholder")
+        client = MinimaxChatOpenAI(
+            model="MiniMax-M2.7",
+            api_key="placeholder",
+            base_url="https://api.minimax.io/v1",
+            extra_body={"ttl": 300},  # user-provided custom param
+        )
+        payload = client._get_request_payload([HumanMessage(content="hi")])
+        eb = payload.get("extra_body") or {}
+        assert eb.get("reasoning_split") is True
+        assert eb.get("ttl") == 300  # original user value kept
 
 
 @pytest.mark.unit

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -33,15 +33,17 @@ class ModelValidationTests(unittest.TestCase):
                     self.assertTrue(validate_model(provider, model))
 
     def test_unknown_model_emits_warning_for_strict_provider(self):
-        client = DummyLLMClient("openai", "not-a-real-openai-model")
+        for provider in ("openai", "kimi"):
+            with self.subTest(provider=provider):
+                client = DummyLLMClient(provider, f"not-a-real-{provider}-model")
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            client.get_llm()
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    client.get_llm()
 
-        self.assertEqual(len(caught), 1)
-        self.assertIn("not-a-real-openai-model", str(caught[0].message))
-        self.assertIn("openai", str(caught[0].message))
+                self.assertEqual(len(caught), 1)
+                self.assertIn(f"not-a-real-{provider}-model", str(caught[0].message))
+                self.assertIn(provider, str(caught[0].message))
 
     def test_openrouter_and_ollama_accept_custom_models_without_warning(self):
         for provider in ("openrouter", "ollama"):

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -51,6 +51,9 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # Pending entries are never pruned. None disables rotation entirely.
     "memory_log_max_entries": None,
     # LLM settings
+    # Supported llm_provider values (see also CLI and factory):
+    # openai, google, anthropic, xai, deepseek, kimi, qwen, qwen-cn, glm, glm-cn,
+    # minimax, minimax-cn, openrouter, ollama, azure
     "llm_provider": "openai",
     "deep_think_llm": "gpt-5.4",
     "quick_think_llm": "gpt-5.4-mini",

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -21,6 +21,7 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "azure":      "AZURE_OPENAI_API_KEY",
     "xai":        "XAI_API_KEY",
     "deepseek":   "DEEPSEEK_API_KEY",
+    "kimi":       "MOONSHOT_API_KEY",
     # Dual-region providers each carry their own account; keys are not
     # interchangeable between the international and China endpoints.
     "qwen":       "DASHSCOPE_API_KEY",

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -83,6 +83,14 @@ _MINIMAX_THINKING = ModelCapabilities(
     requires_reasoning_split=True,
 )
 
+_KIMI_THINKING = ModelCapabilities(
+    supports_tool_choice=True,
+    supports_json_mode=True,
+    supports_json_schema=True,
+    preferred_structured_method="function_calling",
+    requires_reasoning_content_roundtrip=True,
+)
+
 _DEFAULT = ModelCapabilities(
     supports_tool_choice=True,
     supports_json_mode=True,
@@ -106,6 +114,8 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "MiniMax-M2.1": _MINIMAX_THINKING,
     "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
     "MiniMax-M2": _MINIMAX_THINKING,
+    "kimi-k2.6": _KIMI_THINKING,
+    "kimi-k2.5": _KIMI_THINKING,
 }
 
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
@@ -114,6 +124,8 @@ _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
     (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    (re.compile(r"^kimi-k2"), _KIMI_THINKING),
+    (re.compile(r"^kimi-thinking"), _KIMI_THINKING),
 ]
 
 

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -9,6 +9,7 @@ _OPENAI_COMPATIBLE = (
     "glm", "glm-cn",
     "minimax", "minimax-cn",
     "ollama", "openrouter",
+    "kimi",
 )
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -72,6 +72,19 @@ _MINIMAX_MODELS: Dict[str, List[ModelOption]] = {
     ],
 }
 
+# Kimi (Moonshot AI) — single endpoint, excellent long-context + tool use.
+# kimi-k2.6 is the current flagship (256K context). Thinking is enabled by default
+# on K2 models and emits reasoning_content (must be round-tripped).
+_KIMI_MODELS: Dict[str, List[ModelOption]] = {
+    "quick": [
+        ("Kimi K2.5 - Fast, strong agentic performance", "kimi-k2.5"),
+        ("Custom model ID", "custom"),
+    ],
+    "deep": [
+        ("Kimi K2.6 - Flagship, 256K context, best reasoning & tool use", "kimi-k2.6"),
+        ("Custom model ID", "custom"),
+    ],
+}
 
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
@@ -153,6 +166,7 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # so the two provider keys share one model list.
     "minimax": _MINIMAX_MODELS,
     "minimax-cn": _MINIMAX_MODELS,
+    "kimi": _KIMI_MODELS,
     # OpenRouter: fetched dynamically. Azure: any deployed model name.
     # Ollama display labels intentionally omit a "local" marker — the
     # endpoint is now configurable via OLLAMA_BASE_URL, so the same labels

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -118,10 +118,13 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     ``reasoning_split=True`` in the request body redirects the thinking
     block into ``reasoning_details`` so ``content`` stays clean.
 
+    The value is placed under ``extra_body`` (not as a top-level key) so
+    that langchain_openai's ``create(**payload)`` call does not pass an
+    unknown kwarg to the OpenAI SDK, which rejects it with TypeError.
+
     The flag is gated by ``ModelCapabilities.requires_reasoning_split``
     because non-reasoning MiniMax endpoints (Coding Plan, MiniMax-Text-01)
-    reject the parameter via the openai SDK's strict kwarg validation
-    (#826).
+    reject the parameter via the openai SDK's strict validation (#826).
 
     Tool-choice handling for M2.x — those models accept only the string
     enum ``{"none", "auto"}`` and reject langchain's function-spec dict —
@@ -132,8 +135,53 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         if get_capabilities(self.model_name).requires_reasoning_split:
-            payload.setdefault("reasoning_split", True)
+            # Provider-specific params must go under extra_body so the
+            # OpenAI SDK's create(**payload) call does not receive unknown
+            # top-level kwargs (which raises TypeError).
+            extra_body = payload.setdefault("extra_body", {})
+            if isinstance(extra_body, dict):
+                extra_body.setdefault("reasoning_split", True)
         return payload
+
+
+class KimiChatOpenAI(NormalizedChatOpenAI):
+    """Kimi-specific overrides.
+
+    K2 models (kimi-k2.6, kimi-k2.5, etc.) emit ``reasoning_content`` by default
+    when thinking is active. This must be echoed back on subsequent turns for
+    multi-turn tool calling to succeed — identical requirement to DeepSeek.
+
+    The roundtrip logic is safe (and a no-op) for legacy moonshot-v1-* models
+    that do not emit reasoning_content.
+    """
+
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        outgoing = payload.get("messages", [])
+        for message_dict, message in zip(outgoing, _input_to_messages(input_)):
+            if not isinstance(message, AIMessage):
+                continue
+            reasoning = message.additional_kwargs.get("reasoning_content")
+            if reasoning is not None:
+                message_dict["reasoning_content"] = reasoning
+        return payload
+
+    def _create_chat_result(self, response, generation_info=None):
+        chat_result = super()._create_chat_result(response, generation_info)
+        response_dict = (
+            response
+            if isinstance(response, dict)
+            else response.model_dump(
+                exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+            )
+        )
+        for generation, choice in zip(
+            chat_result.generations, response_dict.get("choices", [])
+        ):
+            reasoning = choice.get("message", {}).get("reasoning_content")
+            if reasoning is not None:
+                generation.message.additional_kwargs["reasoning_content"] = reasoning
+        return chat_result
 
 
 # Kwargs forwarded from user config to ChatOpenAI
@@ -156,6 +204,7 @@ _PROVIDER_BASE_URL = {
     "glm-cn":     "https://open.bigmodel.cn/api/paas/v4/",
     "minimax":    "https://api.minimax.io/v1",
     "minimax-cn": "https://api.minimaxi.com/v1",
+    "kimi":       "https://api.moonshot.ai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama":     "http://localhost:11434/v1",
 }
@@ -166,12 +215,19 @@ def _resolve_provider_base_url(provider: str) -> Optional[str]:
 
     Currently only Ollama supports an env-var override (``OLLAMA_BASE_URL``),
     matching the convention in the broader Ollama tooling ecosystem so users
-    can point at a remote ollama-serve without editing code. The check is
-    call-time, not import-time, so tests that monkeypatch the env after
-    import behave correctly.
+    can point at a remote ollama-serve without editing code. Kimi also supports
+    an override via ``KIMI_BASE_URL`` because Moonshot operates multiple
+    consoles whose keys are not interchangeable and may require different
+    API endpoints (e.g. api.moonshot.ai vs api.moonshot.cn).
+    The check is call-time, not import-time, so tests that monkeypatch the
+    env after import behave correctly.
     """
     if provider == "ollama":
         env_url = os.environ.get("OLLAMA_BASE_URL")
+        if env_url:
+            return env_url
+    if provider == "kimi":
+        env_url = os.environ.get("KIMI_BASE_URL")
         if env_url:
             return env_url
     return _PROVIDER_BASE_URL.get(provider)
@@ -238,6 +294,8 @@ class OpenAIClient(BaseLLMClient):
             chat_cls = DeepSeekChatOpenAI
         elif self.provider in ("minimax", "minimax-cn"):
             chat_cls = MinimaxChatOpenAI
+        elif self.provider == "kimi":
+            chat_cls = KimiChatOpenAI
         else:
             chat_cls = NormalizedChatOpenAI
         return chat_cls(**llm_kwargs)


### PR DESCRIPTION
## Summary

Adds support for **Kimi (Moonshot AI)** as an LLM provider (`kimi`).

### Changes
- New provider using the OpenAI-compatible API
- Default endpoint: `https://api.moonshot.ai/v1`
- Proper `reasoning_content` roundtripping for K2 models (required for multi-turn agent workflows)
- Supports `KIMI_BASE_URL` override for users whose keys come from other Moonshot consoles (e.g. `api.moonshot.cn`)
- Added to CLI + model catalog
- Documentation and CHANGELOG updated

### Configuration
- API Key: `MOONSHOT_API_KEY`
- Optional override: `KIMI_BASE_URL`

### Notes
Keys from different Moonshot/Kimi consoles are not interchangeable. The provider defaults to the `.ai` portal.

## Testing
- Added `tests/test_kimi_reasoning.py`
- Full CLI flow + live calls verified
