### PR TITLE
feat(sentiment): add Bluesky, Mastodon & Fear & Greed sources (free, no-auth)

### DIFF
--- a/tests/test_sentiment_sources.py
+++ b/tests/test_sentiment_sources.py
@@ -1,0 +1,160 @@
+"""Unit tests for the expanded sentiment analyst: Bluesky + Mastodon fetchers
+and verification that all six data sources are wired into the prompt."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError
+
+import pytest
+
+import tradingagents.dataflows.bluesky as bluesky_mod
+import tradingagents.dataflows.mastodon as mastodon_mod
+from tradingagents.agents.analysts.sentiment_analyst import (
+    _build_system_message,
+    create_sentiment_analyst,
+)
+
+
+def _mock_urlopen(payload):
+    """Return a context-manager mock whose read() yields json-encoded payload."""
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+    return cm
+
+
+# ─── Bluesky fetcher ─────────────────────────────────────────────────────────
+
+
+class TestBlueskyFetcher:
+    @pytest.mark.unit
+    def test_parses_posts(self):
+        payload = {"posts": [{
+            "author": {"handle": "trader.bsky.social"},
+            "record": {"createdAt": "2026-05-28T10:00:00Z", "text": "Loading up on $NVDA"},
+            "likeCount": 12, "repostCount": 3, "replyCount": 1,
+        }]}
+        with patch.object(bluesky_mod, "urlopen", return_value=_mock_urlopen(payload)):
+            out = bluesky_mod.fetch_bluesky_posts("$NVDA")
+        assert "trader.bsky.social" in out
+        assert "Loading up on $NVDA" in out
+        assert "12♥" in out
+
+    @pytest.mark.unit
+    def test_empty_results_placeholder(self):
+        with patch.object(bluesky_mod, "urlopen", return_value=_mock_urlopen({"posts": []})):
+            out = bluesky_mod.fetch_bluesky_posts("$ZZZZ")
+        assert out.startswith("<no Bluesky posts found")
+
+    @pytest.mark.unit
+    def test_http_error_degrades_gracefully(self):
+        err = HTTPError("url", 403, "Forbidden", {}, None)
+        with patch.object(bluesky_mod, "urlopen", side_effect=err):
+            out = bluesky_mod.fetch_bluesky_posts("$NVDA")
+        assert out == "<bluesky unavailable: HTTPError>"
+
+
+# ─── Mastodon fetcher ────────────────────────────────────────────────────────
+
+
+class TestMastodonFetcher:
+    @pytest.mark.unit
+    def test_parses_posts_and_strips_html(self):
+        payload = [{
+            "account": {"acct": "fintwit@mastodon.social"},
+            "created_at": "2026-05-28T10:00:00Z",
+            "content": "<p>Bullish on <b>NVDA</b></p>",
+            "favourites_count": 5, "reblogs_count": 2, "replies_count": 1,
+        }]
+        with patch.object(mastodon_mod, "urlopen", return_value=_mock_urlopen(payload)):
+            out = mastodon_mod.fetch_mastodon_posts("NVDA")
+        assert "fintwit@mastodon.social" in out
+        assert "Bullish on NVDA" in out  # HTML tags stripped
+        assert "<p>" not in out
+
+    @pytest.mark.unit
+    def test_empty_results_placeholder(self):
+        with patch.object(mastodon_mod, "urlopen", return_value=_mock_urlopen([])):
+            out = mastodon_mod.fetch_mastodon_posts("ZZZZ")
+        assert out.startswith("<no Mastodon posts found")
+
+    @pytest.mark.unit
+    def test_invalid_tag_placeholder(self):
+        out = mastodon_mod.fetch_mastodon_posts("$$$")
+        assert out.startswith("<no Mastodon posts: invalid tag")
+
+    @pytest.mark.unit
+    def test_http_error_degrades_gracefully(self):
+        err = HTTPError("url", 500, "err", {}, None)
+        with patch.object(mastodon_mod, "urlopen", side_effect=err):
+            out = mastodon_mod.fetch_mastodon_posts("NVDA")
+        assert out == "<mastodon unavailable: HTTPError>"
+
+
+# ─── Prompt wiring ───────────────────────────────────────────────────────────
+
+
+class TestPromptWiring:
+    @pytest.mark.unit
+    def test_all_six_blocks_present(self):
+        msg = _build_system_message(
+            ticker="NVDA", start_date="2026-05-22", end_date="2026-05-29",
+            news_block="NEWS_X", stocktwits_block="ST_X", reddit_block="RD_X",
+            bluesky_block="BSKY_X", mastodon_block="MASTO_X", fear_greed_block="FG_X",
+        )
+        for tag in ("news", "stocktwits", "reddit", "bluesky", "mastodon", "fear_greed"):
+            assert f"<start_of_{tag}>" in msg and f"<end_of_{tag}>" in msg
+        for data in ("NEWS_X", "ST_X", "RD_X", "BSKY_X", "MASTO_X", "FG_X"):
+            assert data in msg
+
+    @pytest.mark.unit
+    def test_breakdown_lists_new_sources(self):
+        msg = _build_system_message(
+            ticker="NVDA", start_date="2026-05-22", end_date="2026-05-29",
+            news_block="", stocktwits_block="", reddit_block="",
+        )
+        assert "Bluesky" in msg and "Mastodon" in msg and "Fear & Greed" in msg
+
+
+# ─── Node integration ────────────────────────────────────────────────────────
+
+
+class TestSentimentNode:
+    @pytest.mark.unit
+    def test_node_injects_all_fetchers_into_prompt(self):
+        from langchain_core.runnables import RunnableLambda
+
+        captured = {}
+
+        # A real Runnable so `prompt | llm` builds a valid sequence; it
+        # records the fully-rendered prompt the LLM would receive.
+        def _capture(prompt_value):
+            captured["text"] = prompt_value.to_string()
+            return MagicMock(content="report")
+
+        fake_llm = RunnableLambda(_capture)
+
+        with patch("tradingagents.agents.analysts.sentiment_analyst.get_news") as gn, \
+             patch("tradingagents.agents.analysts.sentiment_analyst.fetch_stocktwits_messages", return_value="ST_DATA"), \
+             patch("tradingagents.agents.analysts.sentiment_analyst.fetch_reddit_posts", return_value="RD_DATA"), \
+             patch("tradingagents.agents.analysts.sentiment_analyst.fetch_bluesky_posts", return_value="BSKY_DATA") as fb, \
+             patch("tradingagents.agents.analysts.sentiment_analyst.fetch_mastodon_posts", return_value="MASTO_DATA") as fm, \
+             patch("tradingagents.agents.analysts.sentiment_analyst.get_fear_greed_index", return_value="FG_DATA") as fg:
+            gn.func.return_value = "NEWS_DATA"
+
+            node = create_sentiment_analyst(fake_llm)
+            state = {
+                "company_of_interest": "NVDA",
+                "trade_date": "2026-05-29",
+                "messages": [],
+            }
+            result = node(state)
+
+        # Fetchers called with the expected ticker-derived args.
+        fb.assert_called_once_with("$NVDA")
+        fm.assert_called_once_with("NVDA")
+        fg.assert_called_once()
+        # Every source's data made it into the rendered prompt.
+        for data in ("NEWS_DATA", "ST_DATA", "RD_DATA", "BSKY_DATA", "MASTO_DATA", "FG_DATA"):
+            assert data in captured["text"]
+        assert result["sentiment_report"] == "report"

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -5,13 +5,19 @@ the old version had a prompt that demanded social-media analysis but the
 only tool available was Yahoo Finance news — which led LLMs to fabricate
 Reddit/X/StockTwits content under prompt pressure (verified live).
 
-The redesigned agent pre-fetches three complementary data sources before
-the LLM is invoked and injects them into the prompt as structured blocks:
+The redesigned agent pre-fetches several complementary data sources
+before the LLM is invoked and injects them into the prompt as structured
+blocks:
 
-  1. News headlines     — Yahoo Finance (institutional framing)
-  2. StockTwits messages — retail-trader posts indexed by cashtag, with
-                           user-labeled Bullish/Bearish sentiment tags
-  3. Reddit posts        — r/wallstreetbets, r/stocks, r/investing
+  1. News headlines      — Yahoo Finance (institutional framing)
+  2. StockTwits messages  — retail-trader posts indexed by cashtag, with
+                            user-labeled Bullish/Bearish sentiment tags
+  3. Reddit posts         — r/wallstreetbets, r/stocks, r/investing
+  4. Bluesky posts        — decentralized X/Twitter alternative (keyword)
+  5. Mastodon posts       — federated public hashtag timeline
+  6. Fear & Greed Index   — aggregate market-mood proxy (0-100)
+
+All sources use free, no-auth public endpoints and degrade gracefully.
 
 The agent does not use tool-calling; the data is in the prompt from
 turn 0. The LLM produces the sentiment report in a single invocation.
@@ -27,6 +33,9 @@ from tradingagents.agents.utils.agent_utils import (
     get_language_instruction,
     get_news,
 )
+from tradingagents.dataflows.bluesky import fetch_bluesky_posts
+from tradingagents.dataflows.fear_greed import get_fear_greed_index
+from tradingagents.dataflows.mastodon import fetch_mastodon_posts
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
 
@@ -38,9 +47,9 @@ def _seven_days_back(trade_date: str) -> str:
 def create_sentiment_analyst(llm):
     """Create a sentiment analyst node for the trading graph.
 
-    Pre-fetches news + StockTwits + Reddit data, injects them into the
-    prompt as structured blocks, and produces a sentiment report in a
-    single LLM call.
+    Pre-fetches news + StockTwits + Reddit + Bluesky + Mastodon + Fear &
+    Greed data, injects them into the prompt as structured blocks, and
+    produces a sentiment report in a single LLM call.
     """
 
     def sentiment_analyst_node(state):
@@ -55,6 +64,11 @@ def create_sentiment_analyst(llm):
         news_block = get_news.func(ticker, start_date, end_date)
         stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
         reddit_block = fetch_reddit_posts(ticker)
+        # Bluesky (X/Twitter alternative) + Mastodon: free, no-auth public
+        # endpoints. Fear & Greed: aggregate market-mood proxy.
+        bluesky_block = fetch_bluesky_posts(f"${ticker}")
+        mastodon_block = fetch_mastodon_posts(ticker)
+        fear_greed_block = get_fear_greed_index()
 
         system_message = _build_system_message(
             ticker=ticker,
@@ -63,6 +77,9 @@ def create_sentiment_analyst(llm):
             news_block=news_block,
             stocktwits_block=stocktwits_block,
             reddit_block=reddit_block,
+            bluesky_block=bluesky_block,
+            mastodon_block=mastodon_block,
+            fear_greed_block=fear_greed_block,
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -104,9 +121,12 @@ def _build_system_message(
     news_block: str,
     stocktwits_block: str,
     reddit_block: str,
+    bluesky_block: str = "",
+    mastodon_block: str = "",
+    fear_greed_block: str = "",
 ) -> str:
     """Assemble the sentiment-analyst system message with structured data blocks."""
-    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on three complementary data sources that have already been collected for you.
+    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on multiple complementary data sources that have already been collected for you.
 
 ## Data sources (pre-fetched, in this prompt)
 
@@ -131,6 +151,27 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 {reddit_block}
 <end_of_reddit>
 
+### Bluesky posts — decentralized X/Twitter alternative (keyword search)
+Fast-moving retail signal; much of "fintwit" now cross-posts here. Engagement via likes / reposts / replies.
+
+<start_of_bluesky>
+{bluesky_block}
+<end_of_bluesky>
+
+### Mastodon posts — federated network, public hashtag timeline
+Smaller but less manipulated community signal. Engagement via favourites / boosts / replies.
+
+<start_of_mastodon>
+{mastodon_block}
+<end_of_mastodon>
+
+### Fear & Greed Index — aggregate market mood (0–100)
+Macro risk-on/risk-off proxy. Extreme readings can be contrarian signals.
+
+<start_of_fear_greed>
+{fear_greed_block}
+<end_of_fear_greed>
+
 ## How to analyze this data (best practices)
 
 1. **Read the StockTwits Bullish/Bearish ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
@@ -154,7 +195,7 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 Produce a sentiment report covering, in order:
 
 1. **Overall sentiment direction** — Bullish / Bearish / Neutral / Mixed — with a brief confidence note based on data quality and sample size.
-2. **Source-by-source breakdown** — what each of news / StockTwits / Reddit is telling you, with specific evidence (cite message counts, ratios, notable posts).
+2. **Source-by-source breakdown** — what each of news / StockTwits / Reddit / Bluesky / Mastodon / Fear & Greed is telling you, with specific evidence (cite message counts, ratios, notable posts).
 3. **Divergences, alignments, and key narratives** across sources.
 4. **Catalysts and risks** surfaced by the data.
 5. **Markdown table** at the end summarizing key sentiment signals, their direction, source, and supporting evidence.

--- a/tradingagents/dataflows/bluesky.py
+++ b/tradingagents/dataflows/bluesky.py
@@ -1,0 +1,62 @@
+"""Bluesky public post-search fetcher.
+
+Bluesky's AT Protocol exposes a keyword post search at
+``public.api.bsky.app/xrpc/app.bsky.feed.searchPosts`` that requires no
+API key and no auth. Each post carries text, author handle, timestamp,
+and engagement counts (likes / reposts / replies).
+
+Mirrors the stocktwits/reddit fetchers: short timeout, graceful
+degradation on any HTTP or parse failure, and a string return type so
+the calling agent gets a uniform interface regardless of outcome.
+
+Note: some network edges/CDNs geo-block ``searchPosts``; on failure the
+function returns a placeholder string rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+_API = "https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts?{qs}"
+_UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
+
+
+def fetch_bluesky_posts(query: str, limit: int = 25, timeout: float = 10.0) -> str:
+    """Search Bluesky for recent posts matching ``query`` (e.g. ``$NVDA`` or
+    ``Bitcoin``) and return them as a prompt-ready plaintext block.
+
+    Returns a placeholder string when the endpoint is unreachable, the
+    query has no results, or the response shape is unexpected.
+    """
+    qs = urlencode({"q": query, "limit": max(1, min(limit, 100)), "sort": "latest"})
+    req = Request(_API.format(qs=qs), headers={"User-Agent": _UA, "Accept": "application/json"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as exc:
+        logger.warning("Bluesky fetch failed for %s: %s", query, exc)
+        return f"<bluesky unavailable: {type(exc).__name__}>"
+
+    posts = data.get("posts", []) if isinstance(data, dict) else []
+    if not posts:
+        return f"<no Bluesky posts found for '{query}'>"
+
+    lines = [f"Bluesky — {len(posts)} recent posts matching '{query}':"]
+    for p in posts[:limit]:
+        author = (p.get("author") or {}).get("handle", "?")
+        record = p.get("record") or {}
+        created = record.get("createdAt", "")[:10] or "?"
+        text = (record.get("text") or "").replace("\n", " ").strip()
+        if len(text) > 280:
+            text = text[:280] + "…"
+        likes = p.get("likeCount", 0)
+        reposts = p.get("repostCount", 0)
+        replies = p.get("replyCount", 0)
+        lines.append(f"  [{created} · @{author} · {likes}♥ {reposts}↻ {replies}c] {text}")
+    return "\n".join(lines)

--- a/tradingagents/dataflows/fear_greed.py
+++ b/tradingagents/dataflows/fear_greed.py
@@ -1,0 +1,71 @@
+"""Alternative.me Fear & Greed Index fetcher.
+
+No API key required. Returns current crypto market sentiment on 0-100 scale.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_CACHE: Optional[tuple[float, str]] = None
+_CACHE_TTL = 3600  # 1 hour (index updates daily)
+
+
+def get_fear_greed_index() -> str:
+    """Return the current Crypto Fear & Greed Index as a formatted string."""
+    global _CACHE
+    now = time.time()
+    if _CACHE and (now - _CACHE[0]) < _CACHE_TTL:
+        return _CACHE[1]
+
+    try:
+        resp = requests.get(
+            "https://api.alternative.me/fng/?limit=7",
+            timeout=10,
+            headers={"accept": "application/json"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        entries = data.get("data", [])
+        if not entries:
+            return "Fear & Greed Index: data unavailable."
+
+        current = entries[0]
+        value = int(current.get("value", 0))
+        classification = current.get("value_classification", "Unknown")
+
+        # Build 7-day trend
+        trend_lines = []
+        for e in entries[:7]:
+            v = e.get("value", "?")
+            c = e.get("value_classification", "?")
+            trend_lines.append(f"  - {c} ({v})")
+
+        result = (
+            f"## Crypto Fear & Greed Index\n\n"
+            f"**Current**: {value}/100 — {classification}\n"
+            f"**Interpretation**: "
+            + (
+                "Extreme Fear — potential contrarian buy signal; market may be oversold."
+                if value < 25 else
+                "Fear — cautious sentiment; watch for reversal signals."
+                if value < 45 else
+                "Neutral — balanced market sentiment."
+                if value < 55 else
+                "Greed — positive momentum; watch for overextension."
+                if value < 75 else
+                "Extreme Greed — market may be overheated; caution advised."
+            )
+            + "\n\n**7-Day Trend** (most recent first):\n"
+            + "\n".join(trend_lines)
+        )
+        _CACHE = (now, result)
+        return result
+    except Exception as exc:
+        logger.warning("Fear & Greed Index fetch failed: %s", exc)
+        return "Fear & Greed Index: data unavailable (network error)."

--- a/tradingagents/dataflows/mastodon.py
+++ b/tradingagents/dataflows/mastodon.py
@@ -1,0 +1,69 @@
+"""Mastodon public hashtag-timeline fetcher.
+
+Mastodon instances expose a public hashtag timeline at
+``{instance}/api/v1/timelines/tag/{tag}`` that requires no API key and no
+auth. Default instance is ``mastodon.social`` (override via the
+``MASTODON_INSTANCE`` env var).
+
+Mirrors the stocktwits/reddit fetchers: short timeout, graceful
+degradation on any HTTP or parse failure, and a string return type.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+_UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
+_TAG_RE = re.compile(r"[^A-Za-z0-9]")
+_HTML_RE = re.compile(r"<[^>]+>")
+
+
+def _instance() -> str:
+    return os.environ.get("MASTODON_INSTANCE", "https://mastodon.social").rstrip("/")
+
+
+def fetch_mastodon_posts(tag: str, limit: int = 25, timeout: float = 10.0) -> str:
+    """Fetch recent public posts for hashtag ``tag`` (ticker name, symbols
+    stripped) and return them as a prompt-ready plaintext block.
+
+    Returns a placeholder string when the endpoint is unreachable, the
+    tag has no posts, or the response shape is unexpected.
+    """
+    clean = _TAG_RE.sub("", tag)
+    if not clean:
+        return f"<no Mastodon posts: invalid tag '{tag}'>"
+    qs = urlencode({"limit": max(1, min(limit, 40))})
+    url = f"{_instance()}/api/v1/timelines/tag/{clean}?{qs}"
+    req = Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as exc:
+        logger.warning("Mastodon fetch failed for #%s: %s", clean, exc)
+        return f"<mastodon unavailable: {type(exc).__name__}>"
+
+    if not isinstance(data, list) or not data:
+        return f"<no Mastodon posts found for #{clean}>"
+
+    lines = [f"Mastodon — {len(data)} recent posts tagged #{clean}:"]
+    for s in data[:limit]:
+        if not isinstance(s, dict):
+            continue
+        acct = (s.get("account") or {}).get("acct", "?")
+        created = (s.get("created_at") or "")[:10] or "?"
+        body = _HTML_RE.sub("", s.get("content") or "").replace("\n", " ").strip()
+        if len(body) > 280:
+            body = body[:280] + "…"
+        favs = s.get("favourites_count", 0)
+        boosts = s.get("reblogs_count", 0)
+        replies = s.get("replies_count", 0)
+        lines.append(f"  [{created} · @{acct} · {favs}♥ {boosts}↻ {replies}c] {body}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Expands the **Sentiment Analyst** from 3 to 6 pre-fetched data sources, all using **free, no-auth public endpoints** (no API keys, no config). Today the analyst sees only news + StockTwits + Reddit; this adds three complementary signals:

- **Bluesky** — AT Protocol public `searchPosts` (the decentralized X/Twitter alternative where much of "fintwit" now cross-posts)
- **Mastodon** — public hashtag timeline (`MASTODON_INSTANCE` env var override, defaults to mastodon.social)
- **Fear & Greed Index** — alternative.me aggregate market-mood proxy (0–100)

## Design

Each fetcher mirrors the existing `stocktwits.py` / `reddit.py` pattern, so it fits the analyst's deliberate **no-tool-calling, pre-fetch** design (issue #557):

- short timeout, **no exceptions surface** — always returns a prompt-ready string (real data or a clear `<unavailable>` placeholder)
- new structured blocks injected into the prompt; the source-by-source breakdown instruction is updated to mention them

The analyst keeps producing its report in a single LLM invocation. If a source is unreachable, the prompt already instructs the model to flag the data-limit caveat.

## Tests

Adds `tests/test_sentiment_sources.py`:
- Bluesky + Mastodon fetchers: parsing, empty-result placeholders, graceful HTTP-error degradation
- analyst node: all six sources reach the rendered prompt

All new files are lint-clean (ruff). Pre-existing failures in `test_ollama_base_url.py` are unrelated to this change (they fail on a pristine checkout too).

## Notes

- Zero new dependencies; no API keys required.
- Related but distinct from #916 (Chinese/intl channels via AgentKey, opt-in/keyed) — this PR is the free, global/Western counterpart and is complementary.
