### PR TITLE
Add default configuration memory

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import datetime
+import json
 import typer
 import questionary
 from pathlib import Path
@@ -462,6 +463,28 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     layout["footer"].update(Panel(stats_table, border_style="grey50"))
 
 
+CONFIG_DIR = Path.home() / ".tradingagents"
+CONFIG_FILE = CONFIG_DIR / "default_config.json"
+
+
+def load_default_config():
+    if not CONFIG_FILE.exists():
+        return None
+
+    try:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def save_default_config(cfg):
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
 def get_user_selections():
     """Get all user selections before starting the analysis display."""
     # Display ASCII art welcome message
@@ -492,6 +515,21 @@ def get_user_selections():
     # Fetch and display announcements (silent on failure)
     announcements = fetch_announcements()
     display_announcements(console, announcements)
+
+    saved_config = load_default_config()
+
+    if saved_config:
+        use_saved = questionary.select(
+            "Configuration found:",
+            choices=[
+                questionary.Choice("Use saved configuration", value=True),
+                questionary.Choice("Configure manually", value=False),
+            ],
+        ).ask()
+
+        if use_saved:
+            console.print("[green]Using saved configuration[/green]")
+            return saved_config
 
     # Create a boxed questionnaire for each step
     def create_question_box(title, prompt, default=None):
@@ -622,11 +660,11 @@ def get_user_selections():
         )
         anthropic_effort = ask_anthropic_effort()
 
-    return {
+    config_data = {
         "ticker": selected_ticker,
         "asset_type": asset_type.value,
         "analysis_date": analysis_date,
-        "analysts": selected_analysts,
+        "analysts": [analyst.value for analyst in selected_analysts],
         "research_depth": selected_research_depth,
         "llm_provider": selected_llm_provider.lower(),
         "backend_url": backend_url,
@@ -637,6 +675,10 @@ def get_user_selections():
         "anthropic_effort": anthropic_effort,
         "output_language": output_language,
     }
+
+    save_default_config(config_data)
+
+    return config_data
 
 
 def get_ticker():
@@ -997,7 +1039,10 @@ def run_analysis(checkpoint: bool = False):
     stats_handler = StatsCallbackHandler()
 
     # Normalize analyst selection to predefined order (selection is a 'set', order is fixed)
-    selected_set = {analyst.value for analyst in selections["analysts"]}
+    selected_set = {
+        analyst.value if hasattr(analyst, "value") else analyst
+        for analyst in selections["analysts"]
+    }
     selected_analyst_keys = [a for a in ANALYST_ORDER if a in selected_set]
     analyst_execution_plan = build_analyst_execution_plan(
         selected_analyst_keys,
@@ -1082,7 +1127,7 @@ def run_analysis(checkpoint: bool = False):
         )
         message_buffer.add_message(
             "System",
-            f"Selected analysts: {', '.join(analyst.value for analyst in selections['analysts'])}",
+            f"Selected analysts: {', '.join(analyst.value if hasattr(analyst, 'value') else analyst for analyst in selections['analysts'])}",
         )
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 


### PR DESCRIPTION


## What this PR does

This PR adds a small local config memory for the interactive CLI setup.

Right now, whenever users start the TradingAgents CLI, they have to manually select the same options again and again like ticker, analysts, research depth, provider, models, output language etc. This gets repetative for daily usage.

With this change, after the user completes the setup once, the selected configuration is saved locally in:

```bash
~/.tradingagents/default_config.json
```

Next time when the CLI starts, it checks if this saved config exists and asks the user if they want to reuse it or configure everything manually again.

## Changes made

* Added local default config save/load logic
* Added startup prompt when saved config exists
* Added option to use saved configuration directly
* Added option to configure manually again
* Manual configuration overwrites the old saved config
* Converted selected analysts into JSON safe values before saving
* Updated analysis flow to support saved analyst values also

## Why this is useful

This should reduce repeated manual selections for users who mostly run the CLI with same settings. It keeps the existing manual flow same, but gives users a faster path after first setup.

This is mostly focused on improving CLI user experience and fixing the repeated config selection issue.

## Testing done

I tested it manually with the CLI.

First I removed old saved config:

```bash
rm -f ~/.tradingagents/default_config.json
```

Then I ran the CLI:

```bash
python -m cli.main
```

I completed the setup manually once and verified that config file was created:

```bash
cat ~/.tradingagents/default_config.json
```

Then I ran the CLI again:

```bash
python -m cli.main
```

It showed the saved config prompt and I was able to choose:

```txt
Use saved configuration
```

Also checked the file compiles:

```bash
python -m compileall cli/main.py
```

## Notes

The config is stored locally in user's home folder, so it does not touch project files or git tracked files.

Fixes #920

<img width="936" height="733" alt="Screenshot 2026-05-31 193106" src="https://github.com/user-attachments/assets/cddf38e0-9830-441f-84a6-ecabdc9b70f8" />
