### PR TITLE
Add NVIDIA NIM provider support

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -275,6 +275,7 @@ def select_llm_provider() -> tuple[str, str | None]:
         ("Qwen", "qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
         ("MiniMax", "minimax", "https://api.minimax.io/v1"),
+        ("NVIDIA NIM", "nvidia_nim", "https://integrate.api.nvidia.com/v1"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", ollama_url),

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -29,6 +29,7 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "glm-cn":     "ZHIPU_CN_API_KEY",
     "minimax":    "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",
+    "nvidia_nim": "NVIDIA_NIM_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -8,7 +8,7 @@ _OPENAI_COMPATIBLE = (
     "qwen", "qwen-cn",
     "glm", "glm-cn",
     "minimax", "minimax-cn",
-    "ollama", "openrouter",
+    "ollama", "openrouter","nvidia_nim",
 )
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -73,6 +73,31 @@ _MINIMAX_MODELS: Dict[str, List[ModelOption]] = {
 }
 
 
+
+# NVIDIA NIM exposes an OpenAI-compatible endpoint at
+# https://integrate.api.nvidia.com/v1. These are the suggested model IDs
+# from the provider request, while "Custom model ID" keeps the flow usable
+# for any other NIM-hosted model.
+_NVIDIA_NIM_MODELS: Dict[str, List[ModelOption]] = {
+    "quick": [
+        ("DeepSeek V4 Flash Free", "z-ai/deepseek-v4-flash-free"),
+        ("Kimi K2.6", "z-ai/kimi-k2.6"),
+        ("MiniMax M2.7", "z-ai/minimax-m2.7"),
+        ("Qwen 3.6 Plus", "z-ai/qwen3.6-plus"),
+        ("Nemotron 3 Super Free", "z-ai/nemotron-3-super-free"),
+        ("Custom model ID", "custom"),
+    ],
+    "deep": [
+        ("DeepSeek V4 Flash Free", "z-ai/deepseek-v4-flash-free"),
+        ("Kimi K2.6", "z-ai/kimi-k2.6"),
+        ("MiniMax M2.7", "z-ai/minimax-m2.7"),
+        ("Qwen 3.6 Plus", "z-ai/qwen3.6-plus"),
+        ("Nemotron 3 Super Free", "z-ai/nemotron-3-super-free"),
+        ("Custom model ID", "custom"),
+    ],
+}
+
+
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
         "quick": [
@@ -153,6 +178,7 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # so the two provider keys share one model list.
     "minimax": _MINIMAX_MODELS,
     "minimax-cn": _MINIMAX_MODELS,
+    "nvidia_nim": _NVIDIA_NIM_MODELS,
     # OpenRouter: fetched dynamically. Azure: any deployed model name.
     # Ollama display labels intentionally omit a "local" marker — the
     # endpoint is now configurable via OLLAMA_BASE_URL, so the same labels


### PR DESCRIPTION
## What this PR does

This PR adds support for NVIDIA NIM as a LLM provider in the CLI.

The issue mentioned that NVIDIA NIM provides an OpenAI compatible endpoint, so I added it in the same flow as other compatible providers.

Base URL used:

```bash
https://integrate.api.nvidia.com/v1
```

Env variable used:

```bash
NVIDIA_NIM_API_KEY
```

## Changes made

* Added `NVIDIA NIM` in the CLI provider selection list
* Added `nvidia_nim` as provider key
* Added `NVIDIA_NIM_API_KEY` in provider API key mapping
* Added NVIDIA NIM model options in shared model catalog
* Added `nvidia_nim` to OpenAI-compatible provider list
* Kept custom model ID option also, so users can enter any other NIM model manually

## Models added in dropdown

```bash
z-ai/deepseek-v4-flash-free
z-ai/kimi-k2.6
z-ai/minimax-m2.7
z-ai/qwen3.6-plus
z-ai/nemotron-3-super-free
```

## Testing done

I tested the CLI flow manually.

Ran:

```bash
python -m cli.main
```

Then selected NVIDIA NIM from the LLM provider list.

The CLI correctly asked for:

```bash
NVIDIA_NIM_API_KEY
```

After skipping the key prompt for local testing, the quick/deep model selector showed the NVIDIA NIM model options correctly.

Also ran compile check:

```bash
python -m compileall cli/utils.py tradingagents/llm_clients/api_key_env.py tradingagents/llm_clients/model_catalog.py tradingagents/llm_clients/*.py
```

No compile errors from these files.

## Note

I did not include or use the API key from the issue screenshot. The provider uses `NVIDIA_NIM_API_KEY` from the user's local env or `.env`.

Fixes #912
