### PR TITLE
PR-1 — Route CLI analysis through propagate() (enable --checkpoint + memory/reflection)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1113,26 +1113,10 @@ def run_analysis(checkpoint: bool = False):
         )
         update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
 
-        # Initialize state and get graph args with callbacks.
-        # Resolve the instrument identity once here so all agents anchor to
-        # the real company (#814); the CLI builds state directly rather than
-        # going through propagate(), so this must happen on the CLI path too.
-        instrument_context = graph.resolve_instrument_context(
-            selections["ticker"], selections["asset_type"]
-        )
-        init_agent_state = graph.propagator.create_initial_state(
-            selections["ticker"],
-            selections["analysis_date"],
-            asset_type=selections["asset_type"],
-            instrument_context=instrument_context,
-        )
-        # Pass callbacks to graph config for tool execution tracking
-        # (LLM tracking is handled separately via LLM constructor)
-        args = graph.propagator.get_graph_args(callbacks=[stats_handler])
-
-        # Stream the analysis
-        trace = []
-        for chunk in graph.graph.stream(init_agent_state, **args):
+        # Stream through propagate() so checkpoint/resume and memory/reflection
+        # stay on the same path as programmatic callers. The on_chunk hook keeps
+        # the TUI render loop and stats callbacks intact.
+        def render_chunk(chunk):
             # Process all messages in chunk, deduplicating by message ID
             for message in chunk.get("messages", []):
                 msg_id = getattr(message, "id", None)
@@ -1233,14 +1217,12 @@ def run_analysis(checkpoint: bool = False):
             # Update the display
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-            trace.append(chunk)
-
-        # Streamed chunks are per-node deltas, not full state. Merge them
-        # so every report field populated across the run is present.
-        final_state = {}
-        for chunk in trace:
-            final_state.update(chunk)
-        decision = graph.process_signal(final_state["final_trade_decision"])
+        final_state, decision = graph.propagate(
+            selections["ticker"],
+            selections["analysis_date"],
+            asset_type=selections["asset_type"],
+            on_chunk=render_chunk,
+        )
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -379,7 +379,7 @@ class TradingAgentsGraph:
             tid = thread_id(company_name, str(trade_date))
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
 
-        if self.debug:
+        if self.debug or on_chunk is not None:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
                 if on_chunk is not None:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -313,7 +313,7 @@ class TradingAgentsGraph:
         identity = resolve_instrument_identity(ticker)
         return build_instrument_context(ticker, asset_type, identity)
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -347,14 +347,19 @@ class TradingAgentsGraph:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
         try:
-            return self._run_graph(company_name, trade_date, asset_type=asset_type)
+            return self._run_graph(
+                company_name,
+                trade_date,
+                asset_type=asset_type,
+                on_chunk=on_chunk,
+            )
         finally:
             if self._checkpointer_ctx is not None:
                 self._checkpointer_ctx.__exit__(None, None, None)
                 self._checkpointer_ctx = None
                 self.graph = self.workflow.compile()
 
-    def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
+    def _run_graph(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents.
@@ -367,7 +372,7 @@ class TradingAgentsGraph:
             past_context=past_context,
             instrument_context=instrument_context,
         )
-        args = self.propagator.get_graph_args()
+        args = self.propagator.get_graph_args(callbacks=self.callbacks)
 
         # Inject thread_id so same ticker+date resumes, different date starts fresh.
         if self.config.get("checkpoint_enabled"):
@@ -377,11 +382,13 @@ class TradingAgentsGraph:
         if self.debug:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
-                if len(chunk["messages"]) == 0:
+                if on_chunk is not None:
+                    on_chunk(chunk)
+                elif len(chunk["messages"]) == 0:
                     pass
                 else:
                     chunk["messages"][-1].pretty_print()
-                    trace.append(chunk)
+                trace.append(chunk)
             # Streamed chunks are per-node deltas. Merge them so the returned
             # state matches what graph.invoke() yields in the non-debug path.
             final_state = {}


### PR DESCRIPTION
**Audit findings:** C1 (critical) + C2 (high) · **Branch:** `fix/cli-route-through-propagate`

### Problem
`cli/main.py::run_analysis` built graph state by hand and streamed
`graph.graph.stream(init_agent_state, **args)` directly — a graph instance
compiled **without** a checkpointer and **without** calling `graph.propagate()`.
Consequences:

- `config["checkpoint_enabled"] = True` (set by `--checkpoint`) was never honored;
  checkpoint recompile + `thread_id` injection live only in `propagate()`/`_run_graph`.
- `store_decision` and `_resolve_pending_entries` ran only in `_run_graph`, so the
  memory log and deferred reflection were effectively dead for CLI users.

### Change
Add an `on_chunk` streaming hook to `propagate()` / `_run_graph()` so the CLI TUI
keeps rendering per-node chunks while checkpointing + memory log run centrally.
The CLI stops building state manually and calls
`graph.propagate(ticker, date, asset_type=..., on_chunk=render_chunk)`.

- `tradingagents/graph/trading_graph.py`
  - Store constructor callbacks on `self.callbacks`; forward them via
    `get_graph_args(callbacks=self.callbacks)`.
  - `propagate()` / `_run_graph()` accept `on_chunk`; the debug stream loop calls
    `on_chunk(chunk)` when provided, else falls back to `pretty_print()` for
    non-CLI callers.
  - Checkpointer opened via context manager and cleaned up in `finally`
    (recompiled back to a plain graph after the run).
- `cli/main.py::run_analysis`
  - Move all per-chunk TUI processing into a `render_chunk(chunk)` closure
    (message dedup, analyst statuses, investment/risk debate state).
  - Replace the manual `create_initial_state` / `get_graph_args` /
    `for chunk in graph.graph.stream(...)` block with a single `propagate(...)` call.

### Tests
See PR-2 (integration lock). `tests/test_checkpoint_resume.py` covers
crash-and-resume via the checkpointer.

### Acceptance
- `tradingagents analyze --checkpoint` creates a per-ticker SQLite checkpoint;
  a crashed run resumes from the last successful node (`Resuming from step N`).
- After a successful run, the memory log records the decision; a second run on the
  same ticker resolves the pending entry and injects reflection context.
- The live TUI still shows analyst progress and token stats.
