### PR TITLE
PR-5 — Timeout + retry/backoff for Alpha Vantage requests

### DIFF
--- a/tests/test_alpha_vantage_request.py
+++ b/tests/test_alpha_vantage_request.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_make_api_request_retries_then_succeeds(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_common as av
+
+    calls = {"n": 0}
+
+    class Response:
+        text = '{"ok": 1}'
+
+        def raise_for_status(self):
+            return None
+
+    def flaky_get(url, params, timeout):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise av.requests.Timeout()
+        assert timeout == av.AV_REQUEST_TIMEOUT
+        return Response()
+
+    monkeypatch.setattr(av.requests, "get", flaky_get)
+    monkeypatch.setattr(av, "get_api_key", lambda: "KEY")
+    monkeypatch.setattr(av.time, "sleep", lambda *_: None)
+
+    out = av._make_api_request("OVERVIEW", {"symbol": "AAPL"})
+
+    assert calls["n"] == 2
+    assert '"ok"' in out

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -1,4 +1,5 @@
 import os
+import time
 import requests
 import pandas as pd
 import json
@@ -6,6 +7,9 @@ from datetime import datetime
 from io import StringIO
 
 API_BASE_URL = "https://www.alphavantage.co/query"
+AV_REQUEST_TIMEOUT = 15
+AV_MAX_RETRIES = 3
+AV_BACKOFF_BASE = 1.5
 
 
 class AlphaVantageNotConfiguredError(ValueError):
@@ -52,6 +56,24 @@ class AlphaVantageRateLimitError(Exception):
     """Exception raised when Alpha Vantage API rate limit is exceeded."""
     pass
 
+def _get_with_retry(params: dict) -> requests.Response:
+    last_exc: Exception | None = None
+    for attempt in range(AV_MAX_RETRIES):
+        try:
+            response = requests.get(
+                API_BASE_URL,
+                params=params,
+                timeout=AV_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response
+        except (requests.Timeout, requests.ConnectionError, requests.HTTPError) as exc:
+            last_exc = exc
+            if attempt < AV_MAX_RETRIES - 1:
+                time.sleep(AV_BACKOFF_BASE * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
 def _make_api_request(function_name: str, params: dict) -> dict | str:
     """Helper function to make API requests and handle responses.
     
@@ -76,8 +98,7 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
         # Remove entitlement if it's None or empty
         api_params.pop("entitlement", None)
     
-    response = requests.get(API_BASE_URL, params=api_params)
-    response.raise_for_status()
+    response = _get_with_retry(api_params)
 
     response_text = response.text
     

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -71,8 +71,9 @@ def _get_with_retry(params: dict) -> requests.Response:
             last_exc = exc
             if attempt < AV_MAX_RETRIES - 1:
                 time.sleep(AV_BACKOFF_BASE * (2**attempt))
-    assert last_exc is not None
-    raise last_exc
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Request failed without an exception")
 
 def _make_api_request(function_name: str, params: dict) -> dict | str:
     """Helper function to make API requests and handle responses.


### PR DESCRIPTION
**Audit findings:** D1 · **Branch:** `fix/alpha-vantage-timeout-retry`

### Problem
`dataflows/alpha_vantage_common.py::_make_api_request` called
`requests.get(API_BASE_URL, params=api_params)` with **no `timeout`** and no retry —
it could hang indefinitely (unlike the yfinance path, which has `yf_retry`).

### Change
Introduce a bounded retry helper:

- Module constants `AV_REQUEST_TIMEOUT`, `AV_MAX_RETRIES`, backoff base.
- `_get_with_retry(params)` issues `requests.get(..., timeout=AV_REQUEST_TIMEOUT)`,
  retries on `Timeout` / `ConnectionError` / `HTTPError` with exponential backoff,
  and re-raises the last exception when retries are exhausted.
- `_make_api_request` calls `_get_with_retry(api_params)`.

### Tests
`tests/test_alpha_vantage_request.py` — a flaky transport that times out once then
succeeds; asserts the call retried and returned the payload (with `time.sleep`
monkeypatched).

### Acceptance
Every `requests.get` carries a `timeout`; transient transport errors retry with
backoff then raise.
