### PR TITLE
PR-8 — De-duplicate the shadowed get_analysis_date

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -676,24 +676,6 @@ def get_user_selections():
     }
 
 
-def get_analysis_date():
-    """Get the analysis date from user input."""
-    while True:
-        date_str = typer.prompt(
-            "", default=datetime.datetime.now().strftime("%Y-%m-%d")
-        )
-        try:
-            # Validate date format and ensure it's not in the future
-            analysis_date = datetime.datetime.strptime(date_str, "%Y-%m-%d")
-            if analysis_date.date() > datetime.datetime.now().date():
-                console.print("[red]Error: Analysis date cannot be in the future[/red]")
-                continue
-            return date_str
-        except ValueError:
-            console.print(
-                "[red]Error: Invalid date format. Please use YYYY-MM-DD[/red]"
-            )
-
 
 def save_report_to_disk(final_state, ticker: str, save_path: Path):
     """Save complete analysis report to disk with organized subfolders."""

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -82,19 +82,21 @@ def get_analysis_date() -> str:
     import re
     from datetime import datetime
 
-    def validate_date(date_str: str) -> bool:
+    def validate_date(date_str: str) -> bool | str:
         if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
         try:
-            datetime.strptime(date_str, "%Y-%m-%d")
+            analysis_date = datetime.strptime(date_str, "%Y-%m-%d")
+            if analysis_date.date() > datetime.today().date():
+                return "Analysis date cannot be in the future."
             return True
         except ValueError:
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
 
     date = questionary.text(
         "Enter the analysis date (YYYY-MM-DD):",
-        validate=lambda x: validate_date(x.strip())
-        or "Please enter a valid date in YYYY-MM-DD format.",
+        default=datetime.today().strftime("%Y-%m-%d"),
+        validate=lambda x: validate_date(x.strip()),
         style=questionary.Style(
             [
                 ("text", "fg:green"),

--- a/tests/test_ticker_symbol_handling.py
+++ b/tests/test_ticker_symbol_handling.py
@@ -24,6 +24,13 @@ class TickerSymbolHandlingTests(unittest.TestCase):
         import cli.utils
         self.assertIs(cli.main.get_ticker, cli.utils.get_ticker)
 
+    def test_single_get_analysis_date_no_shadow(self):
+        # Regression: cli/main.py also shadowed cli.utils.get_analysis_date,
+        # causing date validation and prompt UX to diverge.
+        import cli.main
+        import cli.utils
+        self.assertIs(cli.main.get_analysis_date, cli.utils.get_analysis_date)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Audit findings:** C3 + T2 · **Branch:** `fix/dedup-get-analysis-date`

### Problem
`cli/main.py` did `from cli.utils import *` (which brings in
`cli/utils.get_analysis_date`, questionary-based, accepts any date) and then
**shadowed** it with a second `cli/main.py::get_analysis_date` (typer-based, rejects
future dates). The questionary version became dead code — the same class of bug
already fixed for `get_ticker` (with `test_single_get_ticker_no_shadow`).

### Change
Single source of truth: keep the validating behavior in
`cli/utils.get_analysis_date` and **remove** the `cli/main.py` definition so the
imported version is used (consistent questionary UX with `get_ticker`).

### Tests
`test_single_get_analysis_date_no_shadow` —
`cli.main.get_analysis_date is cli.utils.get_analysis_date`.

### Acceptance
The identity assertion holds; the date prompt rejects future dates with a
consistent UI.
