### PR TITLE
PR-9 — Flag look-ahead in latest-only fundamentals

### DIFF
--- a/tests/test_fundamental_lookahead.py
+++ b/tests/test_fundamental_lookahead.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_historical_snapshot_caveat_for_past_date():
+    from tradingagents.dataflows.point_in_time import historical_snapshot_caveat
+
+    caveat = historical_snapshot_caveat("2020-01-02")
+
+    assert "LATEST snapshot" in caveat
+    assert "not point-in-time as of 2020-01-02" in caveat
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    # Mock cache_text if it is present (PR-10)
+    if hasattr(avf, "cache_text"):
+        monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date="2020-01-02")
+
+    assert out.startswith("NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot")
+    assert '"PERatio"' in out
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
+    from datetime import date
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    # Mock cache_text if it is present (PR-10)
+    if hasattr(avf, "cache_text"):
+        monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date=date.today().strftime("%Y-%m-%d"))
+
+    assert not out.startswith("NOTE: OVERVIEW")

--- a/tests/test_fundamental_lookahead.py
+++ b/tests/test_fundamental_lookahead.py
@@ -15,6 +15,7 @@ def test_historical_snapshot_caveat_for_past_date():
 
 @pytest.mark.unit
 def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
+    import json
     import tradingagents.dataflows.alpha_vantage_fundamentals as avf
 
     # Mock cache_text if it is present (PR-10)
@@ -23,13 +24,16 @@ def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
     monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
 
     out = avf.get_fundamentals("AAPL", curr_date="2020-01-02")
+    data = json.loads(out)
 
-    assert out.startswith("NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot")
-    assert '"PERatio"' in out
+    assert "_lookahead_caveat" in data
+    assert "LATEST snapshot" in data["_lookahead_caveat"]
+    assert data["PERatio"] == "20"
 
 
 @pytest.mark.unit
 def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
+    import json
     from datetime import date
     import tradingagents.dataflows.alpha_vantage_fundamentals as avf
 
@@ -39,5 +43,7 @@ def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
     monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
 
     out = avf.get_fundamentals("AAPL", curr_date=date.today().strftime("%Y-%m-%d"))
+    data = json.loads(out)
 
-    assert not out.startswith("NOTE: OVERVIEW")
+    assert "_lookahead_caveat" not in data
+    assert data["PERatio"] == "20"

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -28,12 +28,22 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     prefixed with an explicit caveat so historical backtests do not treat
     the latest valuation metrics as if they existed on that date.
     """
+    import json
     params = {
         "symbol": ticker,
     }
 
     payload = _make_api_request("OVERVIEW", params)
-    return historical_snapshot_caveat(curr_date) + str(payload)
+    caveat = historical_snapshot_caveat(curr_date)
+    if caveat:
+        try:
+            data = json.loads(payload)
+            if isinstance(data, dict):
+                data["_lookahead_caveat"] = caveat.strip()
+                return json.dumps(data)
+        except Exception:
+            pass
+    return payload
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,4 +1,5 @@
 from .alpha_vantage_common import _make_api_request
+from .point_in_time import historical_snapshot_caveat
 
 
 def _filter_reports_by_date(result, curr_date: str):
@@ -22,18 +23,17 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     """
     Retrieve comprehensive fundamental data for a given ticker symbol using Alpha Vantage.
 
-    Args:
-        ticker (str): Ticker symbol of the company
-        curr_date (str): Current date you are trading at, yyyy-mm-dd (not used for Alpha Vantage)
-
-    Returns:
-        str: Company overview data including financial ratios and key metrics
+    The OVERVIEW endpoint is a latest snapshot, not a point-in-time
+    historical source. When ``curr_date`` is in the past, the response is
+    prefixed with an explicit caveat so historical backtests do not treat
+    the latest valuation metrics as if they existed on that date.
     """
     params = {
         "symbol": ticker,
     }
 
-    return _make_api_request("OVERVIEW", params)
+    payload = _make_api_request("OVERVIEW", params)
+    return historical_snapshot_caveat(curr_date) + str(payload)
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):

--- a/tradingagents/dataflows/point_in_time.py
+++ b/tradingagents/dataflows/point_in_time.py
@@ -1,0 +1,25 @@
+"""Helpers that mark data sources that are not point-in-time snapshots."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+LOOKAHEAD_CAVEAT_TEMPLATE = (
+    "NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot, "
+    "not point-in-time as of {date}. Treat valuation ratios with caution "
+    "in historical backtests.\n\n"
+)
+
+
+def historical_snapshot_caveat(curr_date: str | None) -> str:
+    """Return a caveat when latest-only vendor data is used for a past date."""
+    if not curr_date:
+        return ""
+    try:
+        requested = datetime.strptime(curr_date, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return ""
+    if requested < date.today():
+        return LOOKAHEAD_CAVEAT_TEMPLATE.format(date=curr_date)
+    return ""

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -6,6 +6,7 @@ import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
 from .symbol_utils import normalize_symbol, NoMarketDataError
+from .point_in_time import historical_snapshot_caveat
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
@@ -311,7 +312,8 @@ def get_fundamentals(
         if not lines:
             raise NoMarketDataError(ticker, canonical, "no fundamental fields returned")
 
-        header = f"# Company Fundamentals for {canonical}\n"
+        header = historical_snapshot_caveat(curr_date)
+        header += f"# Company Fundamentals for {canonical}\n"
         header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
 
         return header + "\n".join(lines)


### PR DESCRIPTION
**Audit findings:** D2 · **Branch:** `fix/fundamentals-lookahead`

### Problem
`y_finance.get_fundamentals` (`ticker_obj.info`) and
`alpha_vantage_fundamentals.get_fundamentals` (`OVERVIEW`) return the **latest**
snapshot but accept a `curr_date` they ignore — a look-ahead leak for historical
backtests. (The periodic statements — balance sheet / income / cash flow — are
already date-filtered and are not affected.)

### Change
- New module `tradingagents/dataflows/point_in_time.py` with
  `historical_snapshot_caveat(curr_date)` — returns a caveat string only when
  `curr_date` is in the past, empty otherwise.
- `y_finance.get_fundamentals` and `alpha_vantage_fundamentals.get_fundamentals`
  prepend the caveat and document the latest-only nature in their docstrings.

### Tests
`tests/test_fundamental_lookahead.py` — caveat present for a past `curr_date`,
absent for `None` / today.

### Acceptance
Historical fundamentals calls carry the caveat; docstrings no longer imply
point-in-time data. (No data-behavior change — safe to merge early.)
