### PR TITLE
PR-10 — Hardening & polish (data-flow, error typing, UX, prompt fidelity)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,10 @@ MINIMAX_CN_API_KEY=
 OPENROUTER_API_KEY=
 
 # Optional: point at a remote Ollama server. When unset, defaults to
-# the local instance at http://localhost:11434/v1. Convention follows
-# the broader Ollama ecosystem; both the CLI dropdown and programmatic
-# client pick this up.
+# the local instance at http://localhost:11434/v1. The TRADINGAGENTS_* name
+# matches the config/env override convention; OLLAMA_BASE_URL is retained as
+# a compatibility alias for broader Ollama tooling.
+#TRADINGAGENTS_OLLAMA_BASE_URL=http://your-ollama-host:11434/v1
 #OLLAMA_BASE_URL=http://your-ollama-host:11434/v1
 
 # Optional: override DEFAULT_CONFIG without editing code.

--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ cd TradingAgents
 
 Create a virtual environment in any of your favorite environment managers:
 ```bash
-conda create -n tradingagents python=3.13
+conda create -n tradingagents python=3.12
+# Python 3.11–3.13 are supported; Docker currently builds on Python 3.12.
 conda activate tradingagents
 ```
 
 Install the package and its dependencies:
 ```bash
-pip install .
+pip install -e .
 ```
 
 ### Docker
@@ -153,9 +154,9 @@ export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```
 
-For enterprise providers (e.g. Azure OpenAI, AWS Bedrock), copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
+For enterprise providers, Azure OpenAI is currently supported. Copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials. AWS Bedrock is planned only and is not wired as a runtime client yet.
 
-For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
+For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `TRADINGAGENTS_OLLAMA_BASE_URL` (or `OLLAMA_BASE_URL`) to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 
 Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash

--- a/cli/announcements.py
+++ b/cli/announcements.py
@@ -1,4 +1,3 @@
-import getpass
 import requests
 from rich.console import Console
 from rich.panel import Panel
@@ -46,6 +45,6 @@ def display_announcements(console: Console, data: dict) -> None:
     console.print(panel)
 
     if require_attention:
-        getpass.getpass("Press Enter to continue...")
+        input("Press Enter to continue...")
     else:
         console.print()

--- a/cli/main.py
+++ b/cli/main.py
@@ -676,24 +676,6 @@ def get_user_selections():
     }
 
 
-def get_analysis_date():
-    """Get the analysis date from user input."""
-    while True:
-        date_str = typer.prompt(
-            "", default=datetime.datetime.now().strftime("%Y-%m-%d")
-        )
-        try:
-            # Validate date format and ensure it's not in the future
-            analysis_date = datetime.datetime.strptime(date_str, "%Y-%m-%d")
-            if analysis_date.date() > datetime.datetime.now().date():
-                console.print("[red]Error: Analysis date cannot be in the future[/red]")
-                continue
-            return date_str
-        except ValueError:
-            console.print(
-                "[red]Error: Invalid date format. Please use YYYY-MM-DD[/red]"
-            )
-
 
 def save_report_to_disk(final_state, ticker: str, save_path: Path):
     """Save complete analysis report to disk with organized subfolders."""

--- a/cli/main.py
+++ b/cli/main.py
@@ -1113,26 +1113,10 @@ def run_analysis(checkpoint: bool = False):
         )
         update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
 
-        # Initialize state and get graph args with callbacks.
-        # Resolve the instrument identity once here so all agents anchor to
-        # the real company (#814); the CLI builds state directly rather than
-        # going through propagate(), so this must happen on the CLI path too.
-        instrument_context = graph.resolve_instrument_context(
-            selections["ticker"], selections["asset_type"]
-        )
-        init_agent_state = graph.propagator.create_initial_state(
-            selections["ticker"],
-            selections["analysis_date"],
-            asset_type=selections["asset_type"],
-            instrument_context=instrument_context,
-        )
-        # Pass callbacks to graph config for tool execution tracking
-        # (LLM tracking is handled separately via LLM constructor)
-        args = graph.propagator.get_graph_args(callbacks=[stats_handler])
-
-        # Stream the analysis
-        trace = []
-        for chunk in graph.graph.stream(init_agent_state, **args):
+        # Stream through propagate() so checkpoint/resume and memory/reflection
+        # stay on the same path as programmatic callers. The on_chunk hook keeps
+        # the TUI render loop and stats callbacks intact.
+        def render_chunk(chunk):
             # Process all messages in chunk, deduplicating by message ID
             for message in chunk.get("messages", []):
                 msg_id = getattr(message, "id", None)
@@ -1233,14 +1217,12 @@ def run_analysis(checkpoint: bool = False):
             # Update the display
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-            trace.append(chunk)
-
-        # Streamed chunks are per-node deltas, not full state. Merge them
-        # so every report field populated across the run is present.
-        final_state = {}
-        for chunk in trace:
-            final_state.update(chunk)
-        decision = graph.process_signal(final_state["final_trade_decision"])
+        final_state, decision = graph.propagate(
+            selections["ticker"],
+            selections["analysis_date"],
+            asset_type=selections["asset_type"],
+            on_chunk=render_chunk,
+        )
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/cli/main.py
+++ b/cli/main.py
@@ -594,7 +594,7 @@ def get_user_selections():
         elif selected_llm_provider == "glm":
             selected_llm_provider, backend_url = ask_glm_region()
 
-        # For Ollama, surface the resolved endpoint (OLLAMA_BASE_URL vs default)
+        # For Ollama, surface the resolved endpoint (TRADINGAGENTS_OLLAMA_BASE_URL / OLLAMA_BASE_URL vs default)
         # before model selection so it's obvious where we're connecting.
         if selected_llm_provider == "ollama":
             confirm_ollama_endpoint(backend_url)
@@ -674,25 +674,6 @@ def get_user_selections():
         "anthropic_effort": anthropic_effort,
         "output_language": output_language,
     }
-
-
-def get_analysis_date():
-    """Get the analysis date from user input."""
-    while True:
-        date_str = typer.prompt(
-            "", default=datetime.datetime.now().strftime("%Y-%m-%d")
-        )
-        try:
-            # Validate date format and ensure it's not in the future
-            analysis_date = datetime.datetime.strptime(date_str, "%Y-%m-%d")
-            if analysis_date.date() > datetime.datetime.now().date():
-                console.print("[red]Error: Analysis date cannot be in the future[/red]")
-                continue
-            return date_str
-        except ValueError:
-            console.print(
-                "[red]Error: Invalid date format. Please use YYYY-MM-DD[/red]"
-            )
 
 
 def save_report_to_disk(final_state, ticker: str, save_path: Path):
@@ -1013,10 +994,7 @@ def run_analysis(checkpoint: bool = False):
     # Normalize analyst selection to predefined order (selection is a 'set', order is fixed)
     selected_set = {analyst.value for analyst in selections["analysts"]}
     selected_analyst_keys = [a for a in ANALYST_ORDER if a in selected_set]
-    analyst_execution_plan = build_analyst_execution_plan(
-        selected_analyst_keys,
-        concurrency_limit=config["analyst_concurrency_limit"],
-    )
+    analyst_execution_plan = build_analyst_execution_plan(selected_analyst_keys)
     analyst_wall_time_tracker = AnalystWallTimeTracker(analyst_execution_plan)
 
     # Initialize the graph with callbacks bound to LLMs
@@ -1113,26 +1091,10 @@ def run_analysis(checkpoint: bool = False):
         )
         update_display(layout, spinner_text, stats_handler=stats_handler, start_time=start_time)
 
-        # Initialize state and get graph args with callbacks.
-        # Resolve the instrument identity once here so all agents anchor to
-        # the real company (#814); the CLI builds state directly rather than
-        # going through propagate(), so this must happen on the CLI path too.
-        instrument_context = graph.resolve_instrument_context(
-            selections["ticker"], selections["asset_type"]
-        )
-        init_agent_state = graph.propagator.create_initial_state(
-            selections["ticker"],
-            selections["analysis_date"],
-            asset_type=selections["asset_type"],
-            instrument_context=instrument_context,
-        )
-        # Pass callbacks to graph config for tool execution tracking
-        # (LLM tracking is handled separately via LLM constructor)
-        args = graph.propagator.get_graph_args(callbacks=[stats_handler])
-
-        # Stream the analysis
-        trace = []
-        for chunk in graph.graph.stream(init_agent_state, **args):
+        # Stream through propagate() so checkpoint/resume and memory/reflection
+        # stay on the same path as programmatic callers. The on_chunk hook keeps
+        # the TUI render loop and stats callbacks intact.
+        def render_chunk(chunk):
             # Process all messages in chunk, deduplicating by message ID
             for message in chunk.get("messages", []):
                 msg_id = getattr(message, "id", None)
@@ -1233,14 +1195,12 @@ def run_analysis(checkpoint: bool = False):
             # Update the display
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-            trace.append(chunk)
-
-        # Streamed chunks are per-node deltas, not full state. Merge them
-        # so every report field populated across the run is present.
-        final_state = {}
-        for chunk in trace:
-            final_state.update(chunk)
-        decision = graph.process_signal(final_state["final_trade_decision"])
+        final_state, decision = graph.propagate(
+            selections["ticker"],
+            selections["analysis_date"],
+            asset_type=selections["asset_type"],
+            on_chunk=render_chunk,
+        )
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -82,19 +82,21 @@ def get_analysis_date() -> str:
     import re
     from datetime import datetime
 
-    def validate_date(date_str: str) -> bool:
+    def validate_date(date_str: str) -> bool | str:
         if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
         try:
-            datetime.strptime(date_str, "%Y-%m-%d")
+            analysis_date = datetime.strptime(date_str, "%Y-%m-%d")
+            if analysis_date.date() > datetime.today().date():
+                return "Analysis date cannot be in the future."
             return True
         except ValueError:
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
 
     date = questionary.text(
         "Enter the analysis date (YYYY-MM-DD):",
-        validate=lambda x: validate_date(x.strip())
-        or "Please enter a valid date in YYYY-MM-DD format.",
+        default=datetime.today().strftime("%Y-%m-%d"),
+        validate=lambda x: validate_date(x.strip()),
         style=questionary.Style(
             [
                 ("text", "fg:green"),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -78,23 +78,27 @@ def filter_analysts_for_asset_type(
 
 
 def get_analysis_date() -> str:
-    """Prompt the user to enter a date in YYYY-MM-DD format."""
+    """Prompt for an analysis date and reject invalid or future dates."""
     import re
     from datetime import datetime
 
-    def validate_date(date_str: str) -> bool:
+    today = datetime.now().date()
+
+    def validate_date(date_str: str) -> bool | str:
         if not re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
         try:
-            datetime.strptime(date_str, "%Y-%m-%d")
-            return True
+            parsed = datetime.strptime(date_str, "%Y-%m-%d").date()
         except ValueError:
-            return False
+            return "Please enter a valid date in YYYY-MM-DD format."
+        if parsed > today:
+            return "Analysis date cannot be in the future."
+        return True
 
     date = questionary.text(
         "Enter the analysis date (YYYY-MM-DD):",
-        validate=lambda x: validate_date(x.strip())
-        or "Please enter a valid date in YYYY-MM-DD format.",
+        default=today.strftime("%Y-%m-%d"),
+        validate=lambda x: validate_date(x.strip()),
         style=questionary.Style(
             [
                 ("text", "fg:green"),
@@ -273,11 +277,16 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
 
     Shared by the interactive picker and by env-driven configuration so an
     env-set provider resolves to the same default endpoint the menu uses.
-    Ollama users can point at a remote ollama-serve via OLLAMA_BASE_URL
-    (convention from the broader Ollama ecosystem); falls back to the
-    localhost default when unset.
+    Ollama users can point at a remote ollama-serve via
+    TRADINGAGENTS_OLLAMA_BASE_URL (preferred for this app) or OLLAMA_BASE_URL
+    (compatibility with broader Ollama tooling); falls back to the localhost
+    default when unset.
     """
-    ollama_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
+    ollama_url = (
+        os.environ.get("TRADINGAGENTS_OLLAMA_BASE_URL")
+        or os.environ.get("OLLAMA_BASE_URL")
+        or "http://localhost:11434/v1"
+    )
     return [
         ("OpenAI", "openai", "https://api.openai.com/v1"),
         ("Google", "google", None),
@@ -475,13 +484,19 @@ def confirm_ollama_endpoint(url: str) -> None:
 
     Surfaces three things the user benefits from seeing before model
     selection: which URL we'll actually hit, where it came from
-    (\`OLLAMA_BASE_URL\` vs default), and a soft warning if the URL is
+    (`TRADINGAGENTS_OLLAMA_BASE_URL` / `OLLAMA_BASE_URL` vs default), and a soft warning if the URL is
     missing the scheme/port that ollama-serve expects. The warning is
     advisory only — we don't reject malformed input, since the user may
     be doing something deliberately unusual (e.g. a reverse-proxy path).
     """
-    from_env = os.environ.get("OLLAMA_BASE_URL")
-    origin = " (from OLLAMA_BASE_URL)" if from_env and from_env == url else ""
+    preferred_env = os.environ.get("TRADINGAGENTS_OLLAMA_BASE_URL")
+    legacy_env = os.environ.get("OLLAMA_BASE_URL")
+    if preferred_env and preferred_env == url:
+        origin = " (from TRADINGAGENTS_OLLAMA_BASE_URL)"
+    elif legacy_env and legacy_env == url:
+        origin = " (from OLLAMA_BASE_URL)"
+    else:
+        origin = ""
     console.print(f"[green]✓ Using Ollama at {url}{origin}[/green]")
 
     if not url.startswith(("http://", "https://")):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     env_file:
       - .env
     environment:
-      - LLM_PROVIDER=ollama
+      - TRADINGAGENTS_LLM_PROVIDER=ollama
+      - TRADINGAGENTS_OLLAMA_BASE_URL=http://ollama:11434/v1
+      - OLLAMA_BASE_URL=http://ollama:11434/v1
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
     depends_on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tradingagents"
 version = "0.2.5"
 description = "TradingAgents: Multi-Agents LLM Financial Trading Framework"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "langchain-core>=0.3.81",
     "backtrader>=1.9.78.123",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-.
+# Editable install of this project; use: pip install -e .

--- a/scripts/manual_indicator_check.py
+++ b/scripts/manual_indicator_check.py
@@ -1,0 +1,11 @@
+import time
+from tradingagents.dataflows.y_finance import get_YFin_data_online, get_stock_stats_indicators_window, get_balance_sheet as get_yfinance_balance_sheet, get_cashflow as get_yfinance_cashflow, get_income_statement as get_yfinance_income_statement, get_insider_transactions as get_yfinance_insider_transactions
+
+print("Testing optimized implementation with 30-day lookback:")
+start_time = time.time()
+result = get_stock_stats_indicators_window("AAPL", "macd", "2024-11-01", 30)
+end_time = time.time()
+
+print(f"Execution time: {end_time - start_time:.2f} seconds")
+print(f"Result length: {len(result)} characters")
+print(result)

--- a/tests/test_agent_polish.py
+++ b/tests/test_agent_polish.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage
+
+
+@pytest.mark.unit
+def test_news_analyst_prompt_names_get_news_ticker():
+    from pathlib import Path
+
+    source = Path("tradingagents/agents/analysts/news_analyst.py").read_text()
+    assert "get_news(ticker, start_date, end_date)" in source
+    assert "get_news(query, start_date, end_date)" not in source
+
+
+@pytest.mark.unit
+def test_structured_fallback_normalizes_free_text_list_content():
+    from tradingagents.agents.utils.structured import invoke_structured_or_freetext
+
+    plain_llm = MagicMock()
+    plain_llm.invoke.return_value = AIMessage(content=[{"type": "text", "text": "hello"}])
+
+    out = invoke_structured_or_freetext(
+        structured_llm=None,
+        plain_llm=plain_llm,
+        prompt="prompt",
+        render=lambda result: "unused",
+        agent_name="TestAgent",
+    )
+
+    assert out == "hello"
+
+
+@pytest.mark.unit
+def test_market_analyst_preserves_partial_content_with_tool_calls(monkeypatch):
+    from tradingagents.agents.analysts.market_analyst import create_market_analyst
+
+    class Chain:
+        def invoke(self, messages):
+            msg = AIMessage(content="partial market note")
+            msg.tool_calls = [{"name": "get_stock_data", "args": {"symbol": "AAPL"}, "id": "1"}]
+            return msg
+
+    class Prompt:
+        def partial(self, **kwargs):
+            return self
+
+        def __or__(self, other):
+            return Chain()
+
+    class FakePromptTemplate:
+        @staticmethod
+        def from_messages(messages):
+            return Prompt()
+
+    monkeypatch.setattr(
+        "tradingagents.agents.analysts.market_analyst.ChatPromptTemplate",
+        FakePromptTemplate,
+    )
+
+    llm = MagicMock()
+    llm.bind_tools.return_value = object()
+    node = create_market_analyst(llm)
+    out = node({"trade_date": "2024-01-02", "messages": [], "company_of_interest": "AAPL", "asset_type": "stock"})
+
+    assert out["market_report"] == "partial market note"

--- a/tests/test_alpha_vantage_request.py
+++ b/tests/test_alpha_vantage_request.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_make_api_request_retries_then_succeeds(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_common as av
+
+    calls = {"n": 0}
+
+    class Response:
+        text = '{"ok": 1}'
+
+        def raise_for_status(self):
+            return None
+
+    def flaky_get(url, params, timeout):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise av.requests.Timeout()
+        assert timeout == av.AV_REQUEST_TIMEOUT
+        return Response()
+
+    monkeypatch.setattr(av.requests, "get", flaky_get)
+    monkeypatch.setattr(av, "get_api_key", lambda: "KEY")
+    monkeypatch.setattr(av.time, "sleep", lambda *_: None)
+
+    out = av._make_api_request("OVERVIEW", {"symbol": "AAPL"})
+
+    assert calls["n"] == 2
+    assert '"ok"' in out
+
+
+@pytest.mark.unit
+def test_invalid_api_key_is_not_classified_as_rate_limit(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_common as av
+
+    class Response:
+        text = '{"Information": "Invalid API key. Please visit Alpha Vantage."}'
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(av.requests, "get", lambda *a, **k: Response())
+    monkeypatch.setattr(av, "get_api_key", lambda: "BAD")
+
+    with pytest.raises(av.AlphaVantageAuthError):
+        av._make_api_request("OVERVIEW", {"symbol": "AAPL"})
+
+
+@pytest.mark.unit
+def test_rate_limit_uses_rate_limit_error(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_common as av
+
+    class Response:
+        text = '{"Information": "Our standard API rate limit is 25 requests per day."}'
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(av.requests, "get", lambda *a, **k: Response())
+    monkeypatch.setattr(av, "get_api_key", lambda: "KEY")
+
+    with pytest.raises(av.AlphaVantageRateLimitError):
+        av._make_api_request("OVERVIEW", {"symbol": "AAPL"})

--- a/tests/test_alpha_vantage_request.py
+++ b/tests/test_alpha_vantage_request.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_make_api_request_retries_then_succeeds(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_common as av
+
+    calls = {"n": 0}
+
+    class Response:
+        text = '{"ok": 1}'
+
+        def raise_for_status(self):
+            return None
+
+    def flaky_get(url, params, timeout):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise av.requests.Timeout()
+        assert timeout == av.AV_REQUEST_TIMEOUT
+        return Response()
+
+    monkeypatch.setattr(av.requests, "get", flaky_get)
+    monkeypatch.setattr(av, "get_api_key", lambda: "KEY")
+    monkeypatch.setattr(av.time, "sleep", lambda *_: None)
+
+    out = av._make_api_request("OVERVIEW", {"symbol": "AAPL"})
+
+    assert calls["n"] == 2
+    assert '"ok"' in out

--- a/tests/test_analyst_execution.py
+++ b/tests/test_analyst_execution.py
@@ -10,10 +10,9 @@ from tradingagents.graph.analyst_execution import (
 
 class AnalystExecutionPlanTests(unittest.TestCase):
     def test_build_plan_preserves_selected_order(self):
-        plan = build_analyst_execution_plan(["news", "market"], concurrency_limit=2)
+        plan = build_analyst_execution_plan(["news", "market"])
 
         self.assertEqual([spec.key for spec in plan.specs], ["news", "market"])
-        self.assertEqual(plan.concurrency_limit, 2)
         self.assertEqual(plan.specs[0].agent_node, "News Analyst")
         self.assertEqual(plan.specs[0].tool_node, "tools_news")
         self.assertEqual(plan.specs[0].clear_node, "Msg Clear News")
@@ -22,9 +21,11 @@ class AnalystExecutionPlanTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             build_analyst_execution_plan(["market", "macro"])
 
-    def test_requires_positive_concurrency_limit(self):
-        with self.assertRaises(ValueError):
-            build_analyst_execution_plan(["market"], concurrency_limit=0)
+    def test_concurrency_knob_removed_until_parallel_graph_is_safe(self):
+        import inspect
+
+        signature = inspect.signature(build_analyst_execution_plan)
+        self.assertNotIn("concurrency_limit", signature.parameters)
 
     def test_get_initial_analyst_node_uses_plan_metadata(self):
         plan = build_analyst_execution_plan(["fundamentals", "news"])

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -121,3 +121,13 @@ def test_capabilities_dataclass_is_frozen():
     caps = get_capabilities("deepseek-chat")
     with pytest.raises(Exception):
         caps.supports_tool_choice = False  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestOpenAIReasoningCapabilities:
+    def test_gpt5_family_rejects_temperature(self):
+        assert get_capabilities("gpt-5.5").supports_temperature is False
+        assert get_capabilities("gpt-5.9-future").supports_temperature is False
+
+    def test_gpt41_keeps_temperature(self):
+        assert get_capabilities("gpt-4.1").supports_temperature is True

--- a/tests/test_cli_run_analysis.py
+++ b/tests/test_cli_run_analysis.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _DummyLive:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.integration
+def test_run_analysis_routes_through_propagate(monkeypatch, tmp_path):
+    import cli.main as m
+
+    fake_graph = MagicMock()
+    fake_graph.graph.stream = MagicMock()
+    fake_graph.propagate.return_value = (
+        {
+            "market_report": "market done",
+            "investment_plan": "research done",
+            "trader_investment_plan": "trader done",
+            "final_trade_decision": "BUY",
+        },
+        "BUY",
+    )
+
+    monkeypatch.setattr(m, "TradingAgentsGraph", lambda *a, **k: fake_graph)
+    monkeypatch.setattr(m, "Live", _DummyLive)
+    monkeypatch.setattr(m, "create_layout", lambda: object())
+    monkeypatch.setattr(m, "update_display", lambda *a, **k: None)
+    monkeypatch.setattr(m.typer, "prompt", lambda *a, **k: "N")
+    monkeypatch.setitem(m.DEFAULT_CONFIG, "results_dir", str(tmp_path / "results"))
+    monkeypatch.setitem(m.DEFAULT_CONFIG, "data_cache_dir", str(tmp_path / "cache"))
+
+    monkeypatch.setattr(
+        m,
+        "get_user_selections",
+        lambda: {
+            "ticker": "AAPL",
+            "asset_type": "stock",
+            "analysis_date": "2024-01-02",
+            "analysts": [m.AnalystType.MARKET],
+            "research_depth": 1,
+            "llm_provider": "openai",
+            "backend_url": "",
+            "shallow_thinker": "gpt-5.4-mini",
+            "deep_thinker": "gpt-5.5",
+            "google_thinking_level": None,
+            "openai_reasoning_effort": None,
+            "anthropic_effort": None,
+            "output_language": "English",
+        },
+    )
+
+    m.run_analysis(checkpoint=True)
+
+    fake_graph.propagate.assert_called_once()
+    _, kwargs = fake_graph.propagate.call_args
+    assert kwargs["asset_type"] == "stock"
+    assert callable(kwargs["on_chunk"])
+    assert fake_graph.graph.stream.called is False

--- a/tests/test_fundamental_lookahead.py
+++ b/tests/test_fundamental_lookahead.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_historical_snapshot_caveat_for_past_date():
+    from tradingagents.dataflows.point_in_time import historical_snapshot_caveat
+
+    caveat = historical_snapshot_caveat("2020-01-02")
+
+    assert "LATEST snapshot" in caveat
+    assert "not point-in-time as of 2020-01-02" in caveat
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    # Mock cache_text if it is present (PR-10)
+    if hasattr(avf, "cache_text"):
+        monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date="2020-01-02")
+
+    assert out.startswith("NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot")
+    assert '"PERatio"' in out
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
+    from datetime import date
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    # Mock cache_text if it is present (PR-10)
+    if hasattr(avf, "cache_text"):
+        monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date=date.today().strftime("%Y-%m-%d"))
+
+    assert not out.startswith("NOTE: OVERVIEW")

--- a/tests/test_fundamental_lookahead.py
+++ b/tests/test_fundamental_lookahead.py
@@ -15,6 +15,7 @@ def test_historical_snapshot_caveat_for_past_date():
 
 @pytest.mark.unit
 def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
+    import json
     import tradingagents.dataflows.alpha_vantage_fundamentals as avf
 
     # Mock cache_text if it is present (PR-10)
@@ -23,13 +24,16 @@ def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
     monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
 
     out = avf.get_fundamentals("AAPL", curr_date="2020-01-02")
+    data = json.loads(out)
 
-    assert out.startswith("NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot")
-    assert '"PERatio"' in out
+    assert "_lookahead_caveat" in data
+    assert "LATEST snapshot" in data["_lookahead_caveat"]
+    assert data["PERatio"] == "20"
 
 
 @pytest.mark.unit
 def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
+    import json
     from datetime import date
     import tradingagents.dataflows.alpha_vantage_fundamentals as avf
 
@@ -39,5 +43,7 @@ def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
     monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
 
     out = avf.get_fundamentals("AAPL", curr_date=date.today().strftime("%Y-%m-%d"))
+    data = json.loads(out)
 
-    assert not out.startswith("NOTE: OVERVIEW")
+    assert "_lookahead_caveat" not in data
+    assert data["PERatio"] == "20"

--- a/tests/test_fundamental_lookahead.py
+++ b/tests/test_fundamental_lookahead.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_historical_snapshot_caveat_for_past_date():
+    from tradingagents.dataflows.point_in_time import historical_snapshot_caveat
+
+    caveat = historical_snapshot_caveat("2020-01-02")
+
+    assert "LATEST snapshot" in caveat
+    assert "not point-in-time as of 2020-01-02" in caveat
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_prefixes_caveat_for_past_date(monkeypatch):
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date="2020-01-02")
+
+    assert out.startswith("NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot")
+    assert '"PERatio"' in out
+
+
+@pytest.mark.unit
+def test_alpha_vantage_fundamentals_today_has_no_caveat(monkeypatch):
+    from datetime import date
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    monkeypatch.setattr(avf, "cache_text", lambda namespace, parts, fetch: fetch())
+    monkeypatch.setattr(avf, "_make_api_request", lambda function, params: '{"PERatio":"20"}')
+
+    out = avf.get_fundamentals("AAPL", curr_date=date.today().strftime("%Y-%m-%d"))
+
+    assert not out.startswith("NOTE: OVERVIEW")

--- a/tests/test_news_markdown.py
+++ b/tests/test_news_markdown.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_alpha_vantage_news_sentiment_normalized_to_markdown():
+    from tradingagents.dataflows.alpha_vantage_news import _normalize_news_response
+
+    payload = {
+        "feed": [
+            {
+                "title": "Apple launches product",
+                "source": "ExampleWire",
+                "time_published": "20240102T120000",
+                "summary": "A concise summary.",
+                "url": "https://example.com/aapl",
+                "overall_sentiment_label": "Bullish",
+                "overall_sentiment_score": "0.42",
+                "ticker_sentiment": [
+                    {"ticker": "AAPL", "ticker_sentiment_label": "Bullish", "ticker_sentiment_score": "0.44"}
+                ],
+            }
+        ]
+    }
+
+    out = _normalize_news_response(payload, "AAPL")
+
+    assert out.startswith("## Alpha Vantage News Sentiment: AAPL")
+    assert "### Apple launches product (source: ExampleWire)" in out
+    assert "Ticker sentiment: AAPL Bullish" in out
+    assert '"feed"' not in out

--- a/tests/test_ollama_base_url.py
+++ b/tests/test_ollama_base_url.py
@@ -182,3 +182,10 @@ def test_ollama_offers_custom_model_id():
         assert "custom" in values, f"Ollama {mode!r} missing 'custom' option: {entries}"
         # Custom option is last so it doesn't push the curated defaults off-screen
         assert values[-1] == "custom", f"'custom' should be last entry: {values}"
+
+
+def test_resolver_prefers_tradingagents_ollama_env(monkeypatch):
+    monkeypatch.setenv("TRADINGAGENTS_OLLAMA_BASE_URL", "http://preferred-ollama:11434/v1")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://legacy-ollama:11434/v1")
+    mod = _reload_client()
+    assert mod._resolve_provider_base_url("ollama") == "http://preferred-ollama:11434/v1"

--- a/tests/test_reflection_returns.py
+++ b/tests/test_reflection_returns.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+
+@pytest.mark.unit
+def test_fetch_returns_normalizes_symbol(monkeypatch):
+    from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+    seen = []
+
+    class FakeTicker:
+        def __init__(self, symbol):
+            seen.append(symbol)
+
+        def history(self, **kwargs):
+            return pd.DataFrame({"Close": [100, 101, 102, 103, 104, 105, 106]})
+
+    monkeypatch.setattr("tradingagents.graph.trading_graph.yf.Ticker", FakeTicker)
+    graph = TradingAgentsGraph.__new__(TradingAgentsGraph)
+
+    raw, alpha, days = TradingAgentsGraph._fetch_returns(
+        graph,
+        "XAUUSD",
+        "2024-01-02",
+        benchmark="SPY",
+    )
+
+    assert seen[0] == "GC=F"
+    assert seen[1] == "SPY"
+    assert raw is not None
+    assert alpha == pytest.approx(0.0)
+    assert days == 5

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -28,6 +28,16 @@ from tradingagents.agents.schemas import (
 from tradingagents.agents.trader.trader import create_trader
 
 
+@pytest.fixture(autouse=True)
+def _stub_sentiment_prefetchers(monkeypatch):
+    """Keep structured-agent unit tests offline and deterministic."""
+    import tradingagents.agents.analysts.sentiment_analyst as mod
+
+    monkeypatch.setattr(mod.get_news, "func", lambda ticker, start, end: "News fixture")
+    monkeypatch.setattr(mod, "fetch_stocktwits_messages", lambda ticker, limit=30: "StockTwits fixture")
+    monkeypatch.setattr(mod, "fetch_reddit_posts", lambda ticker: "Reddit fixture")
+
+
 # ---------------------------------------------------------------------------
 # Render functions
 # ---------------------------------------------------------------------------

--- a/tests/test_temperature_config.py
+++ b/tests/test_temperature_config.py
@@ -78,3 +78,20 @@ class TestProviderKwargsTemperature:
 
     def test_empty_string_omitted(self):
         assert "temperature" not in self._kwargs_for("")
+
+
+@pytest.mark.unit
+class TestReasoningTemperatureGate:
+    def test_reasoning_model_drops_temperature(self):
+        from tradingagents.llm_clients.openai_client import OpenAIClient
+
+        llm = OpenAIClient("gpt-5.5", provider="openai", temperature=0.0, api_key="placeholder").get_llm()
+
+        assert getattr(llm, "temperature", None) in (None, 1)
+
+    def test_non_reasoning_model_keeps_temperature(self):
+        from tradingagents.llm_clients.openai_client import OpenAIClient
+
+        llm = OpenAIClient("gpt-4.1", provider="openai", temperature=0.3, api_key="placeholder").get_llm()
+
+        assert llm.temperature == 0.3

--- a/tests/test_ticker_symbol_handling.py
+++ b/tests/test_ticker_symbol_handling.py
@@ -24,6 +24,13 @@ class TickerSymbolHandlingTests(unittest.TestCase):
         import cli.utils
         self.assertIs(cli.main.get_ticker, cli.utils.get_ticker)
 
+    def test_single_get_analysis_date_no_shadow(self):
+        # Regression: cli/main.py also shadowed cli.utils.get_analysis_date,
+        # causing date validation and prompt UX to diverge.
+        import cli.main
+        import cli.utils
+        self.assertIs(cli.main.get_analysis_date, cli.utils.get_analysis_date)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -1,4 +1,5 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.llm_clients.base_client import normalize_content
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_balance_sheet,
@@ -14,6 +15,8 @@ from tradingagents.dataflows.config import get_config
 def create_fundamentals_analyst(llm):
     def fundamentals_analyst_node(state):
         current_date = state["trade_date"]
+        asset_type = state.get("asset_type", "stock")
+        subject_label = "company" if asset_type == "stock" else "asset or protocol"
         instrument_context = get_instrument_context_from_state(state)
 
         tools = [
@@ -24,7 +27,7 @@ def create_fundamentals_analyst(llm):
         ]
 
         system_message = (
-            "You are a researcher tasked with analyzing fundamental information over the past week about a company. Please write a comprehensive report of the company's fundamental information such as financial documents, company profile, basic company financials, and company financial history to gain a full view of the company's fundamental information to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+            f"You are a researcher tasked with analyzing fundamental information over the past week about a {subject_label}. Please write a comprehensive report of the {subject_label}'s fundamental information such as financial documents, profile, basic financials or network metrics, and history to gain a full view of the {subject_label}'s fundamentals to inform traders. Make sure to include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
             + " Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."
             + " Use the available tools: `get_fundamentals` for comprehensive company analysis, `get_balance_sheet`, `get_cashflow`, and `get_income_statement` for specific financial statements."
             + get_language_instruction(),
@@ -54,12 +57,11 @@ def create_fundamentals_analyst(llm):
 
         chain = prompt | llm.bind_tools(tools)
 
-        result = chain.invoke(state["messages"])
+        result = normalize_content(chain.invoke(state["messages"]))
 
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Preserve provider text even when the model also emits tool calls;
+        # some APIs return useful partial reasoning/content alongside calls.
+        report = result.content or ""
 
         return {
             "messages": [result],

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,4 +1,5 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.llm_clients.base_client import normalize_content
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_indicators,
@@ -79,12 +80,11 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
 
         chain = prompt | llm.bind_tools(tools)
 
-        result = chain.invoke(state["messages"])
+        result = normalize_content(chain.invoke(state["messages"]))
 
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Preserve provider text even when the model also emits tool calls;
+        # some APIs return useful partial reasoning/content alongside calls.
+        report = result.content or ""
 
         return {
             "messages": [result],

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,4 +1,5 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from tradingagents.llm_clients.base_client import normalize_content
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_global_news,
@@ -21,7 +22,7 @@ def create_news_analyst(llm):
         ]
 
         system_message = (
-            f"You are a news researcher tasked with analyzing recent news and trends over the past week. Please write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics. Use the available tools: get_news(query, start_date, end_date) for {asset_label}-specific or targeted news searches, and get_global_news(curr_date, look_back_days, limit) for broader macroeconomic news. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
+            f"You are a news researcher tasked with analyzing recent news and trends over the past week. Please write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics. Use the available tools: get_news(ticker, start_date, end_date) for {asset_label}-specific or targeted news searches, and get_global_news(curr_date, look_back_days, limit) for broader macroeconomic news. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."
             + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
             + get_language_instruction()
         )
@@ -49,12 +50,11 @@ def create_news_analyst(llm):
         prompt = prompt.partial(instrument_context=instrument_context)
 
         chain = prompt | llm.bind_tools(tools)
-        result = chain.invoke(state["messages"])
+        result = normalize_content(chain.invoke(state["messages"]))
 
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Preserve provider text even when the model also emits tool calls;
+        # some APIs return useful partial reasoning/content alongside calls.
+        report = result.content or ""
 
         return {
             "messages": [result],

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -17,6 +17,12 @@ def create_aggressive_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        asset_type = state.get("asset_type", "stock")
+        fundamentals_label = (
+            "Company Fundamentals Report"
+            if asset_type == "stock"
+            else "Asset / Protocol Fundamentals Report"
+        )
         instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
@@ -31,7 +37,7 @@ Your task is to create a compelling case for the trader's decision by questionin
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+{fundamentals_label}: {fundamentals_report}
 Here is the current conversation history: {history} Here are the last arguments from the conservative analyst: {current_conservative_response} Here are the last arguments from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -17,6 +17,12 @@ def create_conservative_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        asset_type = state.get("asset_type", "stock")
+        fundamentals_label = (
+            "Company Fundamentals Report"
+            if asset_type == "stock"
+            else "Asset / Protocol Fundamentals Report"
+        )
         instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
@@ -31,7 +37,7 @@ Your task is to actively counter the arguments of the Aggressive and Neutral Ana
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+{fundamentals_label}: {fundamentals_report}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -17,6 +17,12 @@ def create_neutral_debator(llm):
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
+        asset_type = state.get("asset_type", "stock")
+        fundamentals_label = (
+            "Company Fundamentals Report"
+            if asset_type == "stock"
+            else "Asset / Protocol Fundamentals Report"
+        )
         instrument_context = get_instrument_context_from_state(state)
 
         trader_decision = state["trader_investment_plan"]
@@ -31,7 +37,7 @@ Your task is to challenge both the Aggressive and Conservative Analysts, pointin
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
-Company Fundamentals Report: {fundamentals_report}
+{fundamentals_label}: {fundamentals_report}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the conservative analyst: {current_conservative_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()

--- a/tradingagents/agents/utils/structured.py
+++ b/tradingagents/agents/utils/structured.py
@@ -23,6 +23,8 @@ from typing import Any, Callable, Optional, TypeVar
 
 from pydantic import BaseModel
 
+from tradingagents.llm_clients.base_client import normalize_content
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
@@ -65,9 +67,9 @@ def invoke_structured_or_freetext(
             return render(result)
         except Exception as exc:
             logger.warning(
-                "%s: structured-output invocation failed (%s); retrying once as free text",
+                "%s: structured-output invocation failed (%s); falling back to free-text generation",
                 agent_name, exc,
             )
 
-    response = plain_llm.invoke(prompt)
+    response = normalize_content(plain_llm.invoke(prompt))
     return response.content

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -1,11 +1,16 @@
-import os
-import requests
-import pandas as pd
 import json
+import os
+import time
 from datetime import datetime
 from io import StringIO
 
+import pandas as pd
+import requests
+
 API_BASE_URL = "https://www.alphavantage.co/query"
+AV_REQUEST_TIMEOUT = 15
+AV_MAX_RETRIES = 3
+AV_BACKOFF_BASE = 1.5
 
 
 class AlphaVantageNotConfiguredError(ValueError):
@@ -15,6 +20,19 @@ class AlphaVantageNotConfiguredError(ValueError):
     already catch ValueError, while letting the routing layer distinguish a
     "vendor unavailable" condition from a genuine data error.
     """
+
+    pass
+
+
+class AlphaVantageRateLimitError(Exception):
+    """Raised when Alpha Vantage API rate limit is exceeded."""
+
+    pass
+
+
+class AlphaVantageAuthError(ValueError):
+    """Raised when Alpha Vantage rejects the configured API key."""
+
     pass
 
 
@@ -27,11 +45,12 @@ def get_api_key() -> str:
         )
     return api_key
 
+
 def format_datetime_for_api(date_input) -> str:
-    """Convert various date formats to YYYYMMDDTHHMM format required by Alpha Vantage API."""
+    """Convert various date formats to YYYYMMDDTHHMM required by Alpha Vantage."""
     if isinstance(date_input, str):
         # If already in correct format, return as-is
-        if len(date_input) == 13 and 'T' in date_input:
+        if len(date_input) == 13 and "T" in date_input:
             return date_input
         # Try to parse common date formats
         try:
@@ -43,58 +62,80 @@ def format_datetime_for_api(date_input) -> str:
                 return dt.strftime("%Y%m%dT%H%M")
             except ValueError:
                 raise ValueError(f"Unsupported date format: {date_input}")
-    elif isinstance(date_input, datetime):
+    if isinstance(date_input, datetime):
         return date_input.strftime("%Y%m%dT%H%M")
-    else:
-        raise ValueError(f"Date must be string or datetime object, got {type(date_input)}")
+    raise ValueError(f"Date must be string or datetime object, got {type(date_input)}")
 
-class AlphaVantageRateLimitError(Exception):
-    """Exception raised when Alpha Vantage API rate limit is exceeded."""
-    pass
+
+def _get_with_retry(params: dict) -> requests.Response:
+    last_exc: Exception | None = None
+    for attempt in range(AV_MAX_RETRIES):
+        try:
+            response = requests.get(
+                API_BASE_URL,
+                params=params,
+                timeout=AV_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response
+        except (requests.Timeout, requests.ConnectionError, requests.HTTPError) as exc:
+            last_exc = exc
+            if attempt < AV_MAX_RETRIES - 1:
+                time.sleep(AV_BACKOFF_BASE * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
+
+def _classify_information_message(info_message: str) -> None:
+    msg = info_message.lower()
+    if "rate limit" in msg or "frequency" in msg or "call frequency" in msg:
+        raise AlphaVantageRateLimitError(
+            f"Alpha Vantage rate limit exceeded: {info_message}"
+        )
+    if "api key" in msg or "apikey" in msg or "invalid key" in msg:
+        raise AlphaVantageAuthError(f"Alpha Vantage API key rejected: {info_message}")
+
 
 def _make_api_request(function_name: str, params: dict) -> dict | str:
-    """Helper function to make API requests and handle responses.
-    
+    """Make an Alpha Vantage request with timeout, retry, and error typing.
+
     Raises:
-        AlphaVantageRateLimitError: When API rate limit is exceeded
+        AlphaVantageRateLimitError: when vendor quota/frequency limit is hit.
+        AlphaVantageAuthError: when the configured API key is invalid/rejected.
+        requests.RequestException: when transport fails after bounded retries.
     """
     # Create a copy of params to avoid modifying the original
     api_params = params.copy()
-    api_params.update({
-        "function": function_name,
-        "apikey": get_api_key(),
-        "source": "trading_agents",
-    })
-    
-    # Handle entitlement parameter if present in params or global variable
-    current_entitlement = globals().get('_current_entitlement')
-    entitlement = api_params.get("entitlement") or current_entitlement
-    
-    if entitlement:
-        api_params["entitlement"] = entitlement
-    elif "entitlement" in api_params:
-        # Remove entitlement if it's None or empty
-        api_params.pop("entitlement", None)
-    
-    response = requests.get(API_BASE_URL, params=api_params)
-    response.raise_for_status()
+    api_params.update(
+        {
+            "function": function_name,
+            "apikey": get_api_key(),
+            "source": "trading_agents",
+        }
+    )
 
+    # Keep entitlement explicit: callers may pass params["entitlement"], but
+    # there is no hidden global entitlement side channel.
+    if not api_params.get("entitlement"):
+        api_params.pop("entitlement", None)
+
+    response = _get_with_retry(api_params)
     response_text = response.text
-    
+
     # Check if response is JSON (error responses are typically JSON)
     try:
         response_json = json.loads(response_text)
-        # Check for rate limit error
         if "Information" in response_json:
-            info_message = response_json["Information"]
-            if "rate limit" in info_message.lower() or "api key" in info_message.lower():
-                raise AlphaVantageRateLimitError(f"Alpha Vantage rate limit exceeded: {info_message}")
+            _classify_information_message(response_json["Information"])
+        if "Error Message" in response_json:
+            message = response_json["Error Message"]
+            if "api key" in message.lower() or "apikey" in message.lower():
+                raise AlphaVantageAuthError(f"Alpha Vantage API key rejected: {message}")
     except json.JSONDecodeError:
         # Response is not JSON (likely CSV data), which is normal
         pass
 
     return response_text
-
 
 
 def _filter_csv_by_date_range(csv_data: str, start_date: str, end_date: str) -> str:

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -1,4 +1,5 @@
 import os
+import time
 import requests
 import pandas as pd
 import json
@@ -6,6 +7,9 @@ from datetime import datetime
 from io import StringIO
 
 API_BASE_URL = "https://www.alphavantage.co/query"
+AV_REQUEST_TIMEOUT = 15
+AV_MAX_RETRIES = 3
+AV_BACKOFF_BASE = 1.5
 
 
 class AlphaVantageNotConfiguredError(ValueError):
@@ -52,6 +56,24 @@ class AlphaVantageRateLimitError(Exception):
     """Exception raised when Alpha Vantage API rate limit is exceeded."""
     pass
 
+def _get_with_retry(params: dict) -> requests.Response:
+    last_exc: Exception | None = None
+    for attempt in range(AV_MAX_RETRIES):
+        try:
+            response = requests.get(
+                API_BASE_URL,
+                params=params,
+                timeout=AV_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            return response
+        except (requests.Timeout, requests.ConnectionError, requests.HTTPError) as exc:
+            last_exc = exc
+            if attempt < AV_MAX_RETRIES - 1:
+                time.sleep(AV_BACKOFF_BASE * (2**attempt))
+    assert last_exc is not None
+    raise last_exc
+
 def _make_api_request(function_name: str, params: dict) -> dict | str:
     """Helper function to make API requests and handle responses.
     
@@ -76,8 +98,7 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
         # Remove entitlement if it's None or empty
         api_params.pop("entitlement", None)
     
-    response = requests.get(API_BASE_URL, params=api_params)
-    response.raise_for_status()
+    response = _get_with_retry(api_params)
 
     response_text = response.text
     

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -71,8 +71,9 @@ def _get_with_retry(params: dict) -> requests.Response:
             last_exc = exc
             if attempt < AV_MAX_RETRIES - 1:
                 time.sleep(AV_BACKOFF_BASE * (2**attempt))
-    assert last_exc is not None
-    raise last_exc
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Request failed without an exception")
 
 def _make_api_request(function_name: str, params: dict) -> dict | str:
     """Helper function to make API requests and handle responses.

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -28,12 +28,22 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     prefixed with an explicit caveat so historical backtests do not treat
     the latest valuation metrics as if they existed on that date.
     """
+    import json
     params = {
         "symbol": ticker,
     }
 
     payload = _make_api_request("OVERVIEW", params)
-    return historical_snapshot_caveat(curr_date) + str(payload)
+    caveat = historical_snapshot_caveat(curr_date)
+    if caveat:
+        try:
+            data = json.loads(payload)
+            if isinstance(data, dict):
+                data["_lookahead_caveat"] = caveat.strip()
+                return json.dumps(data)
+        except Exception:
+            pass
+    return payload
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,4 +1,10 @@
+"""Alpha Vantage fundamental-data fetchers."""
+
+from __future__ import annotations
+
 from .alpha_vantage_common import _make_api_request
+from .cache_utils import cache_text
+from .point_in_time import historical_snapshot_caveat
 
 
 def _filter_reports_by_date(result, curr_date: str):
@@ -20,20 +26,23 @@ def _filter_reports_by_date(result, curr_date: str):
 
 def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     """
-    Retrieve comprehensive fundamental data for a given ticker symbol using Alpha Vantage.
+    Retrieve Alpha Vantage company overview data.
 
-    Args:
-        ticker (str): Ticker symbol of the company
-        curr_date (str): Current date you are trading at, yyyy-mm-dd (not used for Alpha Vantage)
-
-    Returns:
-        str: Company overview data including financial ratios and key metrics
+    The OVERVIEW endpoint is a latest snapshot, not a point-in-time
+    historical source. When ``curr_date`` is in the past, the response is
+    prefixed with an explicit caveat so historical backtests do not treat
+    the latest valuation metrics as if they existed on that date.
     """
-    params = {
-        "symbol": ticker,
-    }
 
-    return _make_api_request("OVERVIEW", params)
+    def fetch() -> str:
+        payload = _make_api_request("OVERVIEW", {"symbol": ticker})
+        return historical_snapshot_caveat(curr_date) + str(payload)
+
+    return cache_text(
+        "alpha_vantage_fundamentals",
+        (str(ticker), str(curr_date or "latest")),
+        fetch,
+    )
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):
@@ -52,4 +61,3 @@ def get_income_statement(ticker: str, freq: str = "quarterly", curr_date: str = 
     """Retrieve income statement data for a given ticker symbol using Alpha Vantage."""
     result = _make_api_request("INCOME_STATEMENT", {"symbol": ticker})
     return _filter_reports_by_date(result, curr_date)
-

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,4 +1,5 @@
 from .alpha_vantage_common import _make_api_request
+from .point_in_time import historical_snapshot_caveat
 
 
 def _filter_reports_by_date(result, curr_date: str):
@@ -22,18 +23,17 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     """
     Retrieve comprehensive fundamental data for a given ticker symbol using Alpha Vantage.
 
-    Args:
-        ticker (str): Ticker symbol of the company
-        curr_date (str): Current date you are trading at, yyyy-mm-dd (not used for Alpha Vantage)
-
-    Returns:
-        str: Company overview data including financial ratios and key metrics
+    The OVERVIEW endpoint is a latest snapshot, not a point-in-time
+    historical source. When ``curr_date`` is in the past, the response is
+    prefixed with an explicit caveat so historical backtests do not treat
+    the latest valuation metrics as if they existed on that date.
     """
     params = {
         "symbol": ticker,
     }
 
-    return _make_api_request("OVERVIEW", params)
+    payload = _make_api_request("OVERVIEW", params)
+    return historical_snapshot_caveat(curr_date) + str(payload)
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):

--- a/tradingagents/dataflows/alpha_vantage_news.py
+++ b/tradingagents/dataflows/alpha_vantage_news.py
@@ -1,71 +1,129 @@
+"""Alpha Vantage news fetchers with markdown normalization and date-scoped cache."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
 from .alpha_vantage_common import _make_api_request, format_datetime_for_api
+from .cache_utils import cache_text
 
-def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
-    """Returns live and historical market news & sentiment data from premier news outlets worldwide.
 
-    Covers stocks, cryptocurrencies, forex, and topics like fiscal policy, mergers & acquisitions, IPOs.
+def _format_score(value: Any) -> str:
+    try:
+        return f"{float(value):.3f}"
+    except (TypeError, ValueError):
+        return str(value) if value is not None else ""
 
-    Args:
-        ticker: Stock symbol for news articles.
-        start_date: Start date for news search.
-        end_date: End date for news search.
 
-    Returns:
-        Dictionary containing news sentiment data or JSON string.
-    """
+def _format_ticker_sentiment(items: list[dict[str, Any]] | None) -> str:
+    if not items:
+        return ""
+    parts = []
+    for item in items[:8]:
+        ticker = item.get("ticker") or item.get("symbol") or "unknown"
+        label = item.get("ticker_sentiment_label") or item.get("relevance_score") or ""
+        score = item.get("ticker_sentiment_score")
+        rendered = ticker
+        if label:
+            rendered += f" {label}"
+        if score is not None:
+            rendered += f" ({_format_score(score)})"
+        parts.append(rendered)
+    return "; ".join(parts)
 
-    params = {
-        "tickers": ticker,
-        "time_from": format_datetime_for_api(start_date),
-        "time_to": format_datetime_for_api(end_date),
-    }
 
-    return _make_api_request("NEWS_SENTIMENT", params)
+def _format_news_sentiment_payload(payload: dict[str, Any], heading: str) -> str:
+    feed = payload.get("feed") if isinstance(payload, dict) else None
+    if not isinstance(feed, list) or not feed:
+        return f"No Alpha Vantage news found for {heading}"
 
-def get_global_news(curr_date, look_back_days: int = 7, limit: int = 50) -> dict[str, str] | str:
-    """Returns global market news & sentiment data without ticker-specific filtering.
+    lines = [f"## Alpha Vantage News Sentiment: {heading}", ""]
+    for article in feed:
+        if not isinstance(article, dict):
+            continue
+        title = article.get("title") or "No title"
+        source = article.get("source") or "Unknown"
+        published = article.get("time_published") or "unknown date"
+        summary = article.get("summary") or ""
+        url = article.get("url") or ""
+        overall_label = article.get("overall_sentiment_label")
+        overall_score = article.get("overall_sentiment_score")
+        ticker_sentiment = _format_ticker_sentiment(article.get("ticker_sentiment"))
 
-    Covers broad market topics like financial markets, economy, and more.
+        lines.append(f"### {title} (source: {source})")
+        lines.append(f"Published: {published}")
+        if overall_label or overall_score is not None:
+            label_part = f" {overall_label}" if overall_label else ""
+            score_part = f" ({_format_score(overall_score)})" if overall_score is not None else ""
+            lines.append(f"Overall sentiment:{label_part}{score_part}".strip())
+        if ticker_sentiment:
+            lines.append(f"Ticker sentiment: {ticker_sentiment}")
+        if summary:
+            lines.append(summary)
+        if url:
+            lines.append(f"Link: {url}")
+        lines.append("")
 
-    Args:
-        curr_date: Current date in yyyy-mm-dd format.
-        look_back_days: Number of days to look back (default 7).
-        limit: Maximum number of articles (default 50).
+    return "\n".join(lines).strip() or f"No Alpha Vantage news found for {heading}"
 
-    Returns:
-        Dictionary containing global news sentiment data or JSON string.
-    """
+
+def _normalize_news_response(response: dict[str, Any] | str, heading: str) -> str:
+    if isinstance(response, dict):
+        return _format_news_sentiment_payload(response, heading)
+    if not isinstance(response, str):
+        return str(response)
+    try:
+        parsed = json.loads(response)
+    except json.JSONDecodeError:
+        return response
+    return _format_news_sentiment_payload(parsed, heading)
+
+
+def get_news(ticker, start_date, end_date) -> str:
+    """Return ticker-specific market news & sentiment as markdown."""
+
+    def fetch() -> str:
+        params = {
+            "tickers": ticker,
+            "time_from": format_datetime_for_api(start_date),
+            "time_to": format_datetime_for_api(end_date),
+        }
+        return _normalize_news_response(
+            _make_api_request("NEWS_SENTIMENT", params),
+            f"{ticker}, from {start_date} to {end_date}",
+        )
+
+    return cache_text("alpha_vantage_news", (str(ticker), str(start_date), str(end_date)), fetch)
+
+
+def get_global_news(curr_date, look_back_days: int = 7, limit: int = 50) -> str:
+    """Return broad market news & sentiment as markdown."""
     from datetime import datetime, timedelta
 
-    # Calculate start date
     curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
     start_dt = curr_dt - timedelta(days=look_back_days)
     start_date = start_dt.strftime("%Y-%m-%d")
 
-    params = {
-        "topics": "financial_markets,economy_macro,economy_monetary",
-        "time_from": format_datetime_for_api(start_date),
-        "time_to": format_datetime_for_api(curr_date),
-        "limit": str(limit),
-    }
+    def fetch() -> str:
+        params = {
+            "topics": "financial_markets,economy_macro,economy_monetary",
+            "time_from": format_datetime_for_api(start_date),
+            "time_to": format_datetime_for_api(curr_date),
+            "limit": str(limit),
+        }
+        return _normalize_news_response(
+            _make_api_request("NEWS_SENTIMENT", params),
+            f"global markets, from {start_date} to {curr_date}",
+        )
 
-    return _make_api_request("NEWS_SENTIMENT", params)
+    return cache_text(
+        "alpha_vantage_global_news",
+        (str(curr_date), str(look_back_days), str(limit)),
+        fetch,
+    )
 
 
 def get_insider_transactions(symbol: str) -> dict[str, str] | str:
-    """Returns latest and historical insider transactions by key stakeholders.
-
-    Covers transactions by founders, executives, board members, etc.
-
-    Args:
-        symbol: Ticker symbol. Example: "IBM".
-
-    Returns:
-        Dictionary containing insider transaction data or JSON string.
-    """
-
-    params = {
-        "symbol": symbol,
-    }
-
-    return _make_api_request("INSIDER_TRANSACTIONS", params)
+    """Returns latest and historical insider transactions by key stakeholders."""
+    return _make_api_request("INSIDER_TRANSACTIONS", {"symbol": symbol})

--- a/tradingagents/dataflows/cache_utils.py
+++ b/tradingagents/dataflows/cache_utils.py
@@ -1,0 +1,68 @@
+"""Small text-cache helpers for date-scoped dataflow fetchers.
+
+The cache is intentionally plain text and key-based: news/fundamentals tools
+return strings that are later injected into LLM prompts, so preserving the exact
+string makes historical reruns more reproducible and avoids unnecessary vendor
+quota use.  Callers should cache successful, deterministic payloads only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Callable, Optional
+
+from .config import get_config
+from .utils import safe_ticker_component
+
+
+def _safe_component(value: str, *, max_len: int = 80) -> str:
+    """Return a filesystem-safe cache path component for arbitrary inputs."""
+    if value and len(value) <= 32:
+        try:
+            return safe_ticker_component(value, max_len=32)
+        except ValueError:
+            pass
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    cleaned = "".join(ch if ch.isalnum() or ch in "._-^=+" else "_" for ch in value)
+    cleaned = cleaned.strip("._-")[: max_len - 17]
+    return f"{cleaned or 'key'}-{digest}"
+
+
+def cache_path(namespace: str, *parts: str) -> Path:
+    base = Path(get_config()["data_cache_dir"]) / "text_cache" / namespace
+    safe_parts = [_safe_component(str(part)) for part in parts]
+    return base.joinpath(*safe_parts).with_suffix(".txt")
+
+
+def read_text_cache(namespace: str, *parts: str) -> Optional[str]:
+    path = cache_path(namespace, *parts)
+    try:
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return None
+
+
+def write_text_cache(namespace: str, value: str, *parts: str) -> str:
+    path = cache_path(namespace, *parts)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value, encoding="utf-8")
+    except OSError:
+        # Cache is an optimization; never fail a data tool because disk cache
+        # cannot be written.
+        pass
+    return value
+
+
+def cache_text(namespace: str, parts: tuple[str, ...], fetch: Callable[[], str]) -> str:
+    cached = read_text_cache(namespace, *parts)
+    if cached is not None:
+        return cached
+    value = fetch()
+    # Avoid pinning transient vendor failures into reproducible cache.
+    if isinstance(value, str) and not value.lstrip().lower().startswith("error"):
+        write_text_cache(namespace, value, *parts)
+    return value

--- a/tradingagents/dataflows/point_in_time.py
+++ b/tradingagents/dataflows/point_in_time.py
@@ -1,0 +1,25 @@
+"""Helpers that mark data sources that are not point-in-time snapshots."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+LOOKAHEAD_CAVEAT_TEMPLATE = (
+    "NOTE: OVERVIEW/company-info metrics reflect the LATEST snapshot, "
+    "not point-in-time as of {date}. Treat valuation ratios with caution "
+    "in historical backtests.\n\n"
+)
+
+
+def historical_snapshot_caveat(curr_date: str | None) -> str:
+    """Return a caveat when latest-only vendor data is used for a past date."""
+    if not curr_date:
+        return ""
+    try:
+        requested = datetime.strptime(curr_date, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return ""
+    if requested < date.today():
+        return LOOKAHEAD_CAVEAT_TEMPLATE.format(date=curr_date)
+    return ""

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -6,6 +6,7 @@ import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
 from .symbol_utils import normalize_symbol, NoMarketDataError
+from .point_in_time import historical_snapshot_caveat
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
@@ -311,7 +312,8 @@ def get_fundamentals(
         if not lines:
             raise NoMarketDataError(ticker, canonical, "no fundamental fields returned")
 
-        header = f"# Company Fundamentals for {canonical}\n"
+        header = historical_snapshot_caveat(curr_date)
+        header += f"# Company Fundamentals for {canonical}\n"
         header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
 
         return header + "\n".join(lines)

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -6,6 +6,8 @@ import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
 from .symbol_utils import normalize_symbol, NoMarketDataError
+from .cache_utils import cache_text
+from .point_in_time import historical_snapshot_caveat
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
@@ -257,70 +259,84 @@ def get_stockstats_indicator(
 
 def get_fundamentals(
     ticker: Annotated[str, "ticker symbol of the company"],
-    curr_date: Annotated[str, "current date (not used for yfinance)"] = None
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None
 ):
-    """Get company fundamentals overview from yfinance."""
+    """Get latest company fundamentals overview from yfinance.
+
+    yfinance ``Ticker.info`` is a latest snapshot, not a point-in-time
+    historical data source. When ``curr_date`` is in the past, the returned
+    text starts with an explicit caveat so backtests do not treat valuation
+    ratios as historical truth.
+    """
     canonical = normalize_symbol(ticker)
-    try:
-        ticker_obj = yf.Ticker(canonical)
-        info = yf_retry(lambda: ticker_obj.info)
 
-        if not info:
-            raise NoMarketDataError(ticker, canonical, "no fundamentals returned")
+    def fetch() -> str:
+        try:
+            ticker_obj = yf.Ticker(canonical)
+            info = yf_retry(lambda: ticker_obj.info)
 
-        fields = [
-            ("Name", info.get("longName")),
-            ("Sector", info.get("sector")),
-            ("Industry", info.get("industry")),
-            ("Market Cap", info.get("marketCap")),
-            ("PE Ratio (TTM)", info.get("trailingPE")),
-            ("Forward PE", info.get("forwardPE")),
-            ("PEG Ratio", info.get("pegRatio")),
-            ("Price to Book", info.get("priceToBook")),
-            ("EPS (TTM)", info.get("trailingEps")),
-            ("Forward EPS", info.get("forwardEps")),
-            ("Dividend Yield", info.get("dividendYield")),
-            ("Beta", info.get("beta")),
-            ("52 Week High", info.get("fiftyTwoWeekHigh")),
-            ("52 Week Low", info.get("fiftyTwoWeekLow")),
-            ("50 Day Average", info.get("fiftyDayAverage")),
-            ("200 Day Average", info.get("twoHundredDayAverage")),
-            ("Revenue (TTM)", info.get("totalRevenue")),
-            ("Gross Profit", info.get("grossProfits")),
-            ("EBITDA", info.get("ebitda")),
-            ("Net Income", info.get("netIncomeToCommon")),
-            ("Profit Margin", info.get("profitMargins")),
-            ("Operating Margin", info.get("operatingMargins")),
-            ("Return on Equity", info.get("returnOnEquity")),
-            ("Return on Assets", info.get("returnOnAssets")),
-            ("Debt to Equity", info.get("debtToEquity")),
-            ("Current Ratio", info.get("currentRatio")),
-            ("Book Value", info.get("bookValue")),
-            ("Free Cash Flow", info.get("freeCashflow")),
-        ]
+            if not info:
+                raise NoMarketDataError(ticker, canonical, "no fundamentals returned")
 
-        lines = []
-        for label, value in fields:
-            if value is not None:
-                lines.append(f"{label}: {value}")
+            fields = [
+                ("Name", info.get("longName")),
+                ("Sector", info.get("sector")),
+                ("Industry", info.get("industry")),
+                ("Market Cap", info.get("marketCap")),
+                ("PE Ratio (TTM)", info.get("trailingPE")),
+                ("Forward PE", info.get("forwardPE")),
+                ("PEG Ratio", info.get("pegRatio")),
+                ("Price to Book", info.get("priceToBook")),
+                ("EPS (TTM)", info.get("trailingEps")),
+                ("Forward EPS", info.get("forwardEps")),
+                ("Dividend Yield", info.get("dividendYield")),
+                ("Beta", info.get("beta")),
+                ("52 Week High", info.get("fiftyTwoWeekHigh")),
+                ("52 Week Low", info.get("fiftyTwoWeekLow")),
+                ("50 Day Average", info.get("fiftyDayAverage")),
+                ("200 Day Average", info.get("twoHundredDayAverage")),
+                ("Revenue (TTM)", info.get("totalRevenue")),
+                ("Gross Profit", info.get("grossProfits")),
+                ("EBITDA", info.get("ebitda")),
+                ("Net Income", info.get("netIncomeToCommon")),
+                ("Profit Margin", info.get("profitMargins")),
+                ("Operating Margin", info.get("operatingMargins")),
+                ("Return on Equity", info.get("returnOnEquity")),
+                ("Return on Assets", info.get("returnOnAssets")),
+                ("Debt to Equity", info.get("debtToEquity")),
+                ("Current Ratio", info.get("currentRatio")),
+                ("Book Value", info.get("bookValue")),
+                ("Free Cash Flow", info.get("freeCashflow")),
+            ]
 
-        # yfinance returns a stub dict (e.g. {"trailingPegRatio": None}) for
-        # unknown symbols, so `info` is truthy but every field is empty. Treat
-        # "no usable fields" as no data rather than emitting a bare header the
-        # agent might fabricate around.
-        if not lines:
-            raise NoMarketDataError(ticker, canonical, "no fundamental fields returned")
+            lines = []
+            for label, value in fields:
+                if value is not None:
+                    lines.append(f"{label}: {value}")
 
-        header = f"# Company Fundamentals for {canonical}\n"
-        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+            # yfinance returns a stub dict (e.g. {"trailingPegRatio": None}) for
+            # unknown symbols, so `info` is truthy but every field is empty. Treat
+            # "no usable fields" as no data rather than emitting a bare header the
+            # agent might fabricate around.
+            if not lines:
+                raise NoMarketDataError(ticker, canonical, "no fundamental fields returned")
 
-        return header + "\n".join(lines)
+            header = historical_snapshot_caveat(curr_date)
+            header += f"# Company Fundamentals for {canonical}\n"
+            header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
 
-    except NoMarketDataError:
-        raise
-    except Exception as e:
-        return f"Error retrieving fundamentals for {ticker}: {str(e)}"
+            return header + "\n".join(lines)
 
+        except NoMarketDataError:
+            raise
+        except Exception as e:
+            return f"Error retrieving fundamentals for {ticker}: {str(e)}"
+
+    return cache_text(
+        "yfinance_fundamentals",
+        (canonical, str(curr_date or "latest")),
+        fetch,
+    )
 
 def get_balance_sheet(
     ticker: Annotated[str, "ticker symbol of the company"],

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -8,6 +8,7 @@ from dateutil.relativedelta import relativedelta
 
 from .config import get_config
 from .stockstats_utils import yf_retry
+from .cache_utils import cache_text
 
 
 def _extract_article_data(article: dict) -> dict:
@@ -51,22 +52,11 @@ def _extract_article_data(article: dict) -> dict:
         }
 
 
-def get_news_yfinance(
+def _get_news_yfinance_uncached(
     ticker: str,
     start_date: str,
     end_date: str,
 ) -> str:
-    """
-    Retrieve news for a specific stock ticker using yfinance.
-
-    Args:
-        ticker: Stock ticker symbol (e.g., "AAPL")
-        start_date: Start date in yyyy-mm-dd format
-        end_date: End date in yyyy-mm-dd format
-
-    Returns:
-        Formatted string containing news articles
-    """
     article_limit = get_config()["news_article_limit"]
     try:
         stock = yf.Ticker(ticker)
@@ -108,7 +98,25 @@ def get_news_yfinance(
         return f"Error fetching news for {ticker}: {str(e)}"
 
 
-def get_global_news_yfinance(
+def get_news_yfinance(
+    ticker: str,
+    start_date: str,
+    end_date: str,
+) -> str:
+    """
+    Retrieve news for a specific stock ticker using yfinance.
+
+    The result is cached by ticker and date range so historical/replay runs
+    reuse the same fetched article set instead of silently drifting with
+    yfinance's latest feed.
+    """
+    return cache_text(
+        "yfinance_news",
+        (str(ticker), str(start_date), str(end_date)),
+        lambda: _get_news_yfinance_uncached(ticker, start_date, end_date),
+    )
+
+def _get_global_news_yfinance_uncached(
     curr_date: str,
     look_back_days: Optional[int] = None,
     limit: Optional[int] = None,
@@ -200,3 +208,20 @@ def get_global_news_yfinance(
 
     except Exception as e:
         return f"Error fetching global news: {str(e)}"
+
+
+
+def get_global_news_yfinance(
+    curr_date: str,
+    look_back_days: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> str:
+    """Retrieve global/macro news with date-scoped cache."""
+    config = get_config()
+    effective_lookback = look_back_days if look_back_days is not None else config["global_news_lookback_days"]
+    effective_limit = limit if limit is not None else config["global_news_article_limit"]
+    return cache_text(
+        "yfinance_global_news",
+        (str(curr_date), str(effective_lookback), str(effective_limit)),
+        lambda: _get_global_news_yfinance_uncached(curr_date, look_back_days, limit),
+    )

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -80,7 +80,6 @@ DEFAULT_CONFIG = _apply_env_overrides({
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,
     "max_recur_limit": 100,
-    "analyst_concurrency_limit": 1,
     # News / data fetching parameters
     # Increase for longer lookback strategies or to broaden macro coverage;
     # decrease to reduce token usage in agent prompts.

--- a/tradingagents/graph/analyst_execution.py
+++ b/tradingagents/graph/analyst_execution.py
@@ -15,7 +15,6 @@ class AnalystNodeSpec:
 @dataclass(frozen=True)
 class AnalystExecutionPlan:
     specs: List[AnalystNodeSpec]
-    concurrency_limit: int
 
 
 ANALYST_NODE_SPECS: Dict[str, AnalystNodeSpec] = {
@@ -56,11 +55,7 @@ ANALYST_NODE_SPECS: Dict[str, AnalystNodeSpec] = {
 
 def build_analyst_execution_plan(
     selected_analysts: Iterable[str],
-    concurrency_limit: int = 1,
 ) -> AnalystExecutionPlan:
-    if concurrency_limit < 1:
-        raise ValueError("analyst concurrency limit must be >= 1")
-
     specs: List[AnalystNodeSpec] = []
     for analyst_key in selected_analysts:
         spec = ANALYST_NODE_SPECS.get(analyst_key)
@@ -71,7 +66,7 @@ def build_analyst_execution_plan(
     if not specs:
         raise ValueError("at least one analyst must be selected")
 
-    return AnalystExecutionPlan(specs=specs, concurrency_limit=concurrency_limit)
+    return AnalystExecutionPlan(specs=specs)
 
 
 def get_initial_analyst_node(plan: AnalystExecutionPlan) -> str:

--- a/tradingagents/graph/conditional_logic.py
+++ b/tradingagents/graph/conditional_logic.py
@@ -54,7 +54,7 @@ class ConditionalLogic:
 
         if (
             state["investment_debate_state"]["count"] >= 2 * self.max_debate_rounds
-        ):  # 3 rounds of back-and-forth between 2 agents
+        ):  # 2 * max_debate_rounds turns total (default 1 -> bull + bear)
             return "Research Manager"
         if state["investment_debate_state"]["current_response"].startswith("Bull"):
             return "Bear Researcher"
@@ -64,7 +64,7 @@ class ConditionalLogic:
         """Determine if risk analysis should continue."""
         if (
             state["risk_debate_state"]["count"] >= 3 * self.max_risk_discuss_rounds
-        ):  # 3 rounds of back-and-forth between 3 agents
+        ):  # 3 * max_risk_discuss_rounds turns total (default 1 -> one per risk agent)
             return "Portfolio Manager"
         if state["risk_debate_state"]["latest_speaker"].startswith("Aggressive"):
             return "Conservative Analyst"

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -20,14 +20,12 @@ class GraphSetup:
         deep_thinking_llm: Any,
         tool_nodes: Dict[str, ToolNode],
         conditional_logic: ConditionalLogic,
-        analyst_concurrency_limit: int = 1,
     ):
         """Initialize with required components."""
         self.quick_thinking_llm = quick_thinking_llm
         self.deep_thinking_llm = deep_thinking_llm
         self.tool_nodes = tool_nodes
         self.conditional_logic = conditional_logic
-        self.analyst_concurrency_limit = analyst_concurrency_limit
 
     def setup_graph(
         self, selected_analysts=["market", "social", "news", "fundamentals"]
@@ -41,10 +39,7 @@ class GraphSetup:
                 - "news": News analyst
                 - "fundamentals": Fundamentals analyst
         """
-        plan = build_analyst_execution_plan(
-            selected_analysts,
-            concurrency_limit=self.analyst_concurrency_limit,
-        )
+        plan = build_analyst_execution_plan(selected_analysts)
 
         analyst_factories = {
             "market": lambda: create_market_analyst(self.quick_thinking_llm),
@@ -88,7 +83,7 @@ class GraphSetup:
         # Start with the first analyst
         workflow.add_edge(START, plan.specs[0].agent_node)
 
-        # Connect analysts in sequence
+        # Connect analysts in sequence; no concurrency knob is exposed until the shared message/tool-call channel is refactored into per-analyst lanes.
         for i, spec in enumerate(plan.specs):
             current_analyst = spec.agent_node
             current_tools = spec.tool_node

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -379,7 +379,7 @@ class TradingAgentsGraph:
             tid = thread_id(company_name, str(trade_date))
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
 
-        if self.debug:
+        if self.debug or on_chunk is not None:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
                 if on_chunk is not None:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -19,6 +19,7 @@ from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.dataflows.utils import safe_ticker_component
+from tradingagents.dataflows.symbol_utils import normalize_symbol
 from tradingagents.agents.utils.agent_states import (
     AgentState,
     InvestDebateState,
@@ -116,7 +117,6 @@ class TradingAgentsGraph:
             self.deep_thinking_llm,
             self.tool_nodes,
             self.conditional_logic,
-            analyst_concurrency_limit=self.config.get("analyst_concurrency_limit", 1),
         )
 
         self.propagator = Propagator(
@@ -237,7 +237,8 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
+            yahoo_symbol = normalize_symbol(ticker)
+            stock = yf.Ticker(yahoo_symbol).history(start=trade_date, end=end_str)
             bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:
@@ -313,7 +314,7 @@ class TradingAgentsGraph:
         identity = resolve_instrument_identity(ticker)
         return build_instrument_context(ticker, asset_type, identity)
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -347,14 +348,19 @@ class TradingAgentsGraph:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
         try:
-            return self._run_graph(company_name, trade_date, asset_type=asset_type)
+            return self._run_graph(
+                company_name,
+                trade_date,
+                asset_type=asset_type,
+                on_chunk=on_chunk,
+            )
         finally:
             if self._checkpointer_ctx is not None:
                 self._checkpointer_ctx.__exit__(None, None, None)
                 self._checkpointer_ctx = None
                 self.graph = self.workflow.compile()
 
-    def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
+    def _run_graph(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents.
@@ -367,7 +373,7 @@ class TradingAgentsGraph:
             past_context=past_context,
             instrument_context=instrument_context,
         )
-        args = self.propagator.get_graph_args()
+        args = self.propagator.get_graph_args(callbacks=self.callbacks)
 
         # Inject thread_id so same ticker+date resumes, different date starts fresh.
         if self.config.get("checkpoint_enabled"):
@@ -377,13 +383,13 @@ class TradingAgentsGraph:
         if self.debug:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
-                if len(chunk["messages"]) == 0:
-                    pass
-                else:
+                if on_chunk is not None:
+                    on_chunk(chunk)
+                elif chunk.get("messages"):
                     chunk["messages"][-1].pretty_print()
-                    trace.append(chunk)
-            # Streamed chunks are per-node deltas. Merge them so the returned
-            # state matches what graph.invoke() yields in the non-debug path.
+                trace.append(chunk)
+            # stream_mode='values' yields cumulative state snapshots. Merging is
+            # still harmless and keeps returned state parity with graph.invoke().
             final_state = {}
             for chunk in trace:
                 final_state.update(chunk)

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -239,8 +239,9 @@ class TradingAgentsGraph:
             end_str = end.strftime("%Y-%m-%d")
 
             yahoo_symbol = normalize_symbol(ticker)
+            yahoo_bench = normalize_symbol(benchmark)
             stock = yf.Ticker(yahoo_symbol).history(start=trade_date, end=end_str)
-            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+            bench = yf.Ticker(yahoo_bench).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:
                 return None, None, None

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -313,7 +313,7 @@ class TradingAgentsGraph:
         identity = resolve_instrument_identity(ticker)
         return build_instrument_context(ticker, asset_type, identity)
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -347,14 +347,19 @@ class TradingAgentsGraph:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
         try:
-            return self._run_graph(company_name, trade_date, asset_type=asset_type)
+            return self._run_graph(
+                company_name,
+                trade_date,
+                asset_type=asset_type,
+                on_chunk=on_chunk,
+            )
         finally:
             if self._checkpointer_ctx is not None:
                 self._checkpointer_ctx.__exit__(None, None, None)
                 self._checkpointer_ctx = None
                 self.graph = self.workflow.compile()
 
-    def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
+    def _run_graph(self, company_name, trade_date, asset_type: str = "stock", on_chunk=None):
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents.
@@ -367,7 +372,7 @@ class TradingAgentsGraph:
             past_context=past_context,
             instrument_context=instrument_context,
         )
-        args = self.propagator.get_graph_args()
+        args = self.propagator.get_graph_args(callbacks=self.callbacks)
 
         # Inject thread_id so same ticker+date resumes, different date starts fresh.
         if self.config.get("checkpoint_enabled"):
@@ -377,11 +382,13 @@ class TradingAgentsGraph:
         if self.debug:
             trace = []
             for chunk in self.graph.stream(init_agent_state, **args):
-                if len(chunk["messages"]) == 0:
+                if on_chunk is not None:
+                    on_chunk(chunk)
+                elif len(chunk["messages"]) == 0:
                     pass
                 else:
                     chunk["messages"][-1].pretty_print()
-                    trace.append(chunk)
+                trace.append(chunk)
             # Streamed chunks are per-node deltas. Merge them so the returned
             # state matches what graph.invoke() yields in the non-debug path.
             final_state = {}

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -19,6 +19,7 @@ from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.dataflows.utils import safe_ticker_component
+from tradingagents.dataflows.symbol_utils import normalize_symbol
 from tradingagents.agents.utils.agent_states import (
     AgentState,
     InvestDebateState,
@@ -237,7 +238,8 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
+            yahoo_symbol = normalize_symbol(ticker)
+            stock = yf.Ticker(yahoo_symbol).history(start=trade_date, end=end_str)
             bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -35,6 +35,7 @@ class ModelCapabilities:
     supports_json_mode: bool
     supports_json_schema: bool
     preferred_structured_method: StructuredMethod
+    supports_temperature: bool = True
     # DeepSeek thinking-mode models 400 if reasoning_content from prior
     # assistant turns is not echoed back on the next request.
     requires_reasoning_content_roundtrip: bool = False
@@ -83,6 +84,17 @@ _MINIMAX_THINKING = ModelCapabilities(
     requires_reasoning_split=True,
 )
 
+# OpenAI GPT-5 reasoning-family models reject user sampling temperatures
+# (anything other than provider default). Keep GPT-4.1 on _DEFAULT: it is a
+# non-reasoning model and continues to accept temperature.
+_OPENAI_REASONING = ModelCapabilities(
+    supports_tool_choice=True,
+    supports_json_mode=True,
+    supports_json_schema=True,
+    preferred_structured_method="function_calling",
+    supports_temperature=False,
+)
+
 _DEFAULT = ModelCapabilities(
     supports_tool_choice=True,
     supports_json_mode=True,
@@ -97,6 +109,12 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "deepseek-reasoner": _DEEPSEEK_THINKING,
     "deepseek-v4-flash": _DEEPSEEK_THINKING,
     "deepseek-v4-pro": _DEEPSEEK_THINKING,
+    "gpt-5.5": _OPENAI_REASONING,
+    "gpt-5.5-pro": _OPENAI_REASONING,
+    "gpt-5.4": _OPENAI_REASONING,
+    "gpt-5.4-mini": _OPENAI_REASONING,
+    "gpt-5.4-nano": _OPENAI_REASONING,
+    "gpt-5.2": _OPENAI_REASONING,
     # MiniMax — full official model lineup per
     # platform.minimax.io/docs/api-reference/text-openai-api
     "MiniMax-M2.7": _MINIMAX_THINKING,
@@ -111,6 +129,7 @@ _BY_ID: dict[str, ModelCapabilities] = {
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
 # or ``MiniMax-M3*`` variants inherit the thinking-mode quirks automatically.
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
+    (re.compile(r"^gpt-5"), _OPENAI_REASONING),
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
     (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -59,6 +59,7 @@ _DEEPSEEK_THINKING = ModelCapabilities(
     supports_json_schema=False,
     preferred_structured_method="function_calling",
     requires_reasoning_content_roundtrip=True,
+    supports_temperature=False,
 )
 
 _DEEPSEEK_CHAT = ModelCapabilities(

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Optional
 
@@ -8,6 +9,8 @@ from .api_key_env import get_api_key_env
 from .base_client import BaseLLMClient, normalize_content
 from .capabilities import get_capabilities
 from .validators import validate_model
+
+logger = logging.getLogger(__name__)
 
 
 class NormalizedChatOpenAI(ChatOpenAI):
@@ -177,7 +180,7 @@ def _resolve_provider_base_url(provider: str) -> Optional[str]:
     import behave correctly.
     """
     if provider == "ollama":
-        env_url = os.environ.get("OLLAMA_BASE_URL")
+        env_url = os.environ.get("TRADINGAGENTS_OLLAMA_BASE_URL") or os.environ.get("OLLAMA_BASE_URL")
         if env_url:
             return env_url
     return _PROVIDER_BASE_URL.get(provider)
@@ -228,10 +231,19 @@ class OpenAIClient(BaseLLMClient):
         elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 
-        # Forward user-provided kwargs
+        # Forward user-provided kwargs, but gate options rejected by the
+        # selected model family before LangChain/OpenAI sends the request.
+        caps = get_capabilities(self.model)
         for key in _PASSTHROUGH_KWARGS:
-            if key in self.kwargs:
-                llm_kwargs[key] = self.kwargs[key]
+            if key not in self.kwargs:
+                continue
+            if key == "temperature" and not caps.supports_temperature:
+                logger.warning(
+                    "Model %s rejects user temperature; dropping configured value.",
+                    self.model,
+                )
+                continue
+            llm_kwargs[key] = self.kwargs[key]
 
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -238,10 +238,11 @@ class OpenAIClient(BaseLLMClient):
             if key not in self.kwargs:
                 continue
             if key == "temperature" and not caps.supports_temperature:
-                logger.warning(
-                    "Model %s rejects user temperature; dropping configured value.",
-                    self.model,
-                )
+                if self.kwargs.get("temperature") is not None:
+                    logger.warning(
+                        "Model %s rejects user temperature; dropping configured value.",
+                        self.model,
+                    )
                 continue
             llm_kwargs[key] = self.kwargs[key]
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Optional
 
@@ -8,6 +9,8 @@ from .api_key_env import get_api_key_env
 from .base_client import BaseLLMClient, normalize_content
 from .capabilities import get_capabilities
 from .validators import validate_model
+
+logger = logging.getLogger(__name__)
 
 
 class NormalizedChatOpenAI(ChatOpenAI):
@@ -228,10 +231,19 @@ class OpenAIClient(BaseLLMClient):
         elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 
-        # Forward user-provided kwargs
+        # Forward user-provided kwargs, but gate options rejected by the
+        # selected model family before LangChain/OpenAI sends the request.
+        caps = get_capabilities(self.model)
         for key in _PASSTHROUGH_KWARGS:
-            if key in self.kwargs:
-                llm_kwargs[key] = self.kwargs[key]
+            if key not in self.kwargs:
+                continue
+            if key == "temperature" and not caps.supports_temperature:
+                logger.warning(
+                    "Model %s rejects user temperature; dropping configured value.",
+                    self.model,
+                )
+                continue
+            llm_kwargs[key] = self.kwargs[key]
 
         # Native OpenAI: use Responses API for consistent behavior across
         # all model families. Third-party providers use Chat Completions.


### PR DESCRIPTION
**Audit findings:** D3, D4, D6, D7, AG2, AG3, AG4, G2, G4/C4, C5 · **Branch prefix:** `chore/polish-*` (splittable into micro-PRs)

### Changes

**Data flow**
- **D3** — `alpha_vantage_common.py`: classify errors explicitly — rate-limit
  (`"rate limit"|"frequency"|"call frequency"`) → `AlphaVantageRateLimitError`;
  key problems (`"api key"|"apikey"|"invalid key"`) → new `AlphaVantageAuthError`
  (previously misclassified as rate-limit).
- **D4** — `alpha_vantage_news.py`: render `NEWS_SENTIMENT` JSON to the same markdown
  shape as the yfinance news path (`_normalize_news_response` /
  `_format_news_sentiment_payload`).
- **D6** — `alpha_vantage_common.py`: remove the unused
  `globals().get("_current_entitlement")` side-channel; entitlement is explicit via
  `params["entitlement"]`.
- **D7** — `cache_utils.py` (+ news/fundamentals fetchers): date-scoped caching for
  news & fundamentals, mirroring the OHLCV cache (reproducibility + quota savings).

**Agents**
- **AG2** — `risk_mgmt/{aggressive,conservative,neutral}_debator.py`: read
  `state.get("asset_type", "stock")` and frame language for crypto vs equity.
- **AG3** — `analysts/news_analyst.py`: prompt now documents
  `get_news(ticker, start_date, end_date)` (was `query`).
- **AG4** — `agents/utils/structured.py`: free-text fallback passes the response
  through `normalize_content(...)` so multi-block content (Responses API / Gemini)
  becomes a plain string; docstring corrected (single free-text fallback, no
  structured retry).

**Graph**
- **G2** — `conditional_logic.py`: fix "3 rounds" comments to match
  `2 * max_debate_rounds` / `3 * max_risk_discuss_rounds`.
- **G4 / C4** — `trading_graph.py`: replace "per-node deltas" comment with the real
  `stream_mode="values"` (cumulative snapshots) semantics.

**CLI**
- **C5** — `cli/announcements.py`: `getpass.getpass("Press Enter to continue...")` →
  `input(...)`; remove the now-unused `getpass` import.

### Tests
`tests/test_alpha_vantage_request.py` (D3), `tests/test_news_markdown.py` (D4),
`tests/test_crypto_asset_mode.py` (AG2), `tests/test_structured_agents.py` (AG4),
conditional-logic round assertions (G2).

### Risk & rollback
Low risk; no execution-path or public-API change beyond the additive
`AlphaVantageAuthError`. Each item is a localized, independently revertible diff.
