### PR TITLE
Add Chinese A-share news (East Money) and fix non-US ticker robustness

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import os
 import datetime
+import logging
 import typer
 import questionary
 from pathlib import Path
@@ -988,7 +989,34 @@ def format_tool_args(args, max_length=80) -> str:
         return result[:max_length - 3] + "..."
     return result
 
+def _configure_file_logging() -> None:
+    """Route library logging to a file instead of stderr.
+
+    The CLI renders progress with a Rich ``Live`` display that owns the
+    terminal. Library ``logger.warning`` calls (e.g. StockTwits 404 / Reddit
+    403 for non-US tickers) would otherwise hit Python's lastResort handler,
+    write straight to stderr, and tear the Live layout — the repeated banner /
+    border artefact. Attaching a file handler to the root logger both captures
+    those messages for debugging and stops lastResort from touching stderr.
+    """
+    root = logging.getLogger()
+    if any(getattr(h, "_ta_cli_file", False) for h in root.handlers):
+        return  # already configured this process
+    log_dir = Path(DEFAULT_CONFIG["results_dir"])
+    log_dir.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_dir / "tradingagents.log", encoding="utf-8")
+    handler._ta_cli_file = True
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    root.addHandler(handler)
+    root.setLevel(logging.WARNING)
+
+
 def run_analysis(checkpoint: bool = False):
+    # Send library logs to a file so they don't corrupt the Rich Live display.
+    _configure_file_logging()
+
     # First get all user selections
     selections = get_user_selections()
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1112,7 +1112,13 @@ def run_analysis(checkpoint: bool = False):
     # Now start the display layout
     layout = create_layout()
 
-    with Live(layout, refresh_per_second=4) as live:
+    # screen=True renders the dashboard on the terminal's alternate buffer so
+    # every refresh repaints in place. Without it, a layout taller than the
+    # window (e.g. a long Current Report) can't be overwritten and each refresh
+    # stacks another frame, tiling the header banner down the screen. The full
+    # report is printed to the normal screen after this block, so clipping the
+    # live view to the window is fine.
+    with Live(layout, refresh_per_second=4, screen=True) as live:
         # Initial display
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 

--- a/tests/test_eastmoney_news.py
+++ b/tests/test_eastmoney_news.py
@@ -1,0 +1,124 @@
+"""Tests for the East Money (东方财富) A-share news vendor and its auto-routing."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+import pytest
+
+from tradingagents.dataflows import eastmoney_news
+from tradingagents.dataflows.eastmoney_news import get_news_eastmoney, is_ashare
+
+
+def _jsonp(articles: list[dict]) -> bytes:
+    body = json.dumps({"code": 0, "result": {"cmsArticleWebOld": articles}}, ensure_ascii=False)
+    return f"cb({body});".encode("utf-8")
+
+
+@contextmanager
+def _fake_response(payload: bytes):
+    class _Resp:
+        def read(self):
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    yield _Resp()
+
+
+_ARTICLES = [
+    {
+        "date": "2026-05-30 06:54:37",
+        "title": "贵州茅台(<em>600519</em>.SH)一季报点评",
+        "content": "净利润同比增长。",
+        "mediaName": "每日经济新闻",
+        "url": "http://finance.eastmoney.com/a/1.html",
+    },
+    {
+        "date": "2026-04-01 09:00:00",  # before the window
+        "title": "旧闻不应入选",
+        "content": "",
+        "mediaName": "证券时报网",
+        "url": "http://finance.eastmoney.com/a/2.html",
+    },
+]
+
+
+@pytest.mark.unit
+class TestIsAshare:
+    def test_shanghai_and_shenzhen_are_ashares(self):
+        assert is_ashare("600519.SS")
+        assert is_ashare("000858.SZ")
+        assert is_ashare("600519.ss")  # case-insensitive
+
+    def test_other_markets_are_not(self):
+        for t in ("AAPL", "0700.HK", "7203.T", "BTC-USD", "RELIANCE.NS"):
+            assert not is_ashare(t)
+
+
+@pytest.mark.unit
+class TestGetNewsEastmoney:
+    def test_non_ashare_returns_out_of_scope_without_network(self):
+        with patch.object(eastmoney_news, "urlopen") as m:
+            out = get_news_eastmoney("AAPL", "2026-05-01", "2026-06-02")
+        m.assert_not_called()
+        assert "out of scope" in out
+
+    def test_parses_filters_and_strips_tags(self):
+        with patch.object(eastmoney_news, "urlopen", return_value=_fake_response(_jsonp(_ARTICLES))):
+            out = get_news_eastmoney("600519.SS", "2026-05-01", "2026-06-02")
+        assert "East Money" in out
+        assert "贵州茅台(600519.SH)一季报点评" in out  # <em> tags stripped
+        assert "每日经济新闻" in out
+        assert "旧闻不应入选" not in out  # filtered out by date window
+
+    def test_http_error_degrades_gracefully(self):
+        err = HTTPError("u", 406, "Not Acceptable", {}, None)
+        with patch.object(eastmoney_news, "urlopen", side_effect=err):
+            out = get_news_eastmoney("600519.SS", "2026-05-01", "2026-06-02")
+        assert "unavailable" in out  # never raises
+
+    def test_empty_result_reports_no_news(self):
+        with patch.object(eastmoney_news, "urlopen", return_value=_fake_response(_jsonp([]))):
+            out = get_news_eastmoney("600519.SS", "2026-05-01", "2026-06-02")
+        assert "No news found" in out
+
+
+@pytest.mark.unit
+class TestRouting:
+    """A-share get_news must prefer East Money; other markets must not."""
+
+    @staticmethod
+    def _patched_vendors():
+        # VENDOR_METHODS caches function references at import time, so patch the
+        # dict entries directly rather than the module-level names.
+        from tradingagents.dataflows import interface
+
+        em = lambda *a, **k: "EASTMONEY"  # noqa: E731
+        yf = lambda *a, **k: "YFINANCE"  # noqa: E731
+        patched = dict(interface.VENDOR_METHODS["get_news"])
+        patched.update({"eastmoney": em, "yfinance": yf})
+        return interface, patched
+
+    def test_ashare_routes_to_eastmoney(self):
+        interface, patched = self._patched_vendors()
+        # Pin the configured news vendor so the test is independent of any
+        # global config another test may have mutated.
+        with patch.dict(interface.VENDOR_METHODS, {"get_news": patched}), \
+             patch.object(interface, "get_vendor", return_value="yfinance"):
+            result = interface.route_to_vendor("get_news", "600519.SS", "2026-05-01", "2026-06-02")
+        assert result == "EASTMONEY"
+
+    def test_us_ticker_routes_to_yfinance(self):
+        interface, patched = self._patched_vendors()
+        with patch.dict(interface.VENDOR_METHODS, {"get_news": patched}), \
+             patch.object(interface, "get_vendor", return_value="yfinance"):
+            result = interface.route_to_vendor("get_news", "AAPL", "2026-05-01", "2026-06-02")
+        assert result == "YFINANCE"

--- a/tradingagents/dataflows/eastmoney_news.py
+++ b/tradingagents/dataflows/eastmoney_news.py
@@ -1,0 +1,147 @@
+"""East Money (东方财富) per-stock news fetcher for Chinese A-shares.
+
+Yahoo Finance and Alpha Vantage are English-centric and return little or no
+news for Shanghai/Shenzhen-listed tickers (e.g. ``600519.SS``). East Money's
+public search endpoint indexes Chinese-language financial news keyed by the
+six-digit stock code, requires no API key, OAuth, or registration, and returns
+structured JSON (title, publish date, summary, media outlet, link).
+
+The function mirrors :func:`get_news_yfinance`: same signature, same date
+filtering, and the same plaintext block shape so the News Analyst prompt is
+identical regardless of which vendor served the request. Like every other
+fetcher here it degrades gracefully — any network or parse failure returns a
+string rather than raising, so the run is never crashed by a flaky source.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+# Public East Money site-search endpoint. ``cmsArticleWebOld`` is the news
+# article index; the response is JSONP wrapped in ``<cb>( ... )``.
+_API = "https://search-api-web.eastmoney.com/search/jsonp"
+_UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
+
+# A-share exchange suffixes (Yahoo convention): Shanghai / Shenzhen.
+_ASHARE_SUFFIXES = (".SS", ".SZ")
+
+_TAG_RE = re.compile(r"</?em>")
+_JSONP_RE = re.compile(r"^[^(]*\((.*)\)\s*;?\s*$", re.DOTALL)
+
+
+def is_ashare(ticker: str) -> bool:
+    """True for Shanghai/Shenzhen-listed tickers (``600519.SS``, ``000858.SZ``)."""
+    return ticker.upper().endswith(_ASHARE_SUFFIXES)
+
+
+def _strip_tags(text: str) -> str:
+    """Remove the ``<em>`` highlight tags East Money wraps around query matches."""
+    return _TAG_RE.sub("", text or "").strip()
+
+
+def _build_url(code: str, page_size: int) -> str:
+    param = {
+        "uid": "",
+        "keyword": code,
+        "type": ["cmsArticleWebOld"],
+        "client": "web",
+        "clientType": "web",
+        "clientVersion": "curr",
+        "param": {
+            "cmsArticleWebOld": {
+                "searchScope": "default",
+                "sort": "time",
+                "pageIndex": 1,
+                "pageSize": page_size,
+                "preTag": "",
+                "postTag": "",
+            }
+        },
+    }
+    return f"{_API}?cb=cb&param={quote(json.dumps(param, ensure_ascii=False))}"
+
+
+def get_news_eastmoney(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve Chinese news for an A-share ``ticker`` via East Money.
+
+    Args:
+        ticker: A-share ticker with exchange suffix, e.g. ``600519.SS``.
+        start_date: Start date in ``yyyy-mm-dd`` format (inclusive).
+        end_date: End date in ``yyyy-mm-dd`` format (inclusive).
+
+    Returns:
+        A formatted plaintext block of news, or an explanatory string when the
+        ticker is not an A-share, no news falls in the window, or the source is
+        unreachable. Never raises.
+    """
+    if not is_ashare(ticker):
+        # Defensive: this vendor only covers A-shares. Returning a plain string
+        # lets the router fall through to an English-centric vendor.
+        return f"East Money only covers A-shares; {ticker} is out of scope."
+
+    code = ticker.split(".")[0]
+    article_limit = get_config()["news_article_limit"]
+    url = _build_url(code, article_limit)
+    # The endpoint replies with JSONP (text/javascript); requesting
+    # application/json gets a 406, so accept any content type.
+    req = Request(url, headers={"User-Agent": _UA, "Accept": "*/*"})
+
+    try:
+        with urlopen(req, timeout=10.0) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        match = _JSONP_RE.match(raw.strip())
+        data = json.loads(match.group(1) if match else raw)
+    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError, UnicodeError) as exc:
+        logger.warning("East Money news fetch failed for %s: %s", ticker, exc)
+        return f"<east money news unavailable: {type(exc).__name__}>"
+
+    articles = (data.get("result") or {}).get("cmsArticleWebOld") or []
+    if not articles:
+        return f"No news found for {ticker}"
+
+    start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+
+    news_str = ""
+    kept = 0
+    for art in articles:
+        date_raw = (art.get("date") or "").strip()
+        pub_dt = None
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+            try:
+                pub_dt = datetime.strptime(date_raw, fmt)
+                break
+            except ValueError:
+                continue
+        if pub_dt and not (start_dt <= pub_dt <= end_dt):
+            continue
+
+        title = _strip_tags(art.get("title", ""))
+        if not title:
+            continue
+        media = _strip_tags(art.get("mediaName", "")) or "东方财富"
+        summary = _strip_tags(art.get("content", ""))
+        link = (art.get("url") or "").strip()
+
+        news_str += f"### {title} (source: {media}, {date_raw})\n"
+        if summary:
+            news_str += f"{summary}\n"
+        if link:
+            news_str += f"Link: {link}\n"
+        news_str += "\n"
+        kept += 1
+
+    if kept == 0:
+        return f"No news found for {ticker} between {start_date} and {end_date}"
+
+    return f"## {ticker} News (East Money / 东方财富), from {start_date} to {end_date}:\n\n{news_str}"

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -11,6 +11,7 @@ from .y_finance import (
     get_insider_transactions as get_yfinance_insider_transactions,
 )
 from .yfinance_news import get_news_yfinance, get_global_news_yfinance
+from .eastmoney_news import get_news_eastmoney, is_ashare
 from .alpha_vantage import (
     get_stock as get_alpha_vantage_stock,
     get_indicator as get_alpha_vantage_indicator,
@@ -64,6 +65,7 @@ TOOLS_CATEGORIES = {
 VENDOR_LIST = [
     "yfinance",
     "alpha_vantage",
+    "eastmoney",  # Chinese A-share news only (get_news)
 ]
 
 # Mapping of methods to their vendor-specific implementations
@@ -99,6 +101,7 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "eastmoney": get_news_eastmoney,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
@@ -140,6 +143,23 @@ def route_to_vendor(method: str, *args, **kwargs):
 
     if method not in VENDOR_METHODS:
         raise ValueError(f"Method '{method}' not supported")
+
+    # Market-aware routing: the English-centric vendors return little or no
+    # news for Chinese A-shares (and yfinance returns an empty-but-successful
+    # string, so it would shadow any fallback). Prefer East Money for per-stock
+    # news on Shanghai/Shenzhen tickers, matching the framework's "resolve
+    # automatically per market" behaviour. Honoured only when not already
+    # overridden by an explicit vendor config.
+    if (
+        method == "get_news"
+        and args
+        and isinstance(args[0], str)
+        and is_ashare(args[0])
+        and vendor_config in ("default", "yfinance")
+    ):
+        primary_vendors = ["eastmoney"] + [
+            v for v in primary_vendors if v != "eastmoney"
+        ]
 
     # Build fallback chain: primary vendors first, then remaining available vendors
     all_available_vendors = list(VENDOR_METHODS[method].keys())

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -40,7 +40,11 @@ def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.
     try:
         with urlopen(req, timeout=timeout) as resp:
             data = json.loads(resp.read())
-    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as exc:
+    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError, UnicodeError) as exc:
+        # UnicodeError covers the UnicodeEncodeError raised by http.client when
+        # a non-ASCII ticker (e.g. a Chinese company name passed instead of the
+        # exchange-suffixed symbol) reaches the ASCII-only request line. Degrade
+        # gracefully like every other failure rather than crashing the run.
         logger.warning("StockTwits fetch failed for %s: %s", ticker, exc)
         return f"<stocktwits unavailable: {type(exc).__name__}>"
 


### PR DESCRIPTION
## Summary

Adds Chinese-language news coverage for A-shares and fixes three robustness/UX issues that surface when analyzing non-US tickers. Discovered while running the framework on Shanghai/Shenzhen tickers (e.g. `600519.SS`, `300450.SZ`).

## Motivation

When analyzing an A-share, the English-centric sources have little to no coverage, and two of them actively broke the run:

- The Sentiment Analyst crashed the **entire** run with an unhandled `UnicodeEncodeError` when a non-ASCII symbol reached the StockTwits request line.
- The News Analyst had no real news for A-shares (Yahoo/Alpha Vantage return next to nothing for `.SS`/`.SZ`).
- Library `logger.warning` calls (StockTwits 404 / Reddit 403) wrote straight to stderr and tore the Rich `Live` dashboard.
- A live layout taller than the terminal tiled the header banner down the screen on every refresh.

## Changes (one focused commit each)

1. **fix(dataflows): stop non-ASCII tickers from crashing StockTwits fetch** — catch `UnicodeError` so the fetcher degrades gracefully like every other failure it already handles, instead of crashing the run.
2. **feat(dataflows): add East Money Chinese news for A-shares with auto-routing** — new `get_news_eastmoney` vendor (东方财富, no API key) mirroring `get_news_yfinance`'s signature/format. Registered as a `get_news` vendor and auto-preferred for `.SS`/`.SZ` tickers. Market-aware routing is required because `get_news_yfinance` returns an empty-but-successful string for A-shares, which would otherwise shadow any fallback. Other markets are unaffected; an explicit vendor config still wins. Adds unit tests.
3. **fix(cli): route library logs to a file so they don't corrupt the Live display** — attach a root file handler at the start of `run_analysis` (logs to `results_dir/tradingagents.log`), which also stops logging's lastResort handler from writing to stderr during the Live render.
4. **fix(cli): render progress dashboard on the alternate screen** — pass `screen=True` to `Live` so frames repaint in place instead of tiling. The full report is still printed to the normal screen after the Live block.

## Testing

- New `tests/test_eastmoney_news.py` (8 tests): A-share detection, JSON/JSONP parsing + date filtering + tag stripping, graceful degradation on HTTP error, and the routing preference (A-share → East Money, US → yfinance).
- Full suite green: `319 passed, 75 subtests passed`.
- Manually verified live fetches return real Chinese news for `600519.SS`, `000858.SZ`, and `603688.SS`, and that US tickers (`AAPL`) still route to yfinance.

## Notes

- East Money is a `get_news` (per-stock) vendor only; `get_global_news` and the social sources are unchanged.
- No new dependencies; the source uses the stdlib HTTP client and needs no API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
