### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ export DASHSCOPE_API_KEY=...       # Qwen — International (dashscope-intl.aliy
 export DASHSCOPE_CN_API_KEY=...    # Qwen — China (dashscope.aliyuncs.com)
 export ZHIPU_API_KEY=...           # GLM via Z.AI (international)
 export ZHIPU_CN_API_KEY=...        # GLM via BigModel (China, open.bigmodel.cn)
-export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io, M2.x, 204K ctx)
-export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com, M2.x, 204K ctx)
+export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io, M3 default, 512K ctx)
+export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com, M3 default, 512K ctx)
 export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -47,10 +47,6 @@ class TestPatternMatches:
         caps = get_capabilities("deepseek-reasoner-pro")
         assert caps.supports_tool_choice is False
 
-    def test_future_minimax_m3_inherits_thinking_quirks(self):
-        caps = get_capabilities("MiniMax-M3")
-        assert caps.supports_tool_choice is False
-
     def test_future_minimax_m4_highspeed_inherits_thinking_quirks(self):
         caps = get_capabilities("MiniMax-M4-highspeed")
         assert caps.supports_tool_choice is False
@@ -58,8 +54,13 @@ class TestPatternMatches:
 
 @pytest.mark.unit
 class TestMinimaxExactMatches:
-    """MiniMax M2.x models reject langchain's function-spec dict tool_choice
-    (official API enum: none/auto only)."""
+    """MiniMax M2.x and M3 models reject langchain's function-spec dict
+    tool_choice (official API enum: none/auto only)."""
+
+    def test_m3_rejects_tool_choice(self):
+        caps = get_capabilities("MiniMax-M3")
+        assert caps.supports_tool_choice is False
+        assert caps.supports_json_mode is False  # only MiniMax-Text-01 supports json_object
 
     def test_m2_7_rejects_tool_choice(self):
         caps = get_capabilities("MiniMax-M2.7")
@@ -69,23 +70,17 @@ class TestMinimaxExactMatches:
     def test_m2_7_highspeed_rejects_tool_choice(self):
         assert get_capabilities("MiniMax-M2.7-highspeed").supports_tool_choice is False
 
-    def test_m2_1_rejects_tool_choice(self):
-        assert get_capabilities("MiniMax-M2.1").supports_tool_choice is False
-
-    def test_m2_base_rejects_tool_choice(self):
-        assert get_capabilities("MiniMax-M2").supports_tool_choice is False
-
     def test_m2_x_requires_reasoning_split(self):
-        # M2.x reasoning models need reasoning_split=True so <think> blocks
-        # land in reasoning_details instead of content (#826).
-        for model in ("MiniMax-M2.7", "MiniMax-M2.5-highspeed", "MiniMax-M2"):
+        # M2.x and M3 reasoning models need reasoning_split=True so <think>
+        # blocks land in reasoning_details instead of content (#826).
+        for model in ("MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
             assert get_capabilities(model).requires_reasoning_split is True
 
-    def test_future_m3_inherits_reasoning_split(self):
+    def test_future_m3_highspeed_inherits_reasoning_split(self):
         assert get_capabilities("MiniMax-M3-highspeed").requires_reasoning_split is True
 
     def test_non_reasoning_minimax_does_not_get_reasoning_split(self):
-        # Coding Plan, MiniMax-Text-01, and any non-M2-prefixed MiniMax model
+        # Coding Plan, MiniMax-Text-01, and any non-M-prefixed MiniMax model
         # reject the reasoning_split kwarg via the openai SDK's strict
         # validation (#826). Default capability has it disabled.
         for model in ("minimax-text-01", "MiniMax-Coding-Plan", "abab6.5-chat"):

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,7 +1,7 @@
 """Tests for MinimaxChatOpenAI quirks.
 
 Verifies the subclass injects ``reasoning_split=True`` into outgoing
-requests so M2.x reasoning models put their <think> block into
+requests so M2.x / M3 reasoning models put their <think> block into
 ``reasoning_details`` instead of polluting ``message.content``.
 """
 
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI
 
 
-def _client(model: str = "MiniMax-M2.7"):
+def _client(model: str = "MiniMax-M3"):
     os.environ.setdefault("MINIMAX_API_KEY", "placeholder")
     return MinimaxChatOpenAI(
         model=model,
@@ -33,7 +33,7 @@ class TestMinimaxReasoningSplit:
         assert "reasoning_split" not in payload  # never top-level
 
     def test_non_reasoning_minimax_does_not_inject_reasoning_split(self):
-        """Coding Plan / MiniMax-Text-01 / any non-M2-prefixed model must NOT
+        """Coding Plan / MiniMax-Text-01 / any non-M-prefixed model must NOT
         receive reasoning_split at all (top-level or extra_body) (#826)."""
         for model in ("minimax-text-01", "MiniMax-Coding-Plan"):
             payload = _client(model)._get_request_payload(
@@ -45,8 +45,8 @@ class TestMinimaxReasoningSplit:
 
 @pytest.mark.unit
 class TestMinimaxStructuredOutputDispatch:
-    """M2.x models route through the capability table — tool_choice is
-    suppressed but the schema is still bound as a tool."""
+    """M2.x and M3 models route through the capability table — tool_choice
+    is suppressed but the schema is still bound as a tool."""
 
     class _Pick(BaseModel):
         action: str
@@ -54,6 +54,11 @@ class TestMinimaxStructuredOutputDispatch:
     def _bound_kwargs(self, runnable):
         first = runnable.steps[0] if hasattr(runnable, "steps") else runnable
         return getattr(first, "kwargs", {})
+
+    def test_m3_suppresses_tool_choice(self):
+        bound = _client("MiniMax-M3").with_structured_output(self._Pick)
+        kwargs = self._bound_kwargs(bound)
+        assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
 
     def test_m2_7_suppresses_tool_choice(self):
         bound = _client("MiniMax-M2.7").with_structured_output(self._Pick)
@@ -66,7 +71,7 @@ class TestMinimaxStructuredOutputDispatch:
         assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
 
     def test_schema_still_bound_as_tool(self):
-        bound = _client("MiniMax-M2.7").with_structured_output(self._Pick)
+        bound = _client("MiniMax-M3").with_structured_output(self._Pick)
         tools = self._bound_kwargs(bound).get("tools", [])
         assert any(
             t.get("function", {}).get("name") == "_Pick" for t in tools

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -99,13 +99,9 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "deepseek-v4-pro": _DEEPSEEK_THINKING,
     # MiniMax — full official model lineup per
     # platform.minimax.io/docs/api-reference/text-openai-api
+    "MiniMax-M3": _MINIMAX_THINKING,
     "MiniMax-M2.7": _MINIMAX_THINKING,
     "MiniMax-M2.7-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2.5": _MINIMAX_THINKING,
-    "MiniMax-M2.5-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2.1": _MINIMAX_THINKING,
-    "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2": _MINIMAX_THINKING,
 }
 
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -54,20 +54,18 @@ _QWEN_MODELS: Dict[str, List[ModelOption]] = {
 
 # Shared model list for MiniMax's global and CN endpoints (same IDs).
 # Full official lineup per platform.minimax.io/docs/api-reference/text-openai-api.
-# All M2.x models share a 204,800-token context window.
+# M3: 512K context, 128K max output, image input support. M2.7 retains a
+# 204K context window; both endpoints share the same model IDs.
 _MINIMAX_MODELS: Dict[str, List[ModelOption]] = {
     "quick": [
+        ("MiniMax-M3 - Latest flagship, 512K ctx, image input (default)", "MiniMax-M3"),
         ("MiniMax-M2.7-highspeed - Faster M2.7, 204K ctx, ~100 TPS", "MiniMax-M2.7-highspeed"),
-        ("MiniMax-M2.5-highspeed - Previous-gen highspeed, 204K ctx", "MiniMax-M2.5-highspeed"),
-        ("MiniMax-M2.1-highspeed - M2.1 highspeed, 204K ctx", "MiniMax-M2.1-highspeed"),
         ("Custom model ID", "custom"),
     ],
     "deep": [
-        ("MiniMax-M2.7 - Flagship, SOTA on coding/agent benchmarks, 204K ctx", "MiniMax-M2.7"),
+        ("MiniMax-M3 - Latest flagship, 512K ctx, image input (default)", "MiniMax-M3"),
+        ("MiniMax-M2.7 - Previous-gen flagship, 204K ctx", "MiniMax-M2.7"),
         ("MiniMax-M2.7-highspeed - Same quality as M2.7, ~100 TPS", "MiniMax-M2.7-highspeed"),
-        ("MiniMax-M2.5 - Previous-gen flagship, 204K ctx", "MiniMax-M2.5"),
-        ("MiniMax-M2.1 - Earlier M2 line, 204K ctx", "MiniMax-M2.1"),
-        ("MiniMax-M2 - Base M2, 204K ctx", "MiniMax-M2"),
         ("Custom model ID", "custom"),
     ],
 }


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default (512K context, 128K max output, image input)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives (204K context)
- Remove older models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2`)
- Update capability table to add M3 exact-ID match (pattern-based `^MiniMax-M\d` already covers future variants)
- Update unit tests in `tests/test_capabilities.py` and `tests/test_minimax.py`
- Update README to reflect the M3 default

## Why
MiniMax-M3 is the latest flagship, with a 512K context window, up to 128K output, and image input support on both OpenAI-compatible and Anthropic-compatible endpoints.

## Testing
- `tests/test_minimax.py` — 6 tests pass (M3 default, M2.7, M2.7-highspeed, schema binding)
- `tests/test_capabilities.py` — 19 tests pass (M3 exact + M2.7 exact + forward-compat patterns)
- `tests/test_api_key_env.py` — 23 tests pass (provider/env-var mapping unchanged)