### PR TITLE
feat(llm): add native Opencode provider with OPENCODE_API_KEY / OPENCODE_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ MINIMAX_API_KEY=
 MINIMAX_CN_API_KEY=
 OPENROUTER_API_KEY=
 
+# Opencode API (OpenAI-compatible endpoint)
+#OPENCODE_API_KEY=
+#OPENCODE_BASE_URL=https://opencode.ai/zen/go/v1
+
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows
 # the broader Ollama ecosystem; both the CLI dropdown and programmatic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Opencode provider.** Native support for the OpenAI-compatible Opencode
+  endpoint via `OPENCODE_API_KEY` / `OPENCODE_BASE_URL` environment
+  variables. Registerable through the CLI provider menu, env-driven config
+  (`TRADINGAGENTS_LLM_PROVIDER=opencode`), or programmatic client.
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -278,6 +278,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
     localhost default when unset.
     """
     ollama_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
+    opencode_url = os.environ.get("OPENCODE_BASE_URL") or "https://opencode.ai/zen/go/v1"
     return [
         ("OpenAI", "openai", "https://api.openai.com/v1"),
         ("Google", "google", None),
@@ -288,6 +289,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
         ("MiniMax", "minimax", "https://api.minimax.io/v1"),
         ("OpenRouter", "openrouter", "https://openrouter.ai/api/v1"),
+        ("Opencode", "opencode", opencode_url),
         ("Azure OpenAI", "azure", None),
         ("Ollama", "ollama", ollama_url),
     ]

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -24,7 +24,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         "qwen", "qwen-cn",
         "glm", "glm-cn",
         "minimax", "minimax-cn",
-        "openrouter", "azure", "ollama",
+        "openrouter", "opencode", "azure", "ollama",
     }
     assert expected.issubset(PROVIDER_API_KEY_ENV.keys())
 
@@ -45,6 +45,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         ("minimax",    "MINIMAX_API_KEY"),
         ("minimax-cn", "MINIMAX_CN_API_KEY"),
         ("openrouter", "OPENROUTER_API_KEY"),
+        ("opencode",   "OPENCODE_API_KEY"),
     ],
 )
 def test_known_providers_resolve(provider, env_var):
@@ -53,6 +54,10 @@ def test_known_providers_resolve(provider, env_var):
 
 def test_ollama_has_no_key():
     assert get_api_key_env("ollama") is None
+
+
+def test_opencode_has_key():
+    assert get_api_key_env("opencode") == "OPENCODE_API_KEY"
 
 
 def test_unknown_provider_returns_none():

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -30,6 +30,7 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "minimax":    "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "opencode":   "OPENCODE_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
 }

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -8,7 +8,7 @@ _OPENAI_COMPATIBLE = (
     "qwen", "qwen-cn",
     "glm", "glm-cn",
     "minimax", "minimax-cn",
-    "ollama", "openrouter",
+    "ollama", "openrouter", "opencode",
 )
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -175,6 +175,11 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Custom model ID", "custom"),
         ],
     },
+    # Opencode: generic OpenAI-compatible endpoint — any model ID accepted.
+    "opencode": {
+        "quick": [("Custom model ID", "custom")],
+        "deep":  [("Custom model ID", "custom")],
+    },
 }
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -163,6 +163,7 @@ _PROVIDER_BASE_URL = {
     "minimax":    "https://api.minimax.io/v1",
     "minimax-cn": "https://api.minimaxi.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "opencode":   "https://opencode.ai/zen/go/v1",
     "ollama":     "http://localhost:11434/v1",
 }
 
@@ -178,6 +179,10 @@ def _resolve_provider_base_url(provider: str) -> Optional[str]:
     """
     if provider == "ollama":
         env_url = os.environ.get("OLLAMA_BASE_URL")
+        if env_url:
+            return env_url
+    if provider == "opencode":
+        env_url = os.environ.get("OPENCODE_BASE_URL")
         if env_url:
             return env_url
     return _PROVIDER_BASE_URL.get(provider)

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -17,7 +17,7 @@ def validate_model(provider: str, model: str) -> bool:
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in ("ollama", "openrouter", "opencode"):
         return True
 
     if provider_lower not in VALID_MODELS:


### PR DESCRIPTION
## Summary

Adds **opencode** as a first-class OpenAI-compatible provider throughout the codebase.

Users can now set `OPENCODE_API_KEY` and `OPENCODE_BASE_URL` in their environment and use the provider directly via:
- CLI interactive menu (select "Opencode" from provider list)
- Env-driven config (`TRADINGAGENTS_LLM_PROVIDER=opencode`)
- Programmatic client

No more manual `os.environ` overrides required.

## Changes

| File | Change |
|---|---|
| `tradingagents/llm_clients/api_key_env.py` | Register `OPENCODE_API_KEY` mapping |
| `tradingagents/llm_clients/factory.py` | Add `opencode` to OpenAI-compatible providers |
| `tradingagents/llm_clients/openai_client.py` | Default base URL + `OPENCODE_BASE_URL` env override |
| `tradingagents/llm_clients/model_catalog.py` | Entry with Custom model ID |
| `tradingagents/llm_clients/validators.py` | Skip model validation (any model accepted) |
| `cli/utils.py` | Add Opencode to provider selection table |
| `.env.example` | Document `OPENCODE_API_KEY` and `OPENCODE_BASE_URL` |
| `CHANGELOG.md` | Unreleased entry |
| `tests/test_api_key_env.py` | Test coverage |

## Test plan

- [x] `test_api_key_env.py` — 25 passed
- [x] Full test suite — 312 passed (1 pre-existing DeepSeek key failure, unrelated)
- [x] Smoke tests: factory, client creation, base URL resolution, model validation, CLI table
- [x] `OPENCODE_BASE_URL` env override verified
- [x] Live analysis run completed successfully with Opencode + DeepSeek V4 Flash
