### PR TITLE
Handle invalid News Analyst tool calls without aborting

### DIFF
--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,3 +1,6 @@
+import logging
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
@@ -6,6 +9,65 @@ from tradingagents.agents.utils.agent_utils import (
     get_news,
 )
 from tradingagents.dataflows.config import get_config
+
+
+logger = logging.getLogger(__name__)
+
+
+def _describe_invalid_tool_call(tool_call) -> str:
+    if isinstance(tool_call, dict):
+        name = tool_call.get("name", "unknown")
+        tool_call_id = tool_call.get("id", "unknown")
+        args = tool_call.get("args")
+        error = tool_call.get("error")
+    else:
+        name = getattr(tool_call, "name", "unknown")
+        tool_call_id = getattr(tool_call, "id", "unknown")
+        args = getattr(tool_call, "args", None)
+        error = getattr(tool_call, "error", None)
+
+    parts = [f"tool={name}", f"id={tool_call_id}"]
+    if args is not None:
+        parts.append(f"args={args}")
+    if error:
+        parts.append(f"error={error}")
+    return " | ".join(parts)
+
+
+def _retry_messages_for_invalid_tool_calls(
+    messages, assistant_message: AIMessage, invalid_tool_calls
+) -> list:
+    retry_hint_lines = [
+        "The previous tool call was invalid.",
+        "Please correct the tool arguments and retry with valid JSON only.",
+        "Do not change the analysis intent; just fix the tool call payload.",
+    ]
+    tool_messages = []
+    for tool_call in invalid_tool_calls:
+        retry_hint_lines.append(f"- {_describe_invalid_tool_call(tool_call)}")
+        if isinstance(tool_call, dict):
+            tool_call_id = tool_call.get("id", "unknown")
+            error = tool_call.get("error") or "Invalid tool call arguments."
+        else:
+            tool_call_id = getattr(tool_call, "id", "unknown")
+            error = getattr(tool_call, "error", None) or "Invalid tool call arguments."
+        tool_messages.append(ToolMessage(content=error, tool_call_id=tool_call_id, status="error"))
+    return list(messages) + [assistant_message] + tool_messages + [
+        HumanMessage(content="\n".join(retry_hint_lines))
+    ]
+
+
+def _sanitize_ai_message(message: AIMessage) -> AIMessage:
+    """Drop invalid-tool metadata so the graph can continue safely."""
+    return AIMessage(
+        content=message.content,
+        additional_kwargs=dict(message.additional_kwargs or {}),
+        response_metadata=dict(message.response_metadata or {}),
+        name=message.name,
+        id=message.id,
+        tool_calls=list(message.tool_calls or []),
+        invalid_tool_calls=[],
+    )
 
 
 def create_news_analyst(llm):
@@ -52,6 +114,32 @@ def create_news_analyst(llm):
 
         chain = prompt | llm.bind_tools(tools)
         result = chain.invoke(state["messages"])
+        invalid_tool_calls = list(getattr(result, "invalid_tool_calls", []) or [])
+
+        if invalid_tool_calls:
+            for invalid_tool_call in invalid_tool_calls:
+                logger.warning(
+                    "News Analyst produced invalid tool call; retrying once: %s",
+                    _describe_invalid_tool_call(invalid_tool_call),
+                )
+
+            retry_result = chain.invoke(
+                _retry_messages_for_invalid_tool_calls(
+                    state["messages"], result, invalid_tool_calls
+                )
+            )
+            retry_invalid_tool_calls = list(
+                getattr(retry_result, "invalid_tool_calls", []) or []
+            )
+
+            if retry_invalid_tool_calls:
+                logger.warning(
+                    "News Analyst still produced invalid tool calls after retry; "
+                    "continuing with sanitized message.",
+                )
+                result = _sanitize_ai_message(retry_result)
+            else:
+                result = retry_result
 
         report = ""
 


### PR DESCRIPTION
## Summary
- Retry the News Analyst once when the model emits malformed tool-call arguments.
- If the retry still produces invalid tool calls, log the issue and continue the agent loop instead of crashing the run.
- Normal news-analysis tool usage is unchanged; this only hardens the failure path.

## Validation
- `python -m py_compile tradingagents/agents/analysts/news_analyst.py`

## Sanitized failure trace
```text
Traceback (most recent call last):
  ...
  File in the TradingAgents runtime
  ...
openai.BadRequestError: Error code: 400 - {'error': {'message': "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)", 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
During task with name 'News Analyst'
```

## Notes
- The root cause was a malformed `get_news` tool call emitted during the News Analyst turn.
