### PR TITLE
fix: declare python-dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pandas>=2.3.0",
     "parsel>=1.10.0",
     "pytz>=2025.2",
+    "python-dotenv>=1.0",
     "questionary>=2.1.0",
     "redis>=6.2.0",
     "requests>=2.32.4",


### PR DESCRIPTION
Fixes #994

This PR adds `python-dotenv` as a direct runtime dependency.

The CLI imports from `dotenv` in `cli/utils.py`, specifically `find_dotenv`, `load_dotenv`, and `set_key`. But `python-dotenv` was not declared directly in `pyproject.toml`.

Because of that, a clean install could fail at runtime with:

```bash
ModuleNotFoundError: No module named 'dotenv'
```

if no transitive package happens to install it.

### What changed

- Added `python-dotenv>=1.0` to `pyproject.toml`
- Verified the CLI still compiles
- Verified the dotenv imports work after installing the package

### Why this helps

Since the CLI directly imports `dotenv`, it should also declare `python-dotenv` directly instead of relying on some other dependency to bring it indirectly.

This makes clean installs more reliable.

### Validation

I ran:

```bash
python -m compileall cli
python -m pip install -e .
python -c "from dotenv import find_dotenv, set_key; print('python-dotenv import ok')"
```

Result:

```bash
python-dotenv import ok
```