### PR TITLE
fix: harden OpenAI-compatible Phase 1 routing

### DIFF
--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -11,7 +11,12 @@ import pytest
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 
-from tradingagents.llm_clients.capabilities import _MINIMAX_THINKING, get_capabilities
+from tradingagents.llm_clients.capabilities import (
+    _DEEPSEEK_CHAT,
+    _DEEPSEEK_THINKING,
+    _MINIMAX_THINKING,
+    get_capabilities,
+)
 from tradingagents.llm_clients.factory import create_llm_client
 from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI, NormalizedChatOpenAI
 
@@ -97,14 +102,26 @@ class TestOpenAICompatibleResponsesApiRouting:
 
         assert llm.use_responses_api is True
 
-    def test_openai_provider_with_nvidia_base_url_uses_chat_completions(self, monkeypatch):
-        llm = self._openai_llm(monkeypatch, "https://integrate.api.nvidia.com/v1")
+    def test_openai_provider_with_scheme_less_native_base_url_uses_responses_api(self, monkeypatch):
+        llm = self._openai_llm(monkeypatch, "api.openai.com/v1")
+
+        assert llm.use_responses_api is True
+
+    def test_openai_provider_with_custom_compatible_base_url_uses_chat_completions(self, monkeypatch):
+        llm = self._openai_llm(monkeypatch, "https://compatible.example/v1")
 
         assert isinstance(llm, NormalizedChatOpenAI)
         assert llm.use_responses_api is False
 
 
 @pytest.mark.unit
-class TestNvidiaHostedMinimaxCapabilities:
-    def test_nvidia_hosted_minimax_m2_7_uses_minimax_thinking_capabilities(self):
+class TestHostedModelCapabilities:
+    def test_hosted_minimax_m2_7_uses_minimax_thinking_capabilities(self):
         assert get_capabilities("minimaxai/minimax-m2.7") == _MINIMAX_THINKING
+
+    def test_hosted_deepseek_reasoning_models_use_deepseek_thinking_capabilities(self):
+        assert get_capabilities("deepseek-ai/deepseek-v3") == _DEEPSEEK_THINKING
+        assert get_capabilities("third-party/deepseek-r1") == _DEEPSEEK_THINKING
+
+    def test_hosted_deepseek_chat_uses_deepseek_chat_capabilities(self):
+        assert get_capabilities("deepseek-ai/deepseek-chat") == _DEEPSEEK_CHAT

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -11,7 +11,9 @@ import pytest
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 
-from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI
+from tradingagents.llm_clients.capabilities import _MINIMAX_THINKING, get_capabilities
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI, NormalizedChatOpenAI
 
 
 def _client(model: str = "MiniMax-M2.7"):
@@ -71,3 +73,38 @@ class TestMinimaxStructuredOutputDispatch:
         assert any(
             t.get("function", {}).get("name") == "_Pick" for t in tools
         ), f"schema not bound: {tools}"
+
+
+@pytest.mark.unit
+class TestOpenAICompatibleResponsesApiRouting:
+    """Only native OpenAI hosts should enable the Responses API."""
+
+    def _openai_llm(self, monkeypatch, base_url=None):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-dummy-not-a-real-key")
+        return create_llm_client(
+            "openai",
+            "gpt-5.4-mini",
+            base_url=base_url,
+        ).get_llm()
+
+    def test_openai_provider_without_base_url_uses_responses_api(self, monkeypatch):
+        llm = self._openai_llm(monkeypatch)
+
+        assert llm.use_responses_api is True
+
+    def test_openai_provider_with_native_openai_base_url_uses_responses_api(self, monkeypatch):
+        llm = self._openai_llm(monkeypatch, "https://api.openai.com/v1")
+
+        assert llm.use_responses_api is True
+
+    def test_openai_provider_with_nvidia_base_url_uses_chat_completions(self, monkeypatch):
+        llm = self._openai_llm(monkeypatch, "https://integrate.api.nvidia.com/v1")
+
+        assert isinstance(llm, NormalizedChatOpenAI)
+        assert llm.use_responses_api is False
+
+
+@pytest.mark.unit
+class TestNvidiaHostedMinimaxCapabilities:
+    def test_nvidia_hosted_minimax_m2_7_uses_minimax_thinking_capabilities(self):
+        assert get_capabilities("minimaxai/minimax-m2.7") == _MINIMAX_THINKING

--- a/tests/test_structured_fallback.py
+++ b/tests/test_structured_fallback.py
@@ -1,0 +1,49 @@
+import unittest
+
+from tradingagents.agents.utils.structured import invoke_structured_or_freetext
+
+
+class _StructuredReturnsNone:
+    def __init__(self):
+        self.calls = 0
+
+    def invoke(self, prompt):
+        self.calls += 1
+        return None
+
+
+class _PlainLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def invoke(self, prompt):
+        self.calls += 1
+        return type("Response", (), {"content": "fallback text"})()
+
+
+class StructuredFallbackTests(unittest.TestCase):
+    def test_none_structured_result_falls_back_without_rendering_none(self):
+        structured = _StructuredReturnsNone()
+        plain = _PlainLLM()
+        render_calls = []
+
+        def render(value):
+            render_calls.append(value)
+            raise AssertionError("render should not be called for a None structured result")
+
+        result = invoke_structured_or_freetext(
+            structured,
+            plain,
+            "prompt",
+            render,
+            "Test Agent",
+        )
+
+        self.assertEqual(result, "fallback text")
+        self.assertEqual(structured.calls, 1)
+        self.assertEqual(plain.calls, 1)
+        self.assertEqual(render_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/agents/utils/structured.py
+++ b/tradingagents/agents/utils/structured.py
@@ -62,6 +62,8 @@ def invoke_structured_or_freetext(
     if structured_llm is not None:
         try:
             result = structured_llm.invoke(prompt)
+            if result is None:
+                raise ValueError("structured output returned None")
             return render(result)
         except Exception as exc:
             logger.warning(

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -108,12 +108,15 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "MiniMax-M2": _MINIMAX_THINKING,
 }
 
-# Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
-# or ``MiniMax-M3*`` variants inherit the thinking-mode quirks automatically.
+# Forward-compat patterns. Hosted providers often prepend their own namespace
+# (``deepseek-ai/deepseek-v3``, ``third-party/deepseek-r1``,
+# ``minimaxai/minimax-m2.7``), so patterns match either the start of the
+# model ID or the segment after a slash.
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
-    (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
-    (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
-    (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    (re.compile(r"(^|/)deepseek-chat($|[:/_-])", re.IGNORECASE), _DEEPSEEK_CHAT),
+    (re.compile(r"(^|/)deepseek-v\d", re.IGNORECASE), _DEEPSEEK_THINKING),
+    (re.compile(r"(^|/)deepseek-r\d", re.IGNORECASE), _DEEPSEEK_THINKING),
+    (re.compile(r"(^|/)deepseek-reasoner", re.IGNORECASE), _DEEPSEEK_THINKING),
     (re.compile(r"(^|/)minimax-m\d", re.IGNORECASE), _MINIMAX_THINKING),
 ]
 

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -114,6 +114,7 @@ _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
     (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    (re.compile(r"(^|/)minimax-m\d", re.IGNORECASE), _MINIMAX_THINKING),
 ]
 
 
@@ -122,6 +123,6 @@ def get_capabilities(model_name: str) -> ModelCapabilities:
     if model_name in _BY_ID:
         return _BY_ID[model_name]
     for pattern, caps in _BY_PATTERN:
-        if pattern.match(model_name):
+        if pattern.search(model_name):
             return caps
     return _DEFAULT

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -188,12 +188,14 @@ def _is_native_openai_base_url(base_url: Optional[str]) -> bool:
     """True when ``base_url`` is unset or points at api.openai.com.
 
     The Responses API (/v1/responses) only exists on native OpenAI. An
-    OpenAI-compatible custom endpoint (NVIDIA integrate API, LM Studio,
+    OpenAI-compatible custom endpoint (third-party gateways, LM Studio,
     vLLM, ...) only supports Chat Completions, so the Responses API must
     stay off there.
     """
     if not base_url:
         return True
+    if "://" not in base_url:
+        base_url = "https://" + base_url
     host = urlparse(base_url).hostname or ""
     return host == "api.openai.com" or host.endswith(".openai.com")
 
@@ -249,8 +251,8 @@ class OpenAIClient(BaseLLMClient):
                 llm_kwargs[key] = self.kwargs[key]
 
         # Native OpenAI uses the Responses API; OpenAI-compatible custom
-        # endpoints (NVIDIA, LM Studio, vLLM, ...) only speak Chat Completions,
-        # so only enable it for the real api.openai.com host.
+        # endpoints (third-party gateways, LM Studio, vLLM, ...) only speak
+        # Chat Completions, so only enable it for the real api.openai.com host.
         if self.provider == "openai":
             llm_kwargs["use_responses_api"] = _is_native_openai_base_url(self.base_url)
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
@@ -183,6 +184,20 @@ def _resolve_provider_base_url(provider: str) -> Optional[str]:
     return _PROVIDER_BASE_URL.get(provider)
 
 
+def _is_native_openai_base_url(base_url: Optional[str]) -> bool:
+    """True when ``base_url`` is unset or points at api.openai.com.
+
+    The Responses API (/v1/responses) only exists on native OpenAI. An
+    OpenAI-compatible custom endpoint (NVIDIA integrate API, LM Studio,
+    vLLM, ...) only supports Chat Completions, so the Responses API must
+    stay off there.
+    """
+    if not base_url:
+        return True
+    host = urlparse(base_url).hostname or ""
+    return host == "api.openai.com" or host.endswith(".openai.com")
+
+
 class OpenAIClient(BaseLLMClient):
     """Client for OpenAI, Ollama, OpenRouter, and xAI providers.
 
@@ -233,10 +248,11 @@ class OpenAIClient(BaseLLMClient):
             if key in self.kwargs:
                 llm_kwargs[key] = self.kwargs[key]
 
-        # Native OpenAI: use Responses API for consistent behavior across
-        # all model families. Third-party providers use Chat Completions.
+        # Native OpenAI uses the Responses API; OpenAI-compatible custom
+        # endpoints (NVIDIA, LM Studio, vLLM, ...) only speak Chat Completions,
+        # so only enable it for the real api.openai.com host.
         if self.provider == "openai":
-            llm_kwargs["use_responses_api"] = True
+            llm_kwargs["use_responses_api"] = _is_native_openai_base_url(self.base_url)
 
         # Provider-specific quirks live in their own subclasses so the
         # base NormalizedChatOpenAI stays free of provider branches.


### PR DESCRIPTION
## Summary
- Route native OpenAI hosts to the Responses API while keeping OpenAI-compatible custom endpoints on Chat Completions.
- Recognize NVIDIA-hosted MiniMax model IDs such as `minimaxai/minimax-m2.7` as MiniMax thinking-capable.
- Harden structured-output fallback when a structured invocation returns `None`.
- Add regression coverage for endpoint routing, MiniMax capability matching, and structured fallback.

## Verification
- Targeted Docker verification passed inside `tradingagents:phase1` with network disabled and read-only source mount: `targeted_checks=PASS`.
- Pre-push privacy scan passed: no hardcoded credential assignments, no OpenRouter/NVIDIA/OpenAI key-shaped secrets, no personal paths/emails, no local artifacts staged.
- Independent code review passed with no blocking security concerns or logic errors.

## Notes
- This PR does not include local runtime smoke logs, cache files, `.env`, or Docker override artifacts.
- Phase 1 OpenRouter smoke results were treated as capability evaluation evidence only, not investment conclusions.
