### PR TITLE
[codex] fix Ollama compose env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
     env_file:
       - .env
     environment:
-      - LLM_PROVIDER=ollama
+      - TRADINGAGENTS_LLM_PROVIDER=ollama
+      - TRADINGAGENTS_LLM_BACKEND_URL=http://ollama:11434/v1
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
     depends_on:


### PR DESCRIPTION
## Summary

- Configure the Docker Ollama profile with `TRADINGAGENTS_LLM_PROVIDER=ollama`, which is the env var read by `DEFAULT_CONFIG`.
- Point containerized Ollama traffic at the Compose service hostname with `TRADINGAGENTS_LLM_BACKEND_URL=http://ollama:11434/v1`.

## Why

The previous `LLM_PROVIDER=ollama` variable was ignored by the application, so `docker compose --profile ollama run --rm tradingagents-ollama` could still start with the default provider and then fail when trying to reach the wrong LLM endpoint.

Fixes #975.

## Validation

- Checked the local compose diff.
- Ran a lightweight file assertion confirming the corrected env entries are present.
- Could not run `docker compose --profile ollama config` or pytest in this Codex shell because `docker`, `pytest`, and project dependencies are not installed on `PATH`.