### PR TITLE
Add Windows launcher for setup and CLI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ Install the package and its dependencies:
 pip install .
 ```
 
+### Windows one-click launcher
+
+On Windows, you can let the launcher create the virtual environment, install
+dependencies, prepare `.env`, and start the interactive CLI:
+
+```powershell
+.\start_tradingagents.bat
+```
+
+PowerShell users can run the underlying script directly:
+
+```powershell
+.\scripts\start_tradingagents.ps1
+.\scripts\start_tradingagents.ps1 -SetupOnly      # prepare env without launching
+.\scripts\start_tradingagents.ps1 -Checkpoint     # enable checkpoint resume
+```
+
 ### Docker
 
 Alternatively, run with Docker:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pandas>=2.3.0",
     "parsel>=1.10.0",
     "pytz>=2025.2",
+    "python-dotenv>=1.1.0",
     "questionary>=2.1.0",
     "redis>=6.2.0",
     "requests>=2.32.4",

--- a/scripts/start_tradingagents.ps1
+++ b/scripts/start_tradingagents.ps1
@@ -1,0 +1,127 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipInstall,
+    [switch]$SetupOnly,
+    [switch]$Checkpoint,
+    [switch]$ClearCheckpoints,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$CliArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$VenvDir = Join-Path $ProjectRoot ".venv"
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+$InstallMarker = Join-Path $VenvDir ".tradingagents-installed"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Invoke-Checked {
+    param(
+        [string]$FilePath,
+        [string[]]$Arguments
+    )
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function New-ProjectVenv {
+    Write-Step "Creating Python virtual environment"
+
+    $pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($pyLauncher) {
+        & py -3 -m venv $VenvDir
+    }
+    else {
+        $python = Get-Command python -ErrorAction SilentlyContinue
+        if (-not $python) {
+            throw "Python was not found. Install Python 3.10+ and run this launcher again."
+        }
+        & python -m venv $VenvDir
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not create virtual environment at $VenvDir"
+    }
+}
+
+Set-Location $ProjectRoot
+
+Write-Host "TradingAgents launcher" -ForegroundColor Green
+Write-Host "Project: $ProjectRoot"
+
+if (-not (Test-Path $VenvPython)) {
+    New-ProjectVenv
+}
+
+& $VenvPython -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
+if ($LASTEXITCODE -ne 0) {
+    throw "The virtual environment must use Python 3.10 or newer."
+}
+
+if (-not (Test-Path (Join-Path $ProjectRoot ".env")) -and (Test-Path (Join-Path $ProjectRoot ".env.example"))) {
+    Write-Step "Creating .env from .env.example"
+    Copy-Item (Join-Path $ProjectRoot ".env.example") (Join-Path $ProjectRoot ".env")
+    Write-Host "Created .env. The CLI can help fill provider API keys during first run."
+}
+
+$needsInstall = -not (Test-Path $InstallMarker)
+$consoleScript = Join-Path $VenvDir "Scripts\tradingagents.exe"
+if (-not (Test-Path $consoleScript)) {
+    $needsInstall = $true
+}
+elseif (Test-Path $InstallMarker) {
+    $pyproject = Get-Item (Join-Path $ProjectRoot "pyproject.toml")
+    $marker = Get-Item $InstallMarker
+    if ($pyproject.LastWriteTimeUtc -gt $marker.LastWriteTimeUtc) {
+        $needsInstall = $true
+    }
+}
+
+if ($SkipInstall) {
+    Write-Step "Skipping dependency install"
+}
+elseif ($needsInstall) {
+    Write-Step "Installing project dependencies"
+    $uv = Get-Command uv -ErrorAction SilentlyContinue
+    if ($uv) {
+        Invoke-Checked $uv.Source @("pip", "install", "--python", $VenvPython, "-e", ".")
+    }
+    else {
+        Invoke-Checked $VenvPython @("-m", "pip", "install", "--upgrade", "pip")
+        Invoke-Checked $VenvPython @("-m", "pip", "install", "-e", ".")
+    }
+    Set-Content -Path $InstallMarker -Value (Get-Date).ToString("o") -Encoding ASCII
+}
+else {
+    Write-Step "Environment already installed"
+}
+
+if ($SetupOnly) {
+    Write-Step "Setup complete"
+    exit 0
+}
+
+Write-Step "Starting TradingAgents CLI"
+
+$runArgs = @("-m", "cli.main", "analyze")
+if ($Checkpoint) {
+    $runArgs += "--checkpoint"
+}
+if ($ClearCheckpoints) {
+    $runArgs += "--clear-checkpoints"
+}
+if ($CliArgs) {
+    $runArgs += $CliArgs
+}
+
+& $VenvPython @runArgs
+exit $LASTEXITCODE

--- a/scripts/start_tradingagents.ps1
+++ b/scripts/start_tradingagents.ps1
@@ -10,7 +10,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptDir = $PSScriptRoot
 $ProjectRoot = Split-Path -Parent $ScriptDir
 $VenvDir = Join-Path $ProjectRoot ".venv"
 $VenvPython = Join-Path $VenvDir "Scripts\python.exe"

--- a/start_tradingagents.bat
+++ b/start_tradingagents.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\start_tradingagents.ps1" %*
+if errorlevel 1 (
+    echo.
+    echo TradingAgents launcher failed. See the message above.
+    pause
+)


### PR DESCRIPTION
Adds a Windows launcher that prepares the local virtual environment, creates .env from .env.example when needed, installs the project in editable mode, and starts the interactive CLI.

Also documents the launcher in README and declares python-dotenv as an explicit dependency because the package imports dotenv when loading .env files.