### PR TITLE
fix(news): silent look-ahead bias in yfinance articles — flat-format articles bypass all date filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Fixed
+
+- **yfinance Flat-Format News Filter.** `get_global_news_yfinance` now
+  parses `providerPublishTime` (Unix timestamp) from flat-format articles
+  returned by `yf.Search()`, applying the same date-range filter as
+  nested-format articles. Previously flat articles bypassed all date
+  checks, causing future-dated news to appear in historical backtests.
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/tests/test_yf_search_date_filter.py
+++ b/tests/test_yf_search_date_filter.py
@@ -1,0 +1,187 @@
+"""Regression tests for yfinance flat-format article date filtering.
+
+yf.Search() currently returns articles exclusively in flat format, where
+the publish timestamp is stored as a Unix integer in ``providerPublishTime``.
+The previous code returned ``pub_date=None`` for flat articles, causing
+get_global_news_yfinance() to bypass all date filtering and inject
+future-dated news into historical backtest runs.
+
+These tests verify:
+1. _extract_article_data() correctly parses providerPublishTime for flat articles.
+2. get_global_news_yfinance() filters out articles outside the date window,
+   regardless of whether the article is nested or flat format.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest import mock
+
+from tradingagents.dataflows.yfinance_news import (
+    _extract_article_data,
+    get_global_news_yfinance,
+)
+from tradingagents.dataflows.config import set_config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _flat_article(title: str, pub_ts: int) -> dict:
+    """Minimal flat-format article as returned by yf.Search()."""
+    return {
+        "title": title,
+        "publisher": "Test Publisher",
+        "link": "https://example.com/article",
+        "providerPublishTime": pub_ts,
+        "type": "STORY",
+    }
+
+
+def _nested_article(title: str, pub_iso: str) -> dict:
+    """Minimal nested-format article (older yfinance versions)."""
+    return {
+        "content": {
+            "title": title,
+            "summary": "Summary text.",
+            "provider": {"displayName": "Test Publisher"},
+            "canonicalUrl": {"url": "https://example.com/article"},
+            "pubDate": pub_iso,
+        }
+    }
+
+
+def _ts(dt: datetime) -> int:
+    """Convert a naive UTC datetime to a Unix timestamp integer."""
+    return int(dt.replace(tzinfo=timezone.utc).timestamp())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no network required
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestExtractArticleData:
+    def test_flat_article_pub_date_parsed(self):
+        """Flat articles expose pub_date when providerPublishTime is present."""
+        ts = _ts(datetime(2026, 4, 10, 15, 33, 30))
+        article = _flat_article("Test headline", ts)
+        data = _extract_article_data(article)
+
+        assert data["pub_date"] is not None
+        assert data["pub_date"].year == 2026
+        assert data["pub_date"].month == 4
+        assert data["pub_date"].day == 10
+        assert data["title"] == "Test headline"
+
+    def test_flat_article_missing_timestamp_returns_none(self):
+        """Flat articles without providerPublishTime return pub_date=None."""
+        article = {"title": "No timestamp", "publisher": "X", "link": ""}
+        data = _extract_article_data(article)
+        assert data["pub_date"] is None
+
+    def test_nested_article_pub_date_parsed(self):
+        """Nested articles continue to have pub_date parsed from pubDate."""
+        article = _nested_article("Nested headline", "2026-04-10T15:33:30Z")
+        data = _extract_article_data(article)
+        assert data["pub_date"] is not None
+        assert data["pub_date"].year == 2026
+
+    def test_nested_article_missing_pub_date_returns_none(self):
+        """Nested articles without pubDate return pub_date=None."""
+        article = {"content": {"title": "No date", "provider": {}}}
+        data = _extract_article_data(article)
+        assert data["pub_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests using mocked yf.Search — no real network calls
+# ---------------------------------------------------------------------------
+
+def _make_search_mock(articles: list):
+    """Return a mock that makes yf.Search(...).news return ``articles``."""
+    search_instance = mock.MagicMock()
+    search_instance.news = articles
+
+    search_cls = mock.MagicMock(return_value=search_instance)
+    return search_cls
+
+
+@pytest.mark.unit
+class TestGlobalNewsDateFilter:
+    """get_global_news_yfinance must filter articles by date regardless of format."""
+
+    def setup_method(self):
+        # Use a minimal config so get_config() doesn't fail.
+        set_config({
+            "global_news_lookback_days": 7,
+            "global_news_article_limit": 10,
+            "global_news_queries": ["test query"],
+        })
+
+    def test_flat_future_article_filtered_for_historical_date(self):
+        """A flat article dated 2026 must not appear when curr_date=2022-01-19."""
+        future_ts = _ts(datetime(2026, 4, 10, 15, 0, 0))
+        articles = [_flat_article("Future news headline", future_ts)]
+
+        with mock.patch(
+            "tradingagents.dataflows.yfinance_news.yf.Search",
+            _make_search_mock(articles),
+        ):
+            result = get_global_news_yfinance("2022-01-19")
+
+        assert "Future news headline" not in result
+
+    def test_flat_article_within_window_passes_for_today(self):
+        """A flat article from today's window must appear when curr_date matches."""
+        # Use a timestamp squarely inside the 7-day window of 2026-06-08
+        in_window_ts = _ts(datetime(2026, 6, 5, 10, 0, 0))
+        articles = [_flat_article("Recent market news", in_window_ts)]
+
+        with mock.patch(
+            "tradingagents.dataflows.yfinance_news.yf.Search",
+            _make_search_mock(articles),
+        ):
+            result = get_global_news_yfinance("2026-06-08")
+
+        assert "Recent market news" in result
+
+    def test_nested_future_article_filtered_for_historical_date(self):
+        """A nested article dated 2026 must not appear when curr_date=2022-01-19."""
+        articles = [_nested_article("Nested future news", "2026-04-10T15:00:00Z")]
+
+        with mock.patch(
+            "tradingagents.dataflows.yfinance_news.yf.Search",
+            _make_search_mock(articles),
+        ):
+            result = get_global_news_yfinance("2022-01-19")
+
+        assert "Nested future news" not in result
+
+    def test_flat_article_too_old_filtered(self):
+        """A flat article older than the lookback window must be excluded."""
+        # 30 days before curr_date, well outside the 7-day window
+        old_ts = _ts(datetime(2026, 5, 9, 10, 0, 0))
+        articles = [_flat_article("Old news headline", old_ts)]
+
+        with mock.patch(
+            "tradingagents.dataflows.yfinance_news.yf.Search",
+            _make_search_mock(articles),
+        ):
+            result = get_global_news_yfinance("2026-06-08")
+
+        assert "Old news headline" not in result
+
+    def test_all_filtered_returns_no_news_message(self):
+        """When all articles are outside the date window the function says so."""
+        future_ts = _ts(datetime(2026, 4, 10, 15, 0, 0))
+        articles = [_flat_article("Future article", future_ts)]
+
+        with mock.patch(
+            "tradingagents.dataflows.yfinance_news.yf.Search",
+            _make_search_mock(articles),
+        ):
+            result = get_global_news_yfinance("2022-01-19")
+
+        # Should return the header line but no article sections
+        assert "###" not in result

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -41,13 +41,20 @@ def _extract_article_data(article: dict) -> dict:
             "pub_date": pub_date,
         }
     else:
-        # Fallback for flat structure
+        # Flat structure — parse providerPublishTime (Unix timestamp)
+        pub_date = None
+        ts = article.get("providerPublishTime")
+        if ts:
+            try:
+                pub_date = datetime.fromtimestamp(int(ts))
+            except (ValueError, OSError, TypeError):
+                pass
         return {
             "title": article.get("title", "No title"),
             "summary": article.get("summary", ""),
             "publisher": article.get("publisher", "Unknown"),
             "link": article.get("link", ""),
-            "pub_date": None,
+            "pub_date": pub_date,
         }
 
 
@@ -171,23 +178,25 @@ def get_global_news_yfinance(
 
         news_str = ""
         for article in all_news[:limit]:
-            # Handle both flat and nested structures
-            if "content" in article:
-                data = _extract_article_data(article)
-                # Skip articles published after curr_date (look-ahead guard)
-                if data.get("pub_date"):
-                    pub_naive = data["pub_date"].replace(tzinfo=None) if hasattr(data["pub_date"], "replace") else data["pub_date"]
-                    if pub_naive > curr_dt + relativedelta(days=1):
-                        continue
-                title = data["title"]
-                publisher = data["publisher"]
-                link = data["link"]
-                summary = data["summary"]
-            else:
-                title = article.get("title", "No title")
-                publisher = article.get("publisher", "Unknown")
-                link = article.get("link", "")
-                summary = ""
+            data = _extract_article_data(article)
+
+            # Unified date filter for both nested and flat formats.
+            # _extract_article_data now parses providerPublishTime for flat
+            # articles, so pub_date is populated for both formats when available.
+            pub_date = data.get("pub_date")
+            if pub_date is not None:
+                pub_naive = pub_date.replace(tzinfo=None)
+                if pub_naive > curr_dt + relativedelta(days=1):
+                    continue  # future article — look-ahead guard
+                if pub_naive < start_dt:
+                    continue  # outside lookback window
+            # pub_date is None only when timestamp is missing/unparseable;
+            # include the article but it will show no date metadata.
+
+            title = data["title"]
+            publisher = data["publisher"]
+            link = data["link"]
+            summary = data["summary"]
 
             news_str += f"### {title} (source: {publisher})\n"
             if summary:


### PR DESCRIPTION
## Problem

`yf.Search()` now returns articles exclusively in **flat format**, where the publish timestamp is stored as a Unix integer in `providerPublishTime`. The previous code only parsed dates for nested-format articles (`content.pubDate`); flat articles returned `pub_date=None`, **bypassing all date filtering**. This caused future-dated news to be injected into historical backtests.

### Reproduction

```python
from tradingagents.dataflows.yfinance_news import get_global_news_yfinance

# Before fix — returns articles dated 2025/2026 for a 2022 backtest date
result = get_global_news_yfinance("2022-01-19")
print(result)  # Contains future news headlines
```

## Root Cause

In `_extract_article_data()`, the flat-format branch did not parse `providerPublishTime`:

```python
# Before — flat branch always returned pub_date=None
else:
    return {
        "title": article.get("title", "No title"),
        ...
        # pub_date never set → date filter skipped entirely
    }
```

In `get_global_news_yfinance()`, the filter only ran for nested articles because flat articles had `pub_date=None`, which the `if pub_date is not None:` guard skipped.

## Fix

**`tradingagents/dataflows/yfinance_news.py`**

1. `_extract_article_data()`: parse `providerPublishTime` (Unix timestamp) for flat-format articles
2. `get_global_news_yfinance()`: unified date-range filter now applies to both nested and flat formats

```python
# After — flat branch parses Unix timestamp
else:
    pub_date = None
    ts = article.get("providerPublishTime")
    if ts:
        try:
            pub_date = datetime.fromtimestamp(int(ts))
        except (ValueError, OSError, TypeError):
            pass
    return {"title": ..., "pub_date": pub_date, ...}
```

## Tests

**`tests/test_yf_search_date_filter.py`** — 9 regression tests, no network required:

| Class | Tests |
|---|---|
| `TestExtractArticleData` | flat article timestamp parsed correctly; missing timestamp → `None`; nested format unchanged |
| `TestGlobalNewsDateFilter` | future article filtered for historical date; recent article passes for current date; article older than lookback window excluded; all-filtered case returns no `###` sections |

```
pytest tests/test_yf_search_date_filter.py -v
# 9 passed
```

## Verification

```python
from tradingagents.dataflows.yfinance_news import get_global_news_yfinance

# Historical date — should return no articles
print(get_global_news_yfinance("2022-01-19"))
# → "Global Market News, from 2022-01-12 to 2022-01-19:\n\n" (no ### sections)

# Current date — should return articles
print(get_global_news_yfinance("2026-06-08")[:300])
# → articles with 2026-06 timestamps
```
