### PR TITLE
fix(alpha_vantage): add request timeout and stop mislabeling bad API key as rate limit

### DIFF
--- a/tests/test_alpha_vantage_request.py
+++ b/tests/test_alpha_vantage_request.py
@@ -75,6 +75,20 @@ class TestAlphaVantageRequest(unittest.TestCase):
             result = av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
         self.assertEqual(result, csv_text)
 
+    def test_unexpected_json_shape_passes_through(self):
+        body = json.dumps(["unexpected", "payload"])
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", return_value=_FakeResponse(body)):
+            result = av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+        self.assertEqual(result, body)
+
+    def test_non_string_information_passes_through(self):
+        body = json.dumps({"Information": {"message": "Invalid API key"}})
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", return_value=_FakeResponse(body)):
+            result = av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+        self.assertEqual(result, body)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_alpha_vantage_request.py
+++ b/tests/test_alpha_vantage_request.py
@@ -1,0 +1,80 @@
+"""Tests for Alpha Vantage request hardening.
+
+Covers:
+  - #990: HTTP requests must pass a bounded timeout so a stalled network path
+    cannot block analysis indefinitely.
+  - #991: an invalid/missing API key must not be mislabeled as a rate-limit
+    error, while genuine rate-limit messages (which can also mention the API
+    key) must stay rate-limit errors.
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import pytest
+
+from tradingagents.dataflows import alpha_vantage_common as av
+from tradingagents.dataflows.alpha_vantage_common import (
+    AlphaVantageNotConfiguredError,
+    AlphaVantageRateLimitError,
+)
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.mark.unit
+class TestAlphaVantageRequest(unittest.TestCase):
+    def test_request_passes_timeout(self):
+        captured = {}
+
+        def fake_get(url, params=None, timeout=None):
+            captured["timeout"] = timeout
+            return _FakeResponse("timestamp,open\n2026-01-01,1.0\n")
+
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", side_effect=fake_get):
+            av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+
+        self.assertEqual(captured["timeout"], av.REQUEST_TIMEOUT)
+
+    def test_api_key_message_raises_not_configured(self):
+        body = json.dumps(
+            {"Information": "Invalid API key. Please claim your free API key."}
+        )
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", return_value=_FakeResponse(body)):
+            with self.assertRaises(AlphaVantageNotConfiguredError):
+                av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+
+    def test_rate_limit_message_stays_rate_limit_even_when_mentioning_api_key(self):
+        # Regression guard: AV throttling messages also mention the API key.
+        body = json.dumps(
+            {
+                "Information": (
+                    "We have detected your API key as DEMO and our standard "
+                    "API rate limit is 25 requests per day."
+                )
+            }
+        )
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", return_value=_FakeResponse(body)):
+            with self.assertRaises(AlphaVantageRateLimitError):
+                av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+
+    def test_csv_response_passes_through(self):
+        csv_text = "timestamp,open,close\n2026-01-02,1.0,1.1\n"
+        with mock.patch.object(av, "get_api_key", return_value="demo"), \
+                mock.patch.object(av.requests, "get", return_value=_FakeResponse(csv_text)):
+            result = av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+        self.assertEqual(result, csv_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -89,7 +89,7 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
     try:
         response_json = json.loads(response_text)
         # Alpha Vantage returns soft errors as JSON under "Information".
-        if "Information" in response_json:
+        if isinstance(response_json, dict) and isinstance(response_json.get("Information"), str):
             info_message = response_json["Information"]
             lowered = info_message.lower()
             # Check rate limit first: throttling messages can also mention the

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -7,6 +7,10 @@ from io import StringIO
 
 API_BASE_URL = "https://www.alphavantage.co/query"
 
+# (connect, read) timeout in seconds for Alpha Vantage HTTP requests, so a
+# stalled network path can't block the whole analysis indefinitely (see #990).
+REQUEST_TIMEOUT = (5, 30)
+
 
 class AlphaVantageNotConfiguredError(ValueError):
     """Raised when Alpha Vantage is selected but no API key is configured.
@@ -76,7 +80,7 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
         # Remove entitlement if it's None or empty
         api_params.pop("entitlement", None)
     
-    response = requests.get(API_BASE_URL, params=api_params)
+    response = requests.get(API_BASE_URL, params=api_params, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
 
     response_text = response.text
@@ -84,11 +88,20 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
     # Check if response is JSON (error responses are typically JSON)
     try:
         response_json = json.loads(response_text)
-        # Check for rate limit error
+        # Alpha Vantage returns soft errors as JSON under "Information".
         if "Information" in response_json:
             info_message = response_json["Information"]
-            if "rate limit" in info_message.lower() or "api key" in info_message.lower():
+            lowered = info_message.lower()
+            # Check rate limit first: throttling messages can also mention the
+            # API key (e.g. "detected your API key ... rate limit is ..."), so
+            # they must stay rate-limit errors.
+            if "rate limit" in lowered:
                 raise AlphaVantageRateLimitError(f"Alpha Vantage rate limit exceeded: {info_message}")
+            # An API-key message that is not a rate limit is a configuration
+            # problem, not throttling — surface it as such so callers don't back
+            # off as if rate limited (see #991).
+            if "api key" in lowered:
+                raise AlphaVantageNotConfiguredError(f"Alpha Vantage API key rejected: {info_message}")
     except json.JSONDecodeError:
         # Response is not JSON (likely CSV data), which is normal
         pass


### PR DESCRIPTION
## Summary

Two robustness fixes in `alpha_vantage_common._make_api_request`. They're in the same function, so they're bundled into one PR to avoid conflicting changes — happy to split if you prefer.

### #990 — request had no timeout
`requests.get(...)` was called without a `timeout`, so a stalled network/DNS/TLS path could block the entire analysis indefinitely. Added a `REQUEST_TIMEOUT = (5, 30)` constant and pass it, as suggested in the issue.

### #991 — invalid API key mislabeled as rate limit
The handler raised `AlphaVantageRateLimitError` whenever the `Information` message contained `rate limit` **or** `api key`, so an invalid/missing key surfaced as throttling and misled both users and fallback logic.

Now the message is classified in order:
1. contains `rate limit` → `AlphaVantageRateLimitError` (checked **first**, because AV throttling messages also mention the API key, e.g. *"detected your API key … rate limit is 25 requests per day"* — this avoids any regression),
2. otherwise contains `api key` → the existing `AlphaVantageNotConfiguredError` (a config problem, not throttling).

`AlphaVantageNotConfiguredError` already exists and subclasses `ValueError`, matching the path the issue suggested.

## Tests

Adds `tests/test_alpha_vantage_request.py` (`@pytest.mark.unit`):
- timeout is passed to `requests.get`,
- an API-key message → `AlphaVantageNotConfiguredError`,
- a rate-limit message that also mentions the API key → still `AlphaVantageRateLimitError` (regression guard),
- normal CSV response passes through unchanged.

All 4 pass locally. No behavior change for successful responses.

Fixes #990, fixes #991
