### PR TITLE
fix(dataflows): log swallowed vendor errors so a broken primary isn't silently masked

### DIFF
--- a/tests/test_route_vendor_logging.py
+++ b/tests/test_route_vendor_logging.py
@@ -36,6 +36,7 @@ class TestRouteToVendorLogging(unittest.TestCase):
         self.assertIn("boomvendor", joined)
         self.assertIn("get_stock_data", joined)
         self.assertIn("configured primary", joined)
+        self.assertTrue(any(record.exc_info for record in cm.records))
 
 
 if __name__ == "__main__":

--- a/tests/test_route_vendor_logging.py
+++ b/tests/test_route_vendor_logging.py
@@ -1,0 +1,42 @@
+"""route_to_vendor must log when it swallows an unexpected vendor error, so a
+broken primary vendor isn't silently masked by a later succeeding fallback
+(see #989)."""
+
+import unittest
+from unittest import mock
+
+import pytest
+
+from tradingagents.dataflows import interface
+
+
+@pytest.mark.unit
+class TestRouteToVendorLogging(unittest.TestCase):
+    def test_primary_failure_is_logged_but_fallback_result_returned(self):
+        def primary_boom(*a, **k):
+            raise RuntimeError("primary vendor exploded")
+
+        def fallback_ok(*a, **k):
+            return "FALLBACK_DATA"
+
+        patched = {"boomvendor": primary_boom, "okvendor": fallback_ok}
+        with mock.patch.object(interface, "get_vendor", return_value="boomvendor,okvendor"), \
+                mock.patch.dict(
+                    interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+                ):
+            with self.assertLogs(interface.logger, level="WARNING") as cm:
+                result = interface.route_to_vendor(
+                    "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+                )
+
+        # The fallback's data is still returned (no behavior change)...
+        self.assertEqual(result, "FALLBACK_DATA")
+        # ...but the masked primary failure is now visible in the logs.
+        joined = "\n".join(cm.output)
+        self.assertIn("boomvendor", joined)
+        self.assertIn("get_stock_data", joined)
+        self.assertIn("configured primary", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -181,6 +181,7 @@ def route_to_vendor(method: str, *args, **kwargs):
                 method,
                 " (configured primary)" if vendor in primary_vendors else "",
                 e,
+                exc_info=True,
             )
             if first_error is None:
                 first_error = e

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Annotated
 
 # Import from vendor-specific modules
@@ -132,6 +133,9 @@ def get_vendor(category: str, method: str = None) -> str:
     # Fall back to category-level configuration
     return config.get("data_vendors", {}).get(category, "default")
 
+logger = logging.getLogger(__name__)
+
+
 def route_to_vendor(method: str, *args, **kwargs):
     """Route method calls to appropriate vendor implementation with fallback support."""
     category = get_category_for_method(method)
@@ -169,6 +173,15 @@ def route_to_vendor(method: str, *args, **kwargs):
             # key configured) must not crash the call when another vendor
             # already determined the symbol simply has no data. Remember the
             # first error so a genuine primary-vendor failure still surfaces.
+            # Log it so a broken primary vendor isn't silently masked when a
+            # later fallback succeeds (see #989).
+            logger.warning(
+                "Vendor %r failed for %s%s: %s",
+                vendor,
+                method,
+                " (configured primary)" if vendor in primary_vendors else "",
+                e,
+            )
             if first_error is None:
                 first_error = e
             continue


### PR DESCRIPTION
## Summary

`route_to_vendor()` already surfaces the first error when **every** vendor fails (it stores `first_error` and re-raises it after the loop). But when a fallback vendor *succeeds*, the primary vendor's unexpected failure is swallowed with no trace — so a broken primary data source can be silently masked while the agents reason on fallback data.

This adds a `logger.warning` in the `except Exception` branch that names the method, the vendor, and whether it was a **configured primary**, so the masked failure is visible:

```
Vendor 'alpha_vantage' failed for get_stock_data (configured primary): <error>
```

## Scope

Deliberately minimal and additive:
- **No control-flow change** — fallback still works exactly as before; this only makes the swallowed error observable.
- Follows the existing logging convention in `tradingagents/dataflows/` (`logger = logging.getLogger(__name__)` + `logger.warning("… %s", …)`).
- The issue also suggests *narrowing the swallowed exception types*. That changes behavior (which failures are fallback-safe vs. fatal), so I've left it out as a separate maintainer decision rather than bundle a behavior change here.

## Tests

`tests/test_route_vendor_logging.py` asserts the warning is emitted (naming the primary vendor and method) while the fallback's result is still returned. Existing `tests/test_no_data_handling.py` route tests still pass.

Addresses #989
