### PR TITLE
Fix CLI handling for normalized Yahoo symbols

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -7,12 +7,14 @@ from dotenv import find_dotenv, set_key
 from rich.console import Console
 
 from cli.models import AnalystType, AssetType
+from tradingagents.dataflows.symbol_utils import normalize_symbol
+from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.llm_clients.api_key_env import get_api_key_env
 from tradingagents.llm_clients.model_catalog import get_model_options
 
 console = Console()
 
-TICKER_INPUT_EXAMPLES = "SPY, 0700.HK, BTC-USD"
+TICKER_INPUT_EXAMPLES = "SPY, 0700.HK, BTC-USD, GC=F"
 
 ANALYST_ORDER = [
     ("Market Analyst", AnalystType.MARKET),
@@ -22,6 +24,15 @@ ANALYST_ORDER = [
 ]
 
 CRYPTO_SUFFIXES = ("-USD", "-USDT", "-USDC", "-BTC", "-ETH")
+
+
+def is_valid_ticker_symbol(ticker: str) -> bool:
+    """Return True when ticker input is safe and matches supported symbol syntax."""
+    try:
+        safe_ticker_component(ticker.strip())
+    except (AttributeError, ValueError):
+        return False
+    return True
 
 
 def get_ticker() -> str:
@@ -35,8 +46,8 @@ def get_ticker() -> str:
         f"Enter ticker symbol (e.g. {TICKER_INPUT_EXAMPLES}):",
         validate=lambda x: (
             not x.strip()
-            or (all(ch.isalnum() or ch in "._-^" for ch in x.strip()) and len(x.strip()) <= 32)
-            or "Please enter a valid ticker symbol, e.g. AAPL, 000404.SZ, 0700.HK."
+            or is_valid_ticker_symbol(x)
+            or "Please enter a valid ticker symbol, e.g. AAPL, 000404.SZ, 0700.HK, GC=F."
         ),
         style=questionary.Style(
             [
@@ -59,7 +70,7 @@ def normalize_ticker_symbol(ticker: str) -> str:
 
 
 def detect_asset_type(ticker: str) -> AssetType:
-    normalized_ticker = ticker.strip().upper()
+    normalized_ticker = normalize_symbol(ticker).strip().upper()
     if normalized_ticker.endswith(CRYPTO_SUFFIXES):
         return AssetType.CRYPTO
     return AssetType.STOCK

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -7,7 +7,7 @@ from dotenv import find_dotenv, set_key
 from rich.console import Console
 
 from cli.models import AnalystType, AssetType
-from tradingagents.dataflows.symbol_utils import normalize_symbol
+from tradingagents.dataflows.symbol_utils import CRYPTO_BASES, normalize_symbol
 from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.llm_clients.api_key_env import get_api_key_env
 from tradingagents.llm_clients.model_catalog import get_model_options
@@ -73,6 +73,10 @@ def detect_asset_type(ticker: str) -> AssetType:
     normalized_ticker = normalize_symbol(ticker).strip().upper()
     if normalized_ticker.endswith(CRYPTO_SUFFIXES):
         return AssetType.CRYPTO
+    if "-" in normalized_ticker:
+        base, _ = normalized_ticker.split("-", 1)
+        if base in CRYPTO_BASES:
+            return AssetType.CRYPTO
     return AssetType.STOCK
 
 

--- a/tests/test_crypto_asset_mode.py
+++ b/tests/test_crypto_asset_mode.py
@@ -12,6 +12,7 @@ class CryptoAssetModeTests(unittest.TestCase):
         self.assertEqual(detect_asset_type("BTCUSD"), AssetType.CRYPTO)
         self.assertEqual(detect_asset_type("ethusd"), AssetType.CRYPTO)
         self.assertEqual(detect_asset_type("BTC-USDT"), AssetType.CRYPTO)
+        self.assertEqual(detect_asset_type("BTC-EUR"), AssetType.CRYPTO)
 
     def test_defaults_non_crypto_symbols_to_stock(self):
         self.assertEqual(detect_asset_type("AAPL"), AssetType.STOCK)

--- a/tests/test_crypto_asset_mode.py
+++ b/tests/test_crypto_asset_mode.py
@@ -9,10 +9,14 @@ class CryptoAssetModeTests(unittest.TestCase):
     def test_detects_crypto_pair_symbols(self):
         self.assertEqual(detect_asset_type("BTC-USD"), AssetType.CRYPTO)
         self.assertEqual(detect_asset_type("eth-usd"), AssetType.CRYPTO)
+        self.assertEqual(detect_asset_type("BTCUSD"), AssetType.CRYPTO)
+        self.assertEqual(detect_asset_type("ethusd"), AssetType.CRYPTO)
+        self.assertEqual(detect_asset_type("BTC-USDT"), AssetType.CRYPTO)
 
     def test_defaults_non_crypto_symbols_to_stock(self):
         self.assertEqual(detect_asset_type("AAPL"), AssetType.STOCK)
         self.assertEqual(detect_asset_type("SPY"), AssetType.STOCK)
+        self.assertEqual(detect_asset_type("EURUSD"), AssetType.STOCK)
 
     def test_filters_out_fundamentals_analyst_for_crypto(self):
         analysts = [

--- a/tests/test_symbol_utils.py
+++ b/tests/test_symbol_utils.py
@@ -42,6 +42,8 @@ class TestNormalizeSymbol(unittest.TestCase):
     def test_crypto_pairs_get_dash_usd(self):
         self.assertEqual(normalize_symbol("BTCUSD"), "BTC-USD")
         self.assertEqual(normalize_symbol("ETHUSD"), "ETH-USD")
+        self.assertEqual(normalize_symbol("BTC-USDT"), "BTC-USD")
+        self.assertEqual(normalize_symbol("ethusdt"), "ETH-USD")
 
     def test_six_letter_non_currency_left_alone(self):
         # GOOGLE-style 6-letter tickers that aren't two currency codes

--- a/tests/test_ticker_symbol_handling.py
+++ b/tests/test_ticker_symbol_handling.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 
-from cli.utils import normalize_ticker_symbol
+from cli.utils import is_valid_ticker_symbol, normalize_ticker_symbol
 from tradingagents.agents.utils.agent_utils import build_instrument_context
 
 
@@ -10,6 +10,14 @@ from tradingagents.agents.utils.agent_utils import build_instrument_context
 class TickerSymbolHandlingTests(unittest.TestCase):
     def test_normalize_ticker_symbol_preserves_exchange_suffix(self):
         self.assertEqual(normalize_ticker_symbol(" cnc.to "), "CNC.TO")
+
+    def test_cli_ticker_validation_accepts_yahoo_and_broker_symbols(self):
+        for symbol in ("GC=F", "XAUUSD+", "EURUSD+", "^GSPC"):
+            self.assertTrue(is_valid_ticker_symbol(symbol), symbol)
+
+    def test_cli_ticker_validation_rejects_unsafe_symbols(self):
+        for symbol in ("AAP L", "../AAPL", "AAPL\x00", "A" * 33):
+            self.assertFalse(is_valid_ticker_symbol(symbol), symbol)
 
     def test_build_instrument_context_mentions_exact_symbol(self):
         context = build_instrument_context("7203.T")

--- a/tradingagents/dataflows/symbol_utils.py
+++ b/tradingagents/dataflows/symbol_utils.py
@@ -61,6 +61,7 @@ _FOREX_CURRENCIES = frozenset(
 _CRYPTO_BASES = frozenset(
     {"BTC", "ETH", "SOL", "XRP", "ADA", "DOGE", "LTC", "BCH", "DOT", "AVAX", "LINK"}
 )
+_STABLECOIN_QUOTES = ("USDT", "USDC")
 
 # Explicit aliases for instruments whose broker symbol does not map to a
 # Yahoo symbol by rule. Metals/energy resolve to their front-month future;
@@ -95,8 +96,9 @@ def normalize_symbol(raw: str) -> str:
     Resolution order (first match wins):
       1. Explicit alias table (metals, energy, index CFDs).
       2. Crypto rule: ``<BASE>USD`` where BASE is a known crypto -> ``BASE-USD``.
-      3. Forex rule: six letters that are two ISO currency codes -> ``PAIR=X``.
-      4. Otherwise the upper-cased symbol is returned unchanged (plain
+      3. Stablecoin crypto pairs map to Yahoo's USD quote, e.g. ``BTC-USDT`` -> ``BTC-USD``.
+      4. Forex rule: six letters that are two ISO currency codes -> ``PAIR=X``.
+      5. Otherwise the upper-cased symbol is returned unchanged (plain
          equities, ETFs, Yahoo-native symbols like ``GC=F`` or ``^GSPC``).
 
     A trailing ``+`` (broker CFD marker, e.g. ``XAUUSD+``) is stripped before
@@ -116,6 +118,19 @@ def normalize_symbol(raw: str) -> str:
         canonical = f"{s[:3]}-USD"
     elif s[:-3] in _CRYPTO_BASES and s.endswith("USD") and "-" not in s:
         canonical = f"{s[:-3]}-USD"
+    elif "-" in s:
+        base, quote = s.split("-", 1)
+        if base in _CRYPTO_BASES and quote in _STABLECOIN_QUOTES:
+            canonical = f"{base}-USD"
+        else:
+            canonical = s
+    elif any(s.endswith(quote) for quote in _STABLECOIN_QUOTES):
+        quote = next(quote for quote in _STABLECOIN_QUOTES if s.endswith(quote))
+        base = s[: -len(quote)]
+        if base in _CRYPTO_BASES:
+            canonical = f"{base}-USD"
+        else:
+            canonical = s
     elif len(s) == 6 and s[:3] in _FOREX_CURRENCIES and s[3:] in _FOREX_CURRENCIES:
         canonical = f"{s}=X"
     else:

--- a/tradingagents/dataflows/symbol_utils.py
+++ b/tradingagents/dataflows/symbol_utils.py
@@ -61,6 +61,7 @@ _FOREX_CURRENCIES = frozenset(
 _CRYPTO_BASES = frozenset(
     {"BTC", "ETH", "SOL", "XRP", "ADA", "DOGE", "LTC", "BCH", "DOT", "AVAX", "LINK"}
 )
+CRYPTO_BASES = _CRYPTO_BASES
 _STABLECOIN_QUOTES = ("USDT", "USDC")
 
 # Explicit aliases for instruments whose broker symbol does not map to a


### PR DESCRIPTION
## Summary
- allow the CLI ticker prompt to accept Yahoo/broker symbols already supported by the data layer, including `GC=F` and `XAUUSD+`
- route CLI asset-type detection through `normalize_symbol()` so bare crypto pairs like `BTCUSD` are treated as crypto
- normalize stablecoin crypto quotes such as `BTC-USDT` / `ETHUSDT` to Yahoo-supported `BASE-USD` symbols

Fixes #980
Fixes #981
Fixes #982

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_crypto_asset_mode.py tests\test_ticker_symbol_handling.py tests\test_symbol_utils.py tests\test_safe_ticker_component.py -q`
- `.\.venv\Scripts\python -m pytest -q` → `312 passed, 1 skipped, 75 subtests passed`