### PR TITLE
Normalize symbols for identity and memory lookups

### DIFF
--- a/tests/test_instrument_identity.py
+++ b/tests/test_instrument_identity.py
@@ -37,6 +37,13 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
         self.assertEqual(identity["industry"], "Building Products & Equipment")
         self.assertEqual(identity["exchange"], "PNK")
 
+    def test_queries_yfinance_with_normalized_symbol(self):
+        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
+            mock.return_value.info = {"longName": "Gold Futures", "quoteType": "FUTURE"}
+            identity = resolve_instrument_identity("XAUUSD+")
+        mock.assert_called_once_with("GC=F")
+        self.assertEqual(identity["company_name"], "Gold Futures")
+
     def test_falls_back_to_short_name(self):
         with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
             mock.return_value.info = {"shortName": "TOTO", "sector": "Industrials"}

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -514,6 +514,22 @@ class TestDeferredReflection:
         assert raw is not None and alpha is not None and days == 5
         assert mock_ticker_cls.call_args_list[0].args[0] == "BTC-USD"
 
+    def test_fetch_returns_normalizes_benchmark_before_yfinance_lookup(self):
+        stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
+        bench_prices = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            def _make_ticker(sym):
+                m = MagicMock()
+                m.history.return_value = _price_df(bench_prices if sym == "^GSPC" else stock_prices)
+                return m
+            mock_ticker_cls.side_effect = _make_ticker
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "NVDA", "2026-01-05", benchmark="US500"
+            )
+        assert raw is not None and alpha is not None and days == 5
+        assert mock_ticker_cls.call_args_list[1].args[0] == "^GSPC"
+
     def test_fetch_returns_too_recent(self):
         """Only 1 data point available → returns (None, None, None), no crash."""
         mock_graph = MagicMock(spec=TradingAgentsGraph)

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -500,6 +500,20 @@ class TestDeferredReflection:
         assert isinstance(raw, float) and isinstance(alpha, float) and isinstance(days, int)
         assert days == 5
 
+    def test_fetch_returns_normalizes_ticker_before_yfinance_lookup(self):
+        stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
+        spy_prices = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        with patch("yfinance.Ticker") as mock_ticker_cls:
+            def _make_ticker(sym):
+                m = MagicMock()
+                m.history.return_value = _price_df(spy_prices if sym == "SPY" else stock_prices)
+                return m
+            mock_ticker_cls.side_effect = _make_ticker
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(mock_graph, "BTCUSD", "2026-01-05")
+        assert raw is not None and alpha is not None and days == 5
+        assert mock_ticker_cls.call_args_list[0].args[0] == "BTC-USD"
+
     def test_fetch_returns_too_recent(self):
         """Only 1 data point available → returns (None, None, None), no crash."""
         mock_graph = MagicMock(spec=TradingAgentsGraph)

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -5,6 +5,8 @@ from typing import Any, Mapping, Optional
 import yfinance as yf
 from langchain_core.messages import HumanMessage, RemoveMessage
 
+from tradingagents.dataflows.symbol_utils import normalize_symbol
+
 # Import tools from separate utility files
 from tradingagents.agents.utils.core_stock_tools import (
     get_stock_data
@@ -72,7 +74,8 @@ def resolve_instrument_identity(ticker: str) -> dict:
     the lookup happens at most once per ticker per process.
     """
     try:
-        info = yf.Ticker(ticker.upper()).info or {}
+        canonical = normalize_symbol(ticker)
+        info = yf.Ticker(canonical).info or {}
     except Exception as exc:  # noqa: BLE001 — fail open, never block the run
         logger.debug("Could not resolve instrument identity for %s: %s", ticker, exc)
         return {}

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -18,6 +18,7 @@ from tradingagents.llm_clients import create_llm_client
 from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import TradingMemoryLog
+from tradingagents.dataflows.symbol_utils import normalize_symbol
 from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.agents.utils.agent_states import (
     AgentState,
@@ -237,7 +238,8 @@ class TradingAgentsGraph:
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            stock = yf.Ticker(ticker).history(start=trade_date, end=end_str)
+            canonical = normalize_symbol(ticker)
+            stock = yf.Ticker(canonical).history(start=trade_date, end=end_str)
             bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -239,8 +239,9 @@ class TradingAgentsGraph:
             end_str = end.strftime("%Y-%m-%d")
 
             canonical = normalize_symbol(ticker)
+            canonical_benchmark = normalize_symbol(benchmark)
             stock = yf.Ticker(canonical).history(start=trade_date, end=end_str)
-            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+            bench = yf.Ticker(canonical_benchmark).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:
                 return None, None, None


### PR DESCRIPTION
## Summary
- resolve instrument identity through the shared Yahoo symbol normalizer
- fetch deferred memory reflection returns with the same canonical Yahoo symbol used by market data
- add regression tests for broker-style aliases (`XAUUSD+`, `BTCUSD`)

Fixes #983.
Fixes #984.

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_instrument_identity.py tests\test_memory_log.py -q`
- `git diff --check`