### PR TITLE
Include requested end date in yfinance downloads

### DIFF
--- a/tests/test_yfinance_inclusive_end.py
+++ b/tests/test_yfinance_inclusive_end.py
@@ -1,0 +1,69 @@
+"""Regression tests for yfinance's exclusive end-date semantics."""
+
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from tradingagents.dataflows import stockstats_utils, y_finance
+from tradingagents.dataflows.config import get_config, set_config
+
+
+def _history_frame() -> pd.DataFrame:
+    dates = pd.to_datetime(["2026-01-05"])
+    return pd.DataFrame(
+        {
+            "Open": [100.0],
+            "High": [101.0],
+            "Low": [99.0],
+            "Close": [100.5],
+            "Adj Close": [100.5],
+            "Volume": [1_000_000],
+        },
+        index=dates,
+    )
+
+
+@pytest.mark.unit
+def test_get_yfin_data_online_requests_day_after_end_date():
+    frame = _history_frame()
+
+    with mock.patch.object(y_finance.yf, "Ticker") as ticker_cls:
+        ticker = ticker_cls.return_value
+        ticker.history.return_value = frame
+
+        output = y_finance.get_YFin_data_online(
+            "AAPL", "2026-01-01", "2026-01-05"
+        )
+
+    ticker.history.assert_called_once_with(start="2026-01-01", end="2026-01-06")
+    assert "from 2026-01-01 to 2026-01-05" in output
+
+
+@pytest.mark.unit
+def test_load_ohlcv_downloads_through_day_after_cache_end(monkeypatch, tmp_path):
+    original_config = get_config()
+    set_config({"data_cache_dir": str(tmp_path)})
+
+    real_timestamp = pd.Timestamp
+    frame = _history_frame()
+    frame.index.name = "Date"
+
+    class FrozenTimestamp:
+        @staticmethod
+        def today():
+            return real_timestamp("2026-01-05")
+
+    monkeypatch.setattr(stockstats_utils.pd, "Timestamp", FrozenTimestamp)
+
+    try:
+        with mock.patch.object(
+            stockstats_utils.yf, "download", return_value=frame
+        ) as download:
+            data = stockstats_utils.load_ohlcv("AAPL", "2026-01-05")
+    finally:
+        set_config(original_config)
+
+    kwargs = download.call_args.kwargs
+    assert kwargs["end"] == "2026-01-06"
+    assert data["Date"].max() == real_timestamp("2026-01-05")

--- a/tests/test_yfinance_inclusive_end.py
+++ b/tests/test_yfinance_inclusive_end.py
@@ -50,6 +50,9 @@ def test_load_ohlcv_downloads_through_day_after_cache_end(monkeypatch, tmp_path)
     frame.index.name = "Date"
 
     class FrozenTimestamp:
+        def __new__(cls, *args, **kwargs):
+            return real_timestamp(*args, **kwargs)
+
         @staticmethod
         def today():
             return real_timestamp("2026-01-05")

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -83,6 +83,7 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     start_date = today_date - pd.DateOffset(years=5)
     start_str = start_date.strftime("%Y-%m-%d")
     end_str = today_date.strftime("%Y-%m-%d")
+    download_end_str = (today_date + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
 
     os.makedirs(config["data_cache_dir"], exist_ok=True)
     data_file = os.path.join(
@@ -103,7 +104,7 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
         downloaded = yf_retry(lambda: yf.download(
             canonical,
             start=start_str,
-            end=end_str,
+            end=download_end_str,
             multi_level_index=False,
             progress=False,
             auto_adjust=True,

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -1,11 +1,18 @@
 from typing import Annotated
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 import pandas as pd
 import yfinance as yf
 import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
 from .symbol_utils import normalize_symbol, NoMarketDataError
+
+
+def _inclusive_history_end(end_date: str) -> str:
+    return (
+        datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+
 
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
@@ -15,13 +22,14 @@ def get_YFin_data_online(
 
     datetime.strptime(start_date, "%Y-%m-%d")
     datetime.strptime(end_date, "%Y-%m-%d")
+    history_end = _inclusive_history_end(end_date)
 
     # Resolve broker/forex symbols to Yahoo's convention (XAUUSD+ -> GC=F).
     canonical = normalize_symbol(symbol)
     ticker = yf.Ticker(canonical)
 
     # Fetch historical data for the specified date range
-    data = yf_retry(lambda: ticker.history(start=start_date, end=end_date))
+    data = yf_retry(lambda: ticker.history(start=start_date, end=history_end))
 
     # Empty result means the symbol is unknown/delisted. Raise a typed error
     # instead of returning prose: the routing layer turns it into a single

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -7,13 +7,6 @@ import os
 from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
 from .symbol_utils import normalize_symbol, NoMarketDataError
 
-
-def _inclusive_history_end(end_date: str) -> str:
-    return (
-        datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1)
-    ).strftime("%Y-%m-%d")
-
-
 def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
     start_date: Annotated[str, "Start date in yyyy-mm-dd format"],
@@ -21,8 +14,8 @@ def get_YFin_data_online(
 ):
 
     datetime.strptime(start_date, "%Y-%m-%d")
-    datetime.strptime(end_date, "%Y-%m-%d")
-    history_end = _inclusive_history_end(end_date)
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+    history_end = (end_dt + timedelta(days=1)).strftime("%Y-%m-%d")
 
     # Resolve broker/forex symbols to Yahoo's convention (XAUUSD+ -> GC=F).
     canonical = normalize_symbol(symbol)


### PR DESCRIPTION
## Summary
- request `end_date + 1 day` from `Ticker.history()` so the user-requested end date can be included
- request `today + 1 day` for cached OHLCV downloads while keeping the existing look-ahead filter
- add regression tests for both yfinance call sites that use exclusive end dates

Fixes #986.
Fixes #987.

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_yfinance_inclusive_end.py tests\test_no_data_handling.py tests\test_stockstats_date_column.py -q`
- `git diff --check`