### PR TITLE
Respect explicit single-vendor routing config

### DIFF
--- a/tests/test_no_data_handling.py
+++ b/tests/test_no_data_handling.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 
 from tradingagents.dataflows import stockstats_utils, interface
+from tradingagents.dataflows.alpha_vantage_common import AlphaVantageRateLimitError
 from tradingagents.dataflows.config import set_config
 from tradingagents.dataflows.symbol_utils import NoMarketDataError
 
@@ -82,6 +83,49 @@ class TestRouteToVendorSentinel(unittest.TestCase):
                 "get_stock_data", "FAKE", "2026-01-01", "2026-01-10"
             )
         self.assertIn("NO_DATA_AVAILABLE", result)
+
+    def test_single_configured_vendor_does_not_auto_fallback(self):
+        def raises_no_data(symbol, *a, **k):
+            raise NoMarketDataError(symbol, symbol, "no rows")
+
+        yfinance = mock.Mock(side_effect=raises_no_data)
+        alpha_vantage = mock.Mock(return_value="fallback data")
+        patched = {"yfinance": yfinance, "alpha_vantage": alpha_vantage}
+
+        with (
+            mock.patch.dict(
+                interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+            ),
+            mock.patch.object(interface, "get_vendor", return_value="yfinance"),
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "FAKE", "2026-01-01", "2026-01-10"
+            )
+
+        self.assertIn("NO_DATA_AVAILABLE", result)
+        yfinance.assert_called_once()
+        alpha_vantage.assert_not_called()
+
+    def test_comma_separated_vendor_config_enables_explicit_fallback(self):
+        alpha_vantage = mock.Mock(side_effect=AlphaVantageRateLimitError())
+        yfinance = mock.Mock(return_value="fallback data")
+        patched = {"alpha_vantage": alpha_vantage, "yfinance": yfinance}
+
+        with (
+            mock.patch.dict(
+                interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+            ),
+            mock.patch.object(
+                interface, "get_vendor", return_value="alpha_vantage,yfinance"
+            ),
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+            )
+
+        self.assertEqual(result, "fallback data")
+        alpha_vantage.assert_called_once()
+        yfinance.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_no_data_handling.py
+++ b/tests/test_no_data_handling.py
@@ -127,6 +127,48 @@ class TestRouteToVendorSentinel(unittest.TestCase):
         alpha_vantage.assert_called_once()
         yfinance.assert_called_once()
 
+    def test_list_vendor_config_enables_explicit_fallback(self):
+        alpha_vantage = mock.Mock(side_effect=AlphaVantageRateLimitError())
+        yfinance = mock.Mock(return_value="fallback data")
+        patched = {"alpha_vantage": alpha_vantage, "yfinance": yfinance}
+
+        with (
+            mock.patch.dict(
+                interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+            ),
+            mock.patch.object(
+                interface, "get_vendor", return_value=["alpha_vantage", "yfinance"]
+            ),
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+            )
+
+        self.assertEqual(result, "fallback data")
+        alpha_vantage.assert_called_once()
+        yfinance.assert_called_once()
+
+    def test_default_in_vendor_chain_expands_remaining_vendors(self):
+        alpha_vantage = mock.Mock(side_effect=AlphaVantageRateLimitError())
+        yfinance = mock.Mock(return_value="fallback data")
+        patched = {"alpha_vantage": alpha_vantage, "yfinance": yfinance}
+
+        with (
+            mock.patch.dict(
+                interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+            ),
+            mock.patch.object(
+                interface, "get_vendor", return_value="alpha_vantage, default"
+            ),
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+            )
+
+        self.assertEqual(result, "fallback data")
+        alpha_vantage.assert_called_once()
+        yfinance.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -132,21 +132,34 @@ def get_vendor(category: str, method: str = None) -> str:
     # Fall back to category-level configuration
     return config.get("data_vendors", {}).get(category, "default")
 
+
+def _vendor_chain(method: str, vendor_config: str) -> list[str]:
+    """Resolve the configured vendor string into the exact routing chain."""
+    available = list(VENDOR_METHODS[method].keys())
+    requested = [
+        vendor.strip()
+        for vendor in str(vendor_config or "").split(",")
+        if vendor.strip()
+    ]
+
+    if not requested or requested == ["default"]:
+        return available
+    return requested
+
+
 def route_to_vendor(method: str, *args, **kwargs):
-    """Route method calls to appropriate vendor implementation with fallback support."""
+    """Route method calls to the configured vendor implementation.
+
+    Fallback is explicit: use a comma-separated vendor list in config, such as
+    ``"alpha_vantage,yfinance"``. A single configured vendor is authoritative.
+    """
     category = get_category_for_method(method)
     vendor_config = get_vendor(category, method)
-    primary_vendors = [v.strip() for v in vendor_config.split(',')]
 
     if method not in VENDOR_METHODS:
         raise ValueError(f"Method '{method}' not supported")
 
-    # Build fallback chain: primary vendors first, then remaining available vendors
-    all_available_vendors = list(VENDOR_METHODS[method].keys())
-    fallback_vendors = primary_vendors.copy()
-    for vendor in all_available_vendors:
-        if vendor not in fallback_vendors:
-            fallback_vendors.append(vendor)
+    fallback_vendors = _vendor_chain(method, vendor_config)
 
     last_no_data: NoMarketDataError | None = None
     first_error: Exception | None = None

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -133,17 +133,27 @@ def get_vendor(category: str, method: str = None) -> str:
     return config.get("data_vendors", {}).get(category, "default")
 
 
-def _vendor_chain(method: str, vendor_config: str) -> list[str]:
+def _vendor_chain(method: str, vendor_config: str | list[str] | None) -> list[str]:
     """Resolve the configured vendor string into the exact routing chain."""
     available = list(VENDOR_METHODS[method].keys())
-    requested = [
-        vendor.strip()
-        for vendor in str(vendor_config or "").split(",")
-        if vendor.strip()
-    ]
+    if isinstance(vendor_config, list):
+        raw_requested = [str(vendor).strip() for vendor in vendor_config if str(vendor).strip()]
+    else:
+        raw_requested = [
+            vendor.strip()
+            for vendor in str(vendor_config or "").split(",")
+            if vendor.strip()
+        ]
 
-    if not requested or requested == ["default"]:
+    if not raw_requested:
         return available
+
+    requested: list[str] = []
+    for vendor in raw_requested:
+        if vendor == "default":
+            requested.extend(v for v in available if v not in requested)
+        else:
+            requested.append(vendor)
     return requested
 
 


### PR DESCRIPTION
## Summary
- make a single configured data vendor authoritative instead of appending every other vendor automatically
- keep fallback available when config explicitly lists multiple vendors, e.g. `alpha_vantage,yfinance`
- preserve `default`/empty config behavior by routing through all vendors
- add router regression tests for single-vendor no-fallback and explicit comma-separated fallback

Fixes #988.

## Tests
- `.\.venv\Scripts\python -m pytest tests\test_no_data_handling.py tests\test_dataflows_config.py -q`
- `git diff --check`
