### PR TITLE
feat(llm): add 9Router provider support

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -278,8 +278,12 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
     localhost default when unset.
     """
     ollama_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
+    ninerouter_url = os.environ.get("NINEROUTER_URL", "http://localhost:20128").rstrip("/")
+    if not ninerouter_url.endswith("/v1"):
+        ninerouter_url += "/v1"
     return [
         ("OpenAI", "openai", "https://api.openai.com/v1"),
+        ("9Router", "9router", ninerouter_url),
         ("Google", "google", None),
         ("Anthropic", "anthropic", "https://api.anthropic.com/"),
         ("xAI", "xai", "https://api.x.ai/v1"),
@@ -518,6 +522,12 @@ def ensure_api_key(provider: str) -> Optional[str]:
     existing = os.environ.get(env_var)
     if existing:
         return existing
+
+    if provider.lower() == "9router":
+        console.print(
+            "\n[yellow]NINEROUTER_KEY is not set; continuing because 9Router can run with auth disabled.[/yellow]"
+        )
+        return None
 
     console.print(
         f"\n[yellow]{env_var} is not set in your environment.[/yellow]"

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -24,6 +24,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         "qwen", "qwen-cn",
         "glm", "glm-cn",
         "minimax", "minimax-cn",
+        "9router",
         "openrouter", "azure", "ollama",
     }
     assert expected.issubset(PROVIDER_API_KEY_ENV.keys())
@@ -44,6 +45,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         ("glm-cn",     "ZHIPU_CN_API_KEY"),
         ("minimax",    "MINIMAX_API_KEY"),
         ("minimax-cn", "MINIMAX_CN_API_KEY"),
+        ("9router",    "NINEROUTER_KEY"),
         ("openrouter", "OPENROUTER_API_KEY"),
     ],
 )
@@ -86,6 +88,14 @@ def test_ensure_api_key_no_op_for_ollama(monkeypatch, cli_utils):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with patch.object(cli_utils, "questionary") as mock_q:
         result = cli_utils.ensure_api_key("ollama")
+    assert result is None
+    mock_q.password.assert_not_called()
+
+
+def test_ensure_api_key_no_prompt_for_9router_without_key(monkeypatch, cli_utils):
+    monkeypatch.delenv("NINEROUTER_KEY", raising=False)
+    with patch.object(cli_utils, "questionary") as mock_q:
+        result = cli_utils.ensure_api_key("9router")
     assert result is None
     mock_q.password.assert_not_called()
 

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -17,8 +17,14 @@ class TestProviderDefaultUrl(unittest.TestCase):
     def test_known_providers_resolve(self):
         from cli.utils import provider_default_url
         self.assertEqual(provider_default_url("openai"), "https://api.openai.com/v1")
+        self.assertEqual(provider_default_url("9router"), "http://localhost:20128/v1")
         self.assertEqual(provider_default_url("DeepSeek"), "https://api.deepseek.com")
         self.assertIsNone(provider_default_url("google"))  # uses SDK default
+
+    def test_9router_honors_base_url_env(self):
+        from cli.utils import provider_default_url
+        with mock.patch.dict(os.environ, {"NINEROUTER_URL": "http://host:20128"}):
+            self.assertEqual(provider_default_url("9router"), "http://host:20128/v1")
 
     def test_unknown_provider_returns_none(self):
         from cli.utils import provider_default_url

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -43,8 +43,8 @@ class ModelValidationTests(unittest.TestCase):
         self.assertIn("not-a-real-openai-model", str(caught[0].message))
         self.assertIn("openai", str(caught[0].message))
 
-    def test_openrouter_and_ollama_accept_custom_models_without_warning(self):
-        for provider in ("openrouter", "ollama"):
+    def test_openrouter_ollama_and_9router_accept_custom_models_without_warning(self):
+        for provider in ("openrouter", "ollama", "9router"):
             client = DummyLLMClient(provider, "custom-model-name")
 
             with self.subTest(provider=provider):

--- a/tests/test_ollama_base_url.py
+++ b/tests/test_ollama_base_url.py
@@ -38,6 +38,62 @@ def test_resolver_returns_default_when_env_unset(monkeypatch):
     assert mod._resolve_provider_base_url("ollama") == "http://localhost:11434/v1"
 
 
+def test_9router_resolver_returns_default_when_env_unset(monkeypatch):
+    monkeypatch.delenv("NINEROUTER_URL", raising=False)
+    mod = _reload_client()
+    assert mod._resolve_provider_base_url("9router") == "http://localhost:20128/v1"
+
+
+def test_9router_resolver_appends_v1(monkeypatch):
+    monkeypatch.setenv("NINEROUTER_URL", "http://remote-9router:20128")
+    mod = _reload_client()
+    assert mod._resolve_provider_base_url("9router") == "http://remote-9router:20128/v1"
+
+
+def test_9router_resolver_keeps_existing_v1(monkeypatch):
+    monkeypatch.setenv("NINEROUTER_URL", "http://remote-9router:20128/v1")
+    mod = _reload_client()
+    assert mod._resolve_provider_base_url("9router") == "http://remote-9router:20128/v1"
+
+
+def test_9router_client_uses_chat_completions_not_responses(monkeypatch):
+    monkeypatch.setenv("NINEROUTER_URL", "http://my-9router:20128")
+    monkeypatch.delenv("NINEROUTER_KEY", raising=False)
+    mod = _reload_client()
+    client = mod.OpenAIClient(model="openai/gpt-5", provider="9router")
+    llm = client.get_llm()
+    assert "my-9router" in str(llm.openai_api_base)
+    assert llm.openai_api_key.get_secret_value() == "ninerouter"
+    assert getattr(llm, "use_responses_api", None) is None
+
+
+def test_9router_unwraps_nested_data_response(monkeypatch):
+    monkeypatch.delenv("NINEROUTER_KEY", raising=False)
+    mod = _reload_client()
+    client = mod.OpenAIClient(model="openai/gpt-5", provider="9router").get_llm()
+    result = client._create_chat_result(
+        {
+            "id": "chatcmpl-wrapper",
+            "choices": None,
+            "created": 123,
+            "model": "openai/gpt-5",
+            "object": "chat.completion",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            "data": {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "market ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            "success": True,
+        }
+    )
+    assert result.generations[0].message.content == "market ok"
+
+
 def test_resolver_returns_env_when_set(monkeypatch):
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://remote-ollama:11434/v1")
     mod = _reload_client()

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -30,6 +30,8 @@ PROVIDER_API_KEY_ENV: dict[str, Optional[str]] = {
     "minimax":    "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    # Optional for 9Router: deployments with requireApiKey=false do not need it.
+    "9router":    "NINEROUTER_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
 }

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -8,7 +8,7 @@ _OPENAI_COMPATIBLE = (
     "qwen", "qwen-cn",
     "glm", "glm-cn",
     "minimax", "minimax-cn",
-    "ollama", "openrouter",
+    "ollama", "openrouter", "9router",
 )
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -142,6 +142,35 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
         return payload
 
 
+class NinerouterChatOpenAI(NormalizedChatOpenAI):
+    """9Router-specific response normalization.
+
+    Some 9Router responses wrap the upstream OpenAI-compatible payload in a
+    top-level ``data`` object while leaving top-level ``choices`` as ``null``.
+    LangChain validates ``choices`` before looking anywhere else, so unwrap the
+    nested payload first.
+    """
+
+    def _create_chat_result(self, response, generation_info=None):
+        response_dict = (
+            response
+            if isinstance(response, dict)
+            else response.model_dump(
+                exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+            )
+        )
+        if response_dict.get("choices") is None and isinstance(response_dict.get("data"), dict):
+            nested = dict(response_dict["data"])
+            for key in (
+                "id", "created", "model", "object", "usage",
+                "service_tier", "system_fingerprint",
+            ):
+                if key not in nested and key in response_dict:
+                    nested[key] = response_dict[key]
+            response = nested
+        return super()._create_chat_result(response, generation_info)
+
+
 # Kwargs forwarded from user config to ChatOpenAI
 _PASSTHROUGH_KWARGS = (
     "timeout", "max_retries", "reasoning_effort", "temperature",
@@ -163,6 +192,7 @@ _PROVIDER_BASE_URL = {
     "minimax":    "https://api.minimax.io/v1",
     "minimax-cn": "https://api.minimaxi.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
+    "9router":    "http://localhost:20128/v1",
     "ollama":     "http://localhost:11434/v1",
 }
 
@@ -170,16 +200,19 @@ _PROVIDER_BASE_URL = {
 def _resolve_provider_base_url(provider: str) -> Optional[str]:
     """Default base URL for ``provider``, with env-var overrides where defined.
 
-    Currently only Ollama supports an env-var override (``OLLAMA_BASE_URL``),
-    matching the convention in the broader Ollama tooling ecosystem so users
-    can point at a remote ollama-serve without editing code. The check is
-    call-time, not import-time, so tests that monkeypatch the env after
-    import behave correctly.
+    Ollama and 9Router support env-var overrides (``OLLAMA_BASE_URL`` and
+    ``NINEROUTER_URL``). The check is call-time, not import-time, so tests
+    that monkeypatch the env after import behave correctly.
     """
     if provider == "ollama":
         env_url = os.environ.get("OLLAMA_BASE_URL")
         if env_url:
             return env_url
+    if provider == "9router":
+        env_url = os.environ.get("NINEROUTER_URL")
+        if env_url:
+            env_url = env_url.rstrip("/")
+            return env_url if env_url.endswith("/v1") else env_url + "/v1"
     return _PROVIDER_BASE_URL.get(provider)
 
 
@@ -213,7 +246,9 @@ class OpenAIClient(BaseLLMClient):
         if self.provider in _PROVIDER_BASE_URL:
             llm_kwargs["base_url"] = self.base_url or _resolve_provider_base_url(self.provider)
             api_key_env = get_api_key_env(self.provider)
-            if api_key_env:
+            if self.provider == "9router":
+                llm_kwargs["api_key"] = os.environ.get(api_key_env or "") or "ninerouter"
+            elif api_key_env:
                 api_key = os.environ.get(api_key_env)
                 if api_key:
                     llm_kwargs["api_key"] = api_key
@@ -244,6 +279,8 @@ class OpenAIClient(BaseLLMClient):
             chat_cls = DeepSeekChatOpenAI
         elif self.provider in ("minimax", "minimax-cn"):
             chat_cls = MinimaxChatOpenAI
+        elif self.provider == "9router":
+            chat_cls = NinerouterChatOpenAI
         else:
             chat_cls = NormalizedChatOpenAI
         return chat_cls(**llm_kwargs)

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -13,11 +13,11 @@ VALID_MODELS = {
 def validate_model(provider: str, model: str) -> bool:
     """Check if model name is valid for the given provider.
 
-    For ollama, openrouter - any model is accepted.
+    For ollama, openrouter, 9router - any model is accepted.
     """
     provider_lower = provider.lower()
 
-    if provider_lower in ("ollama", "openrouter"):
+    if provider_lower in ("ollama", "openrouter", "9router"):
         return True
 
     if provider_lower not in VALID_MODELS:


### PR DESCRIPTION
## Summary

Add 9Router as an LLM provider option in TradingAgents. 9Router is an OpenAI-compatible AI gateway that routes through multiple backends with fallback support.

## Changes

- **cli/utils.py**: Add 9Router to provider table, skip API key prompt for 9Router
- **tradingagents/llm_clients/api_key_env.py**: Map NINEROUTER_KEY env var
- **tradingagents/llm_clients/factory.py**: Route 9Router to OpenAI-compatible client
- **tradingagents/llm_clients/openai_client.py**: Add default 9Router base URL and model config

## Testing

Verified with TRADINGAGENTS_LLM_PROVIDER=9router on XAUUSD analysis — all 4 analysts + research team completed successfully via 9Router gateway.