### PR TITLE
fix: reject stale yfinance OHLCV data

### DIFF
--- a/tests/test_yfinance_stale_ohlcv_guard.py
+++ b/tests/test_yfinance_stale_ohlcv_guard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import tradingagents.dataflows.y_finance as y_finance
+from tradingagents.dataflows.stockstats_utils import (
+    StaleMarketDataError,
+    _assert_ohlcv_not_stale,
+)
+
+
+def test_ohlcv_stale_guard_accepts_recent_prior_trading_day():
+    data = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2026-06-10")],
+            "Open": [330.0],
+            "High": [332.0],
+            "Low": [328.0],
+            "Close": [330.58],
+            "Volume": [1000000],
+        }
+    )
+
+    _assert_ohlcv_not_stale(data, "2026-06-11", "CB")
+
+
+def test_ohlcv_stale_guard_rejects_one_year_old_same_month_day():
+    data = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2025-06-11")],
+            "Open": [280.0],
+            "High": [286.0],
+            "Low": [278.0],
+            "Close": [284.45],
+            "Volume": [1000000],
+        }
+    )
+
+    with pytest.raises(StaleMarketDataError) as exc_info:
+        _assert_ohlcv_not_stale(data, "2026-06-11", "CB")
+
+    message = str(exc_info.value)
+
+    assert "Latest OHLCV row for CB is stale" in message
+    assert "2025-06-11" in message
+    assert "2026-06-11" in message
+
+
+def test_ohlcv_stale_guard_rejects_empty_data():
+    data = pd.DataFrame(columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+
+    with pytest.raises(StaleMarketDataError) as exc_info:
+        _assert_ohlcv_not_stale(data, "2026-06-11", "INCY")
+
+    assert "No OHLCV rows available" in str(exc_info.value)
+
+
+def test_get_yfin_data_online_returns_stale_data_message(monkeypatch):
+    stale_data = pd.DataFrame(
+        {
+            "Open": [280.0],
+            "High": [286.0],
+            "Low": [278.0],
+            "Close": [284.45],
+            "Volume": [1000000],
+        },
+        index=pd.DatetimeIndex([pd.Timestamp("2025-06-11")], name="Date"),
+    )
+
+    class DummyTicker:
+        def __init__(self, symbol):
+            self.symbol = symbol
+
+        def history(self, start, end):
+            return stale_data
+
+    monkeypatch.setattr(y_finance.yf, "Ticker", DummyTicker)
+
+    result = y_finance.get_YFin_data_online(
+        "CB",
+        "2026-06-01",
+        "2026-06-11",
+    )
+
+    assert "Stale market data for symbol 'CB'" in result
+    assert "2025-06-11" in result
+    assert "2026-06-11" in result

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -13,6 +13,12 @@ from .symbol_utils import normalize_symbol, NoMarketDataError
 
 logger = logging.getLogger(__name__)
 
+MAX_OHLCV_STALE_DAYS = 10
+
+
+class StaleMarketDataError(ValueError):
+    """Raised when latest OHLCV data is too old for the requested analysis date."""
+
 
 def yf_retry(func, max_retries=3, base_delay=2.0):
     """Execute a yfinance call with exponential backoff on rate limits.
@@ -27,7 +33,10 @@ def yf_retry(func, max_retries=3, base_delay=2.0):
         except YFRateLimitError:
             if attempt < max_retries:
                 delay = base_delay * (2 ** attempt)
-                logger.warning(f"Yahoo Finance rate limited, retrying in {delay:.0f}s (attempt {attempt + 1}/{max_retries})")
+                logger.warning(
+                    f"Yahoo Finance rate limited, retrying in {delay:.0f}s "
+                    f"(attempt {attempt + 1}/{max_retries})"
+                )
                 time.sleep(delay)
             else:
                 raise
@@ -62,6 +71,60 @@ def _clean_dataframe(data: pd.DataFrame) -> pd.DataFrame:
     return data
 
 
+def _coerce_ohlcv_dates(data: pd.DataFrame) -> pd.Series:
+    """Return parsed OHLCV dates from a DataFrame that may have Date as index or column."""
+    df = data.copy()
+
+    if "Date" not in df.columns:
+        df = df.reset_index()
+
+    if "Date" not in df.columns and len(df.columns) > 0:
+        df = df.rename(columns={df.columns[0]: "Date"})
+
+    if "Date" not in df.columns:
+        return pd.Series(dtype="datetime64[ns]")
+
+    return pd.to_datetime(df["Date"], errors="coerce").dropna()
+
+
+def _assert_ohlcv_not_stale(
+    data: pd.DataFrame,
+    curr_date: str,
+    symbol: str,
+    *,
+    max_stale_days: int = MAX_OHLCV_STALE_DAYS,
+) -> None:
+    """Reject OHLCV data when the latest row is too far before curr_date."""
+    if data is None or data.empty:
+        raise StaleMarketDataError(
+            f"No OHLCV rows available for {symbol} on or before {curr_date}."
+        )
+
+    requested_date = pd.to_datetime(curr_date, errors="coerce")
+
+    if pd.isna(requested_date):
+        raise ValueError(f"Invalid current date for OHLCV freshness check: {curr_date}")
+
+    requested_date = requested_date.normalize()
+    dates = _coerce_ohlcv_dates(data)
+
+    if dates.empty:
+        raise StaleMarketDataError(
+            f"No valid OHLCV dates available for {symbol} on or before {curr_date}."
+        )
+
+    latest_date = dates.max().normalize()
+    stale_days = (requested_date - latest_date).days
+
+    if stale_days > max_stale_days:
+        raise StaleMarketDataError(
+            f"Latest OHLCV row for {symbol} is stale: latest row is "
+            f"{latest_date.date()}, requested analysis date is "
+            f"{requested_date.date()} ({stale_days} calendar days old). "
+            "Refusing to use stale market data."
+        )
+
+
 def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     """Fetch OHLCV data with caching, filtered to prevent look-ahead bias.
 
@@ -78,7 +141,6 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     config = get_config()
     curr_date_dt = pd.to_datetime(curr_date)
 
-    # Cache uses a fixed window (15y to today) so one file per symbol
     today_date = pd.Timestamp.today()
     start_date = today_date - pd.DateOffset(years=5)
     start_str = start_date.strftime("%Y-%m-%d")
@@ -122,6 +184,8 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
     # Filter to curr_date to prevent look-ahead bias in backtesting
     data = data[data["Date"] <= curr_date_dt]
 
+    _assert_ohlcv_not_stale(data, curr_date, symbol)
+
     return data
 
 
@@ -155,7 +219,7 @@ class StockstatsUtils:
         df["Date"] = df["Date"].dt.strftime("%Y-%m-%d")
         curr_date_str = pd.to_datetime(curr_date).strftime("%Y-%m-%d")
 
-        df[indicator]  # trigger stockstats to calculate the indicator
+        df[indicator]
         matching_rows = df[df["Date"].str.startswith(curr_date_str)]
 
         if not matching_rows.empty:

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -1,10 +1,19 @@
+
 from typing import Annotated
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pandas as pd
 import yfinance as yf
 import os
-from .stockstats_utils import StockstatsUtils, _clean_dataframe, yf_retry, load_ohlcv, filter_financials_by_date
+from .stockstats_utils import (
+    StockstatsUtils,
+    StaleMarketDataError,
+    _assert_ohlcv_not_stale,
+    _clean_dataframe,
+    yf_retry,
+    load_ohlcv,
+    filter_financials_by_date,
+)
 from .symbol_utils import normalize_symbol, NoMarketDataError
 
 def get_YFin_data_online(
@@ -32,8 +41,18 @@ def get_YFin_data_online(
         )
 
     # Remove timezone info from index for cleaner output
+    # Remove timezone info from index for cleaner output
     if data.index.tz is not None:
         data.index = data.index.tz_localize(None)
+
+    freshness_data = _clean_dataframe(data.reset_index())
+
+    try:
+        _assert_ohlcv_not_stale(freshness_data, end_date, symbol)
+    except StaleMarketDataError as e:
+        return f"Stale market data for symbol '{symbol}': {e}"
+
+    # Round numerical values to 2 decimal places for cleaner display
 
     # Round numerical values to 2 decimal places for cleaner display
     numeric_columns = ["Open", "High", "Low", "Close", "Adj Close"]
@@ -168,9 +187,10 @@ def get_stock_stats_indicators_window(
         ind_string = ""
         for date_str, value in date_values:
             ind_string += f"{date_str}: {value}\n"
-
     except NoMarketDataError:
         raise  # Unknown/delisted symbol — let the router emit the sentinel
+    except StaleMarketDataError as e:
+        return f"Stale market data for symbol '{symbol}': {e}"
     except Exception as e:
         print(f"Error getting bulk stockstats data: {e}")
         # Fallback to original implementation if bulk method fails
@@ -246,6 +266,8 @@ def get_stockstats_indicator(
         )
     except NoMarketDataError:
         raise  # Unknown/delisted symbol — let the router emit the sentinel
+    except StaleMarketDataError as e:
+        return f"Stale market data for symbol '{symbol}': {e}"
     except Exception as e:
         print(
             f"Error getting stockstats indicator data for indicator {indicator} on {curr_date}: {e}"


### PR DESCRIPTION
Fixes #1021

This PR adds a stale-data guard for yfinance OHLCV data before it is used by the analyst workflow.

The issue reported cases where analysis for June 2026 was using quote data from June 2025, basically same month/day but one year old. That can make the current close price, technical indicators, and final market report badly incorrect.

### What changed

- Added a shared stale OHLCV check in `stockstats_utils.py`
- The check compares the latest available OHLCV row with the requested analysis date
- If the latest row is too far before the requested date, it raises a stale market data error
- Kept the latest upstream symbol normalization logic, including `normalize_symbol()` and `NoMarketDataError`
- Applied the stale-data guard to:
  - `load_ohlcv()` used by stockstats / indicator paths
  - `get_YFin_data_online()` used by raw yfinance stock data output
- Added handling so stale data returns a clear message instead of silently feeding old prices into the report
- Added tests for stale OHLCV behavior

### Why this helps

This prevents the workflow from silently using old market data as if it was the latest available quote.

For example, if the requested analysis date is:

```text
2026-06-11
```

but the latest OHLCV row returned by yfinance/cache is:

```text
2025-06-11
```

the data layer now rejects it and surfaces the stale-data problem instead of letting the LLM build technical analysis using the wrong close price.

### Tests added

The tests cover:

- accepting a recent prior trading day
- rejecting one-year-old stale data
- rejecting empty OHLCV data
- returning a stale-data message from `get_YFin_data_online()`

### Validation

I ran:

```bash
python -m compileall tradingagents/dataflows/stockstats_utils.py tradingagents/dataflows/y_finance.py
python -m pytest tests/test_yfinance_stale_ohlcv_guard.py -q
```

Result:

```bash
4 passed
```