### PR TITLE
fix(reddit): go RSS-first to avoid 403→429 rate-limit churn (follow-up to #862)

### DIFF
--- a/tests/test_reddit_fallback.py
+++ b/tests/test_reddit_fallback.py
@@ -1,4 +1,5 @@
-"""Tests for the Reddit RSS/Atom fallback when the JSON endpoint 403s (#862)."""
+"""Tests for the RSS-first Reddit fetcher, its 429 backoff and the opt-in
+JSON path's degradation (#862)."""
 
 from __future__ import annotations
 
@@ -76,14 +77,69 @@ class TestRssFallbackParsing:
 
 
 @pytest.mark.unit
-class TestJsonFallsBackToRss:
+class TestFetchSubredditIsRssFirst:
+    """The default per-subreddit fetch goes straight to RSS — it must not hit
+    the WAF-blocked JSON endpoint, which only burned rate-limit budget."""
+
+    def test_delegates_to_rss_without_touching_json(self):
+        sentinel = [{"title": "x", "source": "rss", "score": None,
+                     "num_comments": None, "created_utc": None, "selftext": ""}]
+        with patch.object(reddit, "_fetch_subreddit_rss", return_value=sentinel) as rss, \
+             patch.object(reddit, "urlopen",
+                          side_effect=AssertionError("JSON endpoint must not be called")):
+            out = reddit._fetch_subreddit("NVDA", "stocks", 5, 5.0)
+        rss.assert_called_once()
+        assert out is sentinel
+
+
+@pytest.mark.unit
+class TestJsonPathFallsBackToRss:
+    """The opt-in JSON path still degrades to RSS on a 403 (kept for #862)."""
+
     def test_403_triggers_rss(self):
         err = HTTPError("url", 403, "Blocked", {}, None)
         with patch.object(reddit, "urlopen", side_effect=err), \
              patch.object(reddit, "_fetch_subreddit_rss", return_value=[{"title": "x", "source": "rss", "score": None, "num_comments": None, "created_utc": None, "selftext": ""}]) as rss:
-            out = reddit._fetch_subreddit("NVDA", "stocks", 5, 5.0)
+            out = reddit._fetch_subreddit_json("NVDA", "stocks", 5, 5.0)
         rss.assert_called_once()
         assert out and out[0]["source"] == "rss"
+
+
+@pytest.mark.unit
+class TestRss429Backoff:
+    def _atom_resp(self):
+        class _Resp:
+            def __enter__(self_inner):
+                return self_inner
+            def __exit__(self_inner, *a):
+                return False
+            def read(self_inner):
+                return _SAMPLE_ATOM.encode("utf-8")
+        return _Resp()
+
+    def test_429_then_success_retries_once(self):
+        err = HTTPError("url", 429, "Too Many Requests", {}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, self._atom_resp()]) as op, \
+             patch.object(reddit.time, "sleep") as slept:
+            posts = reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        assert op.call_count == 2          # original + exactly one retry
+        slept.assert_called_once()         # backed off before retrying
+        assert len(posts) == 2
+
+    def test_429_twice_gives_up_after_one_retry(self):
+        err = HTTPError("url", 429, "Too Many Requests", {}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, err]) as op, \
+             patch.object(reddit.time, "sleep"):
+            posts = reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        assert op.call_count == 2          # one retry, then gives up cleanly
+        assert posts == []
+
+    def test_retry_after_header_is_honoured(self):
+        err = HTTPError("url", 429, "Too Many Requests", {"Retry-After": "12"}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, self._atom_resp()]), \
+             patch.object(reddit.time, "sleep") as slept:
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        slept.assert_called_once_with(12.0)
 
 
 @pytest.mark.unit

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -1,18 +1,18 @@
 """Reddit search fetcher for ticker-specific discussion posts.
 
-Primary path is Reddit's public JSON search endpoint
-(``reddit.com/r/{sub}/search.json``), which carries the richest data
-(score, comment count, body). Reddit's WAF increasingly returns
-``HTTP 403 Blocked`` on that endpoint (issue #862), so when the JSON request
-fails we transparently fall back to the public Atom/RSS search feed
-(``/search.rss``). The RSS feed is gated less aggressively and serves the
-same descriptive User-Agent we already send; the fallback lacks score /
-comment counts, so RSS-sourced posts are marked and the formatter omits those
-metrics rather than printing fake zeros.
+Default path is Reddit's public Atom/RSS search feed
+(``reddit.com/r/{sub}/search.rss``). The richer JSON search endpoint
+(``/search.json``) is reliably WAF-blocked (``HTTP 403``) for public clients
+(issue #862), and probing it on every call only doubled our request volume
+against Reddit's per-IP rate limit — tripping ``429`` on the RSS fallback —
+so it is kept (``_fetch_subreddit_json``) but not used by default. On a 429 we
+back off once (honouring ``Retry-After``). RSS lacks score / comment counts,
+so those posts are marked and the formatter omits the metrics rather than
+printing fake zeros.
 
-No API key required either way. Returns formatted plaintext blocks ready for
-prompt injection and degrades gracefully — returns a placeholder string
-rather than raising, so callers never special-case missing data.
+No API key required. Returns formatted plaintext blocks ready for prompt
+injection and degrades gracefully — returns a placeholder string rather than
+raising, so callers never special-case missing data.
 """
 
 from __future__ import annotations
@@ -78,23 +78,46 @@ def _strip_html(content: str) -> str:
     return " ".join(html.unescape(text).split())
 
 
+def _retry_after_seconds(exc: HTTPError) -> Optional[float]:
+    """Seconds to wait from a 429's ``Retry-After`` header, capped at 30s."""
+    try:
+        val = exc.headers.get("Retry-After") if getattr(exc, "headers", None) else None
+        return min(float(val), 30.0) if val else None
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
 def _fetch_subreddit_rss(
     ticker: str,
     sub: str,
     limit: int,
     timeout: float,
+    _retry: bool = True,
 ) -> list[dict]:
-    """Fallback path: parse the public Atom search feed for a subreddit.
+    """Primary path: parse the public Atom search feed for a subreddit.
 
     Carries no score / comment counts, so those fields are left None and the
-    post is tagged ``source="rss"`` for honest display.
+    post is tagged ``source="rss"`` for honest display. On a 429 (Reddit's
+    per-IP rate limit) we back off once — honouring ``Retry-After`` when
+    present — before giving up, so a transient burst doesn't blank the feed.
     """
     url = _RSS.format(sub=sub, qs=_search_qs(ticker, limit))
     req = Request(url, headers={"User-Agent": _UA})
     try:
         with urlopen(req, timeout=timeout) as resp:
             root = ET.fromstring(resp.read())
-    except (HTTPError, URLError, TimeoutError, ET.ParseError) as exc:
+    except HTTPError as exc:
+        if exc.code == 429 and _retry:
+            wait = _retry_after_seconds(exc) or 5.0
+            logger.warning(
+                "Reddit RSS 429 for r/%s · %s — backing off %.1fs then retrying once",
+                sub, ticker, wait,
+            )
+            time.sleep(wait)
+            return _fetch_subreddit_rss(ticker, sub, limit, timeout, _retry=False)
+        logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
+        return []
+    except (URLError, TimeoutError, ET.ParseError) as exc:
         logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
         return []
 
@@ -116,12 +139,20 @@ def _fetch_subreddit_rss(
     return posts
 
 
-def _fetch_subreddit(
+def _fetch_subreddit_json(
     ticker: str,
     sub: str,
     limit: int,
     timeout: float,
 ) -> list[dict]:
+    """Richer JSON search path (carries score / comment counts).
+
+    Reddit's WAF currently returns ``403 Blocked`` on this endpoint for
+    non-OAuth clients (issue #862), so it is NOT used by default — calling it
+    on every request only doubled our volume against the per-IP rate limit and
+    triggered 429s on the RSS fallback. Kept for the day the WAF relaxes or an
+    OAuth token is wired in; call it explicitly if so.
+    """
     url = _API.format(sub=sub, qs=_search_qs(ticker, limit))
     req = Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
     try:
@@ -137,18 +168,34 @@ def _fetch_subreddit(
         return _fetch_subreddit_rss(ticker, sub, limit, timeout)
 
 
+def _fetch_subreddit(
+    ticker: str,
+    sub: str,
+    limit: int,
+    timeout: float,
+) -> list[dict]:
+    """Fetch one subreddit, RSS-first.
+
+    The JSON search endpoint is reliably WAF-blocked (403) for public clients,
+    so we go straight to the RSS feed — which serves our identified User-Agent
+    reliably — halving our request volume against Reddit's per-IP rate limit.
+    """
+    return _fetch_subreddit_rss(ticker, sub, limit, timeout)
+
+
 def fetch_reddit_posts(
     ticker: str,
     subreddits: Iterable[str] = DEFAULT_SUBREDDITS,
     limit_per_sub: int = 5,
     timeout: float = 10.0,
-    inter_request_delay: float = 0.4,
+    inter_request_delay: float = 1.0,
 ) -> str:
     """Fetch recent Reddit posts mentioning ``ticker`` across finance
     subreddits and return them as a formatted plaintext block.
 
-    ``inter_request_delay`` keeps us under Reddit's public rate limit
-    (~10 req/min per IP) even if the caller queries many subreddits.
+    ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests to
+    stay under Reddit's public per-IP rate limit; combined with the RSS-first
+    path it makes 429s rare even when several analyses run back-to-back.
     """
     blocks = []
     total_posts = 0


### PR DESCRIPTION
## Problem

The social-media analyst's Reddit fetch returns no posts on most runs: every subreddit logs `Reddit JSON fetch failed ... 403 Blocked` followed by `Reddit RSS ... 429 Too Many Requests`, so the sentiment section ends up blank.

## Root cause

`dataflows/reddit.py` tries the JSON search endpoint first and only falls back to RSS on failure. But:

- `/search.json` is **reliably** WAF-blocked (`HTTP 403`) for public / non-OAuth clients — the module docstring already documents this (#862).
- So every call pays for a doomed JSON request **and** an RSS request: ~2× the volume against Reddit's per-IP rate limit.
- The 403s return instantly, which defeats the `inter_request_delay` pacing, so a normal 3-subreddit run fires ~6 requests in ~1.6s and 429s on the 2nd/3rd RSS call.

Reproduced from a single egress IP:

| endpoint | status |
|---|---|
| `https://www.reddit.com/r/stocks/search.json?...` | **403** |
| `https://www.reddit.com/r/stocks/search.rss?...`  | **200** |

The RSS feed itself works fine; it's the doubled volume + instant-403 pacing that trips the limit.

## Fix

- **RSS-first** — the default per-subreddit fetch (`_fetch_subreddit`) now goes straight to `/search.rss`, halving request volume. The JSON path is preserved as `_fetch_subreddit_json` (still degrades to RSS on 403) for the day the WAF relaxes or an OAuth token is wired in.
- **429 backoff** — the RSS path backs off once on `429`, honouring `Retry-After` (capped at 30s), before giving up, so a transient burst no longer blanks the feed.
- Pace per-subreddit requests `0.4s → 1.0s`.

No change to the formatter or returned data shape: RSS posts are still tagged and score/comment counts still omitted when absent.

## Testing

`tests/test_reddit_fallback.py`:
- retargets the existing JSON→RSS fallback test at `_fetch_subreddit_json`,
- adds RSS-first delegation for `_fetch_subreddit` (asserts the JSON endpoint is never hit),
- adds 429 coverage: retry-once-then-success, give-up-after-one-retry, and `Retry-After` honoured.

```
13 passed
```

Also verified against a live run: the social analyst now receives Reddit posts (e.g. r/wallstreetbets) instead of an empty section.
