### PR TITLE
fix(graph): don't reprint unchanged trailing message in debug stream

### DIFF
--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -376,11 +376,19 @@ class TradingAgentsGraph:
 
         if self.debug:
             trace = []
+            last_printed_sig = None
             for chunk in self.graph.stream(init_agent_state, **args):
                 if len(chunk["messages"]) == 0:
                     pass
                 else:
-                    chunk["messages"][-1].pretty_print()
+                    msg = chunk["messages"][-1]
+                    # Streamed chunks repeat the same trailing message across
+                    # consecutive nodes that don't append one; only print when
+                    # it actually changes so the log isn't 5x-duplicated.
+                    sig = (msg.__class__.__name__, getattr(msg, "content", None))
+                    if sig != last_printed_sig:
+                        msg.pretty_print()
+                        last_printed_sig = sig
                     trace.append(chunk)
             # Streamed chunks are per-node deltas. Merge them so the returned
             # state matches what graph.invoke() yields in the non-debug path.


### PR DESCRIPTION
## Problem

Running an analysis with `debug=True` produces a log where the final blocks (e.g. the trader's `FINAL TRANSACTION PROPOSAL` and its reasoning) are repeated ~5× verbatim.

## Root cause

In `_run_graph`, the debug branch calls `pretty_print()` on the last message for **every** streamed chunk:

```python
for chunk in self.graph.stream(init_agent_state, **args):
    if len(chunk["messages"]) == 0:
        pass
    else:
        chunk["messages"][-1].pretty_print()
        trace.append(chunk)
```

`graph.stream` emits a chunk per node, but the `messages` list only grows when a node actually appends a message. The risk/portfolio nodes that run after the trader don't append to `messages`, so `messages[-1]` stays the same object and is pretty-printed once per node — duplicating the last block several times.

## Fix

Track the last-printed message signature `(type, content)` and only `pretty_print()` when it changes.

The returned state is **unchanged**: every chunk is still appended to `trace` and merged into `final_state` exactly as before — only the console/log output is de-duplicated.

## Verification

A real `debug=True` run that previously printed the trader proposal 5× now prints it once; the final decision and merged `final_state` are identical.
