### PR TITLE
fix(cli): declare python-dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",
     "yfinance>=1.4.1",
+    "python-dotenv>=1.1.0",
 ]
 
 [project.scripts]

--- a/tests/test_cli_dependency_metadata.py
+++ b/tests/test_cli_dependency_metadata.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_cli_direct_imports_are_declared_dependencies() -> None:
+    deps = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['dependencies']
+    declared = {item.split('>=')[0].split('==')[0] for item in deps}
+
+    assert 'questionary' in declared
+    assert 'python-dotenv' in declared

--- a/tests/test_cli_dependency_metadata.py
+++ b/tests/test_cli_dependency_metadata.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
-import tomllib
+import re
 from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ImportError:  # pragma: no cover - exercised on Python 3.10
+    tomllib = None  # type: ignore[assignment]
+
+
+def _load_declared_dependencies() -> list[str]:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject_path.read_text(encoding="utf-8")
+
+    if tomllib is not None:
+        return tomllib.loads(content)["project"]["dependencies"]
+
+    match = re.search(r"dependencies\s*=\s*\[(.*?)\]", content, re.DOTALL)
+    if not match:
+        return []
+    return [dep.strip(" '\"") for dep in match.group(1).split(",") if dep.strip()]
 
 
 def test_cli_direct_imports_are_declared_dependencies() -> None:
-    deps = tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['dependencies']
-    declared = {item.split('>=')[0].split('==')[0] for item in deps}
+    declared = {re.split(r"[><=!~;]", item, maxsplit=1)[0].strip() for item in _load_declared_dependencies()}
 
-    assert 'questionary' in declared
-    assert 'python-dotenv' in declared
+    assert "questionary" in declared
+    assert "python-dotenv" in declared


### PR DESCRIPTION
# Summary
- declare `python-dotenv` as a direct dependency because the CLI imports it directly
- add a focused metadata regression test so direct CLI imports stay represented in `pyproject.toml`
- keep the fix scoped to packaging metadata without unrelated lockfile churn

# Testing
- `python3 -m pytest tests/test_cli_dependency_metadata.py -q`
- `python3 -m py_compile tests/test_cli_dependency_metadata.py`
- `git diff --check`

# Breaking Changes
- [x] None
