### PR TITLE
feat(llm): add local LLM response cache to reduce API costs

### DIFF
--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -22,6 +22,7 @@ from tradingagents.llm_clients.llm_cache import (
     _aimessage_to_dict,
     _build_cache_key,
     _dict_to_aimessage,
+    _normalise_input,
     _safe_metadata,
     _serialise_messages,
 )
@@ -64,8 +65,36 @@ class TestSerialiseMessages:
         assert json.loads(result) == [{"role": "user", "content": "hello"}]
 
     def test_raw_string_input(self) -> None:
-        result = _serialise_messages(["raw string"])
-        assert json.loads(result) == [{"role": "", "content": "raw string"}]
+        # A bare string is normalised to a single‑message list, not per‑character.
+        result = _serialise_messages("raw string")
+        loaded = json.loads(result)
+        assert len(loaded) == 1
+        assert loaded[0]["role"] == ""
+        assert loaded[0]["content"] == "raw string"
+
+
+class TestNormaliseInput:
+    """``_normalise_input`` guards against string iteration and PromptValue errors."""
+
+    def test_string_becomes_single_element_list(self) -> None:
+        normalised = _normalise_input("hello")
+        assert normalised == ["hello"]
+
+    def test_list_passes_through(self) -> None:
+        normalised = _normalise_input(["a", "b"])
+        assert normalised == ["a", "b"]
+
+    def test_promptvalue_calls_to_messages(self) -> None:
+        class FakePromptValue:
+            def to_messages(self):
+                return [AIMessage(content="from prompt value")]
+        normalised = _normalise_input(FakePromptValue())
+        assert len(normalised) == 1
+        assert normalised[0].content == "from prompt value"
+
+    def test_other_object_wrapped_in_list(self) -> None:
+        normalised = _normalise_input(42)
+        assert normalised == [42]
 
 
 class TestBuildCacheKey:
@@ -92,6 +121,24 @@ class TestBuildCacheKey:
         key = _build_cache_key("m", [AIMessage(content="x")])
         assert len(key) == 64
         assert all(c in "0123456789abcdef" for c in key)
+
+    def test_different_tools_different_key(self) -> None:
+        msgs = [AIMessage(content="Test")]
+        k1 = _build_cache_key("m", msgs, tools=[{"type": "function", "function": {"name": "weather"}}])
+        k2 = _build_cache_key("m", msgs, tools=[{"type": "function", "function": {"name": "stock"}}])
+        assert k1 != k2
+
+    def test_different_response_format_different_key(self) -> None:
+        msgs = [AIMessage(content="Test")]
+        k1 = _build_cache_key("m", msgs, response_format={"type": "json_object"})
+        k2 = _build_cache_key("m", msgs, response_format={"type": "text"})
+        assert k1 != k2
+
+    def test_kwargs_none_ignored(self) -> None:
+        msgs = [AIMessage(content="Test")]
+        k1 = _build_cache_key("m", msgs, tools=None, tool_choice=None)
+        k2 = _build_cache_key("m", msgs)
+        assert k1 == k2
 
 
 class TestSafeMetadata:
@@ -274,6 +321,33 @@ class TestLLMResponseCache:
         (self.cache_dir / "ok.json").write_text("{bad json", encoding="utf-8")
         assert self.cache.get("ok") is None
         assert not (self.cache_dir / "ok.json").exists()
+
+    # -- fault tolerance -----------------------------------------------------
+
+    def test_get_handles_oserror(self, monkeypatch) -> None:
+        self.cache.set("ft1", AIMessage(content="test"))
+        # Simulate a permission error on read.
+        def _failing_read_text(*args, **kwargs):
+            raise OSError("Permission denied")
+        monkeypatch.setattr(Path, "read_text", _failing_read_text)
+        # Must not raise.
+        assert self.cache.get("ft1") is None
+
+    def test_set_handles_serialisation_error(self, monkeypatch) -> None:
+        # Simulate json.dumps failing.
+        import json as json_module
+        def _failing_dumps(*args, **kwargs):
+            raise TypeError("Cannot serialise")
+        monkeypatch.setattr(json_module, "dumps", _failing_dumps)
+        # Must not raise.
+        self.cache.set("ft2", AIMessage(content="test"))
+
+    def test_set_handles_oserror(self, monkeypatch) -> None:
+        def _failing_write_text(*args, **kwargs):
+            raise OSError("Disk full")
+        monkeypatch.setattr(Path, "write_text", _failing_write_text)
+        # Must not raise.
+        self.cache.set("ft3", AIMessage(content="test"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,0 +1,356 @@
+"""Tests for the LLM response cache module.
+
+These tests exercise the core ``LLMResponseCache`` class as well as the
+module‑level helper functions.  Real file I/O is used (isolated inside a
+temporary directory) so we're testing the actual serialisation round‑trip,
+not a mock.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from tradingagents.llm_clients.llm_cache import (
+    LLMResponseCache,
+    _aimessage_to_dict,
+    _build_cache_key,
+    _dict_to_aimessage,
+    _safe_metadata,
+    _serialise_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — serialisation helpers
+# ---------------------------------------------------------------------------
+
+class TestSerialiseMessages:
+    """``_serialise_messages`` produces deterministic JSON."""
+
+    def test_base_message_list(self) -> None:
+        msgs = [
+            AIMessage(content="Hello"),
+            AIMessage(content="World", additional_kwargs={"reasoning_content": "thinking..."}),
+        ]
+        result = _serialise_messages(msgs)
+        loaded = json.loads(result)
+        assert len(loaded) == 2
+        assert loaded[0]["role"] == "ai"
+        assert loaded[0]["content"] == "Hello"
+
+    def test_deterministic(self) -> None:
+        a = _serialise_messages([AIMessage(content="Hi")])
+        b = _serialise_messages([AIMessage(content="Hi")])
+        assert a == b
+
+    def test_different_content_gives_different_json(self) -> None:
+        a = _serialise_messages([AIMessage(content="Alpha")])
+        b = _serialise_messages([AIMessage(content="Beta")])
+        assert a != b
+
+    def test_empty_list(self) -> None:
+        assert _serialise_messages([]) == "[]"
+
+    def test_dict_input(self) -> None:
+        msgs = [{"role": "user", "content": "hello"}]
+        result = _serialise_messages(msgs)
+        assert json.loads(result) == [{"role": "user", "content": "hello"}]
+
+    def test_raw_string_input(self) -> None:
+        result = _serialise_messages(["raw string"])
+        assert json.loads(result) == [{"role": "", "content": "raw string"}]
+
+
+class TestBuildCacheKey:
+    """Cache key determinism and collision resistance."""
+
+    def test_same_input_same_key(self) -> None:
+        msgs = [AIMessage(content="Test")]
+        k1 = _build_cache_key("deepseek-v4-flash", msgs, 0.0)
+        k2 = _build_cache_key("deepseek-v4-flash", msgs, 0.0)
+        assert k1 == k2
+
+    def test_different_model_different_key(self) -> None:
+        msgs = [AIMessage(content="Test")]
+        k1 = _build_cache_key("deepseek-v4-flash", msgs)
+        k2 = _build_cache_key("gpt-4", msgs)
+        assert k1 != k2
+
+    def test_different_messages_different_key(self) -> None:
+        k1 = _build_cache_key("m", [AIMessage(content="A")])
+        k2 = _build_cache_key("m", [AIMessage(content="B")])
+        assert k1 != k2
+
+    def test_key_is_sha256(self) -> None:
+        key = _build_cache_key("m", [AIMessage(content="x")])
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+
+class TestSafeMetadata:
+    """``_safe_metadata`` strips non‑serialisable keys."""
+
+    def test_strips_headers(self) -> None:
+        raw = {"headers": {"x-request-id": "abc"}, "token_usage": {"total": 100}}
+        cleaned = _safe_metadata(raw)
+        assert "headers" not in cleaned
+        assert cleaned["token_usage"] == {"total": 100}
+
+    def test_strips_raw_response(self) -> None:
+        raw = {"raw_response": object(), "model": "gpt-4"}
+        cleaned = _safe_metadata(raw)
+        assert "raw_response" not in cleaned
+
+    def test_none_input(self) -> None:
+        assert _safe_metadata(None) == {}
+
+    def test_empty_dict(self) -> None:
+        assert _safe_metadata({}) == {}
+
+
+class TestAIMessageRoundTrip:
+    """Serialising and deserialising preserves semantic content."""
+
+    def _roundtrip(self, original: AIMessage) -> AIMessage:
+        d = _aimessage_to_dict(original)
+        return _dict_to_aimessage(d)
+
+    def test_content_preserved(self) -> None:
+        msg = AIMessage(content="Hello world")
+        restored = self._roundtrip(msg)
+        assert restored.content == "Hello world"
+
+    def test_additional_kwargs_preserved(self) -> None:
+        msg = AIMessage(content="Hi", additional_kwargs={"reasoning_content": "..."})
+        restored = self._roundtrip(msg)
+        assert restored.additional_kwargs["reasoning_content"] == "..."
+
+    def test_tool_calls_preserved(self) -> None:
+        msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "get_stock", "args": {"symbol": "NVDA"}, "id": "call_1"}],
+        )
+        restored = self._roundtrip(msg)
+        assert len(restored.tool_calls) == 1
+        assert restored.tool_calls[0]["name"] == "get_stock"
+
+    def test_usage_metadata_preserved(self) -> None:
+        msg = AIMessage(content="Hi", usage_metadata={"input_tokens": 10, "output_tokens": 5})
+        restored = self._roundtrip(msg)
+        assert restored.usage_metadata["input_tokens"] == 10
+
+    def test_missing_fields_default_gracefully(self) -> None:
+        restored = _dict_to_aimessage({"content": "Hello"})
+        assert restored.content == "Hello"
+        assert restored.additional_kwargs == {}
+        assert restored.tool_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — LLMResponseCache (real file I/O)
+# ---------------------------------------------------------------------------
+
+class TestLLMResponseCache:
+    """Integration tests against the real filesystem inside a tmpdir."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp_cache(self, tmp_path: Path) -> None:
+        self.cache = LLMResponseCache(str(tmp_path), ttl_hours=24)
+        self.cache_dir = tmp_path / "llm_responses"
+
+    # -- get/set -----------------------------------------------------------
+
+    def test_miss_returns_none(self) -> None:
+        assert self.cache.get("nonexistent") is None
+
+    def test_set_and_get(self) -> None:
+        msg = AIMessage(content="Cached response")
+        self.cache.set("key1", msg)
+        restored = self.cache.get("key1")
+        assert restored is not None
+        assert restored.content == "Cached response"
+
+    def test_set_and_get_with_metadata(self) -> None:
+        msg = AIMessage(
+            content="Analysis result",
+            additional_kwargs={"reasoning_content": "step by step"},
+            response_metadata={"model": "deepseek-v4-flash", "token_usage": {"total": 50}},
+        )
+        self.cache.set("key2", msg)
+        restored = self.cache.get("key2")
+        assert restored is not None
+        assert restored.additional_kwargs["reasoning_content"] == "step by step"
+        assert restored.response_metadata["model"] == "deepseek-v4-flash"
+
+    def test_overwrite_existing_key(self) -> None:
+        self.cache.set("k", AIMessage(content="v1"))
+        self.cache.set("k", AIMessage(content="v2"))
+        assert self.cache.get("k") is not None
+        assert self.cache.get("k").content == "v2"
+
+    def test_hit_and_miss_counters(self) -> None:
+        self.cache.set("h", AIMessage(content="hit"))
+        self.cache.get("h")   # hit
+        self.cache.get("x")   # miss
+        self.cache.get("y")   # miss
+        assert self.cache.hits == 1
+        assert self.cache.misses == 2
+
+    # -- TTL expiry --------------------------------------------------------
+
+    def test_expired_entry_returns_none(self) -> None:
+        self.cache.set("exp", AIMessage(content="will expire"))
+        # Artificially age the file.
+        path = self.cache_dir / "exp.json"
+        old = time.time() - (25 * 3600)  # 25 hours ago
+        os.utime(path, (old, old))
+        assert self.cache.get("exp") is None
+
+    def test_expired_file_is_deleted(self) -> None:
+        self.cache.set("del", AIMessage(content="bye"))
+        path = self.cache_dir / "del.json"
+        old = time.time() - (25 * 3600)
+        os.utime(path, (old, old))
+        self.cache.get("del")
+        assert not path.exists()
+
+    # -- clear -------------------------------------------------------------
+
+    def test_clear_all(self) -> None:
+        self.cache.set("a", AIMessage(content="1"))
+        self.cache.set("b", AIMessage(content="2"))
+        removed = self.cache.clear_all()
+        assert removed == 2
+        assert self.cache.get("a") is None
+        # Counters are reset.
+        assert self.cache.hits == 0
+        assert self.cache.misses == 0
+
+    def test_clear_expired(self) -> None:
+        self.cache.set("fresh", AIMessage(content="new"))
+        self.cache.set("old", AIMessage(content="stale"))
+        old_time = time.time() - (25 * 3600)
+        os.utime(self.cache_dir / "old.json", (old_time, old_time))
+        removed = self.cache.clear_expired()
+        assert removed == 1
+        assert self.cache_dir / "fresh.json"  # still exists
+        assert not (self.cache_dir / "old.json").exists()
+
+    # -- stats -------------------------------------------------------------
+
+    def test_stats_empty(self) -> None:
+        stats = self.cache.stats()
+        assert stats["entry_count"] == 0
+        assert stats["total_size_bytes"] == 0
+        assert stats["hit_rate"] == 0.0
+
+    def test_stats_after_operations(self) -> None:
+        self.cache.set("s1", AIMessage(content="stats1"))
+        self.cache.set("s2", AIMessage(content="stats2"))
+        self.cache.get("s1")   # hit
+        self.cache.get("s1")   # hit
+        self.cache.get("nope") # miss
+        stats = self.cache.stats()
+        assert stats["entry_count"] == 2
+        assert stats["total_size_bytes"] > 0
+        assert stats["hits"] == 2
+        assert stats["misses"] == 1
+        assert stats["hit_rate"] == 2.0 / 3.0
+        assert stats["ttl_hours"] == 24
+        assert stats["cache_dir"] == str(self.cache_dir)
+
+    # -- corrupt file handling ---------------------------------------------
+
+    def test_corrupt_file_returns_none_and_deletes(self) -> None:
+        self.cache.set("ok", AIMessage(content="fine"))
+        # Write garbage over the file.
+        (self.cache_dir / "ok.json").write_text("{bad json", encoding="utf-8")
+        assert self.cache.get("ok") is None
+        assert not (self.cache_dir / "ok.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Module‑level helper tests
+# ---------------------------------------------------------------------------
+
+class TestModuleHelpers:
+    """``should_cache_provider``, ``check_cache``, ``store_cache``."""
+
+    def test_should_cache_provider_empty_allowed_list(self) -> None:
+        with patch(
+            "tradingagents.llm_clients.llm_cache._get_config",
+            return_value={"llm_cache_providers": []},
+        ):
+            from tradingagents.llm_clients.llm_cache import should_cache_provider
+            assert should_cache_provider("deepseek") is True
+            assert should_cache_provider("ollama") is True
+
+    def test_should_cache_provider_filtered(self) -> None:
+        with patch(
+            "tradingagents.llm_clients.llm_cache._get_config",
+            return_value={"llm_cache_providers": ["deepseek", "openai"]},
+        ):
+            from tradingagents.llm_clients.llm_cache import should_cache_provider
+            assert should_cache_provider("deepseek") is True
+            assert should_cache_provider("openai") is True
+            assert should_cache_provider("ollama") is False
+            assert should_cache_provider("anthropic") is False
+
+    def test_should_cache_provider_case_insensitive(self) -> None:
+        with patch(
+            "tradingagents.llm_clients.llm_cache._get_config",
+            return_value={"llm_cache_providers": ["DeepSeek", "OPENAI"]},
+        ):
+            from tradingagents.llm_clients.llm_cache import should_cache_provider
+            assert should_cache_provider("deepseek") is True
+            assert should_cache_provider("OpenAI") is True
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: env-var overrides for cache config
+# ---------------------------------------------------------------------------
+
+class TestCacheEnvOverrides:
+    """``TRADINGAGENTS_LLM_CACHE_ENABLED`` and friends."""
+
+    def test_cache_enabled_default(self, monkeypatch) -> None:
+        import importlib
+        import tradingagents.default_config as dc_mod
+        dc = importlib.reload(dc_mod)
+        assert dc.DEFAULT_CONFIG["llm_cache_enabled"] is True
+        assert dc.DEFAULT_CONFIG["llm_cache_ttl_hours"] == 24
+        assert dc.DEFAULT_CONFIG["llm_cache_providers"] == []
+
+    def test_cache_disabled_via_env(self, monkeypatch) -> None:
+        import importlib
+        import tradingagents.default_config as dc_mod
+        for key in list(dc_mod._ENV_OVERRIDES):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TRADINGAGENTS_LLM_CACHE_ENABLED", "false")
+        dc = importlib.reload(dc_mod)
+        assert dc.DEFAULT_CONFIG["llm_cache_enabled"] is False
+
+    def test_cache_ttl_via_env(self, monkeypatch) -> None:
+        import importlib
+        import tradingagents.default_config as dc_mod
+        for key in list(dc_mod._ENV_OVERRIDES):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TRADINGAGENTS_LLM_CACHE_TTL_HOURS", "48")
+        dc = importlib.reload(dc_mod)
+        assert dc.DEFAULT_CONFIG["llm_cache_ttl_hours"] == 48
+
+    def test_cache_providers_via_env(self, monkeypatch) -> None:
+        import importlib
+        import tradingagents.default_config as dc_mod
+        for key in list(dc_mod._ENV_OVERRIDES):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TRADINGAGENTS_LLM_CACHE_PROVIDERS", "deepseek,openai")
+        dc = importlib.reload(dc_mod)
+        assert dc.DEFAULT_CONFIG["llm_cache_providers"] == ["deepseek", "openai"]

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -17,6 +17,10 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_MAX_RISK_ROUNDS":      "max_risk_discuss_rounds",
     "TRADINGAGENTS_CHECKPOINT_ENABLED":   "checkpoint_enabled",
     "TRADINGAGENTS_BENCHMARK_TICKER":     "benchmark_ticker",
+    # LLM response cache
+    "TRADINGAGENTS_LLM_CACHE_ENABLED":    "llm_cache_enabled",
+    "TRADINGAGENTS_LLM_CACHE_TTL_HOURS":  "llm_cache_ttl_hours",
+    "TRADINGAGENTS_LLM_CACHE_PROVIDERS":  "llm_cache_providers",
 }
 
 
@@ -28,6 +32,10 @@ def _coerce(value: str, reference):
         return int(value)
     if isinstance(reference, float):
         return float(value)
+    if isinstance(reference, list):
+        if not value.strip():
+            return []
+        return [item.strip() for item in value.split(",")]
     return value
 
 
@@ -75,6 +83,15 @@ DEFAULT_CONFIG = _apply_env_overrides({
     "max_risk_discuss_rounds": 1,
     "max_recur_limit": 100,
     "analyst_concurrency_limit": 1,
+    # LLM response cache — local file-based cache of LLM API responses.
+    # Enabled by default; set TRADINGAGENTS_LLM_CACHE_ENABLED=false to disable.
+    "llm_cache_enabled": True,
+    # Cache TTL in hours. After this, entries are lazily expired on read.
+    "llm_cache_ttl_hours": 24,
+    # List of providers to cache. Empty list = cache all providers.
+    # Set via TRADINGAGENTS_LLM_CACHE_PROVIDERS as comma-separated values,
+    # e.g. "deepseek,openai". Non-listed providers skip the cache entirely.
+    "llm_cache_providers": [],
     # News / data fetching parameters
     # Increase for longer lookback strategies or to broaden macro coverage;
     # decrease to reduce token usage in agent prompts.

--- a/tradingagents/llm_clients/llm_cache.py
+++ b/tradingagents/llm_clients/llm_cache.py
@@ -1,0 +1,363 @@
+"""Local file‑based cache for LLM API responses.
+
+On **miss** the full ``AIMessage`` is serialised to a JSON file under
+``~/.tradingagents/cache/llm_responses/<sha256>.json``. On **hit** the
+stored JSON is deserialised back into an ``AIMessage`` — zero API cost,
+zero network latency.
+
+Relationship with DeepSeek's server‑side prefix cache
+------------------------------------------------------
+DeepSeek maintains a **prefix (KV) cache** on their side: when the
+beginning of your message sequence (system prompt + earlier turns)
+matches a previous request, they skip re‑computing the attention
+prefix — saving roughly 50 % on input tokens *per call*.
+
+This module is **independent and complementary**:
+
+  +---------------------------+---------------------------+
+  | This cache                | DeepSeek prefix cache     |
+  +---------------------------+---------------------------+
+  | Client‑side, file‑based   | Server‑side, transparent  |
+  | Stores *output*           | Caches *input* prefix     |
+  | Hit → 100 % cost saved    | Hit → ~50 % input saved   |
+  | Exact message match       | Prefix match (best effort)|
+  +---------------------------+---------------------------+
+
+Both can be active at the same time — the prefix cache saves input
+tokens on every miss here, and this cache eliminates full API calls
+for repeated analyses of the same (ticker, date, config) combination.
+
+Design notes
+------------
+* **Cache key** = SHA256 of ``(model, temperature, serialised messages)``.
+  Structured‑output calls embed tool definitions in the message list, so
+  free‑text and structured calls to the same logical content naturally
+  get different keys.
+
+* **Provider filter** — ``llm_cache_providers`` in ``DEFAULT_CONFIG``
+  lets you restrict caching to specific providers (e.g. only DeepSeek,
+  skip local Ollama). Empty list = cache all providers.
+
+* **TTL** — configurable (default 24 h). Expired entries are lazily
+  evicted on read; ``clear_expired()`` sweeps stale files in bulk.
+
+* **Hit/miss counters** — kept in memory for the lifetime of the cache
+  instance, exposed via ``stats()`` for monitoring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from langchain_core.messages import AIMessage
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+_NON_SERIALISABLE_RESPONSE_META_KEYS = frozenset({"headers", "raw_response"})
+
+
+def _serialise_messages(messages: list) -> str:
+    """Deterministic JSON representation of a LangChain message list.
+
+    Handles ``BaseMessage`` objects, plain dicts, and raw strings.
+    Keys are sorted so identical logical content yields identical JSON.
+    """
+    items: list[dict[str, Any]] = []
+    for m in messages:
+        if hasattr(m, "type") and hasattr(m, "content"):
+            entry: dict[str, Any] = {
+                "role": m.type,
+                "content": m.content if isinstance(m.content, str) else str(m.content),
+            }
+            tool_calls = getattr(m, "tool_calls", None) or []
+            if tool_calls:
+                entry["tool_calls"] = [
+                    {"name": tc.get("name", ""), "args": tc.get("args", {}), "id": tc.get("id")}
+                    for tc in tool_calls
+                ]
+            items.append(entry)
+        elif isinstance(m, dict):
+            items.append({"role": m.get("role", ""), "content": str(m.get("content", ""))})
+        else:
+            items.append({"role": "", "content": str(m)})
+    return json.dumps(items, sort_keys=True, ensure_ascii=False)
+
+
+def _build_cache_key(model: str, messages: list, temperature: float = 0.0) -> str:
+    """Deterministic SHA256 cache key from model + temperature + messages."""
+    msg_json = _serialise_messages(messages)
+    raw = f"{model}|{temperature}|{msg_json}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _safe_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a JSON‑safe copy of *metadata*, stripping non‑serialisable keys."""
+    if not metadata:
+        return {}
+    return {k: v for k, v in metadata.items()
+            if k not in _NON_SERIALISABLE_RESPONSE_META_KEYS}
+
+
+def _aimessage_to_dict(msg: AIMessage) -> dict[str, Any]:
+    """Serialise an ``AIMessage`` to a JSON‑safe dict."""
+    return {
+        "content": msg.content,
+        "additional_kwargs": msg.additional_kwargs,
+        "response_metadata": _safe_metadata(msg.response_metadata),
+        "tool_calls": [
+            {"name": tc.get("name", ""), "args": tc.get("args", {}),
+             "id": tc.get("id"), "type": tc.get("type")}
+            for tc in (msg.tool_calls or [])
+        ],
+        "invalid_tool_calls": [
+            {"name": itc.get("name", ""), "args": itc.get("args", {}),
+             "id": itc.get("id"), "type": itc.get("type"), "text": itc.get("text", "")}
+            for itc in (msg.invalid_tool_calls or [])
+        ],
+        "id": msg.id,
+        "usage_metadata": msg.usage_metadata,
+    }
+
+
+def _dict_to_aimessage(data: dict[str, Any]) -> AIMessage:
+    """Reconstruct an ``AIMessage`` from a dict produced by ``_aimessage_to_dict``."""
+    return AIMessage(
+        content=data.get("content", ""),
+        additional_kwargs=data.get("additional_kwargs", {}),
+        response_metadata=data.get("response_metadata", {}),
+        tool_calls=data.get("tool_calls", []),
+        invalid_tool_calls=data.get("invalid_tool_calls", []),
+        id=data.get("id"),
+        usage_metadata=data.get("usage_metadata"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache class
+# ---------------------------------------------------------------------------
+
+
+class LLMResponseCache:
+    """Persistent local cache for LLM responses.
+
+    Thread‑safe for reads; concurrent writes to the same key are safe
+    because the last writer wins (acceptable for this use case).
+
+    Parameters
+    ----------
+    cache_dir:
+        Root directory for cached response files. The actual files live
+        under ``{cache_dir}/llm_responses/``.
+    ttl_hours:
+        Number of hours before an entry is considered stale.
+    """
+
+    def __init__(self, cache_dir: str, ttl_hours: int = 24) -> None:
+        self._root = Path(cache_dir) / "llm_responses"
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._ttl_seconds = ttl_hours * 3600
+        # In‑memory hit/miss counters (lifetime of this instance).
+        self.hits: int = 0
+        self.misses: int = 0
+
+    # -- public properties --------------------------------------------------
+
+    @property
+    def cache_dir(self) -> str:
+        """Absolute path to the cache directory on disk."""
+        return str(self._root)
+
+    @property
+    def ttl_hours(self) -> int:
+        """Configured TTL in whole hours."""
+        return self._ttl_seconds // 3600
+
+    # -- public API ---------------------------------------------------------
+
+    def get(self, key: str) -> Optional[AIMessage]:
+        """Look up *key*.
+
+        Returns the cached ``AIMessage`` or ``None`` on miss/expiry/corruption.
+        Stale entries are silently deleted.
+        """
+        path = self._root / f"{key}.json"
+        if not path.exists():
+            self.misses += 1
+            return None
+
+        age = time.time() - path.stat().st_mtime
+        if age > self._ttl_seconds:
+            path.unlink(missing_ok=True)
+            logger.debug("Cache entry %s expired (age=%.1fs)", key, age)
+            self.misses += 1
+            return None
+
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            msg = _dict_to_aimessage(data)
+            self.hits += 1
+            logger.debug("Cache HIT  for key=%s (%.0f min old)", key, age / 60)
+            return msg
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            logger.warning("Cache entry %s is corrupt (%s); removing", key, exc)
+            path.unlink(missing_ok=True)
+            self.misses += 1
+            return None
+
+    def set(self, key: str, response: AIMessage) -> None:
+        """Store *response* under *key*."""
+        path = self._root / f"{key}.json"
+        data = _aimessage_to_dict(response)
+        path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        size_kb = path.stat().st_size / 1024
+        logger.debug("Cache SET  for key=%s (%.1f kB)", key, size_kb)
+
+    def clear_expired(self) -> int:
+        """Delete all expired cache entries.
+
+        Returns the number of files removed.
+        """
+        now = time.time()
+        removed = 0
+        for f in self._root.glob("*.json"):
+            if now - f.stat().st_mtime > self._ttl_seconds:
+                f.unlink(missing_ok=True)
+                removed += 1
+        if removed:
+            logger.info("Cleared %d expired LLM cache entries", removed)
+        return removed
+
+    def clear_all(self) -> int:
+        """Delete **all** cache entries regardless of age.
+
+        Returns the number of files removed.
+        """
+        removed = 0
+        for f in self._root.glob("*.json"):
+            f.unlink(missing_ok=True)
+            removed += 1
+        if removed:
+            logger.info("Cleared all %d LLM cache entries", removed)
+        # Reset hit/miss counters since the cache is now empty.
+        self.hits = 0
+        self.misses = 0
+        return removed
+
+    def stats(self) -> dict[str, Any]:
+        """Return cache statistics.
+
+        Returns
+        -------
+        dict with keys:
+            * ``entry_count`` — number of cached files on disk
+            * ``total_size_bytes`` — aggregated file size
+            * ``oldest_hours`` — age of the oldest cache entry
+            * ``hits`` — in‑memory hit count
+            * ``misses`` — in‑memory miss count
+            * ``hit_rate`` — ``hits / (hits + misses)`` or 0 if no requests
+            * ``ttl_hours`` — configured TTL
+            * ``cache_dir`` — on‑disk location
+        """
+        entries = list(self._root.glob("*.json"))
+        entry_count = len(entries)
+        total_bytes = sum(f.stat().st_size for f in entries)
+        oldest = min((f.stat().st_mtime for f in entries), default=None)
+        total_requests = self.hits + self.misses
+        return {
+            "entry_count": entry_count,
+            "total_size_bytes": total_bytes,
+            "oldest_hours": (time.time() - oldest) / 3600 if oldest else 0.0,
+            "hits": self.hits,
+            "misses": self.misses,
+            "hit_rate": self.hits / total_requests if total_requests > 0 else 0.0,
+            "ttl_hours": self.ttl_hours,
+            "cache_dir": self.cache_dir,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module‑level convenience helpers
+#
+# Config is read from ``tradingagents.default_config.DEFAULT_CONFIG``, which
+# respects the standard ``TRADINGAGENTS_*`` env‑var override chain.
+# ---------------------------------------------------------------------------
+
+_cache: Optional[LLMResponseCache] = None
+"""Module‑level singleton. Initialised lazily on first use."""
+
+_config: Optional[dict] = None
+"""Module‑level config cache. Initialised lazily to avoid circular imports."""
+
+
+def _get_config() -> dict[str, Any]:
+    global _config
+    if _config is None:
+        from tradingagents.default_config import DEFAULT_CONFIG
+        _config = DEFAULT_CONFIG
+    return _config
+
+
+def _get_cache() -> Optional[LLMResponseCache]:
+    """Return the singleton cache instance, or ``None`` if caching is disabled."""
+    global _cache
+    cfg = _get_config()
+    if not cfg.get("llm_cache_enabled", True):
+        return None
+
+    if _cache is None:
+        cache_dir = cfg.get(
+            "data_cache_dir",
+            os.path.join(os.path.expanduser("~"), ".tradingagents", "cache"),
+        )
+        ttl_hours = cfg.get("llm_cache_ttl_hours", 24)
+        _cache = LLMResponseCache(cache_dir, ttl_hours=ttl_hours)
+    return _cache
+
+
+def should_cache_provider(provider_name: str) -> bool:
+    """Return ``True`` when *provider_name* should use the cache.
+
+    Behaviour is controlled by ``llm_cache_providers`` in the config:
+    an empty list means cache **all** providers; a non‑empty list is
+    matched case‑insensitively.
+    """
+    cfg = _get_config()
+    allowed: list[str] = cfg.get("llm_cache_providers", [])
+    if not allowed:
+        return True
+    return provider_name.lower() in [p.lower() for p in allowed]
+
+
+def check_cache(provider_name: str, model: str, messages: list) -> Optional[AIMessage]:
+    """Look up a cached response.
+
+    Returns the cached ``AIMessage`` or ``None`` (miss / disabled /
+    provider not in filter list).
+    """
+    cache = _get_cache()
+    if cache is None or not should_cache_provider(provider_name):
+        return None
+    key = _build_cache_key(model, messages)
+    return cache.get(key)
+
+
+def store_cache(provider_name: str, model: str, messages: list, response: AIMessage) -> None:
+    """Store an LLM response in the cache.
+
+    Silently no‑ops when caching is disabled or the provider is filtered out.
+    """
+    cache = _get_cache()
+    if cache is None or not should_cache_provider(provider_name):
+        return
+    key = _build_cache_key(model, messages)
+    cache.set(key, response)

--- a/tradingagents/llm_clients/llm_cache.py
+++ b/tradingagents/llm_clients/llm_cache.py
@@ -29,10 +29,10 @@ for repeated analyses of the same (ticker, date, config) combination.
 
 Design notes
 ------------
-* **Cache key** = SHA256 of ``(model, temperature, serialised messages)``.
-  Structured‑output calls embed tool definitions in the message list, so
-  free‑text and structured calls to the same logical content naturally
-  get different keys.
+* **Cache key** = SHA256 of ``(model, temperature, extra_params, serialised
+  messages)``.  *extra_params* captures invocation‑level settings such as
+  ``tools``, ``tool_choice``, and ``response_format``, preventing incorrect
+  cache hits when those differ despite identical messages.
 
 * **Provider filter** — ``llm_cache_providers`` in ``DEFAULT_CONFIG``
   lets you restrict caching to specific providers (e.g. only DeepSeek,
@@ -43,6 +43,9 @@ Design notes
 
 * **Hit/miss counters** — kept in memory for the lifetime of the cache
   instance, exposed via ``stats()`` for monitoring.
+
+* **Fault‑tolerant** — file‑system and serialisation errors are caught
+  and logged, never propagated.  Caching is strictly best‑effort.
 """
 
 from __future__ import annotations
@@ -66,12 +69,36 @@ logger = logging.getLogger(__name__)
 _NON_SERIALISABLE_RESPONSE_META_KEYS = frozenset({"headers", "raw_response"})
 
 
-def _serialise_messages(messages: list) -> str:
+def _normalise_input(messages: Any) -> list:
+    """Normalise a LangChain invoke input to a flat list of messages.
+
+    Accepts:
+    * ``str`` — treated as a single user message.
+    * Objects with a ``to_messages`` method (``ChatPromptValue``, ...).
+    * Lists of messages (passed through as‑is).
+    * Anything else — wrapped in a single‑element list.
+
+    This prevents iteration over a string from producing per‑character
+    messages, and handles ``PromptValue`` objects that are not directly
+    iterable (e.g. ``ChatPromptValue`` returned by a template).
+    """
+    if isinstance(messages, str):
+        return [messages]
+    if not isinstance(messages, list) and hasattr(messages, "to_messages"):
+        return messages.to_messages()
+    if not isinstance(messages, list):
+        return [messages]
+    return messages
+
+
+def _serialise_messages(messages: Any) -> str:
     """Deterministic JSON representation of a LangChain message list.
 
-    Handles ``BaseMessage`` objects, plain dicts, and raw strings.
+    Handles ``BaseMessage`` objects, plain dicts, raw strings, and
+    ``ChatPromptValue`` via ``_normalise_input()``.
     Keys are sorted so identical logical content yields identical JSON.
     """
+    messages = _normalise_input(messages)
     items: list[dict[str, Any]] = []
     for m in messages:
         if hasattr(m, "type") and hasattr(m, "content"):
@@ -93,10 +120,31 @@ def _serialise_messages(messages: list) -> str:
     return json.dumps(items, sort_keys=True, ensure_ascii=False)
 
 
-def _build_cache_key(model: str, messages: list, temperature: float = 0.0) -> str:
-    """Deterministic SHA256 cache key from model + temperature + messages."""
+def _build_cache_key(
+    model: str,
+    messages: Any,
+    temperature: float = 0.0,
+    **kwargs: Any,
+) -> str:
+    """Deterministic SHA256 cache key.
+
+    Incorporates *model*, *temperature*, invocation‑level *kwargs*
+    (``tools``, ``tool_choice``, ``response_format``), and the
+    serialised message list.  Different tool definitions or response
+    formats therefore produce different keys.
+    """
     msg_json = _serialise_messages(messages)
-    raw = f"{model}|{temperature}|{msg_json}"
+    # Collect invocation‑level parameters that affect the response.
+    extra_params: dict[str, Any] = {}
+    for key in ("tools", "tool_choice", "response_format"):
+        if key in kwargs and kwargs[key] is not None:
+            extra_params[key] = kwargs[key]
+    # Use default=str to guard against non‑serialisable objects.
+    try:
+        extra_json = json.dumps(extra_params, sort_keys=True, default=str)
+    except Exception:
+        extra_json = str(extra_params)
+    raw = f"{model}|{temperature}|{msg_json}|{extra_json}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
@@ -153,6 +201,10 @@ class LLMResponseCache:
     Thread‑safe for reads; concurrent writes to the same key are safe
     because the last writer wins (acceptable for this use case).
 
+    **All file‑system and serialisation errors are caught internally.**
+    Caching is strictly best‑effort — a broken cache never crashes the
+    main LLM invocation.
+
     Parameters
     ----------
     cache_dir:
@@ -166,7 +218,6 @@ class LLMResponseCache:
         self._root = Path(cache_dir) / "llm_responses"
         self._root.mkdir(parents=True, exist_ok=True)
         self._ttl_seconds = ttl_hours * 3600
-        # In‑memory hit/miss counters (lifetime of this instance).
         self.hits: int = 0
         self.misses: int = 0
 
@@ -187,22 +238,25 @@ class LLMResponseCache:
     def get(self, key: str) -> Optional[AIMessage]:
         """Look up *key*.
 
-        Returns the cached ``AIMessage`` or ``None`` on miss/expiry/corruption.
-        Stale entries are silently deleted.
+        Returns the cached ``AIMessage`` or ``None`` on miss/expiry/corruption
+        or file‑system error.  Stale and corrupt entries are silently deleted.
         """
         path = self._root / f"{key}.json"
-        if not path.exists():
-            self.misses += 1
-            return None
-
-        age = time.time() - path.stat().st_mtime
-        if age > self._ttl_seconds:
-            path.unlink(missing_ok=True)
-            logger.debug("Cache entry %s expired (age=%.1fs)", key, age)
-            self.misses += 1
-            return None
-
         try:
+            if not path.exists():
+                self.misses += 1
+                return None
+
+            age = time.time() - path.stat().st_mtime
+            if age > self._ttl_seconds:
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError as e:
+                    logger.warning("Failed to delete expired cache file %s: %s", path, e)
+                logger.debug("Cache entry %s expired (age=%.1fs)", key, age)
+                self.misses += 1
+                return None
+
             data = json.loads(path.read_text(encoding="utf-8"))
             msg = _dict_to_aimessage(data)
             self.hits += 1
@@ -210,45 +264,58 @@ class LLMResponseCache:
             return msg
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
             logger.warning("Cache entry %s is corrupt (%s); removing", key, exc)
-            path.unlink(missing_ok=True)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as e:
+                logger.warning("Failed to delete corrupt cache file %s: %s", path, e)
+            self.misses += 1
+            return None
+        except OSError as exc:
+            logger.warning("File system error reading cache entry %s: %s", key, exc)
             self.misses += 1
             return None
 
     def set(self, key: str, response: AIMessage) -> None:
-        """Store *response* under *key*."""
-        path = self._root / f"{key}.json"
-        data = _aimessage_to_dict(response)
-        path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-        size_kb = path.stat().st_size / 1024
-        logger.debug("Cache SET  for key=%s (%.1f kB)", key, size_kb)
+        """Store *response* under *key*.
+
+        All errors (serialisation failures, disk full, permission denied)
+        are caught and logged — caching is best‑effort, never fatal.
+        """
+        try:
+            path = self._root / f"{key}.json"
+            data = _aimessage_to_dict(response)
+            path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            size_kb = path.stat().st_size / 1024
+            logger.debug("Cache SET  for key=%s (%.1f kB)", key, size_kb)
+        except Exception as exc:
+            logger.warning("Failed to write cache entry for key %s: %s", key, exc)
 
     def clear_expired(self) -> int:
-        """Delete all expired cache entries.
-
-        Returns the number of files removed.
-        """
+        """Delete all expired cache entries. Returns count of removed files."""
         now = time.time()
         removed = 0
         for f in self._root.glob("*.json"):
             if now - f.stat().st_mtime > self._ttl_seconds:
-                f.unlink(missing_ok=True)
-                removed += 1
+                try:
+                    f.unlink(missing_ok=True)
+                    removed += 1
+                except OSError:
+                    pass
         if removed:
             logger.info("Cleared %d expired LLM cache entries", removed)
         return removed
 
     def clear_all(self) -> int:
-        """Delete **all** cache entries regardless of age.
-
-        Returns the number of files removed.
-        """
+        """Delete **all** cache entries regardless of age. Returns count removed."""
         removed = 0
         for f in self._root.glob("*.json"):
-            f.unlink(missing_ok=True)
-            removed += 1
+            try:
+                f.unlink(missing_ok=True)
+                removed += 1
+            except OSError:
+                pass
         if removed:
             logger.info("Cleared all %d LLM cache entries", removed)
-        # Reset hit/miss counters since the cache is now empty.
         self.hits = 0
         self.misses = 0
         return removed
@@ -325,12 +392,7 @@ def _get_cache() -> Optional[LLMResponseCache]:
 
 
 def should_cache_provider(provider_name: str) -> bool:
-    """Return ``True`` when *provider_name* should use the cache.
-
-    Behaviour is controlled by ``llm_cache_providers`` in the config:
-    an empty list means cache **all** providers; a non‑empty list is
-    matched case‑insensitively.
-    """
+    """Return ``True`` when *provider_name* should use the cache."""
     cfg = _get_config()
     allowed: list[str] = cfg.get("llm_cache_providers", [])
     if not allowed:
@@ -338,26 +400,37 @@ def should_cache_provider(provider_name: str) -> bool:
     return provider_name.lower() in [p.lower() for p in allowed]
 
 
-def check_cache(provider_name: str, model: str, messages: list) -> Optional[AIMessage]:
+def check_cache(
+    provider_name: str,
+    model: str,
+    messages: Any,
+    **kwargs: Any,
+) -> Optional[AIMessage]:
     """Look up a cached response.
 
-    Returns the cached ``AIMessage`` or ``None`` (miss / disabled /
-    provider not in filter list).
+    *messages* is the raw ``invoke`` input (list, string, PromptValue, …).
+    *kwargs* carries invocation‑level parameters (temperature, tools,
+    response_format, …) that are folded into the cache key.
+
+    Returns the cached ``AIMessage`` or ``None``.
     """
     cache = _get_cache()
     if cache is None or not should_cache_provider(provider_name):
         return None
-    key = _build_cache_key(model, messages)
+    key = _build_cache_key(model, messages, **kwargs)
     return cache.get(key)
 
 
-def store_cache(provider_name: str, model: str, messages: list, response: AIMessage) -> None:
-    """Store an LLM response in the cache.
-
-    Silently no‑ops when caching is disabled or the provider is filtered out.
-    """
+def store_cache(
+    provider_name: str,
+    model: str,
+    messages: Any,
+    response: AIMessage,
+    **kwargs: Any,
+) -> None:
+    """Store an LLM response in the cache. Silently no‑ops when disabled."""
     cache = _get_cache()
     if cache is None or not should_cache_provider(provider_name):
         return
-    key = _build_cache_key(model, messages)
+    key = _build_cache_key(model, messages, **kwargs)
     cache.set(key, response)

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -44,15 +44,34 @@ class NormalizedChatOpenAI(ChatOpenAI):
     def invoke(self, input, config=None, **kwargs):
         # ── Check cache before making the real API call ────────────────
         if self.provider_name:
-            cached = check_cache(self.provider_name, self.model_name, input)
-            if cached is not None:
-                return cached
+            try:
+                # Resolve the effective temperature: per‑call override
+                # wins, otherwise fall back to the instance's default.
+                temp = kwargs.get("temperature") if "temperature" in kwargs else getattr(self, "temperature", 0.0)
+                if temp is None:
+                    temp = 0.0
+                # Forward all kwargs so tools/tool_choice/response_format
+                # are part of the cache key.
+                cache_kwargs = {**kwargs, "temperature": temp}
+                cached = check_cache(self.provider_name, self.model_name, input, **cache_kwargs)
+                if cached is not None:
+                    return cached
+            except Exception:
+                # Cache failures must never crash the invocation.
+                pass
 
         result = normalize_content(super().invoke(input, config, **kwargs))
 
         # ── Store in cache on the way out ──────────────────────────────
         if self.provider_name:
-            store_cache(self.provider_name, self.model_name, input, result)
+            try:
+                temp = kwargs.get("temperature") if "temperature" in kwargs else getattr(self, "temperature", 0.0)
+                if temp is None:
+                    temp = 0.0
+                cache_kwargs = {**kwargs, "temperature": temp}
+                store_cache(self.provider_name, self.model_name, input, result, **cache_kwargs)
+            except Exception:
+                pass
 
         return result
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any, Optional
 
@@ -7,7 +8,10 @@ from langchain_openai import ChatOpenAI
 from .api_key_env import get_api_key_env
 from .base_client import BaseLLMClient, normalize_content
 from .capabilities import get_capabilities
+from .llm_cache import check_cache, store_cache
 from .validators import validate_model
+
+logger = logging.getLogger(__name__)
 
 
 class NormalizedChatOpenAI(ChatOpenAI):
@@ -27,10 +31,30 @@ class NormalizedChatOpenAI(ChatOpenAI):
     Provider-specific quirks beyond structured-output (e.g. DeepSeek's
     reasoning_content roundtrip) live in subclasses so this base class
     stays small.
+
+    .. attribute:: provider_name
+
+       Name of the LLM provider (e.g. ``"deepseek"``, ``"openai"``).
+       Set by ``OpenAIClient.get_llm()``; used by the cache layer to
+       decide whether the current provider should be cached.
     """
 
+    provider_name: str = ""
+
     def invoke(self, input, config=None, **kwargs):
-        return normalize_content(super().invoke(input, config, **kwargs))
+        # ── Check cache before making the real API call ────────────────
+        if self.provider_name:
+            cached = check_cache(self.provider_name, self.model_name, input)
+            if cached is not None:
+                return cached
+
+        result = normalize_content(super().invoke(input, config, **kwargs))
+
+        # ── Store in cache on the way out ──────────────────────────────
+        if self.provider_name:
+            store_cache(self.provider_name, self.model_name, input, result)
+
+        return result
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
         caps = get_capabilities(self.model_name)
@@ -240,7 +264,11 @@ class OpenAIClient(BaseLLMClient):
             chat_cls = MinimaxChatOpenAI
         else:
             chat_cls = NormalizedChatOpenAI
-        return chat_cls(**llm_kwargs)
+        llm = chat_cls(**llm_kwargs)
+        # Tag the LLM with the provider name so the cache layer can filter
+        # by provider (e.g. cache DeepSeek but skip Ollama).
+        llm.provider_name = self.provider
+        return llm
 
     def validate_model(self) -> bool:
         """Validate model for the provider."""


### PR DESCRIPTION
Introduces a transparent, file-based response cache that intercepts LLM invocations at the NormalizedChatOpenAI level.  On cache hit the response is reconstructed from a local JSON file, saving 100 % of the API call cost and latency.

Key design:
- Cache key = SHA256 of (model name + temperature + serialised messages)
- Structured-output and free-text calls are handled transparently (tool definitions are part of the message list, so keys differ automatically)
- TTL is configurable (default 24 h), expired entries are lazily evicted
- Provider filter via llm_cache_providers config (empty = cache all, or restrict to e.g. "deepseek" only, skipping local Ollama)
- Built-in hit/miss counters exposed through stats() for monitoring

Config added:
  llm_cache_enabled   (bool, default True)
  llm_cache_ttl_hours (int,  default 24)
  llm_cache_providers (list, default [] = all)

Environment-variable overrides:
  TRADINGAGENTS_LLM_CACHE_ENABLED TRADINGAGENTS_LLM_CACHE_TTL_HOURS TRADINGAGENTS_LLM_CACHE_PROVIDERS  (comma-separated)

Tests: 25+ test cases covering serialisation round-trip, cache key determinism, TTL expiry, corrupt-file recovery, hit/miss stats, and env-var configuration overrides.