### PR TITLE
fix(dataflows): log swallowed vendor errors

### DIFF
--- a/tests/test_route_vendor_logging.py
+++ b/tests/test_route_vendor_logging.py
@@ -20,14 +20,14 @@ class TestRouteToVendorLogging(unittest.TestCase):
             return "FALLBACK_DATA"
 
         patched = {"boomvendor": primary_boom, "okvendor": fallback_ok}
-        with mock.patch.object(interface, "get_vendor", return_value="boomvendor,okvendor"), \
-                mock.patch.dict(
-                    interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
-                ):
-            with self.assertLogs(interface.logger, level="WARNING") as cm:
-                result = interface.route_to_vendor(
-                    "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
-                )
+        with (
+            mock.patch.object(interface, "get_vendor", return_value="boomvendor,okvendor"),
+            mock.patch.dict(interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False),
+            self.assertLogs(interface.logger, level="WARNING") as cm,
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+            )
 
         # The fallback's data is still returned (no behavior change)...
         self.assertEqual(result, "FALLBACK_DATA")
@@ -37,6 +37,29 @@ class TestRouteToVendorLogging(unittest.TestCase):
         self.assertIn("get_stock_data", joined)
         self.assertIn("configured primary", joined)
         self.assertTrue(any(record.exc_info for record in cm.records))
+
+    def test_primary_rate_limit_is_logged_but_fallback_result_returned(self):
+        def primary_rate_limited(*a, **k):
+            raise interface.VendorRateLimitError("slow down")
+
+        def fallback_ok(*a, **k):
+            return "FALLBACK_DATA"
+
+        patched = {"slowvendor": primary_rate_limited, "okvendor": fallback_ok}
+        with (
+            mock.patch.object(interface, "get_vendor", return_value="slowvendor,okvendor"),
+            mock.patch.dict(interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False),
+            self.assertLogs(interface.logger, level="WARNING") as cm,
+        ):
+            result = interface.route_to_vendor(
+                "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+            )
+
+        self.assertEqual(result, "FALLBACK_DATA")
+        joined = "\n".join(cm.output)
+        self.assertIn("slowvendor", joined)
+        self.assertIn("rate-limited", joined)
+        self.assertIn("configured primary", joined)
 
 
 if __name__ == "__main__":

--- a/tests/test_route_vendor_logging.py
+++ b/tests/test_route_vendor_logging.py
@@ -36,6 +36,7 @@ class TestRouteToVendorLogging(unittest.TestCase):
         self.assertIn("boomvendor", joined)
         self.assertIn("get_stock_data", joined)
         self.assertIn("configured primary", joined)
+        self.assertTrue(any(record.exc_info for record in cm.records))
 
 
 if __name__ == "__main__":

--- a/tests/test_route_vendor_logging.py
+++ b/tests/test_route_vendor_logging.py
@@ -1,0 +1,42 @@
+"""route_to_vendor must log when it swallows an unexpected vendor error, so a
+broken primary vendor isn't silently masked by a later succeeding fallback
+(see #989)."""
+
+import unittest
+from unittest import mock
+
+import pytest
+
+from tradingagents.dataflows import interface
+
+
+@pytest.mark.unit
+class TestRouteToVendorLogging(unittest.TestCase):
+    def test_primary_failure_is_logged_but_fallback_result_returned(self):
+        def primary_boom(*a, **k):
+            raise RuntimeError("primary vendor exploded")
+
+        def fallback_ok(*a, **k):
+            return "FALLBACK_DATA"
+
+        patched = {"boomvendor": primary_boom, "okvendor": fallback_ok}
+        with mock.patch.object(interface, "get_vendor", return_value="boomvendor,okvendor"), \
+                mock.patch.dict(
+                    interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
+                ):
+            with self.assertLogs(interface.logger, level="WARNING") as cm:
+                result = interface.route_to_vendor(
+                    "get_stock_data", "AAPL", "2026-01-01", "2026-01-10"
+                )
+
+        # The fallback's data is still returned (no behavior change)...
+        self.assertEqual(result, "FALLBACK_DATA")
+        # ...but the masked primary failure is now visible in the logs.
+        joined = "\n".join(cm.output)
+        self.assertIn("boomvendor", joined)
+        self.assertIn("get_stock_data", joined)
+        self.assertIn("configured primary", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -197,7 +197,12 @@ def route_to_vendor(method: str, *args, **kwargs):
         try:
             return impl_func(*args, **kwargs)
         except VendorRateLimitError:
-            logger.warning("Vendor %r rate-limited for %s; trying next vendor.", vendor, method)
+            logger.warning(
+                "Vendor %r rate-limited for %s%s; trying next vendor.",
+                vendor,
+                method,
+                " (configured primary)" if vendor in primary_vendors else "",
+            )
             continue
         except VendorNotConfiguredError as e:
             logger.warning("Vendor %r not configured for %s; trying next vendor.", vendor, method)
@@ -215,11 +220,10 @@ def route_to_vendor(method: str, *args, **kwargs):
             # Log it so a broken primary vendor isn't silently masked when a
             # later fallback succeeds (see #989).
             logger.warning(
-                "Vendor %r failed for %s%s: %s",
+                "Vendor %r failed for %s%s",
                 vendor,
                 method,
                 " (configured primary)" if vendor in primary_vendors else "",
-                e,
                 exc_info=True,
             )
             if first_error is None:

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -158,6 +158,9 @@ def get_vendor(category: str, method: str = None) -> str:
     # Fall back to category-level configuration
     return config.get("data_vendors", {}).get(category, "default")
 
+logger = logging.getLogger(__name__)
+
+
 def route_to_vendor(method: str, *args, **kwargs):
     """Route method calls to appropriate vendor implementation with fallback support."""
     category = get_category_for_method(method)
@@ -205,10 +208,19 @@ def route_to_vendor(method: str, *args, **kwargs):
             last_no_data = e  # No data here; another configured vendor may have it
             continue
         except Exception as e:
-            # Don't let one vendor's failure crash the call when another can
-            # serve it, but never swallow silently: a broken primary must be
-            # visible in the logs (#989), not hidden behind a fallback's verdict.
-            logger.warning("Vendor %r failed for %s: %s", vendor, method, e)
+            # A fallback vendor failing for an incidental reason (e.g. no API
+            # key configured) must not crash the call when another vendor
+            # already determined the symbol simply has no data. Remember the
+            # first error so a genuine primary-vendor failure still surfaces.
+            # Log it so a broken primary vendor isn't silently masked when a
+            # later fallback succeeds (see #989).
+            logger.warning(
+                "Vendor %r failed for %s%s: %s",
+                vendor,
+                method,
+                " (configured primary)" if vendor in primary_vendors else "",
+                e,
+            )
             if first_error is None:
                 first_error = e
             continue

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -220,6 +220,7 @@ def route_to_vendor(method: str, *args, **kwargs):
                 method,
                 " (configured primary)" if vendor in primary_vendors else "",
                 e,
+                exc_info=True,
             )
             if first_error is None:
                 first_error = e


### PR DESCRIPTION
## Summary
- log swallowed exceptions when a primary data vendor fails and routing falls back
- add regression coverage for the vendor routing failure path

## Why
Without this, a broken primary vendor can be silently masked by fallback behavior, making production diagnosis harder.

## Test Plan
- pytest tests/test_route_vendor_logging.py