### PR TITLE
Add default token/LLM-call budgets + ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Cache
 **/data_cache/
+
+# macOS
+.DS_Store

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -28,6 +28,9 @@ DEFAULT_CONFIG = {
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,
+    # Hard caps on per-run LLM spend. Enforced by webapp BudgetCallbackHandler.
+    "max_tokens_total": 1_500_000,
+    "max_llm_calls": 200,
     # Output language for analyst reports and final decision
     # Internal agent debate stays in English for reasoning quality
     "output_language": "English",


### PR DESCRIPTION
## Summary
- `Add default token and LLM-call budgets` — seed the same per-run spend caps in `tradingagents/default_config.py` that the TradingAgents-Core webapp enforces, so CLI/programmatic entry points read the same defaults. (Commit was already local but unpushed.)
- Ignore `.DS_Store`.

## Verification
`python -m pytest` (base conda env) → **108 passed, 42 subtests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)