### PR TITLE
fix(dataflows): data-source resilience — circuit breaker, off-switch, graceful degradation

### DIFF
--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -157,9 +157,12 @@ class FredRoutingTests(unittest.TestCase):
             out = interface.route_to_vendor("get_macro_indicators", "cpi", "2026-06-01", 365)
         self.assertEqual(out, "MACRO_OK")
 
-    def test_not_configured_surfaces_through_router(self):
-        # With only fred and no key, the router has no fallback and must surface
-        # the real "not configured" failure rather than masking it.
+    def test_not_configured_degrades_gracefully_through_router(self):
+        # macro_data is an OPTIONAL (enrichment) category: with only fred and no
+        # key, the router must NOT abort the run — a missing optional key
+        # destroying an expensive, near-complete run is the worst failure mode.
+        # Instead it returns an instructive sentinel so the analyst proceeds
+        # without the macro signal (see interface.OPTIONAL_CATEGORIES).
         set_config({"data_vendors": {"macro_data": "fred"}})
 
         def _unconfigured(*a, **k):
@@ -169,8 +172,10 @@ class FredRoutingTests(unittest.TestCase):
             interface.VENDOR_METHODS,
             {"get_macro_indicators": {"fred": _unconfigured}},
             clear=False,
-        ), self.assertRaises(fred.FredNotConfiguredError):
-            interface.route_to_vendor("get_macro_indicators", "cpi", "2026-06-01", 365)
+        ):
+            out = interface.route_to_vendor("get_macro_indicators", "cpi", "2026-06-01", 365)
+        self.assertIn("optional data source unavailable", out.lower())
+        self.assertIn("FRED_API_KEY not set", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_optional_source_degradation.py
+++ b/tests/test_optional_source_degradation.py
@@ -1,0 +1,82 @@
+"""Optional/enrichment data sources degrade to a sentinel instead of aborting
+the run; core data sources still raise so a broken primary stays loud.
+
+Regression for the FRED crash: a missing FRED_API_KEY (macro_data) raised
+VendorNotConfiguredError up through the news node and killed an otherwise-
+complete LangGraph run.
+"""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import patch
+
+import pytest
+
+import tradingagents.dataflows.config as config_module
+import tradingagents.default_config as default_config
+from tradingagents.dataflows import interface
+from tradingagents.dataflows.errors import NoMarketDataError, VendorNotConfiguredError
+
+
+@pytest.fixture(autouse=True)
+def _fresh_config():
+    config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+    yield
+    config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+
+def _patch_impl(method, vendor, fn):
+    return patch.dict(interface.VENDOR_METHODS[method], {vendor: fn})
+
+
+@pytest.mark.unit
+def test_macro_missing_key_returns_sentinel_not_raises():
+    """macro_data is optional: a missing key degrades, never raises."""
+    def _missing_key(*_a, **_k):
+        raise VendorNotConfiguredError("FRED_API_KEY environment variable is not set.")
+
+    with _patch_impl("get_macro_indicators", "fred", _missing_key):
+        out = interface.route_to_vendor("get_macro_indicators", "cpi", "2026-06-12")
+
+    assert "optional data source unavailable" in out.lower()
+    assert "do not estimate or fabricate" in out.lower()
+
+
+@pytest.mark.unit
+def test_prediction_markets_network_error_returns_sentinel():
+    """prediction_markets is optional: a hard error degrades, never raises."""
+    def _boom(*_a, **_k):
+        raise RuntimeError("gamma-api.polymarket.com unreachable")
+
+    with _patch_impl("get_prediction_markets", "polymarket", _boom):
+        out = interface.route_to_vendor("get_prediction_markets", "Fed rate cut")
+
+    assert "optional data source unavailable" in out.lower()
+
+
+@pytest.mark.unit
+def test_core_category_still_raises_on_hard_error():
+    """A core category (fundamentals) must still raise — never silently degrade."""
+    config_module._config["data_vendors"]["fundamental_data"] = "yfinance"
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("network down")
+
+    with _patch_impl("get_fundamentals", "yfinance", _boom), \
+            pytest.raises(RuntimeError, match="network down"):
+        interface.route_to_vendor("get_fundamentals", "NVDA", "2026-06-12")
+
+
+@pytest.mark.unit
+def test_market_no_data_sentinel_path_unaffected():
+    """The pre-existing NO_DATA path for NoMarketDataError still wins."""
+    config_module._config["data_vendors"]["core_stock_apis"] = "yfinance"
+
+    def _no_data(*_a, **_k):
+        raise NoMarketDataError("FOOBAR", detail="symbol not found")
+
+    with _patch_impl("get_stock_data", "yfinance", _no_data):
+        out = interface.route_to_vendor("get_stock_data", "FOOBAR", "2026-06-12", "2026-06-12")
+
+    assert out.startswith("NO_DATA_AVAILABLE")

--- a/tests/test_polymarket_resilience.py
+++ b/tests/test_polymarket_resilience.py
@@ -1,0 +1,136 @@
+"""Prediction-market data resilience:
+
+Part A — Polymarket trips a per-session circuit breaker on a *hard* network
+failure (DNS/connection) so it stops re-hitting an unreachable host once per
+topic, but keeps retrying *transient* failures (timeout / HTTP error).
+
+Part B — A category configured "off" routes to a graceful disabled sentinel
+instead of raising or fabricating data.
+"""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import patch
+
+import pytest
+import requests
+
+import tradingagents.dataflows.config as config_module
+import tradingagents.default_config as default_config
+from tradingagents.dataflows import interface, polymarket
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker():
+    """The breaker is process-global; reset it around every test."""
+    polymarket._HOST_UNREACHABLE = False
+    yield
+    polymarket._HOST_UNREACHABLE = False
+
+
+# --------------------------------------------------------------------------- #
+# Part A — circuit breaker
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_hard_failure_trips_breaker_and_skips_repeat_calls():
+    """A ConnectionError trips the breaker; later topics skip the network call."""
+    with patch.object(
+        polymarket, "_request", side_effect=requests.ConnectionError("dns fail")
+    ) as mock_req:
+        first = polymarket.get_prediction_markets("Fed rate cut")
+        second = polymarket.get_prediction_markets("recession 2026")
+        third = polymarket.get_prediction_markets("semiconductor")
+
+    # The host is only actually contacted once — the breaker short-circuits the rest.
+    assert mock_req.call_count == 1
+    assert polymarket._HOST_UNREACHABLE is True
+    assert "unavailable" in first.lower()
+    assert "earlier this session" in second.lower()
+    assert "earlier this session" in third.lower()
+
+
+@pytest.mark.unit
+def test_transient_failure_does_not_trip_breaker():
+    """A timeout is transient — keep trying subsequent topics, breaker stays open."""
+    with patch.object(
+        polymarket, "_request", side_effect=requests.Timeout("slow")
+    ) as mock_req:
+        polymarket.get_prediction_markets("Fed rate cut")
+        polymarket.get_prediction_markets("recession 2026")
+
+    # Both topics were attempted; the breaker did NOT trip.
+    assert mock_req.call_count == 2
+    assert polymarket._HOST_UNREACHABLE is False
+
+
+@pytest.mark.unit
+def test_success_path_unaffected():
+    """A normal response still parses (breaker logic doesn't intercept success)."""
+    payload = {
+        "events": [
+            {
+                "markets": [
+                    {
+                        "question": "Fed cuts in July?",
+                        "closed": False,
+                        "endDate": "2030-07-31T00:00:00Z",
+                        "outcomes": '["Yes", "No"]',
+                        "outcomePrices": '["0.76", "0.24"]',
+                        "volumeNum": 1_000_000,
+                    }
+                ]
+            }
+        ]
+    }
+    with patch.object(polymarket, "_request", return_value=payload):
+        out = polymarket.get_prediction_markets("Fed rate cut")
+    assert "Fed cuts in July?" in out
+    assert "76%" in out
+    assert polymarket._HOST_UNREACHABLE is False
+
+
+# --------------------------------------------------------------------------- #
+# Part B — "off" switch in route_to_vendor
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+@pytest.mark.parametrize("off_value", ["off", "none", "disabled", "", "OFF"])
+def test_disabled_category_returns_sentinel_without_calling_vendor(off_value):
+    """Setting a category to an off-sentinel skips the source gracefully.
+
+    The disabled check returns before the routing table is consulted, so we
+    additionally swap the impl for one that fails loudly if ever invoked.
+    """
+    config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+    config_module._config["data_vendors"]["prediction_markets"] = off_value
+
+    def _boom(*_a, **_k):
+        raise AssertionError("vendor impl should not be called when disabled")
+
+    with patch.dict(
+        interface.VENDOR_METHODS["get_prediction_markets"], {"polymarket": _boom}
+    ):
+        out = interface.route_to_vendor("get_prediction_markets", "Fed rate cut")
+
+    assert "disabled in configuration" in out.lower()
+    assert "prediction_markets" in out
+
+
+@pytest.mark.unit
+def test_enabled_category_still_routes_normally():
+    """A normally-configured category is unaffected by the disable check.
+
+    Patch the routing-table entry itself — ``interface`` binds the vendor
+    function into ``VENDOR_METHODS`` at import time, so patching the source
+    module's attribute would not be seen by the router.
+    """
+    config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+    config_module._config["data_vendors"]["prediction_markets"] = "polymarket"
+
+    with patch.dict(
+        interface.VENDOR_METHODS["get_prediction_markets"],
+        {"polymarket": lambda *a, **k: "ROUTED OK"},
+    ):
+        out = interface.route_to_vendor("get_prediction_markets", "Fed rate cut")
+
+    assert out == "ROUTED OK"

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -158,10 +158,26 @@ def get_vendor(category: str, method: str = None) -> str:
     # Fall back to category-level configuration
     return config.get("data_vendors", {}).get(category, "default")
 
+# Configured vendor values that mean "this data source is turned off". Setting a
+# category to one of these skips the call gracefully instead of erroring, so an
+# optional/flaky source (e.g. prediction_markets) or one whose key is absent
+# (e.g. macro_data) never aborts a run.
+DISABLED_VENDOR_SENTINELS = {"", "none", "off", "disabled"}
+
+
 def route_to_vendor(method: str, *args, **kwargs):
     """Route method calls to appropriate vendor implementation with fallback support."""
     category = get_category_for_method(method)
     vendor_config = get_vendor(category, method)
+
+    # An explicit "off" switch: skip the source with an instructive sentinel
+    # rather than raising or fabricating data.
+    if vendor_config is None or str(vendor_config).strip().lower() in DISABLED_VENDOR_SENTINELS:
+        return (
+            f"{method}: this data source is disabled in configuration "
+            f"(data_vendors[{category!r}]). Proceed without it."
+        )
+
     primary_vendors = [v.strip() for v in vendor_config.split(',')]
 
     if method not in VENDOR_METHODS:

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -164,6 +164,14 @@ def get_vendor(category: str, method: str = None) -> str:
 # (e.g. macro_data) never aborts a run.
 DISABLED_VENDOR_SENTINELS = {"", "none", "off", "disabled"}
 
+# Categories whose data merely *enriches* a run rather than anchoring it. When
+# every configured vendor for one of these fails (missing key, network error),
+# the router returns an instructive sentinel instead of raising — a missing
+# optional source must never abort an expensive, near-complete run. Core
+# categories (price/indicators/fundamentals) still raise so a broken primary is
+# loud. Market data has its own NO_DATA sentinel path and is unaffected.
+OPTIONAL_CATEGORIES = {"macro_data", "prediction_markets"}
+
 
 def route_to_vendor(method: str, *args, **kwargs):
     """Route method calls to appropriate vendor implementation with fallback support."""
@@ -258,6 +266,19 @@ def route_to_vendor(method: str, *args, **kwargs):
     # No vendor returned data and none reported clean "no data" — surface the
     # first real error (e.g. the primary vendor's network failure).
     if first_error is not None:
+        # Enrichment categories degrade to a sentinel rather than aborting the
+        # run: a missing FRED_API_KEY (macro) or an unreachable Polymarket host
+        # should leave the analyst to proceed without that signal, not crash a
+        # graph that is dozens of paid LLM calls deep.
+        if category in OPTIONAL_CATEGORIES:
+            logger.warning(
+                "Optional data source for %s unavailable (%s); continuing without it.",
+                method, first_error,
+            )
+            return (
+                f"{method}: optional data source unavailable ({first_error}). "
+                f"Proceed without this signal — do not estimate or fabricate values."
+            )
         raise first_error
 
     raise RuntimeError(f"No available vendor for '{method}'")

--- a/tradingagents/dataflows/polymarket.py
+++ b/tradingagents/dataflows/polymarket.py
@@ -25,6 +25,11 @@ REQUEST_TIMEOUT = 30
 # Default number of markets to return, ranked by traded volume.
 DEFAULT_LIMIT = 6
 
+# Tripped once per process when the Gamma host is hard-unreachable (DNS failure,
+# connection refused). A dead host won't recover mid-run, so once tripped we skip
+# further lookups instead of re-hitting it for every topic the analyst queries.
+_HOST_UNREACHABLE = False
+
 
 def _request(path: str, params: dict) -> dict:
     response = requests.get(
@@ -79,12 +84,37 @@ def get_prediction_markets(topic: str, limit: int | None = None) -> str:
         each with its implied probability, traded volume, resolution date, and
         recent (1-week) move.
     """
+    global _HOST_UNREACHABLE
     if limit is None:
         limit = DEFAULT_LIMIT
 
+    if _HOST_UNREACHABLE:
+        # Breaker already tripped this session — don't re-hit a host we know is
+        # down. Stay silent (we logged once when it tripped) to avoid noise.
+        return (
+            f"Polymarket was unreachable earlier this session; skipping "
+            f"prediction-market signal for '{topic}'."
+        )
+
     try:
         data = _request("public-search", {"q": topic, "limit_per_type": 20})
+    except requests.ConnectionError as e:
+        # Hard network failure (DNS / refused / unreachable) — won't recover
+        # mid-run. Trip the breaker so subsequent topics skip the call, and log
+        # once instead of once-per-topic.
+        _HOST_UNREACHABLE = True
+        logger.warning(
+            "Polymarket host unreachable (%s); disabling prediction-market "
+            "lookups for the rest of this session.",
+            e,
+        )
+        return (
+            f"Polymarket data is currently unavailable (network error: {e}). "
+            f"Proceed without prediction-market signal for '{topic}'."
+        )
     except requests.RequestException as e:
+        # Transient failure (timeout / HTTP error) — may succeed for another
+        # topic, so keep trying; just report this one as unavailable.
         logger.warning("Polymarket search failed for %r: %s", topic, e)
         return (
             f"Polymarket data is currently unavailable (network error: {e}). "


### PR DESCRIPTION
## Summary

Three independent fixes so non-critical data vendors can't spam logs, waste retries, or abort an expensive run. All surfaced running the full pipeline where Polymarket's API was unreachable and an optional macro key was absent.

### 1. Polymarket circuit breaker (`dataflows/polymarket.py`)
`get_prediction_markets` is called once per analyst topic. When the Gamma host is hard-unreachable (DNS / connection refused), the old code re-attempted and re-logged for **every** topic. Now a **hard** failure (`requests.ConnectionError`) trips a per-process breaker — logged once, subsequent topics short-circuit — while **transient** failures (timeout / HTTP) keep retrying.

### 2. "Off" switch in `route_to_vendor` (`dataflows/interface.py`)
Setting a category to `""`/`none`/`off`/`disabled` previously built an empty vendor chain and raised `ValueError`. It now returns a graceful "disabled in configuration" sentinel, letting users opt out of a flaky/irrelevant source. Example: `config["data_vendors"]["prediction_markets"] = "off"`.

### 3. Graceful degradation of optional sources (`dataflows/interface.py`)
`route_to_vendor` raised `first_error` when no vendor could serve a method. For an **enrichment** category with a single vendor (`macro_data` → fred, `prediction_markets` → polymarket), a missing `FRED_API_KEY` or unreachable host propagated up and **aborted the whole LangGraph run** — dozens of paid LLM calls deep. Now `OPTIONAL_CATEGORIES = {macro_data, prediction_markets}` degrade to an instructive sentinel (mirroring the existing `NO_DATA_AVAILABLE` path) so the analyst proceeds without that signal. Core categories (price/indicators/fundamentals) still raise, so a broken primary stays loud.

## Tests
- `tests/test_polymarket_resilience.py` (9) — breaker trips on hard failure & skips repeats; transient failures don't trip it; success path intact; disabled category routes to sentinel without invoking the vendor.
- `tests/test_optional_source_degradation.py` (4) — optional sources degrade; core categories still raise; the existing NO_DATA path is preserved.
- Updates the FRED router test to the new contract (degrade, don't raise).

`ruff check` clean; related vendor/routing suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)