### PR TITLE
feat: preflight validation, report parity, usage/cost accounting, run manifest

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -48,6 +48,7 @@ from tradingagents.graph.analyst_execution import (
     sync_analyst_tracker_from_chunk,
 )
 from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.reporting import write_reports
 
 console = Console()
 
@@ -724,93 +725,12 @@ def get_analysis_date():
 
 
 def save_report_to_disk(final_state, ticker: str, save_path: Path):
-    """Save complete analysis report to disk with organized subfolders."""
-    save_path.mkdir(parents=True, exist_ok=True)
-    sections = []
+    """Save complete analysis report to disk with organized subfolders.
 
-    # 1. Analysts
-    analysts_dir = save_path / "1_analysts"
-    analyst_parts = []
-    if final_state.get("market_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "market.md").write_text(final_state["market_report"], encoding="utf-8")
-        analyst_parts.append(("Market Analyst", final_state["market_report"]))
-    if final_state.get("sentiment_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "sentiment.md").write_text(final_state["sentiment_report"], encoding="utf-8")
-        analyst_parts.append(("Sentiment Analyst", final_state["sentiment_report"]))
-    if final_state.get("news_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "news.md").write_text(final_state["news_report"], encoding="utf-8")
-        analyst_parts.append(("News Analyst", final_state["news_report"]))
-    if final_state.get("fundamentals_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
-        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
-    if analyst_parts:
-        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
-        sections.append(f"## I. Analyst Team Reports\n\n{content}")
-
-    # 2. Research
-    if final_state.get("investment_debate_state"):
-        research_dir = save_path / "2_research"
-        debate = final_state["investment_debate_state"]
-        research_parts = []
-        if debate.get("bull_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bull.md").write_text(debate["bull_history"], encoding="utf-8")
-            research_parts.append(("Bull Researcher", debate["bull_history"]))
-        if debate.get("bear_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bear.md").write_text(debate["bear_history"], encoding="utf-8")
-            research_parts.append(("Bear Researcher", debate["bear_history"]))
-        if debate.get("judge_decision"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "manager.md").write_text(debate["judge_decision"], encoding="utf-8")
-            research_parts.append(("Research Manager", debate["judge_decision"]))
-        if research_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
-            sections.append(f"## II. Research Team Decision\n\n{content}")
-
-    # 3. Trading
-    if final_state.get("trader_investment_plan"):
-        trading_dir = save_path / "3_trading"
-        trading_dir.mkdir(exist_ok=True)
-        (trading_dir / "trader.md").write_text(final_state["trader_investment_plan"], encoding="utf-8")
-        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}")
-
-    # 4. Risk Management
-    if final_state.get("risk_debate_state"):
-        risk_dir = save_path / "4_risk"
-        risk = final_state["risk_debate_state"]
-        risk_parts = []
-        if risk.get("aggressive_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "aggressive.md").write_text(risk["aggressive_history"], encoding="utf-8")
-            risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
-        if risk.get("conservative_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "conservative.md").write_text(risk["conservative_history"], encoding="utf-8")
-            risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
-        if risk.get("neutral_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "neutral.md").write_text(risk["neutral_history"], encoding="utf-8")
-            risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
-        if risk_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
-            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
-
-        # 5. Portfolio Manager
-        if risk.get("judge_decision"):
-            portfolio_dir = save_path / "5_portfolio"
-            portfolio_dir.mkdir(exist_ok=True)
-            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
-            sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
-
-    # Write consolidated report
-    header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-    (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
-    return save_path / "complete_report.md"
+    Thin wrapper around the reusable library function so the CLI and the Python
+    API produce identical report trees (see tradingagents.reporting.write_reports).
+    """
+    return write_reports(final_state, ticker, save_path)
 
 
 def display_complete_report(final_state):

--- a/cli/stats_handler.py
+++ b/cli/stats_handler.py
@@ -1,76 +1,22 @@
-import threading
 from typing import Any
 
-from langchain_core.callbacks import BaseCallbackHandler
-from langchain_core.messages import AIMessage
-from langchain_core.outputs import LLMResult
+from tradingagents.usage import UsageTrackingCallback
 
 
-class StatsCallbackHandler(BaseCallbackHandler):
-    """Callback handler that tracks LLM calls, tool calls, and token usage."""
+class StatsCallbackHandler(UsageTrackingCallback):
+    """CLI live-display handler: the shared usage tracker plus a get_stats() shim.
 
-    def __init__(self) -> None:
-        super().__init__()
-        self._lock = threading.Lock()
-        self.llm_calls = 0
-        self.tool_calls = 0
-        self.tokens_in = 0
-        self.tokens_out = 0
-
-    def on_llm_start(
-        self,
-        serialized: dict[str, Any],
-        prompts: list[str],
-        **kwargs: Any,
-    ) -> None:
-        """Increment LLM call counter when an LLM starts."""
-        with self._lock:
-            self.llm_calls += 1
-
-    def on_chat_model_start(
-        self,
-        serialized: dict[str, Any],
-        messages: list[list[Any]],
-        **kwargs: Any,
-    ) -> None:
-        """Increment LLM call counter when a chat model starts."""
-        with self._lock:
-            self.llm_calls += 1
-
-    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        """Extract token usage from LLM response."""
-        try:
-            generation = response.generations[0][0]
-        except (IndexError, TypeError):
-            return
-
-        usage_metadata = None
-        if hasattr(generation, "message"):
-            message = generation.message
-            if isinstance(message, AIMessage) and hasattr(message, "usage_metadata"):
-                usage_metadata = message.usage_metadata
-
-        if usage_metadata:
-            with self._lock:
-                self.tokens_in += usage_metadata.get("input_tokens", 0)
-                self.tokens_out += usage_metadata.get("output_tokens", 0)
-
-    def on_tool_start(
-        self,
-        serialized: dict[str, Any],
-        input_str: str,
-        **kwargs: Any,
-    ) -> None:
-        """Increment tool call counter when a tool starts."""
-        with self._lock:
-            self.tool_calls += 1
+    Token/call tracking lives in tradingagents.usage.UsageTrackingCallback (the
+    single source of truth used by both the CLI and the Python API); this
+    subclass only preserves the dict shape the CLI status panel expects.
+    """
 
     def get_stats(self) -> dict[str, Any]:
-        """Return current statistics."""
-        with self._lock:
-            return {
-                "llm_calls": self.llm_calls,
-                "tool_calls": self.tool_calls,
-                "tokens_in": self.tokens_in,
-                "tokens_out": self.tokens_out,
-            }
+        """Return current statistics in the CLI's expected shape."""
+        s = self.summary()
+        return {
+            "llm_calls": s["llm_calls"],
+            "tool_calls": s["tool_calls"],
+            "tokens_in": s["tokens_in"],
+            "tokens_out": s["tokens_out"],
+        }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,77 @@
+"""The run manifest records model/provider, key-presence (booleans only), data
+coverage, analysts, and usage — and never leaks secret values."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import tradingagents.default_config as default_config
+from tradingagents.config_validation import validate_config
+from tradingagents.manifest import build_manifest
+from tradingagents.usage import UsageTrackingCallback
+
+
+def _config(**overrides):
+    cfg = copy.deepcopy(default_config.DEFAULT_CONFIG)
+    cfg["llm_provider"] = "openrouter"
+    cfg["deep_think_llm"] = "minimax/minimax-m2.7"
+    cfg["quick_think_llm"] = "minimax/minimax-m2.7"
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.mark.unit
+def test_manifest_core_fields():
+    env = {"OPENROUTER_API_KEY": "secret-value", "FRED_API_KEY": "another-secret"}
+    m = build_manifest(_config(), "NVDA", "2026-06-12", ["market", "news"], env=env)
+
+    assert m["ticker"] == "NVDA"
+    assert m["trade_date"] == "2026-06-12"
+    assert m["selected_analysts"] == ["market", "news"]
+    assert m["llm"]["provider"] == "openrouter"
+    assert m["llm"]["deep_think_llm"] == "minimax/minimax-m2.7"
+    assert "data_vendors" in m
+
+
+@pytest.mark.unit
+def test_manifest_records_presence_not_values():
+    env = {"OPENROUTER_API_KEY": "sk-or-SECRET", "FRED_API_KEY": ""}
+    m = build_manifest(_config(), "NVDA", "2026-06-12", ["news"], env=env)
+
+    present = m["api_keys_present"]
+    assert present["OPENROUTER_API_KEY"] is True   # set
+    assert present["FRED_API_KEY"] is False        # empty
+    assert present["ALPHA_VANTAGE_API_KEY"] is False  # absent
+
+    # Crucially: no secret value appears anywhere in the manifest.
+    blob = repr(m)
+    assert "sk-or-SECRET" not in blob
+    assert "secret" not in blob.lower() or "secret-value" not in blob
+
+
+@pytest.mark.unit
+def test_manifest_includes_preflight_and_usage():
+    env = {"OPENROUTER_API_KEY": "x"}  # no FRED -> macro optional miss
+    preflight = validate_config(["news"], _config(), env=env)
+
+    usage = UsageTrackingCallback(model_prices={"input": 0.3, "output": 1.2})
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, LLMResult
+    usage.on_chat_model_start({}, [[]])
+    usage.on_llm_end(
+        LLMResult(generations=[[ChatGeneration(
+            message=AIMessage(content="ok", usage_metadata={
+                "input_tokens": 100, "output_tokens": 50, "total_tokens": 150})
+        )]])
+    )
+
+    m = build_manifest(_config(), "NVDA", "2026-06-12", ["news"],
+                       preflight=preflight, usage=usage, env=env)
+
+    assert m["preflight"]["ok"] is True
+    assert "macro_data" in m["preflight"]["missing_optional"]
+    assert m["usage"]["llm_calls"] == 1
+    assert m["usage"]["tokens_total"] == 150
+    assert m["usage"]["estimated_cost_usd"] == pytest.approx(100 / 1e6 * 0.3 + 50 / 1e6 * 1.2)

--- a/tests/test_preflight_validation.py
+++ b/tests/test_preflight_validation.py
@@ -1,0 +1,93 @@
+"""Preflight validation maps selected analysts -> data categories -> required
+keys and reports missing sources at startup, before a run begins."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import tradingagents.default_config as default_config
+from tradingagents.config_validation import (
+    enforce_preflight,
+    validate_config,
+)
+
+
+def _config(**vendor_overrides):
+    cfg = copy.deepcopy(default_config.DEFAULT_CONFIG)
+    cfg["data_vendors"].update(vendor_overrides)
+    return cfg
+
+
+@pytest.mark.unit
+def test_macro_missing_fred_key_is_optional_warning():
+    """News analyst without FRED_API_KEY: warned, not fatal (macro is optional)."""
+    env = {}  # no FRED_API_KEY
+    res = validate_config(["news"], _config(), env=env)
+    assert res.ok is True
+    assert "macro_data" in res.missing_optional
+    assert any("macro_data" in w and "skipped" in w for w in res.warnings)
+
+
+@pytest.mark.unit
+def test_keyless_defaults_produce_no_warnings():
+    """Default vendors are keyless (yfinance/polymarket) except macro; market +
+    fundamentals + social need no keys."""
+    env = {}
+    res = validate_config(["market", "social", "fundamentals"], _config(), env=env)
+    assert res.ok is True
+    assert res.warnings == []
+
+
+@pytest.mark.unit
+def test_alpha_vantage_only_without_key_is_required_error():
+    """Forcing a core category onto alpha_vantage with no key is a hard miss."""
+    env = {}  # no ALPHA_VANTAGE_API_KEY
+    cfg = _config(core_stock_apis="alpha_vantage", technical_indicators="alpha_vantage")
+    res = validate_config(["market"], cfg, env=env)
+    assert res.ok is False
+    assert "core_stock_apis" in res.missing_required
+    assert any("ALPHA_VANTAGE_API_KEY" in w for w in res.warnings)
+
+
+@pytest.mark.unit
+def test_alpha_vantage_with_key_present_is_ok():
+    env = {"ALPHA_VANTAGE_API_KEY": "present"}
+    cfg = _config(core_stock_apis="alpha_vantage")
+    res = validate_config(["market"], cfg, env=env)
+    assert res.ok is True
+
+
+@pytest.mark.unit
+def test_disabled_category_is_skipped_not_flagged():
+    """An explicitly 'off' category isn't a missing source."""
+    env = {}
+    cfg = _config(macro_data="off", prediction_markets="off")
+    res = validate_config(["news"], cfg, env=env)
+    assert res.ok is True
+    assert res.missing_optional == []
+
+
+@pytest.mark.unit
+def test_enforce_strict_raises_on_required_miss():
+    env_cfg = _config(core_stock_apis="alpha_vantage")
+    # enforce_preflight reads os.environ; clear the key for this check.
+    import os
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, {}, clear=True), \
+            pytest.raises(ValueError, match="missing required data sources"):
+        enforce_preflight(["market"], env_cfg, strict=True)
+
+
+@pytest.mark.unit
+def test_enforce_non_strict_returns_result_without_raising():
+    import os
+    from unittest.mock import patch
+
+    cfg = _config(core_stock_apis="alpha_vantage")
+    with patch.dict(os.environ, {}, clear=True):
+        res = enforce_preflight(["market"], cfg, strict=False)
+    assert res.ok is False
+    assert "core_stock_apis" in res.missing_required

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,85 @@
+"""The report tree is written by a reusable library function (not locked inside
+the CLI), so the CLI and the Python API produce identical artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from tradingagents.reporting import write_reports
+
+
+def _full_state():
+    return {
+        "company_of_interest": "NVDA",
+        "trade_date": "2026-06-12",
+        "market_report": "Market looks strong.",
+        "sentiment_report": "Sentiment positive.",
+        "news_report": "News neutral.",
+        "fundamentals_report": "Fundamentals solid.",
+        "investment_debate_state": {
+            "bull_history": "Bull case.",
+            "bear_history": "Bear case.",
+            "history": "...",
+            "current_response": "...",
+            "judge_decision": "Research manager says buy.",
+        },
+        "trader_investment_plan": "Trader: buy with stop.",
+        "risk_debate_state": {
+            "aggressive_history": "Aggressive: lean in.",
+            "conservative_history": "Conservative: trim.",
+            "neutral_history": "Neutral: balanced.",
+            "history": "...",
+            "judge_decision": "Final: Buy.",
+        },
+        "investment_plan": "Plan.",
+        "final_trade_decision": "Buy",
+    }
+
+
+@pytest.mark.unit
+def test_write_reports_full_tree(tmp_path):
+    report = write_reports(_full_state(), "NVDA", tmp_path)
+
+    assert report == tmp_path / "complete_report.md"
+    # Per-section files
+    assert (tmp_path / "1_analysts" / "market.md").read_text() == "Market looks strong."
+    assert (tmp_path / "1_analysts" / "fundamentals.md").exists()
+    assert (tmp_path / "2_research" / "bull.md").read_text() == "Bull case."
+    assert (tmp_path / "2_research" / "manager.md").exists()
+    assert (tmp_path / "3_trading" / "trader.md").exists()
+    assert (tmp_path / "4_risk" / "neutral.md").exists()
+    assert (tmp_path / "5_portfolio" / "decision.md").read_text() == "Final: Buy."
+
+    # Consolidated report stitches the sections together
+    text = report.read_text()
+    assert "# Trading Analysis Report: NVDA" in text
+    assert "I. Analyst Team Reports" in text
+    assert "V. Portfolio Manager Decision" in text
+
+
+@pytest.mark.unit
+def test_write_reports_omits_absent_sections(tmp_path):
+    """A run with only a market analyst writes no research/risk folders."""
+    state = {
+        "company_of_interest": "NVDA",
+        "trade_date": "2026-06-12",
+        "market_report": "Only market.",
+        "investment_debate_state": {},
+        "risk_debate_state": {},
+    }
+    write_reports(state, "NVDA", tmp_path)
+
+    assert (tmp_path / "1_analysts" / "market.md").exists()
+    assert not (tmp_path / "2_research").exists()
+    assert not (tmp_path / "4_risk").exists()
+    assert not (tmp_path / "5_portfolio").exists()
+
+
+@pytest.mark.unit
+def test_cli_wrapper_delegates_to_library(tmp_path):
+    """cli.save_report_to_disk is now a thin wrapper over the library function."""
+    from cli.main import save_report_to_disk
+
+    out = save_report_to_disk(_full_state(), "NVDA", tmp_path)
+    assert out == tmp_path / "complete_report.md"
+    assert out.exists()

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -1,0 +1,76 @@
+"""Usage tracking aggregates token/call counts and (optionally) estimates cost."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from tradingagents.usage import UsageTrackingCallback
+
+
+def _llm_result(input_tokens: int, output_tokens: int) -> LLMResult:
+    msg = AIMessage(
+        content="ok",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    )
+    return LLMResult(generations=[[ChatGeneration(message=msg)]])
+
+
+@pytest.mark.unit
+def test_aggregates_calls_and_tokens():
+    cb = UsageTrackingCallback()
+    cb.on_chat_model_start({}, [[]])
+    cb.on_llm_end(_llm_result(100, 50))
+    cb.on_chat_model_start({}, [[]])
+    cb.on_llm_end(_llm_result(200, 25))
+    cb.on_tool_start({}, "input")
+
+    s = cb.summary()
+    assert s["llm_calls"] == 2
+    assert s["tool_calls"] == 1
+    assert s["tokens_in"] == 300
+    assert s["tokens_out"] == 75
+    assert s["tokens_total"] == 375
+
+
+@pytest.mark.unit
+def test_cost_none_without_prices():
+    cb = UsageTrackingCallback()
+    cb.on_llm_end(_llm_result(1000, 1000))
+    assert cb.estimated_cost_usd() is None
+    assert "set config['model_prices']" in cb.format_summary()
+
+
+@pytest.mark.unit
+def test_cost_estimate_with_prices():
+    # $0.30 / 1M input, $1.20 / 1M output
+    cb = UsageTrackingCallback(model_prices={"input": 0.30, "output": 1.20})
+    cb.on_llm_end(_llm_result(1_000_000, 500_000))
+    # 1M * 0.30 + 0.5M * 1.20 = 0.30 + 0.60 = 0.90
+    assert cb.estimated_cost_usd() == pytest.approx(0.90)
+    assert "est. cost $0.9000" in cb.format_summary()
+
+
+@pytest.mark.unit
+def test_malformed_response_is_ignored():
+    cb = UsageTrackingCallback()
+    cb.on_llm_end(LLMResult(generations=[[]]))  # no generations -> no crash
+    assert cb.summary()["tokens_total"] == 0
+
+
+@pytest.mark.unit
+def test_cli_handler_is_a_usage_tracker():
+    """The CLI handler subclasses the library tracker and keeps get_stats()."""
+    from cli.stats_handler import StatsCallbackHandler
+
+    cb = StatsCallbackHandler()
+    assert isinstance(cb, UsageTrackingCallback)
+    cb.on_chat_model_start({}, [[]])
+    cb.on_llm_end(_llm_result(10, 5))
+    stats = cb.get_stats()
+    assert stats == {"llm_calls": 1, "tool_calls": 0, "tokens_in": 10, "tokens_out": 5}

--- a/tradingagents/config_validation.py
+++ b/tradingagents/config_validation.py
@@ -1,0 +1,157 @@
+"""Preflight configuration validation.
+
+Catch missing data-source API keys at startup (second 0) rather than deep
+inside an analyst node after minutes of paid LLM calls. Maps the selected
+analysts to the data categories they can call, resolves each category's
+configured vendor chain, and checks whether at least one vendor in that chain
+is usable (keyless, or its API key is present in the environment).
+
+Missing *optional* (enrichment) sources only warn — the router degrades them
+gracefully at runtime (see ``dataflows.interface.OPTIONAL_CATEGORIES``). Missing
+*required* (core) sources are reported as errors and, when ``strict`` is set,
+raise before the run starts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# Data vendor -> environment variable holding its API key (None = keyless).
+VENDOR_API_KEY_ENV: dict[str, str | None] = {
+    "yfinance": None,
+    "polymarket": None,
+    "fred": "FRED_API_KEY",
+    "alpha_vantage": "ALPHA_VANTAGE_API_KEY",
+}
+
+# Which data categories each analyst type can pull from (mirrors the ToolNode
+# wiring in TradingAgentsGraph._create_tool_nodes).
+ANALYST_CATEGORIES: dict[str, list[str]] = {
+    "market": ["core_stock_apis", "technical_indicators"],
+    "social": ["news_data"],
+    "news": ["news_data", "macro_data", "prediction_markets"],
+    "fundamentals": ["fundamental_data"],
+}
+
+# Enrichment categories — missing keys here are non-fatal (kept in sync with
+# dataflows.interface.OPTIONAL_CATEGORIES).
+OPTIONAL_CATEGORIES = {"macro_data", "prediction_markets"}
+
+# Values that mean "this category is turned off" (kept in sync with
+# dataflows.interface.DISABLED_VENDOR_SENTINELS). A disabled category is skipped,
+# not reported as a missing source.
+DISABLED_VENDOR_SENTINELS = {"", "none", "off", "disabled"}
+
+
+@dataclass
+class PreflightResult:
+    """Outcome of validate_config."""
+
+    ok: bool = True  # False when a required (core) category is unsatisfiable
+    warnings: list[str] = field(default_factory=list)
+    missing_required: list[str] = field(default_factory=list)
+    missing_optional: list[str] = field(default_factory=list)
+
+
+def _category_vendors(category: str) -> list[str]:
+    """All vendors that can serve any tool in ``category`` (lazy import to keep
+    this module cheap to import)."""
+    from tradingagents.dataflows.interface import TOOLS_CATEGORIES, VENDOR_METHODS
+
+    vendors: list[str] = []
+    for tool in TOOLS_CATEGORIES.get(category, {}).get("tools", []):
+        for vendor in VENDOR_METHODS.get(tool, {}):
+            if vendor not in vendors:
+                vendors.append(vendor)
+    return vendors
+
+
+def _configured_chain(config: dict, category: str) -> list[str]:
+    """The vendor chain for ``category``: the explicit config, or — for the
+    "default" sentinel / unset — all vendors that can serve the category."""
+    raw = config.get("data_vendors", {}).get(category, "default")
+    if raw is None or str(raw).strip().lower() in DISABLED_VENDOR_SENTINELS:
+        return []  # disabled -> skipped, not a missing source
+    explicit = [v.strip() for v in str(raw).split(",") if v.strip() and v.strip() != "default"]
+    return explicit if explicit else _category_vendors(category)
+
+
+def _vendor_usable(vendor: str, env: dict) -> bool:
+    """A vendor is usable if it's keyless or its API-key env var is set."""
+    key_env = VENDOR_API_KEY_ENV.get(vendor)
+    if key_env is None:  # keyless (or unknown vendor — don't block on it)
+        return vendor in VENDOR_API_KEY_ENV  # known keyless -> usable
+    return bool(env.get(key_env))
+
+
+def validate_config(
+    selected_analysts, config: dict, env: dict | None = None
+) -> PreflightResult:
+    """Check that the data sources the selected analysts need are usable.
+
+    Args:
+        selected_analysts: iterable of analyst names ("market", "news", ...).
+        config: the resolved run config (uses ``config["data_vendors"]``).
+        env: environment mapping to check keys against (defaults to os.environ).
+
+    Returns:
+        PreflightResult with human-readable warnings and the missing categories.
+    """
+    env = os.environ if env is None else env
+    result = PreflightResult()
+
+    # Unique categories across the selected analysts, in a stable order.
+    categories: list[str] = []
+    for analyst in selected_analysts:
+        for cat in ANALYST_CATEGORIES.get(analyst, []):
+            if cat not in categories:
+                categories.append(cat)
+
+    for category in categories:
+        chain = _configured_chain(config, category)
+        if not chain:
+            # Category explicitly disabled ("off"/"none"); handled at runtime.
+            continue
+        if any(_vendor_usable(v, env) for v in chain):
+            continue
+
+        # No vendor in the chain is usable — collect the keys that would fix it.
+        needed = sorted(
+            {VENDOR_API_KEY_ENV[v] for v in chain if VENDOR_API_KEY_ENV.get(v)}
+        )
+        keys_hint = " or ".join(needed) if needed else "(no API key configured)"
+        if category in OPTIONAL_CATEGORIES:
+            result.missing_optional.append(category)
+            result.warnings.append(
+                f"Optional data source '{category}' has no usable vendor "
+                f"(set {keys_hint}); it will be skipped at runtime."
+            )
+        else:
+            result.ok = False
+            result.missing_required.append(category)
+            result.warnings.append(
+                f"Required data source '{category}' has no usable vendor "
+                f"(set {keys_hint}); analysts depending on it may fail."
+            )
+
+    return result
+
+
+def enforce_preflight(selected_analysts, config: dict, strict: bool = False) -> PreflightResult:
+    """Run validate_config, log every warning loudly, and (if strict) raise on a
+    missing *required* source. Returns the result for callers/tests."""
+    result = validate_config(selected_analysts, config)
+    for warning in result.warnings:
+        logger.warning("preflight: %s", warning)
+    if not result.ok and strict:
+        raise ValueError(
+            "Preflight check failed — missing required data sources: "
+            f"{', '.join(result.missing_required)}. "
+            "Set the indicated API keys, disable those categories in "
+            "config['data_vendors'], or drop the analysts that need them."
+        )
+    return result

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -28,10 +28,14 @@ from tradingagents.agents.utils.agent_utils import (
     resolve_instrument_identity,
 )
 from tradingagents.agents.utils.memory import TradingMemoryLog
+from tradingagents.config_validation import enforce_preflight
 from tradingagents.dataflows.config import set_config
 from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.llm_clients import create_llm_client
+from tradingagents.manifest import build_manifest
+from tradingagents.reporting import write_reports as _write_reports_tree
+from tradingagents.usage import UsageTrackingCallback
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
 from .conditional_logic import ConditionalLogic
@@ -63,10 +67,31 @@ class TradingAgentsGraph:
         """
         self.debug = debug
         self.config = config or DEFAULT_CONFIG
-        self.callbacks = callbacks or []
+        self.callbacks = list(callbacks or [])
+        self.selected_analysts = list(selected_analysts)
+
+        # Per-run usage/cost accounting. Attached to every LLM (and tool) call so
+        # the run can report tokens in/out + an optional cost estimate. Reuses a
+        # caller-supplied tracker if one was passed in callbacks; otherwise one
+        # is created (unless disabled via config["track_usage"] = False).
+        self.usage = next(
+            (cb for cb in self.callbacks if isinstance(cb, UsageTrackingCallback)), None
+        )
+        if self.usage is None and self.config.get("track_usage", True):
+            self.usage = UsageTrackingCallback(model_prices=self.config.get("model_prices"))
+            self.callbacks.append(self.usage)
 
         # Update the interface's config
         set_config(self.config)
+
+        # Preflight: warn (or, when configured strict, fail) at second 0 if the
+        # selected analysts need data sources whose keys are absent — instead of
+        # discovering it minutes deep into a paid run.
+        self.preflight = enforce_preflight(
+            self.selected_analysts,
+            self.config,
+            strict=bool(self.config.get("preflight_strict", False)),
+        )
 
         # Create necessary directories
         os.makedirs(self.config["data_cache_dir"], exist_ok=True)
@@ -401,6 +426,26 @@ class TradingAgentsGraph:
         # Log state to disk.
         self._log_state(trade_date, final_state)
 
+        # Surface what the run consumed (tokens, calls, optional cost).
+        if self.usage is not None:
+            logger.info(self.usage.format_summary())
+
+        # Write the human-readable markdown report tree (parity with the CLI —
+        # programmatic callers previously only got the JSON blob above).
+        if self.config.get("write_reports", True):
+            try:
+                self.write_reports(trade_date=trade_date)
+            except Exception as e:  # never let reporting break a finished run
+                logger.warning("Failed to write report tree: %s", e)
+
+        # Write an auditable run manifest (model/provider, key-presence,
+        # data-source coverage, analysts, usage) alongside the results.
+        if self.config.get("write_manifest", True):
+            try:
+                self._write_manifest(trade_date)
+            except Exception as e:  # manifest is best-effort, never fatal
+                logger.warning("Failed to write run manifest: %s", e)
+
         # Store decision for deferred reflection on the next same-ticker run.
         self.memory_log.store_decision(
             ticker=company_name,
@@ -457,6 +502,46 @@ class TradingAgentsGraph:
         log_path = directory / f"full_states_log_{trade_date}.json"
         with open(log_path, "w", encoding="utf-8") as f:
             json.dump(self.log_states_dict[str(trade_date)], f, indent=4)
+
+    def _run_output_dir(self, trade_date) -> Path:
+        """Per-run results directory: results_dir/<ticker>/<trade_date> (mirrors
+        the CLI layout)."""
+        safe_ticker = safe_ticker_component(self.ticker)
+        return Path(self.config["results_dir"]) / safe_ticker / str(trade_date)
+
+    def write_reports(self, out_dir=None, trade_date=None) -> Path:
+        """Write the markdown report tree for the most recent run.
+
+        Args:
+            out_dir: destination directory; defaults to
+                results_dir/<ticker>/<trade_date>/reports.
+            trade_date: the run's trade date; defaults to the current state's.
+
+        Returns:
+            Path to the consolidated complete_report.md.
+        """
+        if self.curr_state is None:
+            raise RuntimeError("No completed run to report on; call propagate() first.")
+        td = trade_date or self.curr_state.get("trade_date")
+        out = Path(out_dir) if out_dir else self._run_output_dir(td) / "reports"
+        return _write_reports_tree(self.curr_state, self.ticker, out)
+
+    def _write_manifest(self, trade_date) -> Path:
+        """Write the run manifest (model, key-presence, coverage, usage) as JSON."""
+        manifest = build_manifest(
+            self.config,
+            self.ticker,
+            trade_date,
+            self.selected_analysts,
+            preflight=getattr(self, "preflight", None),
+            usage=self.usage,
+        )
+        out_dir = self._run_output_dir(trade_date)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = out_dir / "manifest.json"
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+        return manifest_path
 
     def process_signal(self, full_signal):
         """Process a signal to extract the core decision."""

--- a/tradingagents/manifest.py
+++ b/tradingagents/manifest.py
@@ -1,0 +1,73 @@
+"""Run manifest.
+
+A small, auditable record written alongside each run's results: what model and
+provider produced it, which API keys were present (booleans only — never the
+values), which data sources were configured/usable, the analysts involved, and
+the usage tally. Makes runs comparable and reproducible-in-intent even though
+LLM output is not bit-identical.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any
+
+from tradingagents.config_validation import VENDOR_API_KEY_ENV
+from tradingagents.llm_clients.api_key_env import get_api_key_env
+
+
+def _relevant_key_envs(config: dict) -> list[str]:
+    """Env-var names worth recording presence for: the LLM provider's key plus
+    every data-vendor key. De-duplicated, stable order."""
+    names: list[str] = []
+    provider = str(config.get("llm_provider", "")).lower()
+    llm_key = get_api_key_env(provider)
+    if llm_key:
+        names.append(llm_key)
+    for key in VENDOR_API_KEY_ENV.values():
+        if key and key not in names:
+            names.append(key)
+    return names
+
+
+def build_manifest(
+    config: dict,
+    ticker: str,
+    trade_date,
+    selected_analysts,
+    preflight: Any | None = None,
+    usage: Any | None = None,
+    env: dict | None = None,
+) -> dict:
+    """Assemble the manifest dict (the graph serializes it to manifest.json)."""
+    env = os.environ if env is None else env
+
+    manifest: dict[str, Any] = {
+        "generated_at": datetime.datetime.now().isoformat(timespec="seconds"),
+        "ticker": ticker,
+        "trade_date": str(trade_date),
+        "selected_analysts": list(selected_analysts),
+        "llm": {
+            "provider": config.get("llm_provider"),
+            "deep_think_llm": config.get("deep_think_llm"),
+            "quick_think_llm": config.get("quick_think_llm"),
+            "backend_url": config.get("backend_url"),
+            "temperature": config.get("temperature"),
+        },
+        "data_vendors": dict(config.get("data_vendors", {})),
+        # Presence only — never the secret values.
+        "api_keys_present": {name: bool(env.get(name)) for name in _relevant_key_envs(config)},
+    }
+
+    if preflight is not None:
+        manifest["preflight"] = {
+            "ok": getattr(preflight, "ok", None),
+            "missing_required": list(getattr(preflight, "missing_required", []) or []),
+            "missing_optional": list(getattr(preflight, "missing_optional", []) or []),
+        }
+
+    if usage is not None:
+        manifest["usage"] = usage.summary() if hasattr(usage, "summary") else dict(usage)
+
+    return manifest

--- a/tradingagents/reporting.py
+++ b/tradingagents/reporting.py
@@ -1,0 +1,119 @@
+"""Reusable report writing.
+
+Turns a finished run's ``final_state`` into an organized markdown report tree on
+disk. Previously this logic lived inside ``cli/main.py`` and was reachable only
+through the interactive CLI; programmatic callers (``TradingAgentsGraph``) got a
+single JSON blob instead. This module is the single source of truth so both
+paths produce identical artifacts.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+
+def write_reports(final_state: dict, ticker: str, out_dir: str | Path) -> Path:
+    """Write the full analysis as an organized markdown tree under ``out_dir``.
+
+    Layout::
+
+        out_dir/
+        ├── 1_analysts/      market.md, sentiment.md, news.md, fundamentals.md
+        ├── 2_research/      bull.md, bear.md, manager.md
+        ├── 3_trading/       trader.md
+        ├── 4_risk/          aggressive.md, conservative.md, neutral.md
+        ├── 5_portfolio/     decision.md
+        └── complete_report.md   (consolidated)
+
+    Each subfolder/section is written only when its content is present, so a run
+    with fewer analysts produces a smaller tree rather than empty files.
+
+    Returns:
+        Path to the consolidated ``complete_report.md``.
+    """
+    save_path = Path(out_dir)
+    save_path.mkdir(parents=True, exist_ok=True)
+    sections: list[str] = []
+
+    # 1. Analysts
+    analysts_dir = save_path / "1_analysts"
+    analyst_specs = [
+        ("market_report", "market.md", "Market Analyst"),
+        ("sentiment_report", "sentiment.md", "Sentiment Analyst"),
+        ("news_report", "news.md", "News Analyst"),
+        ("fundamentals_report", "fundamentals.md", "Fundamentals Analyst"),
+    ]
+    analyst_parts = []
+    for key, filename, label in analyst_specs:
+        text = final_state.get(key)
+        if text:
+            analysts_dir.mkdir(exist_ok=True)
+            (analysts_dir / filename).write_text(text, encoding="utf-8")
+            analyst_parts.append((label, text))
+    if analyst_parts:
+        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
+        sections.append(f"## I. Analyst Team Reports\n\n{content}")
+
+    # 2. Research
+    debate = final_state.get("investment_debate_state") or {}
+    if debate:
+        research_dir = save_path / "2_research"
+        research_specs = [
+            ("bull_history", "bull.md", "Bull Researcher"),
+            ("bear_history", "bear.md", "Bear Researcher"),
+            ("judge_decision", "manager.md", "Research Manager"),
+        ]
+        research_parts = []
+        for key, filename, label in research_specs:
+            text = debate.get(key)
+            if text:
+                research_dir.mkdir(exist_ok=True)
+                (research_dir / filename).write_text(text, encoding="utf-8")
+                research_parts.append((label, text))
+        if research_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
+            sections.append(f"## II. Research Team Decision\n\n{content}")
+
+    # 3. Trading
+    trader_plan = final_state.get("trader_investment_plan")
+    if trader_plan:
+        trading_dir = save_path / "3_trading"
+        trading_dir.mkdir(exist_ok=True)
+        (trading_dir / "trader.md").write_text(trader_plan, encoding="utf-8")
+        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{trader_plan}")
+
+    # 4. Risk Management + 5. Portfolio Manager
+    risk = final_state.get("risk_debate_state") or {}
+    if risk:
+        risk_dir = save_path / "4_risk"
+        risk_specs = [
+            ("aggressive_history", "aggressive.md", "Aggressive Analyst"),
+            ("conservative_history", "conservative.md", "Conservative Analyst"),
+            ("neutral_history", "neutral.md", "Neutral Analyst"),
+        ]
+        risk_parts = []
+        for key, filename, label in risk_specs:
+            text = risk.get(key)
+            if text:
+                risk_dir.mkdir(exist_ok=True)
+                (risk_dir / filename).write_text(text, encoding="utf-8")
+                risk_parts.append((label, text))
+        if risk_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
+            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
+
+        if risk.get("judge_decision"):
+            portfolio_dir = save_path / "5_portfolio"
+            portfolio_dir.mkdir(exist_ok=True)
+            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
+            sections.append(
+                f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}"
+            )
+
+    # Consolidated report
+    generated = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {generated}\n\n"
+    report_path = save_path / "complete_report.md"
+    report_path.write_text(header + "\n\n".join(sections), encoding="utf-8")
+    return report_path

--- a/tradingagents/usage.py
+++ b/tradingagents/usage.py
@@ -1,0 +1,108 @@
+"""Per-run LLM usage and cost accounting.
+
+A provider-agnostic LangChain callback that aggregates token usage and call
+counts across every LLM/tool call in a run, so a framework whose value is "many
+agents debating" can report what a run actually consumed instead of leaving
+users blind. Token counts come from each provider's ``usage_metadata`` (the
+normalized field LangChain populates for OpenAI/Anthropic/Google/etc.).
+
+Cost is only estimated when prices are supplied (``model_prices``) — we do not
+ship a built-in price table that would silently go stale.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import LLMResult
+
+
+class UsageTrackingCallback(BaseCallbackHandler):
+    """Aggregate LLM call counts, tool call counts, and token usage.
+
+    Args:
+        model_prices: optional ``{"input": usd_per_1M, "output": usd_per_1M}``.
+            When provided, ``estimated_cost_usd`` and the summary include a
+            dollar estimate; otherwise cost is ``None``.
+    """
+
+    def __init__(self, model_prices: dict[str, float] | None = None) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self.llm_calls = 0
+        self.tool_calls = 0
+        self.tokens_in = 0
+        self.tokens_out = 0
+        self.model_prices = model_prices
+
+    # LangChain may emit on_llm_start (completion models) or on_chat_model_start
+    # (chat models) — count both so the tally is provider-shape agnostic.
+    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
+        with self._lock:
+            self.llm_calls += 1
+
+    def on_chat_model_start(
+        self, serialized: dict[str, Any], messages: list[list[Any]], **kwargs: Any
+    ) -> None:
+        with self._lock:
+            self.llm_calls += 1
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        try:
+            generation = response.generations[0][0]
+        except (IndexError, TypeError):
+            return
+        usage_metadata = None
+        message = getattr(generation, "message", None)
+        if isinstance(message, AIMessage):
+            usage_metadata = getattr(message, "usage_metadata", None)
+        if usage_metadata:
+            with self._lock:
+                self.tokens_in += usage_metadata.get("input_tokens", 0) or 0
+                self.tokens_out += usage_metadata.get("output_tokens", 0) or 0
+
+    def on_tool_start(self, serialized: dict[str, Any], input_str: str, **kwargs: Any) -> None:
+        with self._lock:
+            self.tool_calls += 1
+
+    def estimated_cost_usd(self) -> float | None:
+        """Dollar estimate from token counts, or None if no prices were given."""
+        if not self.model_prices:
+            return None
+        in_rate = self.model_prices.get("input", 0.0)
+        out_rate = self.model_prices.get("output", 0.0)
+        with self._lock:
+            return (self.tokens_in / 1_000_000) * in_rate + (
+                self.tokens_out / 1_000_000
+            ) * out_rate
+
+    def summary(self) -> dict[str, Any]:
+        """Machine-readable usage summary (used by the run manifest)."""
+        with self._lock:
+            data = {
+                "llm_calls": self.llm_calls,
+                "tool_calls": self.tool_calls,
+                "tokens_in": self.tokens_in,
+                "tokens_out": self.tokens_out,
+                "tokens_total": self.tokens_in + self.tokens_out,
+            }
+        data["estimated_cost_usd"] = self.estimated_cost_usd()
+        return data
+
+    def format_summary(self) -> str:
+        """One-line human-readable summary for end-of-run logging."""
+        s = self.summary()
+        cost = s["estimated_cost_usd"]
+        cost_str = (
+            f", est. cost ${cost:.4f}"
+            if cost is not None
+            else " (set config['model_prices'] to estimate cost)"
+        )
+        return (
+            f"Usage: {s['llm_calls']} LLM calls, {s['tool_calls']} tool calls, "
+            f"{s['tokens_in']:,} in / {s['tokens_out']:,} out "
+            f"({s['tokens_total']:,} tokens){cost_str}"
+        )


### PR DESCRIPTION
## Summary

Four related improvements to run setup, output, and observability. Each is independent and behind a config flag (all default-on except strict preflight). Surfaced while running the full pipeline programmatically (the Python API produced far thinner artifacts than the CLI, and a run's cost was invisible).

### #2 — Preflight config validation (`tradingagents/config_validation.py`)
Maps the selected analysts → data categories → required API keys and checks them at `TradingAgentsGraph` init, instead of discovering a missing key deep inside a node after minutes of paid calls. Missing **optional** sources (macro / prediction-markets) only warn; missing **required** ones warn and, with `config["preflight_strict"]`, raise before any LLM call.

### #3 — Report parity (`tradingagents/reporting.py`)
Extracts the markdown report-tree writer out of `cli/main.py` into a reusable library function. The CLI now delegates to it (no behavior change), and `TradingAgentsGraph` writes the same tree after a run (`config["write_reports"]`, on by default). Programmatic callers previously got only a single JSON blob.

### #5 — Usage / cost accounting (`tradingagents/usage.py`)
A provider-agnostic `UsageTrackingCallback` aggregates LLM/tool call counts and token usage (from each provider's `usage_metadata`), with an optional dollar estimate when `config["model_prices"]` is set — no built-in price table that would silently go stale. Attached to every run by default; a one-line summary is logged at the end. The CLI's `StatsCallbackHandler` now subclasses it, making the library the single source of truth.

### #6 — Run manifest (`tradingagents/manifest.py`)
Writes `manifest.json` beside the results: model/provider, **API-key presence as booleans only (never the values)**, data-vendor coverage, analysts, the preflight result, and the usage tally. Makes runs auditable and comparable.

## Config flags (all opt-out except strict preflight)
- `preflight_strict` (default `false`) — raise on a missing required source
- `write_reports` (default `true`) — write the markdown report tree from the API
- `track_usage` (default `true`) — attach the usage callback
- `model_prices` (default `None`) — `{"input": usd_per_1M, "output": usd_per_1M}` for cost estimates
- `write_manifest` (default `true`) — write manifest.json

## Tests
New: `test_preflight_validation`, `test_reporting`, `test_usage_tracking`, `test_manifest`. Full suite: **470 passed** (4 pre-existing, unrelated failures in temperature/ollama client tests are not touched by this PR). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)