### PR TITLE
test: make the API-key fixture robust to empty-string env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,15 @@ _API_KEY_ENV_VARS = (
 
 @pytest.fixture(autouse=True)
 def _dummy_api_keys(monkeypatch):
+    # Use a placeholder when a key is absent OR present-but-empty. A real .env
+    # (commonly copied from .env.example, which ships blank key fields) is loaded
+    # on `import tradingagents`, leaving e.g. OPENAI_API_KEY="" in the
+    # environment. `os.environ.get(var, default)` returns "" for an existing
+    # empty var — not the default — so without the `or` these tests would see an
+    # empty key and fail, even though CI (no .env) passes. `or "placeholder"`
+    # treats empty as absent, which is correct: an empty key is no key.
     for env_var in _API_KEY_ENV_VARS:
-        monkeypatch.setenv(env_var, os.environ.get(env_var, "placeholder"))
+        monkeypatch.setenv(env_var, os.environ.get(env_var) or "placeholder")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

`tests/test_temperature_config.py` and `tests/test_ollama_base_url.py` fail locally for any developer who has a `.env` file — even though CI is green.

Root cause: `import tradingagents` calls `load_dotenv()`. A `.env` copied from `.env.example` ships **blank** key fields (`OPENAI_API_KEY=`, `DEEPSEEK_API_KEY=`, …), so those vars end up set to `""` in the environment. The autouse `_dummy_api_keys` fixture then does:

```python
monkeypatch.setenv(env_var, os.environ.get(env_var, "placeholder"))
```

`os.environ.get(var, default)` returns `""` (not the default) for an existing-but-empty var, so the placeholder is never applied. The OpenAI-compatible client then correctly rejects the empty key, and the temperature/ollama tests raise `ValueError: API key ... is not set`. CI passes only because it has no `.env`.

## Fix

```python
monkeypatch.setenv(env_var, os.environ.get(env_var) or "placeholder")
```

`os.environ.get(var)` is `None` (absent) or `""` (empty); `or "placeholder"` covers both. An empty key is functionally no key, so falling back to the placeholder is the correct behavior.

## Verification

- The 4 previously-failing tests now pass.
- Full suite with a blank-keys `.env` present: **443 passed, 2 skipped, 0 failed** (was 4 failed).
- No production code touched — test harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)