### PR TITLE
fix(docker): use TRADINGAGENTS_LLM_PROVIDER for ollama profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,12 @@ services:
     env_file:
       - .env
     environment:
-      - LLM_PROVIDER=ollama
+      # Config overrides are read from TRADINGAGENTS_* env vars (see
+      # default_config._ENV_OVERRIDES); a bare LLM_PROVIDER is ignored.
+      - TRADINGAGENTS_LLM_PROVIDER=ollama
+      # Reach the sibling ollama container by service name, not localhost,
+      # which inside this container would resolve to itself.
+      - OLLAMA_BASE_URL=http://ollama:11434/v1
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
     depends_on:


### PR DESCRIPTION
## Summary
The `tradingagents-ollama` Compose service sets `LLM_PROVIDER=ollama`, but config overrides are only read from `TRADINGAGENTS_*` env vars (`default_config._ENV_OVERRIDES`). The bare `LLM_PROVIDER` is never read, so the profile silently falls back to the default provider instead of Ollama.

This also adds `OLLAMA_BASE_URL` pointing at the sibling container's service name. With the provider correctly switched to ollama, the backend URL resolves (via `resolve_backend_url` → `provider_default_url`) to `OLLAMA_BASE_URL or http://localhost:11434/v1`. Inside the app container `localhost` resolves to itself, not the `ollama` service, so without this the profile cannot reach the model server.

## Changes
```yaml
    environment:
      - TRADINGAGENTS_LLM_PROVIDER=ollama
      - OLLAMA_BASE_URL=http://ollama:11434/v1
```

## Testing
- `docker compose config` parses; YAML validated.
- Confirmed `_ENV_OVERRIDES` maps only `TRADINGAGENTS_LLM_PROVIDER`, and the Ollama base URL is resolved from `OLLAMA_BASE_URL` in both the provider table and `resolve_backend_url`.

Fixes #975