### PR TITLE
fix(cli): preserve env debate round overrides

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1019,14 +1019,22 @@ def format_tool_args(args, max_length=80) -> str:
         return result[:max_length - 3] + "..."
     return result
 
+
+def _apply_research_depth(config: dict, research_depth: int) -> None:
+    """Apply interactive research depth unless env vars already configured it."""
+    if not os.environ.get("TRADINGAGENTS_MAX_DEBATE_ROUNDS"):
+        config["max_debate_rounds"] = research_depth
+    if not os.environ.get("TRADINGAGENTS_MAX_RISK_ROUNDS"):
+        config["max_risk_discuss_rounds"] = research_depth
+
+
 def run_analysis(checkpoint: bool = False):
     # First get all user selections
     selections = get_user_selections()
 
     # Create config with selected research depth
     config = DEFAULT_CONFIG.copy()
-    config["max_debate_rounds"] = selections["research_depth"]
-    config["max_risk_discuss_rounds"] = selections["research_depth"]
+    _apply_research_depth(config, selections["research_depth"])
     config["quick_think_llm"] = selections["shallow_thinker"]
     config["deep_think_llm"] = selections["deep_thinker"]
     config["backend_url"] = selections["backend_url"]

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -32,6 +32,38 @@ class TestProviderDefaultUrl(unittest.TestCase):
 
 @pytest.mark.unit
 class TestCliSkipsPromptsFromEnv(unittest.TestCase):
+    def test_research_depth_applies_without_round_env(self):
+        import cli.main as m
+
+        config = {
+            "max_debate_rounds": 4,
+            "max_risk_discuss_rounds": 5,
+        }
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            m._apply_research_depth(config, research_depth=2)
+
+        self.assertEqual(config["max_debate_rounds"], 2)
+        self.assertEqual(config["max_risk_discuss_rounds"], 2)
+
+    def test_research_depth_preserves_round_env(self):
+        import cli.main as m
+
+        config = {
+            "max_debate_rounds": 4,
+            "max_risk_discuss_rounds": 5,
+        }
+        env = {
+            "TRADINGAGENTS_MAX_DEBATE_ROUNDS": "4",
+            "TRADINGAGENTS_MAX_RISK_ROUNDS": "5",
+        }
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            m._apply_research_depth(config, research_depth=2)
+
+        self.assertEqual(config["max_debate_rounds"], 4)
+        self.assertEqual(config["max_risk_discuss_rounds"], 5)
+
     def test_env_config_skips_llm_prompts(self):
         import cli.main as m
 

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -64,6 +64,24 @@ class TestCliSkipsPromptsFromEnv(unittest.TestCase):
         self.assertEqual(config["max_debate_rounds"], 4)
         self.assertEqual(config["max_risk_discuss_rounds"], 5)
 
+    def test_research_depth_preserves_partial_round_env(self):
+        import cli.main as m
+
+        config = {
+            "max_debate_rounds": 4,
+            "max_risk_discuss_rounds": 5,
+        }
+
+        with mock.patch.dict(
+            os.environ,
+            {"TRADINGAGENTS_MAX_DEBATE_ROUNDS": "4"},
+            clear=True,
+        ):
+            m._apply_research_depth(config, research_depth=2)
+
+        self.assertEqual(config["max_debate_rounds"], 4)
+        self.assertEqual(config["max_risk_discuss_rounds"], 2)
+
     def test_env_config_skips_llm_prompts(self):
         import cli.main as m
 


### PR DESCRIPTION
## Problem

`TRADINGAGENTS_MAX_DEBATE_ROUNDS` and `TRADINGAGENTS_MAX_RISK_ROUNDS` are applied into `DEFAULT_CONFIG`, but the interactive CLI then overwrites both values with the selected research depth before constructing the graph. That means a user can set the env vars and still get the menu-selected round count instead.

Closes #977

## Before / after

Before:
- `DEFAULT_CONFIG` could contain env-configured debate/risk round values.
- `run_analysis()` always replaced both values with `selections["research_depth"]`.

After:
- The interactive research depth still applies when no round env vars are set.
- Explicit `TRADINGAGENTS_MAX_DEBATE_ROUNDS` / `TRADINGAGENTS_MAX_RISK_ROUNDS` values are preserved through CLI config assembly.

## Verification

- `python -m pytest tests/test_cli_env_skip.py tests/test_env_overrides.py`
- `python -m ruff check cli/main.py tests/test_cli_env_skip.py tests/test_env_overrides.py`
- `git diff --check`
