### PR TITLE
fix(cli): preserve env checkpoint setting

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1019,7 +1019,13 @@ def format_tool_args(args, max_length=80) -> str:
         return result[:max_length - 3] + "..."
     return result
 
-def run_analysis(checkpoint: bool = False):
+
+def _apply_checkpoint_config(config: dict, checkpoint: bool | None) -> None:
+    if checkpoint is not None:
+        config["checkpoint_enabled"] = checkpoint
+
+
+def run_analysis(checkpoint: bool | None = None):
     # First get all user selections
     selections = get_user_selections()
 
@@ -1036,7 +1042,7 @@ def run_analysis(checkpoint: bool = False):
     config["openai_reasoning_effort"] = selections.get("openai_reasoning_effort")
     config["anthropic_effort"] = selections.get("anthropic_effort")
     config["output_language"] = selections.get("output_language", "English")
-    config["checkpoint_enabled"] = checkpoint
+    _apply_checkpoint_config(config, checkpoint)
 
     # Create stats callback handler for tracking LLM/tool calls
     stats_handler = StatsCallbackHandler()
@@ -1316,10 +1322,10 @@ def run_analysis(checkpoint: bool = False):
 
 @app.command()
 def analyze(
-    checkpoint: bool = typer.Option(
-        False,
-        "--checkpoint",
-        help="Enable checkpoint/resume: save state after each node so a crashed run can resume.",
+    checkpoint: bool | None = typer.Option(
+        None,
+        "--checkpoint/--no-checkpoint",
+        help="Enable or disable checkpoint/resume. Defaults to TRADINGAGENTS_CHECKPOINT_ENABLED.",
     ),
     clear_checkpoints: bool = typer.Option(
         False,

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -32,6 +32,24 @@ class TestProviderDefaultUrl(unittest.TestCase):
 
 @pytest.mark.unit
 class TestCliSkipsPromptsFromEnv(unittest.TestCase):
+    def test_checkpoint_flag_omitted_preserves_env_config(self):
+        import cli.main as m
+
+        config = {"checkpoint_enabled": True}
+
+        m._apply_checkpoint_config(config, checkpoint=None)
+
+        self.assertIs(config["checkpoint_enabled"], True)
+
+    def test_checkpoint_flag_overrides_env_config_when_explicit(self):
+        import cli.main as m
+
+        config = {"checkpoint_enabled": True}
+
+        m._apply_checkpoint_config(config, checkpoint=False)
+
+        self.assertIs(config["checkpoint_enabled"], False)
+
     def test_env_config_skips_llm_prompts(self):
         import cli.main as m
 


### PR DESCRIPTION
## Problem

`TRADINGAGENTS_CHECKPOINT_ENABLED` is applied to `DEFAULT_CONFIG`, but the CLI command default passes `checkpoint=False` into `run_analysis()` whenever `--checkpoint` is omitted. That overwrites an env-enabled checkpoint setting before the graph is constructed.

Closes #976

## Before / after

Before:
- `TRADINGAGENTS_CHECKPOINT_ENABLED=true` was reflected in `DEFAULT_CONFIG`.
- Running `tradingagents analyze` without `--checkpoint` still set `checkpoint_enabled` back to `False`.

After:
- Omitting the checkpoint flag preserves the env/default config value.
- `--checkpoint` explicitly enables checkpointing.
- `--no-checkpoint` explicitly disables checkpointing when a user wants to override an env-enabled default.

## Verification

- `python -m pytest tests/test_cli_env_skip.py tests/test_env_overrides.py`
- `python -m ruff check cli/main.py tests/test_cli_env_skip.py tests/test_env_overrides.py`
- `git diff --check`
