### PR TITLE
docs: add Community Projects section with Streamlit Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ What does not vary anymore: the analyzed company identity is resolved determinis
 
 Backtest results are not guaranteed to match any published figure. Returns depend on the model, the temperature, the date range, data quality, and the sampling above. Treat the framework as a research scaffold for studying multi-agent analysis, not as a strategy with a fixed, replicable return.
 
+## Community Projects
+
+Projects built on TradingAgents by the community:
+
+| Project | Description |
+|---------|-------------|
+| [tradingagents-web-ui](https://github.com/ydhawesome/tradingagents-web-ui) | Streamlit web interface (Chinese/English UI) — fill in a ticker, watch agents run live, read rendered reports in-browser |
+
 ## Contributing
 
 Contributions are welcome: bug fixes, documentation, and feature ideas; past contributions are credited per release in [`CHANGELOG.md`](CHANGELOG.md).


### PR DESCRIPTION
## Summary

- Adds a **Community Projects** table to the README, before the Contributing section
- Lists [tradingagents-web-ui](https://github.com/ydhawesome/tradingagents-web-ui): a Streamlit web interface for TradingAgents (Chinese / English UI, live agent progress, rendered reports, history browser)

## Why

The framework is great but lacks a graphical interface out of the box. This companion project fills that gap. Adding a single-row table here helps users discover it without cluttering the main docs.

## Screenshot

![screenshot](https://raw.githubusercontent.com/ydhawesome/tradingagents-web-ui/main/docs/screenshot.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)