### PR TITLE
fix(config): reject invalid boolean env values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ NVIDIA_API_KEY=
 # Any TRADINGAGENTS_* variable below, when set, replaces the matching key
 # in tradingagents/default_config.py. Values are coerced to the type of
 # the existing default (bool / int / str), so "true"/"3" work as expected.
+# Boolean values accept true/false, 1/0, yes/no, or on/off.
 # In the CLI, setting the LLM provider / models / backend URL / language
 # also skips the matching interactive selection step (useful for
 # OpenAI-compatible endpoints like opencode or LM Studio, and unattended runs).

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -82,11 +82,25 @@ def test_empty_env_value_is_passthrough(monkeypatch):
 def test_invalid_int_raises(monkeypatch):
     """Garbage int values should surface a ValueError at import, not silently misconfigure."""
     monkeypatch.setenv("TRADINGAGENTS_MAX_DEBATE_ROUNDS", "not-a-number")
-    with pytest.raises(ValueError):
+    try:
+        with pytest.raises(ValueError):
+            importlib.reload(default_config_module)
+    finally:
+        # Restore module state for subsequent tests in this process
+        monkeypatch.delenv("TRADINGAGENTS_MAX_DEBATE_ROUNDS", raising=False)
         importlib.reload(default_config_module)
-    # Restore module state for subsequent tests in this process
-    monkeypatch.delenv("TRADINGAGENTS_MAX_DEBATE_ROUNDS", raising=False)
-    importlib.reload(default_config_module)
+
+
+def test_invalid_bool_raises(monkeypatch):
+    """Garbage bool values should not silently disable a boolean config flag."""
+    monkeypatch.setenv("TRADINGAGENTS_CHECKPOINT_ENABLED", "treu")
+    try:
+        with pytest.raises(ValueError, match="TRADINGAGENTS_CHECKPOINT_ENABLED"):
+            importlib.reload(default_config_module)
+    finally:
+        # Restore module state for subsequent tests in this process
+        monkeypatch.delenv("TRADINGAGENTS_CHECKPOINT_ENABLED", raising=False)
+        importlib.reload(default_config_module)
 
 
 def test_unknown_env_var_is_ignored(monkeypatch):

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -24,7 +24,12 @@ _ENV_OVERRIDES = {
 def _coerce(value: str, reference):
     """Coerce env-var string to the type of the existing default value."""
     if isinstance(reference, bool):
-        return value.strip().lower() in ("true", "1", "yes", "on")
+        raw = value.strip().lower()
+        if raw in ("true", "1", "yes", "on"):
+            return True
+        if raw in ("false", "0", "no", "off"):
+            return False
+        raise ValueError("expected one of true/false, 1/0, yes/no, or on/off")
     if isinstance(reference, int) and not isinstance(reference, bool):
         return int(value)
     if isinstance(reference, float):
@@ -38,7 +43,10 @@ def _apply_env_overrides(config: dict) -> dict:
         raw = os.environ.get(env_var)
         if raw is None or raw == "":
             continue
-        config[key] = _coerce(raw, config.get(key))
+        try:
+            config[key] = _coerce(raw, config.get(key))
+        except ValueError as exc:
+            raise ValueError(f"Invalid value for {env_var}: {raw!r} ({exc})") from exc
     return config
 
 


### PR DESCRIPTION
## Summary
- reject invalid boolean values in `TRADINGAGENTS_*` environment overrides instead of silently treating them as `False`
- include the offending environment variable in the `ValueError` so config mistakes are easy to locate
- document the accepted boolean forms in `.env.example` and add regression coverage for a misspelled boolean override

## Why this matters
A typo such as `treu` currently disables a boolean config flag without surfacing the mistake. Failing fast keeps unattended CLI runs and scripted agent workflows from using an unintended configuration.

## Scope
This keeps the change limited to config value parsing. It does not change CLI override precedence or checkpoint flag behavior; adjacent PRs such as #1040/#1041 cover those runtime precedence paths separately.

## Validation
- `python -m pytest tests/test_env_overrides.py -q` - 17 passed
- `git diff --check` - clean