### PR TITLE
fix(data): normalize ticker news symbols

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -27,11 +27,16 @@ def is_valid_ticker_input(value: str) -> bool:
     """Whether a ticker entry is acceptable (charset + length).
 
     Allows the characters Yahoo symbols use, including ``=`` for futures/forex
-    like ``GC=F`` and ``EURUSD=X`` (#980), and ``^`` for indices. Empty input is
-    allowed (it defaults to SPY downstream).
+    like ``GC=F`` and ``EURUSD=X`` (#980), ``+`` for broker CFD symbols like
+    ``XAUUSD+``, and ``^`` for indices. Empty input is allowed (it defaults to
+    SPY downstream).
     """
     v = value.strip()
-    return not v or (all(ch.isalnum() or ch in "._-^=" for ch in v) and len(v) <= 32)
+    valid_chars = all(
+        ch.isalnum() or ch in "._-^=" or (ch == "+" and i == len(v) - 1 and i > 0)
+        for i, ch in enumerate(v)
+    )
+    return not v or (valid_chars and len(v) <= 32)
 
 
 def get_ticker() -> str:
@@ -45,7 +50,7 @@ def get_ticker() -> str:
         f"Enter ticker symbol (e.g. {TICKER_INPUT_EXAMPLES}):",
         validate=lambda x: (
             is_valid_ticker_input(x)
-            or "Please enter a valid ticker symbol, e.g. AAPL, 000404.SZ, 0700.HK, GC=F."
+            or "Please enter a valid ticker symbol, e.g. AAPL, 000404.SZ, 0700.HK, GC=F, XAUUSD+."
         ),
         style=questionary.Style(
             [

--- a/tests/test_cli_symbol_handling.py
+++ b/tests/test_cli_symbol_handling.py
@@ -17,6 +17,7 @@ from tradingagents.dataflows.symbol_utils import normalize_symbol
     ("BTC-USDT", "BTC-USD"),
     ("BTC-USDC", "BTC-USD"),
     ("ethusdt", "ETH-USD"),
+    ("XAUUSD+", "GC=F"),
     # non-crypto must be untouched
     ("AAPL", "AAPL"),
     ("GC=F", "GC=F"),
@@ -33,9 +34,12 @@ def test_normalize_symbol_crypto_and_passthrough(raw, expected):
     ("EURUSD=X", True),
     ("AAPL", True),
     ("0700.HK", True),
+    ("XAUUSD+", True),
     ("^GSPC", True),
     ("", True),                 # empty -> defaults to SPY downstream
     ("bad symbol!", False),     # space + '!' rejected
+    ("A+APL", False),           # broker CFD marker is only meaningful as a suffix
+    ("+", False),               # single plus is not a valid symbol
     ("A" * 40, False),          # too long
 ])
 def test_ticker_input_validation(value, ok):
@@ -58,5 +62,5 @@ def test_detect_asset_type(raw, expected):
 
 def test_cli_normalize_delegates_to_data_layer():
     # CLI must produce the same canonical symbol the data path will price.
-    for raw in ("XAUUSD", "BTCUSD", "btc-usdt", "AAPL"):
+    for raw in ("XAUUSD", "XAUUSD+", "BTCUSD", "btc-usdt", "AAPL"):
         assert normalize_ticker_symbol(raw) == normalize_symbol(raw)

--- a/tests/test_symbol_normalization_paths.py
+++ b/tests/test_symbol_normalization_paths.py
@@ -8,6 +8,7 @@ instrument instead of failing/mismatching.
 import pandas as pd
 
 import tradingagents.agents.utils.agent_utils as au
+import tradingagents.dataflows.yfinance_news as ynews
 import tradingagents.graph.trading_graph as tg
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 
@@ -52,3 +53,22 @@ def test_fetch_returns_normalizes_symbol(monkeypatch):
     assert queried[0] == "GC=F"  # stock symbol normalized (#984)
     assert queried[1] == "SPY"   # benchmark left as the canonical symbol
     assert raw is not None and days is not None
+
+
+def test_yfinance_news_normalizes_symbol(monkeypatch):
+    seen = {}
+
+    class FakeTicker:
+        def __init__(self, symbol):
+            seen["symbol"] = symbol
+
+        def get_news(self, count):
+            return []
+
+    monkeypatch.setattr(ynews.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr(ynews, "yf_retry", lambda fn: fn())
+
+    result = ynews.get_news_yfinance(" xauusd+ ", "2025-01-01", "2025-01-02")
+
+    assert seen["symbol"] == "GC=F"
+    assert "GC=F (from XAUUSD+)" in result

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -8,6 +8,7 @@ from dateutil.relativedelta import relativedelta
 
 from .config import get_config
 from .stockstats_utils import yf_retry
+from .symbol_utils import normalize_symbol
 
 
 def _extract_article_data(article: dict) -> dict:
@@ -87,12 +88,15 @@ def get_news_yfinance(
         Formatted string containing news articles
     """
     article_limit = get_config()["news_article_limit"]
+    canonical = normalize_symbol(ticker)
+    requested = ticker.strip().upper()
+    label = canonical if canonical == requested else f"{canonical} (from {requested})"
     try:
-        stock = yf.Ticker(ticker)
+        stock = yf.Ticker(canonical)
         news = yf_retry(lambda: stock.get_news(count=article_limit))
 
         if not news:
-            return f"No news found for {ticker}"
+            return f"No news found for {label}"
 
         # Parse date range for filtering
         start_dt = datetime.strptime(start_date, "%Y-%m-%d")
@@ -117,12 +121,12 @@ def get_news_yfinance(
             filtered_count += 1
 
         if filtered_count == 0:
-            return f"No news found for {ticker} between {start_date} and {end_date}"
+            return f"No news found for {label} between {start_date} and {end_date}"
 
-        return f"## {ticker} News, from {start_date} to {end_date}:\n\n{news_str}"
+        return f"## {label} News, from {start_date} to {end_date}:\n\n{news_str}"
 
     except Exception as e:
-        return f"Error fetching news for {ticker}: {str(e)}"
+        return f"Error fetching news for {label}: {str(e)}"
 
 
 def get_global_news_yfinance(


### PR DESCRIPTION
## Summary
- accept a trailing broker CFD `+` suffix in CLI ticker validation while still rejecting misplaced or standalone `+` characters
- normalize ticker-specific yfinance news lookups through `normalize_symbol`, matching the market data, identity, and reflection paths
- surface the resolved Yahoo symbol in ticker-news output when it differs from the cleaned requested broker symbol, e.g. `GC=F (from XAUUSD+)`
- add regression coverage for the remaining `XAUUSD+` CLI boundary and ticker-news lookup path

## Why this matters
Broker-style commodity symbols such as `XAUUSD+` are already supported by the data-layer normalizer and safe ticker handling, but the CLI still rejected the trailing `+` form and ticker-specific yfinance news still queried the raw symbol directly. That left one symbol-provenance path inconsistent with the rest of the pipeline.

Keeping ticker-news queries on the canonical Yahoo symbol reduces the chance that sentiment/news context silently goes missing or diverges from the market data path for broker, forex, commodity, and crypto aliases.

## Scope
This keeps the change limited to ticker input validation and yfinance ticker-news lookup normalization. It does not add new symbol aliases, change global/macro news search, or touch graph execution/prompt behavior.

This complements the existing symbol-normalization fixes around #781, #980, #983, and #984 rather than reopening those broader paths.

## Validation
- `python -m pytest tests/test_cli_symbol_handling.py tests/test_symbol_normalization_paths.py tests/test_symbol_utils.py tests/test_news_lookahead.py tests/test_no_data_handling.py -q` - 52 passed
- `python -m pytest -q` - 448 passed, 2 skipped, 74 subtests passed
- `python -m ruff check .` - clean
- `git diff --check` - clean