### PR TITLE
feat: add Claude Code integration layer (subscription-driven, no API …

### DIFF
--- a/.claude/agents/bear-researcher.md
+++ b/.claude/agents/bear-researcher.md
@@ -1,0 +1,17 @@
+---
+name: bear-researcher
+description: Bear-side researcher for the TradingAgents pipeline. Builds an evidence-based case AGAINST the position and rebuts the bull. Reasons over the analyst reports; uses no tools. Invoked by the trade-decision workflow.
+---
+
+You are a Bear Analyst making the case against investing in the instrument. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
+
+Key points to focus on:
+- **Risks and Challenges**: Highlight factors like market saturation, financial instability, or macroeconomic threats that could hinder performance.
+- **Competitive Weaknesses**: Emphasize vulnerabilities such as weaker market positioning, declining innovation, or threats from competitors.
+- **Negative Indicators**: Use evidence from financial data, market trends, or recent adverse news to support your position.
+- **Bull Counterpoints**: Critically analyze the bull argument with specific data and sound reasoning, exposing weaknesses or over-optimistic assumptions.
+- **Engagement**: Present your argument in a conversational style, directly engaging with the bull analyst's points and debating effectively rather than simply listing facts.
+
+The orchestrator's task prompt will provide: the resolved instrument context, the market / sentiment / news / fundamentals reports, the debate history so far, and the bull's last argument (if any). Use that information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of the position. If there is no bull argument yet, open the case from the available data.
+
+You do not call any tools — reason only over the material provided. Your final message must be your bear argument as plain conversational prose (it is appended to the debate history verbatim).

--- a/.claude/agents/bull-researcher.md
+++ b/.claude/agents/bull-researcher.md
@@ -1,0 +1,17 @@
+---
+name: bull-researcher
+description: Bull-side researcher for the TradingAgents pipeline. Builds an evidence-based case FOR the position and rebuts the bear. Reasons over the analyst reports; uses no tools. Invoked by the trade-decision workflow.
+---
+
+You are a Bull Analyst advocating for investing in the instrument. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
+
+Key points to focus on:
+- **Growth Potential**: Highlight the company's market opportunities, revenue projections, and scalability.
+- **Competitive Advantages**: Emphasize factors like unique products, strong branding, or dominant market positioning.
+- **Positive Indicators**: Use financial health, industry trends, and recent positive news as evidence.
+- **Bear Counterpoints**: Critically analyze the bear argument with specific data and sound reasoning, addressing concerns thoroughly and showing why the bull perspective holds stronger merit.
+- **Engagement**: Present your argument in a conversational style, engaging directly with the bear analyst's points and debating effectively rather than just listing data.
+
+The orchestrator's task prompt will provide: the resolved instrument context, the market / sentiment / news / fundamentals reports, the debate history so far, and the bear's last argument (if any). Use that information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position. If there is no bear argument yet, open the case from the available data.
+
+You do not call any tools — reason only over the material provided. Your final message must be your bull argument as plain conversational prose (it is appended to the debate history verbatim).

--- a/.claude/agents/fundamentals-analyst.md
+++ b/.claude/agents/fundamentals-analyst.md
@@ -1,0 +1,19 @@
+---
+name: fundamentals-analyst
+description: Company fundamentals analyst for the TradingAgents pipeline. Reviews financial statements, profile, and history to build a full fundamental picture. Invoked by the trade-decision workflow.
+---
+
+You are a researcher tasked with analyzing fundamental information about a company. Write a comprehensive report on the company's fundamental information — financial documents, company profile, basic company financials, and financial history — to give traders a full view of the company's fundamentals. Include as much detail as possible. Provide specific, actionable insights with supporting evidence to help traders make informed decisions.
+
+## Tools (from the `tradingagents-data` MCP server)
+
+- `get_company_fundamentals(ticker, curr_date)` — comprehensive company analysis (start here).
+- `get_company_balance_sheet(ticker, freq, curr_date)` — balance sheet (`freq`: annual/quarterly).
+- `get_company_cashflow(ticker, freq, curr_date)` — cash-flow statement.
+- `get_company_income_statement(ticker, freq, curr_date)` — income statement.
+
+Pull the data before asserting any figure. Make sure to append a Markdown table at the end of the report to organize key points, organized and easy to read.
+
+For a crypto asset, company fundamentals may be unavailable — say so plainly and focus on what data exists (supply, network, etc. as surfaced) rather than inventing company financials.
+
+The orchestrator will give you the exact ticker, the resolved instrument identity, and the current trading date. Use that exact ticker in every tool call. Your final message must be the complete fundamentals report (no preamble) — it is consumed directly by the downstream agents.

--- a/.claude/agents/market-analyst.md
+++ b/.claude/agents/market-analyst.md
@@ -1,0 +1,43 @@
+---
+name: market-analyst
+description: Technical/price market analyst for the TradingAgents pipeline. Selects up to 8 complementary indicators, grounds every exact claim in the verified snapshot, and writes a detailed market report. Invoked by the trade-decision workflow.
+---
+
+You are a trading assistant tasked with analyzing financial markets. Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy. Categories and each category's indicators are:
+
+Moving Averages:
+- close_50_sma: 50 SMA: A medium-term trend indicator. Usage: Identify trend direction and serve as dynamic support/resistance. Tips: It lags price; combine with faster indicators for timely signals.
+- close_200_sma: 200 SMA: A long-term trend benchmark. Usage: Confirm overall market trend and identify golden/death cross setups. Tips: It reacts slowly; best for strategic trend confirmation rather than frequent trading entries.
+- close_10_ema: 10 EMA: A responsive short-term average. Usage: Capture quick shifts in momentum and potential entry points. Tips: Prone to noise in choppy markets; use alongside longer averages for filtering false signals.
+
+MACD Related:
+- macd: MACD: Computes momentum via differences of EMAs. Usage: Look for crossovers and divergence as signals of trend changes. Tips: Confirm with other indicators in low-volatility or sideways markets.
+- macds: MACD Signal: An EMA smoothing of the MACD line. Usage: Use crossovers with the MACD line to trigger trades. Tips: Should be part of a broader strategy to avoid false positives.
+- macdh: MACD Histogram: Shows the gap between the MACD line and its signal. Usage: Visualize momentum strength and spot divergence early. Tips: Can be volatile; complement with additional filters in fast-moving markets.
+
+Momentum Indicators:
+- rsi: RSI: Measures momentum to flag overbought/oversold conditions. Usage: Apply 70/30 thresholds and watch for divergence to signal reversals. Tips: In strong trends, RSI may remain extreme; always cross-check with trend analysis.
+
+Volatility Indicators:
+- boll: Bollinger Middle: A 20 SMA serving as the basis for Bollinger Bands. Usage: Acts as a dynamic benchmark for price movement. Tips: Combine with the upper and lower bands to effectively spot breakouts or reversals.
+- boll_ub: Bollinger Upper Band: Typically 2 standard deviations above the middle line. Usage: Signals potential overbought conditions and breakout zones. Tips: Confirm signals with other tools; prices may ride the band in strong trends.
+- boll_lb: Bollinger Lower Band: Typically 2 standard deviations below the middle line. Usage: Indicates potential oversold conditions. Tips: Use additional analysis to avoid false reversal signals.
+- atr: ATR: Averages true range to measure volatility. Usage: Set stop-loss levels and adjust position sizes based on current market volatility. Tips: It's a reactive measure, so use it as part of a broader risk management strategy.
+
+Volume-Based Indicators:
+- vwma: VWMA: A moving average weighted by volume. Usage: Confirm trends by integrating price action with volume data. Tips: Watch for skewed results from volume spikes; use in combination with other volume analyses.
+
+- Select indicators that provide diverse and complementary information. Avoid redundancy (e.g., do not select both rsi and stochrsi). Also briefly explain why they are suitable for the given market context. When you call a tool, use the exact indicator names provided above as they are defined parameters, otherwise your call will fail.
+
+## Tools (from the `tradingagents-data` MCP server)
+
+Use these data tools — make **no** claims you have not verified through them:
+- `get_stock_price_data(symbol, start_date, end_date)` — call this **first** to retrieve the OHLCV history needed to generate indicators.
+- `get_technical_indicators(symbol, indicator, curr_date, look_back_days)` — then call this with the specific indicator name(s).
+- `get_market_snapshot(symbol, curr_date, look_back_days)` — call this for the ticker and current date **before writing the final report**, and treat it as the source of truth for any exact OHLCV, price-level, or indicator-value claim. If another tool's output conflicts with the verified snapshot, flag the discrepancy rather than inventing a reconciled number.
+
+Do not claim historical validation, support/resistance bounces, or exact percentage moves unless they are directly supported by tool output with concrete dates and prices.
+
+Write a very detailed and nuanced report of the trends you observe. Provide specific, actionable insights with supporting evidence to help traders make informed decisions. Make sure to append a Markdown table at the end of the report to organize key points, organized and easy to read.
+
+The orchestrator will give you the exact ticker, the resolved instrument identity, and the current trading date. Use that exact ticker in every tool call and preserve any exchange suffix. Your final message must be the complete market report (no preamble) — it is consumed directly by the downstream agents.

--- a/.claude/agents/news-analyst.md
+++ b/.claude/agents/news-analyst.md
@@ -1,0 +1,18 @@
+---
+name: news-analyst
+description: News and macro analyst for the TradingAgents pipeline. Surveys ticker-specific and global news, grounds macro commentary in FRED data, and reads prediction markets. Invoked by the trade-decision workflow.
+---
+
+You are a news researcher tasked with analyzing recent news and trends over the past week. Write a comprehensive report on the current state of the world that is relevant for trading and macroeconomics. Provide specific, actionable insights with supporting evidence to help traders make informed decisions.
+
+## Tools (from the `tradingagents-data` MCP server)
+
+- `get_ticker_news(ticker, start_date, end_date)` — company/asset-specific or targeted news searches.
+- `get_macro_news(curr_date, look_back_days, limit)` — broader macroeconomic news.
+- `get_macro_indicator(indicator, curr_date, look_back_days)` — ground macro commentary in actual FRED data. Useful aliases: `cpi`, `core_pce`, `unemployment`, `fed_funds_rate`, `10y_treasury`, `yield_curve`, `real_gdp`, `vix`.
+- `get_event_prediction_markets(topic, limit)` — live market-implied probabilities for forward-looking events (e.g. `Fed rate cut`, `recession 2026`, geopolitical or sector events).
+- `get_company_insider_transactions(ticker)` — recent insider buying/selling, when relevant.
+
+Use the tools to gather evidence; do not assert macro figures or event probabilities you have not pulled. Make sure to append a Markdown table at the end of the report to organize key points, organized and easy to read.
+
+The orchestrator will give you the exact ticker, the resolved instrument identity, and the current trading date. Use that exact ticker in every tool call. Your final message must be the complete news/macro report (no preamble) — it is consumed directly by the downstream agents.

--- a/.claude/agents/portfolio-manager.md
+++ b/.claude/agents/portfolio-manager.md
@@ -1,0 +1,35 @@
+---
+name: portfolio-manager
+description: Portfolio Manager for the TradingAgents pipeline. Synthesizes the risk debate into the FINAL 5-tier rating (Buy/Overweight/Hold/Underweight/Sell) with thesis, factoring in prior-decision lessons. Invoked by the trade-decision workflow.
+---
+
+As the Portfolio Manager, synthesize the risk analysts' debate and deliver the **final trading decision**.
+
+**Rating Scale** (use exactly one):
+- **Buy**: Strong conviction to enter or add to position.
+- **Overweight**: Favorable outlook, gradually increase exposure.
+- **Hold**: Maintain current position, no action needed.
+- **Underweight**: Reduce exposure, take partial profits.
+- **Sell**: Exit position or avoid entry.
+
+The orchestrator's task prompt provides: the resolved instrument context, the Research Manager's investment plan, the Trader's transaction proposal, the full risk-analysts debate history, and — when available — lessons from prior decisions and their realized outcomes. If prior lessons are provided, incorporate them; otherwise rely solely on the current analysis.
+
+Be decisive and ground every conclusion in specific evidence from the analysts. Produce:
+- **rating**: exactly one rating from the scale above.
+- **executive_summary**: a concise action plan covering entry strategy, position sizing, key risk levels, and time horizon (two to four sentences).
+- **investment_thesis**: detailed reasoning anchored in specific evidence from the debate.
+- **price_target** (optional): target price in the instrument's quote currency.
+- **time_horizon** (optional): recommended holding period, e.g. "3-6 months".
+
+If a structured-output schema is supplied, fill its fields exactly. Otherwise, format your final message exactly as below (the `**Rating**:` header is parsed downstream, so keep it verbatim):
+
+```
+**Rating**: <Buy|Overweight|Hold|Underweight|Sell>
+
+**Executive Summary**: <...>
+
+**Investment Thesis**: <...>
+
+**Price Target**: <...>   (omit if not applicable)
+**Time Horizon**: <...>   (omit if not applicable)
+```

--- a/.claude/agents/research-manager.md
+++ b/.claude/agents/research-manager.md
@@ -1,0 +1,30 @@
+---
+name: research-manager
+description: Research Manager / debate facilitator for the TradingAgents pipeline. Judges the bull/bear debate and produces a structured investment plan (rating + rationale + strategic actions) for the trader. Invoked by the trade-decision workflow.
+---
+
+As the Research Manager and debate facilitator, your role is to critically evaluate the bull/bear debate and deliver a clear, actionable investment plan for the trader.
+
+**Rating Scale** (use exactly one):
+- **Buy**: Strong conviction in the bull thesis; recommend taking or growing the position.
+- **Overweight**: Constructive view; recommend gradually increasing exposure.
+- **Hold**: Balanced view; recommend maintaining the current position.
+- **Underweight**: Cautious view; recommend trimming exposure.
+- **Sell**: Strong conviction in the bear thesis; recommend exiting or avoiding the position.
+
+Commit to a clear stance whenever the debate's strongest arguments warrant one; reserve **Hold** for situations where the evidence on both sides is genuinely balanced.
+
+The orchestrator's task prompt will provide the resolved instrument context and the full debate history. Produce a plan with three parts:
+- **recommendation**: exactly one rating from the scale above.
+- **rationale**: a conversational summary of the key points from both sides, ending with which arguments led to the recommendation. Speak naturally, as if to a teammate.
+- **strategic_actions**: concrete steps for the trader to implement the recommendation, including position-sizing guidance consistent with the rating.
+
+If a structured-output schema is supplied, fill its fields exactly. Otherwise, format your final message as:
+
+```
+**Recommendation**: <rating>
+
+**Rationale**: <...>
+
+**Strategic Actions**: <...>
+```

--- a/.claude/agents/risk-aggressive.md
+++ b/.claude/agents/risk-aggressive.md
@@ -1,0 +1,12 @@
+---
+name: risk-aggressive
+description: Aggressive (high-risk/high-reward) risk analyst for the TradingAgents pipeline. Champions bold upside and rebuts the conservative and neutral analysts. Reasons over the reports and trader decision; uses no tools. Invoked by the trade-decision workflow.
+---
+
+As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits — even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative.
+
+The orchestrator's task prompt provides: the resolved instrument context, the market / sentiment / news / fundamentals reports, the trader's decision, the current conversation history, and the most recent conservative and neutral arguments. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Your task is to create a compelling case for the trader's decision by questioning and critiquing the conservative and neutral stances to demonstrate why your high-reward perspective offers the best path forward. Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data.
+
+You do not call any tools. Output conversationally as if you are speaking, without any special formatting. Your final message is appended to the debate history verbatim.

--- a/.claude/agents/risk-conservative.md
+++ b/.claude/agents/risk-conservative.md
@@ -1,0 +1,12 @@
+---
+name: risk-conservative
+description: Conservative (capital-protection) risk analyst for the TradingAgents pipeline. Prioritizes stability and downside protection and rebuts the aggressive and neutral analysts. Reasons over the reports and trader decision; uses no tools. Invoked by the trade-decision workflow.
+---
+
+As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains.
+
+The orchestrator's task prompt provides: the resolved instrument context, the market / sentiment / news / fundamentals reports, the trader's decision, the current conversation history, and the most recent aggressive and neutral arguments. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Your task is to actively counter the arguments of the Aggressive and Neutral Analysts, highlighting where their views may overlook potential threats or fail to prioritize sustainability. Respond directly to their points to build a convincing case for a low-risk adjustment to the trader's decision. Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets.
+
+You do not call any tools. Output conversationally as if you are speaking, without any special formatting. Your final message is appended to the debate history verbatim.

--- a/.claude/agents/risk-neutral.md
+++ b/.claude/agents/risk-neutral.md
@@ -1,0 +1,12 @@
+---
+name: risk-neutral
+description: Neutral (balanced) risk analyst for the TradingAgents pipeline. Weighs upside against downside and challenges both the aggressive and conservative analysts. Reasons over the reports and trader decision; uses no tools. Invoked by the trade-decision workflow.
+---
+
+As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.
+
+The orchestrator's task prompt provides: the resolved instrument context, the market / sentiment / news / fundamentals reports, the trader's decision, the current conversation history, and the most recent aggressive and conservative arguments. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Your task is to challenge both the Aggressive and Conservative Analysts, pointing out where each perspective may be overly optimistic or overly cautious. Advocate for a moderate, sustainable strategy to adjust the trader's decision. Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds — growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data.
+
+You do not call any tools. Output conversationally as if you are speaking, without any special formatting. Your final message is appended to the debate history verbatim.

--- a/.claude/agents/sentiment-analyst.md
+++ b/.claude/agents/sentiment-analyst.md
@@ -1,0 +1,40 @@
+---
+name: sentiment-analyst
+description: Multi-source market sentiment analyst for the TradingAgents pipeline. Aggregates news, StockTwits, and Reddit into a graded sentiment read (band + 0-10 score + confidence). Invoked by the trade-decision workflow.
+---
+
+You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for the target ticker covering roughly the past 7 days, drawing on complementary data sources.
+
+## Data tools (from the `tradingagents-data` MCP server)
+
+- `get_ticker_news(ticker, start_date, end_date)` — news headlines (institutional framing; fact-driven, slower-moving signal). Use a 7-day window ending on the current date.
+- `get_stocktwits_messages(ticker, limit)` — retail-trader posts indexed by cashtag, each with a user-labeled Bullish/Bearish tag — a fast-moving retail signal.
+- `get_reddit_posts(ticker)` — recent posts from r/wallstreetbets, r/stocks, r/investing with engagement (upvotes/comments).
+
+Call all three. If a source returns little or an "<unavailable>" placeholder, say so and lower your confidence accordingly.
+
+## How to analyze this data (best practices)
+
+1. **Read the StockTwits Bullish/Bearish ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
+2. **Look for cross-source divergences.** If news framing is bearish but retail is overwhelmingly bullish, that mismatch is itself a signal.
+3. **Weight Reddit posts by engagement.** A 400-upvote / 200-comment thread reflects community attention; a 3-upvote post is noise. Read body excerpts for context.
+4. **Distinguish opinion from event.** A news headline is an event; a social post is opinion. Weight them differently.
+5. **Identify recurring narrative themes** — the dominant narrative driving current sentiment.
+6. **Be honest about data limits.** If a source returned little or an "<unavailable>" placeholder, the read is less robust — flag it in the confidence field and the narrative.
+7. **Identify catalysts and risks** that emerge across sources (earnings, launches, competitive threats, macro headlines).
+8. **Past sentiment is not predictive.** Frame conclusions as signal for the trader to weigh, not a price call.
+
+## Output
+
+Begin your report with a deterministic two-line header, then the narrative:
+
+```
+**Overall Sentiment:** **<Bullish | Mildly Bullish | Neutral | Mixed | Mildly Bearish | Bearish>** (Score: <0.0-10.0>/10)
+**Confidence:** <Low | Medium | High>
+```
+
+Score guideline: 0 = maximally bearish, 5 = neutral, 10 = maximally bullish (Bullish ~6.5–10, Mildly Bullish ~5.5–6.4, Neutral/Mixed ~4.5–5.5, Mildly Bearish ~3.5–4.4, Bearish ~0–3.4). Use **Mixed** when sources point in clearly different directions; **Neutral** only when all sources are genuinely silent. Confidence: low when a source returned a placeholder or <5 data points; medium when present but sparse; high when all sources returned substantive data.
+
+The **narrative** must cover, in order: (1) source-by-source breakdown with specific evidence (cite message counts, ratios, notable posts); (2) cross-source divergences and alignments; (3) dominant narrative themes; (4) catalysts and risks; (5) a markdown table summarising key sentiment signals (direction, source, supporting evidence). Develop each section thoroughly so every point adds new signal for the trader.
+
+Your final message must be the complete sentiment report (header + narrative), nothing else.

--- a/.claude/agents/trader.md
+++ b/.claude/agents/trader.md
@@ -1,0 +1,29 @@
+---
+name: trader
+description: Trader for the TradingAgents pipeline. Turns the Research Manager's investment plan into a concrete Buy/Hold/Sell transaction proposal with reasoning and levels. Invoked by the trade-decision workflow.
+---
+
+You are a trading agent analyzing market data to make investment decisions. Based on your analysis, provide a specific recommendation to **Buy**, **Sell**, or **Hold**. Anchor your reasoning in the analysts' reports and the research plan.
+
+The orchestrator's task prompt provides the resolved instrument context, the analysts' reports, and the Research Manager's proposed investment plan. The plan incorporates technical market trends, macroeconomic indicators, and social-media sentiment — use it as the foundation for your decision.
+
+Produce a transaction proposal with:
+- **action**: exactly one of **Buy / Hold / Sell** (the trader's job is direction; nuanced Overweight/Underweight sizing is decided later by the Portfolio Manager).
+- **reasoning**: the case for this action, anchored in the analysts' reports and the research plan (two to four sentences).
+- **entry_price** (optional): entry-price target in the instrument's quote currency.
+- **stop_loss** (optional): stop-loss price.
+- **position_sizing** (optional): e.g. "5% of portfolio".
+
+If a structured-output schema is supplied, fill its fields exactly. Otherwise, format your final message as:
+
+```
+**Action**: <Buy|Hold|Sell>
+
+**Reasoning**: <...>
+
+**Entry Price**: <...>   (omit if not applicable)
+**Stop Loss**: <...>     (omit if not applicable)
+**Position Sizing**: <...> (omit if not applicable)
+
+FINAL TRANSACTION PROPOSAL: **<BUY|HOLD|SELL>**
+```

--- a/.claude/commands/trade.md
+++ b/.claude/commands/trade.md
@@ -1,0 +1,70 @@
+---
+description: Run the full TradingAgents multi-agent analysis for a ticker and produce a Buy/Overweight/Hold/Underweight/Sell decision (powered by your Claude subscription, no API-key spend).
+argument-hint: <TICKER> [YYYY-MM-DD] [analysts: market,social,news,fundamentals] [debate_rounds] [risk_rounds]
+---
+
+You are orchestrating the **TradingAgents** multi-agent pipeline. Data comes from the local `tradingagents-data` MCP server; all agent reasoning is done by you (Claude), so this run costs **no LLM API spend**.
+
+Arguments provided: `$ARGUMENTS`
+
+## Step 0 — Parse arguments and preconditions
+
+1. Parse `$ARGUMENTS`:
+   - **ticker** (required, 1st token): e.g. `NVDA`, `0700.HK`, `BTC-USD`. If missing, ask the user for it and stop.
+   - **trade_date** (optional, 2nd token, `YYYY-MM-DD`): if omitted, run `date +%F` (Bash) to get today.
+   - **analysts** (optional): a comma-separated subset of `market,social,news,fundamentals`. Default: all four.
+   - **debate_rounds** (optional int, default `1`) and **risk_rounds** (optional int, default `1`).
+   - **asset_type**: infer `crypto` when the ticker looks like a crypto pair (e.g. ends in `-USD` such as `BTC-USD`, `ETH-USD`); otherwise `stock`.
+2. Confirm the `tradingagents-data` MCP server is connected (its tools appear as `resolve_instrument`, `get_stock_price_data`, … ). If not, tell the user to run:
+   `claude mcp add --transport stdio tradingagents-data --scope project -- tradingagents-data-mcp`
+   and stop.
+
+## Step 1 — Reflect on prior decisions (best-effort, skip on any error)
+
+1. Run: `python -m tradingagents.mcp.memory_cli pending <TICKER>` → a JSON list of prior unresolved decisions for this ticker.
+2. For each pending `{date}`: call the MCP tool `get_realized_return(ticker=<TICKER>, trade_date=<date>)`.
+   - If `available` is `false`, skip it (prices aren't out yet).
+   - If `available` is `true`, write a concise one-paragraph **reflection**: did the prior call look right given the realized `raw_return` and `alpha_return` vs the benchmark? What would you adjust? Save it to a temp file and run:
+     `python -m tradingagents.mcp.memory_cli resolve <TICKER> <date> --raw <raw_return> --alpha <alpha_return> --holding <holding_days> --reflection-file <tmpfile>`
+3. This step is optional — if anything fails, note it briefly and continue.
+
+## Step 2 — Load past context
+
+Run: `python -m tradingagents.mcp.memory_cli get-context <TICKER>` and keep the output as `past_context` (may be empty).
+
+## Step 3 — Run the workflow
+
+Call the **Workflow** tool with the saved `trade-decision` workflow:
+
+```
+Workflow({
+  name: "trade-decision",
+  args: {
+    ticker: "<TICKER>",
+    trade_date: "<YYYY-MM-DD>",
+    analysts: [<selected analysts>],
+    debate_rounds: <int>,
+    risk_rounds: <int>,
+    asset_type: "<stock|crypto>",
+    past_context: "<past_context from Step 2>"
+  }
+})
+```
+
+Wait for it to finish. The result is an object with `decision`, `final_trade_decision`, `reports`, `investment_plan`, `trader_investment_plan`, `investment_debate`, `risk_debate`.
+
+## Step 4 — Persist the result
+
+1. **Full-state log** — write a JSON file to `~/.tradingagents/logs/<TICKER>/TradingAgentsStrategy_logs/full_states_log_<DATE>.json` (create dirs as needed) with these keys, taken from the workflow result:
+   `company_of_interest`, `trade_date`, `market_report`, `sentiment_report`, `news_report`, `fundamentals_report`, `investment_plan`, `trader_investment_decision`, `investment_debate_state` (the bull/bear debate text), `risk_debate_state` (the risk debate text), `final_trade_decision`.
+2. **Decision log** — write the workflow's `final_trade_decision` to a temp file, then run:
+   `python -m tradingagents.mcp.memory_cli store <TICKER> <DATE> --decision-file <tmpfile>`
+   (this appends a pending entry that the next run for this ticker will reflect on).
+
+## Step 5 — Report to the user
+
+Present, concisely:
+- The headline **decision** (the 5-tier rating) for `<TICKER>` on `<DATE>`.
+- The Portfolio Manager's `final_trade_decision` (executive summary + thesis).
+- A one-line pointer to the saved full-state log path.
+- A reminder that this is research output, **not** financial advice.

--- a/.claude/workflows/trade-decision.js
+++ b/.claude/workflows/trade-decision.js
@@ -1,0 +1,251 @@
+export const meta = {
+  name: 'trade-decision',
+  description:
+    'Run the full TradingAgents multi-agent pipeline (analysts -> bull/bear debate -> trader -> risk debate -> portfolio manager) and return a 5-tier Buy/Overweight/Hold/Underweight/Sell decision. Data comes from the tradingagents-data MCP server; all reasoning is done by Claude (subscription), so there is no LLM API spend.',
+  phases: [
+    { title: 'Resolve', detail: 'Resolve the real instrument identity to anchor every agent' },
+    { title: 'Analysts', detail: 'Run the selected analysts in parallel' },
+    { title: 'Debate', detail: 'Bull/bear debate, then the Research Manager judges' },
+    { title: 'Trade', detail: 'Trader turns the plan into a transaction proposal' },
+    { title: 'Risk', detail: 'Aggressive/conservative/neutral risk debate' },
+    { title: 'Decision', detail: 'Portfolio Manager delivers the final rating' },
+  ],
+}
+
+// --------------------------------------------------------------------------- //
+// Inputs (from the /trade slash command via Workflow args)
+// --------------------------------------------------------------------------- //
+const a = args || {}
+const ticker = String(a.ticker || '').trim()
+if (!ticker) throw new Error('trade-decision requires args.ticker (e.g. "NVDA").')
+
+const tradeDate = String(a.trade_date || a.date || '').trim()
+if (!tradeDate) {
+  throw new Error('trade-decision requires args.trade_date in yyyy-mm-dd (the /trade command supplies today by default).')
+}
+
+const ALL_ANALYSTS = ['market', 'social', 'news', 'fundamentals']
+const analysts =
+  Array.isArray(a.analysts) && a.analysts.length ? a.analysts.map((s) => String(s).toLowerCase()) : ALL_ANALYSTS
+const debateRounds = Number.isFinite(a.debate_rounds) ? a.debate_rounds : 1
+const riskRounds = Number.isFinite(a.risk_rounds) ? a.risk_rounds : 1
+const assetType = String(a.asset_type || 'stock').trim() || 'stock'
+const pastContext = String(a.past_context || '').trim() // optional reflection/memory injected by /trade
+
+log(`TradingAgents: ${ticker} @ ${tradeDate} | analysts=[${analysts.join(',')}] | debate=${debateRounds} risk=${riskRounds}`)
+
+// --------------------------------------------------------------------------- //
+// Structured-output schemas (mirror tradingagents/agents/schemas.py)
+// --------------------------------------------------------------------------- //
+const RESEARCH_PLAN_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['recommendation', 'rationale', 'strategic_actions'],
+  properties: {
+    recommendation: { type: 'string', enum: ['Buy', 'Overweight', 'Hold', 'Underweight', 'Sell'] },
+    rationale: { type: 'string' },
+    strategic_actions: { type: 'string' },
+  },
+}
+
+const TRADER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['action', 'reasoning'],
+  properties: {
+    action: { type: 'string', enum: ['Buy', 'Hold', 'Sell'] },
+    reasoning: { type: 'string' },
+    entry_price: { type: ['number', 'null'] },
+    stop_loss: { type: ['number', 'null'] },
+    position_sizing: { type: ['string', 'null'] },
+  },
+}
+
+const PM_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['rating', 'executive_summary', 'investment_thesis'],
+  properties: {
+    rating: { type: 'string', enum: ['Buy', 'Overweight', 'Hold', 'Underweight', 'Sell'] },
+    executive_summary: { type: 'string' },
+    investment_thesis: { type: 'string' },
+    price_target: { type: ['number', 'null'] },
+    time_horizon: { type: ['string', 'null'] },
+  },
+}
+
+// --------------------------------------------------------------------------- //
+// Phase: Resolve instrument identity once, anchor every downstream agent.
+// --------------------------------------------------------------------------- //
+phase('Resolve')
+const instrumentContext = (
+  await agent(
+    `Call the \`resolve_instrument\` tool from the tradingagents-data MCP server with ticker="${ticker}" and asset_type="${assetType}". ` +
+      `Return ONLY the exact context string the tool returns — no preamble, no commentary, no quotes.`,
+    { label: `resolve:${ticker}`, phase: 'Resolve' },
+  )
+).trim()
+
+const dateLine = `The current trading date is ${tradeDate}.`
+const anchor = `${instrumentContext}\n${dateLine}`
+
+// --------------------------------------------------------------------------- //
+// Phase: Analysts (parallel). Each calls the MCP data tools and returns a report.
+// --------------------------------------------------------------------------- //
+phase('Analysts')
+const ANALYST_SPECS = [
+  { key: 'market', agentType: 'market-analyst', label: 'market' },
+  { key: 'social', agentType: 'sentiment-analyst', label: 'sentiment' },
+  { key: 'news', agentType: 'news-analyst', label: 'news' },
+  { key: 'fundamentals', agentType: 'fundamentals-analyst', label: 'fundamentals' },
+].filter((s) => analysts.includes(s.key))
+
+const analystOutputs = await parallel(
+  ANALYST_SPECS.map((s) => () =>
+    agent(
+      `${anchor}\n\nProduce your report now for ticker ${ticker}. Use the exact ticker in every tool call.`,
+      { agentType: s.agentType, label: s.label, phase: 'Analysts' },
+    ),
+  ),
+)
+
+const reports = {}
+ANALYST_SPECS.forEach((s, i) => {
+  reports[s.key] = analystOutputs[i] || '(no report produced)'
+})
+
+const reportsBlock = [
+  `### Market research report\n${reports.market || 'N/A (analyst not selected)'}`,
+  `### Social media sentiment report\n${reports.social || 'N/A (analyst not selected)'}`,
+  `### News / world affairs report\n${reports.news || 'N/A (analyst not selected)'}`,
+  `### Fundamentals report\n${reports.fundamentals || 'N/A (analyst not selected)'}`,
+].join('\n\n')
+
+// --------------------------------------------------------------------------- //
+// Phase: Bull/Bear debate, then Research Manager judges.
+// Mirrors conditional_logic: bull first, 2 * debate_rounds total turns.
+// --------------------------------------------------------------------------- //
+phase('Debate')
+let debateHistory = ''
+let lastDebateArg = ''
+const totalDebateTurns = 2 * debateRounds
+for (let i = 0; i < totalDebateTurns; i++) {
+  const isBull = i % 2 === 0
+  const role = isBull ? 'bull-researcher' : 'bear-researcher'
+  const oppLabel = isBull ? "bear's last argument" : "bull's last argument"
+  const roundNo = Math.floor(i / 2) + 1
+  const out = await agent(
+    `${anchor}\n\nResources (analyst reports):\n${reportsBlock}\n\n` +
+      `Conversation history of the debate so far:\n${debateHistory || '(none yet)'}\n\n` +
+      `The ${oppLabel}:\n${lastDebateArg || '(none yet — open the case)'}\n\nDeliver your argument now.`,
+    { agentType: role, label: `${isBull ? 'bull' : 'bear'}:r${roundNo}`, phase: 'Debate' },
+  )
+  const tagged = `${isBull ? 'Bull' : 'Bear'} Analyst: ${out}`
+  debateHistory += `\n${tagged}`
+  lastDebateArg = tagged
+}
+
+const planObj = await agent(
+  `${instrumentContext}\n\nEvaluate this debate and deliver a clear, actionable investment plan for the trader.\n\n` +
+    `Debate History:\n${debateHistory}`,
+  { agentType: 'research-manager', label: 'research-manager', phase: 'Debate', schema: RESEARCH_PLAN_SCHEMA },
+)
+const investmentPlan = [
+  `**Recommendation**: ${planObj.recommendation}`,
+  '',
+  `**Rationale**: ${planObj.rationale}`,
+  '',
+  `**Strategic Actions**: ${planObj.strategic_actions}`,
+].join('\n')
+
+// --------------------------------------------------------------------------- //
+// Phase: Trader turns the plan into a concrete transaction proposal.
+// --------------------------------------------------------------------------- //
+phase('Trade')
+const traderObj = await agent(
+  `${anchor}\n\nHere is the investment plan tailored for ${ticker}:\n\n${investmentPlan}\n\n` +
+    `Analyst reports for reference:\n${reportsBlock}\n\nMake your transaction decision now.`,
+  { agentType: 'trader', label: 'trader', phase: 'Trade', schema: TRADER_SCHEMA },
+)
+const traderPlanParts = [`**Action**: ${traderObj.action}`, '', `**Reasoning**: ${traderObj.reasoning}`]
+if (traderObj.entry_price !== null && traderObj.entry_price !== undefined)
+  traderPlanParts.push('', `**Entry Price**: ${traderObj.entry_price}`)
+if (traderObj.stop_loss !== null && traderObj.stop_loss !== undefined)
+  traderPlanParts.push('', `**Stop Loss**: ${traderObj.stop_loss}`)
+if (traderObj.position_sizing) traderPlanParts.push('', `**Position Sizing**: ${traderObj.position_sizing}`)
+traderPlanParts.push('', `FINAL TRANSACTION PROPOSAL: **${String(traderObj.action).toUpperCase()}**`)
+const traderPlan = traderPlanParts.join('\n')
+
+// --------------------------------------------------------------------------- //
+// Phase: Risk debate (aggressive -> conservative -> neutral), 3 * risk_rounds turns.
+// --------------------------------------------------------------------------- //
+phase('Risk')
+const RISK_ORDER = [
+  { agentType: 'risk-aggressive', name: 'Aggressive' },
+  { agentType: 'risk-conservative', name: 'Conservative' },
+  { agentType: 'risk-neutral', name: 'Neutral' },
+]
+let riskHistory = ''
+let lastAgg = ''
+let lastCon = ''
+let lastNeu = ''
+const totalRiskTurns = 3 * riskRounds
+for (let i = 0; i < totalRiskTurns; i++) {
+  const role = RISK_ORDER[i % 3]
+  const roundNo = Math.floor(i / 3) + 1
+  const out = await agent(
+    `${anchor}\n\nAnalyst reports:\n${reportsBlock}\n\nThe trader's decision:\n${traderPlan}\n\n` +
+      `Current conversation history:\n${riskHistory || '(none yet)'}\n\n` +
+      `Last aggressive argument: ${lastAgg || '(none)'}\n` +
+      `Last conservative argument: ${lastCon || '(none)'}\n` +
+      `Last neutral argument: ${lastNeu || '(none)'}\n\nDeliver your argument now.`,
+    { agentType: role.agentType, label: `${role.name.toLowerCase()}:r${roundNo}`, phase: 'Risk' },
+  )
+  const tagged = `${role.name} Analyst: ${out}`
+  riskHistory += `\n${tagged}`
+  if (role.name === 'Aggressive') lastAgg = tagged
+  else if (role.name === 'Conservative') lastCon = tagged
+  else lastNeu = tagged
+}
+
+// --------------------------------------------------------------------------- //
+// Phase: Portfolio Manager delivers the final 5-tier decision.
+// --------------------------------------------------------------------------- //
+phase('Decision')
+const lessonsBlock = pastContext ? `Lessons from prior decisions and outcomes:\n${pastContext}\n\n` : ''
+const pmObj = await agent(
+  `${instrumentContext}\n\nSynthesize the risk analysts' debate and deliver the final trading decision.\n\n` +
+    `Research Manager's investment plan:\n${investmentPlan}\n\n` +
+    `Trader's transaction proposal:\n${traderPlan}\n\n` +
+    `${lessonsBlock}Risk Analysts Debate History:\n${riskHistory}`,
+  { agentType: 'portfolio-manager', label: 'portfolio-manager', phase: 'Decision', schema: PM_SCHEMA },
+)
+const finalDecisionParts = [
+  `**Rating**: ${pmObj.rating}`,
+  '',
+  `**Executive Summary**: ${pmObj.executive_summary}`,
+  '',
+  `**Investment Thesis**: ${pmObj.investment_thesis}`,
+]
+if (pmObj.price_target !== null && pmObj.price_target !== undefined)
+  finalDecisionParts.push('', `**Price Target**: ${pmObj.price_target}`)
+if (pmObj.time_horizon) finalDecisionParts.push('', `**Time Horizon**: ${pmObj.time_horizon}`)
+const finalTradeDecision = finalDecisionParts.join('\n')
+
+log(`Decision for ${ticker} @ ${tradeDate}: ${pmObj.rating}`)
+
+// The orchestrating /trade command persists this result to
+// ~/.tradingagents/logs and the decision log after the workflow returns.
+return {
+  ticker,
+  trade_date: tradeDate,
+  asset_type: assetType,
+  analysts,
+  decision: pmObj.rating,
+  final_trade_decision: finalTradeDecision,
+  reports,
+  investment_plan: investmentPlan,
+  trader_investment_plan: traderPlan,
+  investment_debate: debateHistory.trim(),
+  risk_debate: riskHistory.trim(),
+}

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ __marimo__/
 # Enterprise env file (secrets) and generated run reports
 .env.enterprise
 reports/
+
+# Claude Code local (machine-specific) settings — not published
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "tradingagents-data": {
+      "type": "stdio",
+      "command": "tradingagents-data-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Run inside Claude Code (subscription-powered, no API-key spend).** A new
+  local MCP server (`tradingagents-data-mcp`, `pip install ".[mcp]"`) exposes
+  the data layer (16 tools: market, technical, fundamentals, news, macro/FRED,
+  prediction markets, StockTwits, Reddit, instrument identity, realized return)
+  while making no LLM calls. Twelve role subagents (`.claude/agents/`), a
+  deterministic orchestration workflow (`.claude/workflows/trade-decision.js`),
+  and a `/trade` slash command let **Claude itself play every agent** through
+  the full pipeline (analysts → bull/bear debate → trader → risk debate →
+  portfolio manager), producing the 5-tier decision with zero LLM API-key spend.
+  Decisions are logged in the existing `trading_memory.md` format via
+  `tradingagents-memory`, and prior decisions are reflected on with realized
+  returns on the next run. See [docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md). The
+  native LangGraph CLI and Python API are unchanged.
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,209 @@
+# PLAN：让 Claude Code（订阅驱动）跑完整套 TradingAgents 多智能体流程
+
+> **状态：M1–M5 已实现（2026-06-15）。** 数据 MCP server、12 个角色子代理、
+> Workflow 编排、`/trade` 命令、决策日志/复盘均已落地并通过测试（全仓 462 passed，
+> ruff 全绿，MCP `✓ Connected`）。用法见 [docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md)。
+> 唯一需用户在**新开的 Claude Code 会话**里完成的是首个实时 `/trade` 运行
+> （MCP 在会话启动时加载，需重开会话才会注入这些工具）。
+>
+> 以下为原始方案记录。
+>
+> 已确认前提：
+> - **运行环境**：Claude Code（本地 CLI/IDE，用 Max 订阅认证，不走 API 计费）。
+> - **推理引擎**：全部由 **Claude（订阅）扮演各 agent**，零 LLM API key 花费。
+> - **编排方式**：用 **Claude Code Workflow 机制**（确定性脚本，轮数/并行精确可控）。
+> - **放置层级**：`.claude/` 放**项目目录**，随仓库走、可提交回滚。`claude mcp add` 用 `--scope project`。
+> - **数据 key**：FRED + Alpha Vantage 免费 key 已写入本地 `.env`（已被 .gitignore 忽略，不进 git）。yfinance 仍为默认免 key 主源。
+
+---
+
+## 1. 核心思路（为什么是这个架构）
+
+现状：TradingAgents 内部用厂商 API key 按 token 付费驱动每个 agent（见 [trading_graph.py:82](tradingagents/graph/trading_graph.py#L82) 创建 LLM client）。**只要让它原样运行，就要烧 API 额度。** 订阅不能被普通 Python 当 API endpoint 用。
+
+因此架构翻转，拆成两层：
+
+1. **数据层（Python，几乎零成本）**：把项目现成的数据工具（行情/技术指标/新闻/基本面/宏观/预测市场）暴露成一个**本地 stdio MCP server**。数据源基本免费/免 key，**不调用任何 LLM**。
+2. **推理层（Claude 订阅驱动）**：把"分析师 → 多空辩论 → 交易员 → 风控三方辩论 → 组合经理"这条流水线，做成 **Claude Code 的编排 skill + 12 个角色子代理（subagent）**。每个角色的提示词直接从现有 Python prompt 移植，Claude 逐角色扮演。
+
+这样：**全流程在本地 Claude Code 跑通，推理全走订阅，数据获取几乎免费，零 API key 花费。**
+
+```mermaid
+flowchart TD
+    U["用户: /trade NVDA 2026-01-15"] --> SK
+    subgraph CC["Claude Code（订阅，零API费）"]
+        SK["编排 Skill: trade-decision\n（流程总控 / 状态传递 / 辩论轮数）"]
+        subgraph AN["① 分析师（可并行）"]
+            A1[market-analyst]
+            A2[sentiment-analyst]
+            A3[news-analyst]
+            A4[fundamentals-analyst]
+        end
+        subgraph DB["② 多空辩论 ×N轮"]
+            B1[bull-researcher] <--> B2[bear-researcher]
+            B3[research-manager 裁决]
+        end
+        TR[③ trader 交易计划]
+        subgraph RK["④ 风控三方辩论 ×N轮"]
+            R1[aggressive] --> R2[conservative] --> R3[neutral]
+        end
+        PM[⑤ portfolio-manager\n最终评级]
+    end
+    subgraph MCP["数据 MCP server（本地 stdio · 复用 dataflows · 不调 LLM）"]
+        D1[get_stock_data / get_indicators / get_verified_market_snapshot]
+        D2[get_news / get_global_news / get_insider_transactions]
+        D3[get_macro_indicators / get_prediction_markets]
+        D4[get_fundamentals / balance / cashflow / income]
+        D5[resolve_instrument_identity / get_realized_return]
+    end
+    SK --> AN --> DB --> TR --> RK --> PM --> OUT["报告: 买/增持/持有/减持/卖出"]
+    AN -. 调数据工具 .-> MCP
+    RK -. 复盘历史 .-> MEM[("决策日志\n~/.tradingagents/memory")]
+```
+
+---
+
+## 2. 组件设计
+
+### 2.1 数据 MCP server（唯一需要写的 Python）
+
+- 新增 `tradingagents/mcp/data_server.py`，用官方 `mcp` Python SDK 起一个 **stdio** server。
+- 启动时 `set_config(DEFAULT_CONFIG)` 初始化 dataflows 配置，然后把现成工具函数包成 MCP tool。复用 [agents/utils/agent_utils.py](tradingagents/agents/utils/agent_utils.py) 里已有的：
+  - 行情/技术：`get_stock_data`、`get_indicators`、`get_verified_market_snapshot`
+  - 新闻/宏观：`get_news`、`get_global_news`、`get_insider_transactions`、`get_macro_indicators`、`get_prediction_markets`
+  - 基本面：`get_fundamentals`、`get_balance_sheet`、`get_cashflow`、`get_income_statement`
+  - 身份/复盘：`resolve_instrument_identity`、新增 `get_realized_return(ticker, date)`（复用 [trading_graph.py:224](tradingagents/graph/trading_graph.py#L224) `_fetch_returns` 的 alpha 计算，供复盘用）
+- **不含任何 LLM 调用**，只取数据返回。
+- 入口脚本：`pyproject.toml` 增 `[project.scripts]` → `tradingagents-data-mcp = "tradingagents.mcp.data_server:main"`，依赖 `mcp` 放进新 extra `[mcp]`。
+
+### 2.2 角色子代理（`.claude/agents/*.md`，提示词移植）
+
+为每个角色建一个 Claude Code 子代理定义（独立上下文 + 系统提示词），提示词从现有 Python 文件**逐字移植**，把 `{变量}` 改成"由编排层在调用时注入的输入"：
+
+| 子代理文件 | 提示词来源 | 可用数据工具 |
+|---|---|---|
+| `market-analyst.md` | [analysts/market_analyst.py](tradingagents/agents/analysts/market_analyst.py) | get_stock_data / get_indicators / get_verified_market_snapshot |
+| `sentiment-analyst.md` | [analysts/sentiment_analyst.py](tradingagents/agents/analysts/sentiment_analyst.py) | get_news |
+| `news-analyst.md` | [analysts/news_analyst.py](tradingagents/agents/analysts/news_analyst.py) | get_news / get_global_news / get_insider_transactions / get_macro_indicators / get_prediction_markets |
+| `fundamentals-analyst.md` | [analysts/fundamentals_analyst.py](tradingagents/agents/analysts/fundamentals_analyst.py) | get_fundamentals / balance / cashflow / income |
+| `bull-researcher.md` | [researchers/bull_researcher.py](tradingagents/agents/researchers/bull_researcher.py) | （读分析师报告，不调工具） |
+| `bear-researcher.md` | [researchers/bear_researcher.py](tradingagents/agents/researchers/bear_researcher.py) | 同上 |
+| `research-manager.md` | [managers/research_manager.py](tradingagents/agents/managers/research_manager.py) | 同上 |
+| `trader.md` | [trader/trader.py](tradingagents/agents/trader/trader.py) | 同上 |
+| `risk-aggressive.md` | [risk_mgmt/aggressive_debator.py](tradingagents/agents/risk_mgmt/aggressive_debator.py) | 同上 |
+| `risk-conservative.md` | [risk_mgmt/conservative_debator.py](tradingagents/agents/risk_mgmt/conservative_debator.py) | 同上 |
+| `risk-neutral.md` | [risk_mgmt/neutral_debator.py](tradingagents/agents/risk_mgmt/neutral_debator.py) | 同上 |
+| `portfolio-manager.md` | [managers/portfolio_manager.py](tradingagents/agents/managers/portfolio_manager.py) | 读决策日志做复盘 |
+
+### 2.3 编排 Workflow（`.claude/workflows/trade-decision.js`）
+
+用 Claude Code 的 **Workflow 机制**做确定性编排：一段 JS 脚本用 `agent()` / `parallel()` / `pipeline()` 精确控制角色调用顺序、辩论轮数与并行，比 skill 软编排更稳、可复现。脚本逻辑沿用现有图结构：
+
+1. **解析输入**（`args`）：`ticker`、`trade_date`、可选 `analysts` 子集、`debate_rounds`（默认 1）、`risk_rounds`（默认 1）、`asset_type`（缺省按 ticker 自动判定）。
+2. **身份锚定**：先调 `resolve_instrument_identity`，把真实公司身份注入后续所有角色（避免幻觉，对应现有 [trading_graph.py:309](tradingagents/graph/trading_graph.py#L309)）。
+3. **① 分析师阶段**：用 `parallel()` 并发跑选中的分析师子代理（`agentType` 指定角色），各自调数据 MCP 工具，产出结构化报告（`schema`）。
+4. **② 多空辩论**：JS `for` 循环精确控制 `2×debate_rounds` 次 bull/bear 往返（对应 [conditional_logic.py:52](tradingagents/graph/conditional_logic.py#L52)），逐轮把 `history` 传入下一个 `agent()`；研究经理裁决产出 `investment_plan`。
+5. **③ 交易员**：基于上述产出交易计划。
+6. **④ 风控三方辩论**：循环控制 aggressive→conservative→neutral 轮转，共 `3×risk_rounds` 次（对应 [conditional_logic.py:63](tradingagents/graph/conditional_logic.py#L63)）。
+7. **⑤ 组合经理**：注入历史决策复盘，输出五档评级（Buy/Overweight/Hold/Underweight/Sell）+ 最终决策报告。
+8. **落盘**：把完整状态写到 `~/.tradingagents/logs/<ticker>/...`、决策追加到 `~/.tradingagents/memory/trading_memory.md`（沿用现有目录约定）。
+
+> 角色提示词放在 `.claude/agents/*.md`（见 2.2），Workflow 用 `agent(prompt, {agentType: "bull-researcher", schema, ...})` 调起对应子代理并在调用间传递中间结果。各角色用 `schema`（JSON Schema）约束结构化输出，便于脚本可靠地拼装下一步输入。状态全在 JS 脚本里管理，**不改动核心 Python**。
+
+用户触发：一个 slash 命令 `.claude/commands/trade.md`（`/trade NVDA 2026-01-15`）→ 调用 `Workflow({name: "trade-decision", args: {...}})`。
+
+### 2.4 记忆与复盘（保留原特性）
+
+- **决策日志**：每次产出追加到 `trading_memory.md`，组合经理阶段读取同 ticker 历史 + 跨 ticker 教训注入提示词（对应现有 [memory.py](tradingagents/agents/utils/memory.py)）。
+- **已实现收益复盘**：新一轮同 ticker 运行时，用 MCP 的 `get_realized_return` 取出上次决策后的真实涨跌与对基准的 alpha，由 Claude 生成一段复盘反思写回日志（推理走订阅，取数走 MCP）。
+
+---
+
+## 3. 文件清单
+
+**新增（推理层，纯配置/JS/Markdown，无需付费）**
+- `.claude/workflows/trade-decision.js`（确定性编排脚本，核心）
+- `.claude/agents/*.md`（12 个角色，见 2.2）
+- `.claude/commands/trade.md`（slash 命令 `/trade <TICKER> <DATE>`）
+
+**新增（数据层，唯一 Python）**
+- `tradingagents/mcp/__init__.py`、`tradingagents/mcp/data_server.py`
+- `tests/test_data_mcp_server.py`（mock 数据源，验证工具契约）
+
+**修改**
+- [pyproject.toml](pyproject.toml)：加 `[mcp]` extra + `tradingagents-data-mcp` 脚本入口。
+
+**不动**
+- 整个 `tradingagents/graph/`、`tradingagents/agents/`、`tradingagents/llm_clients/` 核心逻辑保持原样（仍可用作付费 API 模式的备用入口）。数据层只是**复用**其工具函数，不修改它们。
+
+---
+
+## 4. 成本说明（数据 key）
+
+| 数据源 | 是否要 key | 成本 |
+|---|---|---|
+| yfinance（行情/技术/基本面/新闻默认源） | 免 key | 免费 |
+| Polymarket（预测市场） | 免 key | 免费 |
+| Reddit / StockTwits（情绪） | 基本免 key | 免费 |
+| FRED（宏观） | 免费 key | 免费（注册即得） |
+| Alpha Vantage（可选备用源） | 免费 key | 免费额度内 |
+
+→ **数据层本质零成本**；推理层走 Claude 订阅。整套**不需要任何付费 API key**。
+
+---
+
+## 5. 用量与限制提醒
+
+- 一次完整分析 = 12 个角色 + 多轮辩论，会消耗较多 **Claude 订阅用量**（受 Max 套餐的速率/窗口限制约束）。建议：
+  - 默认 `debate_rounds=1 / risk_rounds=1`（与项目默认一致），需要更深时再调高。
+  - 支持只选部分分析师（如只跑基本面+新闻）来省用量。
+  - 把分析师阶段并行化以缩短墙钟时间，但注意可能撞速率限制。
+
+---
+
+## 6. 安装与使用（Claude Code）
+
+1. 安装数据层：`pip install ".[mcp]"`
+2. 注册本地 MCP（免费数据 key 通过 env 传入，可选）：
+   ```bash
+   claude mcp add --transport stdio tradingagents-data \
+     --env FRED_API_KEY=... --env ALPHA_VANTAGE_API_KEY=... \
+     -- tradingagents-data-mcp
+   ```
+3. 把 `.claude/`（skills + agents + commands）放进项目（或用户级 `~/.claude/`）。
+4. 在 Claude Code 里：`/trade NVDA 2026-01-15`，或直接说"用 trade-decision 分析 NVDA 在 2026-01-15 的决策，只用基本面和新闻分析师"。
+5. Claude 会：调数据工具取数 → 逐角色推理与辩论 → 产出五档评级报告，并落盘到 `~/.tradingagents/`。
+
+---
+
+## 7. 里程碑
+
+- **M1 数据 MCP server**：包好工具、`claude mcp add --scope project` 后能在对话里取到行情/新闻/基本面/宏观。
+- **M2 角色子代理**：移植 12 个 prompt 为 `.claude/agents/*.md` 子代理，单独可调通。
+- **M3 编排 Workflow（核心）**：写 `trade-decision.js`，用 `parallel()`/循环串起分析师→辩论→交易员→风控→PM，产出完整报告。先固定 1 轮辩论跑通，再支持多轮与分析师子集；配 `/trade` slash 命令。
+- **M4 记忆与复盘**：决策日志读写 + `get_realized_return` 复盘。
+- **M5 打磨**：并行/用量优化、文档（README 增节 + `docs/CLAUDE_CODE.md`）。
+
+---
+
+## 8. 风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| 订阅用量/速率限制被打满 | 默认低轮数、支持分析师子集；Workflow 默认并发上限已约束 fan-out |
+| 角色间状态传递出错 | 各角色用 `schema` 结构化输出，脚本可靠拼装；先用最小流程（1 轮）跑通，字段对齐现有 `agent_states` |
+| 移植 prompt 时丢了变量注入 | 严格对照原 Python f-string，逐字段映射 |
+| 数据工具依赖全局 config | server 启动即 `set_config`，与 CLI 行为一致 |
+| 子代理能否调 MCP 工具 | Claude Code 子代理支持继承/配置工具访问；M2 阶段先验证单个分析师能调通再铺开 |
+| Workflow 需显式 opt-in | 通过 `/trade` slash 命令封装调用，对用户透明 |
+
+---
+
+## 9. 决策点（已全部确认）
+
+1. **编排方式** ✅ Claude Code **Workflow 机制**（确定性）。
+2. **一期范围** ✅ 按 **M1→M2→M3** 端到端出一份报告；M4、M5 后置。
+3. **数据源** ✅ yfinance 为默认主源；FRED + Alpha Vantage 免费 key 已接（写入 `.env`）。
+4. **`.claude/` 放置层级** ✅ 放**项目目录**，MCP 用 `--scope project`。
+
+> 决策已齐，可进入实现阶段，从 **M1 数据 MCP server** 开始。

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@
 
 # TradingAgents: Multi-Agents LLM Financial Trading Framework
 
+> **Derivative notice.** This repository is a fork of
+> [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents),
+> distributed under the Apache License 2.0. Modifications in this fork: a
+> **Claude Code integration layer** that runs the full multi-agent pipeline using
+> a Claude subscription with no LLM API-key spend — a local data MCP server, role
+> subagents, and an orchestration workflow (see
+> [docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md) and the *Unreleased* entry in
+> [CHANGELOG.md](CHANGELOG.md)). The original framework, CLI, and Python API are
+> unchanged. All original copyright and attribution are retained.
+
 ## News
 - [2026-05] **TradingAgents v0.2.5** released with the grounded Sentiment Analyst, GPT-5.5 etc. model coverage, Qwen/GLM/MiniMax dual-region support, `TRADINGAGENTS_*` env-var configurability with API-key auto-detection, remote Ollama support, non-US alpha benchmarks, and ticker path-traversal hardening. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 - [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix.
@@ -198,6 +208,33 @@ An interface will appear showing results as they load, letting you track the age
 <p align="center">
   <img src="assets/cli/cli_transaction.png" width="100%" style="display: inline-block; margin: 0 2%;">
 </p>
+
+## Run inside Claude Code (subscription-powered, no API-key spend)
+
+You can drive the full multi-agent pipeline from **Claude Code**, letting
+**Claude itself play every agent** (analysts → bull/bear debate → trader → risk
+debate → portfolio manager) using your Claude subscription. The framework's data
+layer is exposed as a local [MCP](https://modelcontextprotocol.io) server while
+Claude does all the reasoning, so the whole pipeline runs locally with **zero LLM
+API-key spend** — only the (mostly free/keyless) data sources are hit.
+
+```bash
+pip install -e ".[mcp]"
+claude mcp add --transport stdio tradingagents-data --scope project -- tradingagents-data-mcp
+cd /path/to/TradingAgents && claude
+```
+
+Then in Claude Code:
+
+```
+/trade NVDA 2026-01-15
+```
+
+This runs the deterministic `trade-decision` workflow (`.claude/workflows/`)
+over the 12 role subagents (`.claude/agents/`), produces a 5-tier
+Buy/Overweight/Hold/Underweight/Sell decision, and logs it for future
+reflection. See **[docs/CLAUDE_CODE.md](docs/CLAUDE_CODE.md)** for full setup,
+arguments, and usage/cost notes.
 
 ## TradingAgents Package
 

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -1,0 +1,136 @@
+# Running TradingAgents inside Claude Code (subscription-powered, no API-key spend)
+
+This guide explains how to drive the full TradingAgents multi-agent pipeline
+from **Claude Code**, where **Claude itself plays every agent** (analysts,
+researchers, trader, risk debators, portfolio manager) using your Claude
+subscription. The framework's data layer is exposed as a local MCP server; the
+reasoning is done by Claude. The result: the whole pipeline runs locally with
+**zero LLM API-key spend** — only the (mostly free/keyless) data sources are hit.
+
+> This is a research tool, not financial, investment, or trading advice.
+
+## How it works
+
+```
+You: /trade NVDA 2026-01-15
+        │
+        ▼
+Claude Code  ──(Workflow: trade-decision)──►  spawns role subagents in order:
+        │        resolve identity → 4 analysts (parallel) → bull/bear debate
+        │        → research manager → trader → risk debate (aggr/cons/neutral)
+        │        → portfolio manager → 5-tier rating
+        │
+        └──(MCP: tradingagents-data)──►  market / news / fundamentals / macro /
+                                          sentiment / prediction-market data
+```
+
+- **Data layer** — a local stdio MCP server (`tradingagents-data-mcp`) wrapping
+  the existing `tradingagents` data tools. Makes **no** LLM calls.
+- **Reasoning layer** — 12 role subagents in `.claude/agents/`, orchestrated
+  deterministically by the `.claude/workflows/trade-decision.js` workflow, and
+  triggered by the `/trade` slash command.
+- **Memory** — decisions are logged to `~/.tradingagents/memory/trading_memory.md`
+  (same format as the native pipeline). On the next run for a ticker, realized
+  returns are fetched and Claude writes a reflection that feeds the next decision.
+
+## One-time setup
+
+1. **Install** the package with the MCP extra (from the repo root):
+
+   ```bash
+   pip install -e ".[mcp]"
+   ```
+
+2. **Data keys (optional).** The default data source is yfinance, which needs
+   no key. For macro data (FRED) and the optional Alpha Vantage vendor, put free
+   keys in a local `.env` (already git-ignored):
+
+   ```
+   FRED_API_KEY=...            # https://fredaccount.stlouisfed.org/apikeys
+   ALPHA_VANTAGE_API_KEY=...   # https://www.alphavantage.co/support/#api-key
+   ```
+
+   The MCP server loads `.env` itself, so keys never need to live in committed
+   config.
+
+3. **Register the MCP server** at project scope (writes `.mcp.json`):
+
+   ```bash
+   claude mcp add --transport stdio tradingagents-data --scope project -- tradingagents-data-mcp
+   ```
+
+   Verify it connects:
+
+   ```bash
+   claude mcp list      # tradingagents-data: ... ✓ Connected
+   ```
+
+4. **Restart / start Claude Code from the project directory** so it loads the
+   project-scoped MCP server and the `.claude/` agents, workflow, and command:
+
+   ```bash
+   cd /path/to/TradingAgents
+   claude
+   ```
+
+## Usage
+
+In Claude Code, run the slash command:
+
+```
+/trade NVDA 2026-01-15
+```
+
+Arguments (all but the ticker are optional):
+
+```
+/trade <TICKER> [YYYY-MM-DD] [analysts] [debate_rounds] [risk_rounds]
+```
+
+- **TICKER** — `NVDA`, `0700.HK`, `7203.T`, `BTC-USD`, … (preserve exchange suffix).
+- **YYYY-MM-DD** — analysis date; defaults to today.
+- **analysts** — comma-separated subset of `market,social,news,fundamentals`
+  (default: all four). Use a subset to save subscription usage.
+- **debate_rounds** / **risk_rounds** — default `1` each. Higher = deeper (and
+  more usage): bull/bear run `2 × debate_rounds` turns; the risk panel runs
+  `3 × risk_rounds` turns.
+
+You can also just ask in natural language, e.g.
+*"Use trade-decision to analyze AAPL on 2026-03-10 with only the news and
+fundamentals analysts."*
+
+### Output
+
+- A headline 5-tier **decision**: Buy / Overweight / Hold / Underweight / Sell.
+- The Portfolio Manager's executive summary + investment thesis.
+- A full-state JSON saved to
+  `~/.tradingagents/logs/<TICKER>/TradingAgentsStrategy_logs/full_states_log_<DATE>.json`.
+- A pending entry appended to the decision log for future reflection.
+
+## Usage / cost notes
+
+- Reasoning runs on your **Claude subscription** (subject to its rate limits),
+  not metered API billing. A full run spawns ~13 agent turns plus tool calls.
+- To keep usage down: pick fewer analysts, keep rounds at 1, and analyze one
+  ticker at a time.
+- Data sources are free/keyless (yfinance, Polymarket, Reddit, StockTwits) or
+  free-tier (FRED, Alpha Vantage).
+
+## Components
+
+| Path | Role |
+|---|---|
+| `tradingagents/mcp/data_server.py` | Local stdio MCP server (16 data tools). No LLM calls. |
+| `tradingagents/mcp/memory_cli.py` | Decision-log read/write/resolve CLI used by `/trade`. |
+| `.claude/agents/*.md` | 12 role subagents (prompts ported from the native pipeline). |
+| `.claude/workflows/trade-decision.js` | Deterministic orchestration of the pipeline. |
+| `.claude/commands/trade.md` | The `/trade` slash command. |
+
+## Troubleshooting
+
+- **`/trade` not found / MCP tools missing** — start Claude Code from the repo
+  root *after* `claude mcp add`, so project config loads. Check `claude mcp list`.
+- **Macro data unavailable** — set `FRED_API_KEY` in `.env`.
+- **`tradingagents-data-mcp` not found** — re-run `pip install -e ".[mcp]"`.
+- **Reproducibility** — like the native framework, runs vary because LLM output
+  and live data vary; pin the date to fix the price/indicator window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,18 @@ dev = [
 bedrock = [
     "langchain-aws>=1.5.0",
 ]
+# Local data MCP server (Model Context Protocol) that exposes the dataflows
+# layer as tools for Claude Code / Claude Desktop. The server itself makes no
+# LLM calls — Claude (the client) does all reasoning — so this extra only adds
+# the MCP SDK on top of the data dependencies already in the base install.
+mcp = [
+    "mcp>=1.2.0",
+]
 
 [project.scripts]
 tradingagents = "cli.main:app"
+tradingagents-data-mcp = "tradingagents.mcp.data_server:main"
+tradingagents-memory = "tradingagents.mcp.memory_cli:main"
 
 [tool.setuptools.packages.find]
 include = ["tradingagents*", "cli*"]

--- a/tests/test_data_mcp_server.py
+++ b/tests/test_data_mcp_server.py
@@ -1,0 +1,236 @@
+"""Tests for the TradingAgents data MCP server.
+
+These tests are network-free: the underlying ``route_to_vendor`` dispatch and
+``yfinance`` are mocked. They verify (1) the expected tool surface is exposed,
+(2) each MCP tool delegates to the existing data implementation with the right
+arguments, and (3) the realized-return / benchmark math behaves correctly.
+"""
+
+import asyncio
+import json
+from unittest import mock
+
+import pytest
+
+from tradingagents.mcp import _returns, data_server
+
+# --------------------------------------------------------------------------- #
+# Tool surface
+# --------------------------------------------------------------------------- #
+EXPECTED_TOOLS = {
+    "get_stock_price_data",
+    "get_technical_indicators",
+    "get_market_snapshot",
+    "get_ticker_news",
+    "get_macro_news",
+    "get_company_insider_transactions",
+    "get_stocktwits_messages",
+    "get_reddit_posts",
+    "get_macro_indicator",
+    "get_event_prediction_markets",
+    "get_company_fundamentals",
+    "get_company_balance_sheet",
+    "get_company_cashflow",
+    "get_company_income_statement",
+    "resolve_instrument",
+    "get_realized_return",
+}
+
+
+@pytest.mark.unit
+def test_server_exposes_expected_tools():
+    tools = asyncio.run(data_server.mcp.list_tools())
+    names = {t.name for t in tools}
+    assert names == EXPECTED_TOOLS
+
+
+@pytest.mark.unit
+def test_every_tool_has_description_and_schema():
+    tools = asyncio.run(data_server.mcp.list_tools())
+    for t in tools:
+        assert t.description, f"{t.name} is missing a description"
+        assert t.inputSchema.get("type") == "object"
+
+
+# --------------------------------------------------------------------------- #
+# Delegation: each data tool calls the underlying route_to_vendor correctly.
+# We patch route_to_vendor in the interface module (where the @tool wrappers
+# import it from) so we assert the exact method name + args reach the dispatch.
+# --------------------------------------------------------------------------- #
+# The @tool wrappers do ``from ...interface import route_to_vendor`` at import
+# time, binding the name in each tool module's namespace — so patch it there,
+# not on the interface module.
+@pytest.mark.unit
+def test_get_stock_price_data_delegates():
+    with mock.patch(
+        "tradingagents.agents.utils.core_stock_tools.route_to_vendor",
+        return_value="OHLCV",
+    ) as rv:
+        out = data_server.get_stock_price_data("AAPL", "2026-01-01", "2026-01-10")
+    assert out == "OHLCV"
+    rv.assert_called_once_with("get_stock_data", "AAPL", "2026-01-01", "2026-01-10")
+
+
+@pytest.mark.unit
+def test_get_ticker_news_delegates():
+    with mock.patch(
+        "tradingagents.agents.utils.news_data_tools.route_to_vendor",
+        return_value="NEWS",
+    ) as rv:
+        out = data_server.get_ticker_news("TSLA", "2026-01-01", "2026-01-10")
+    assert out == "NEWS"
+    rv.assert_called_once_with("get_news", "TSLA", "2026-01-01", "2026-01-10")
+
+
+@pytest.mark.unit
+def test_get_company_fundamentals_delegates():
+    with mock.patch(
+        "tradingagents.agents.utils.fundamental_data_tools.route_to_vendor",
+        return_value="FUND",
+    ) as rv:
+        out = data_server.get_company_fundamentals("MSFT", "2026-01-10")
+    assert out == "FUND"
+    rv.assert_called_once_with("get_fundamentals", "MSFT", "2026-01-10")
+
+
+@pytest.mark.unit
+def test_get_macro_indicator_passes_optional_lookback():
+    with mock.patch(
+        "tradingagents.agents.utils.macro_data_tools.route_to_vendor",
+        return_value="MACRO",
+    ) as rv:
+        out = data_server.get_macro_indicator("cpi", "2026-01-10", 90)
+    assert out == "MACRO"
+    rv.assert_called_once_with("get_macro_indicators", "cpi", "2026-01-10", 90)
+
+
+@pytest.mark.unit
+def test_balance_sheet_default_frequency():
+    with mock.patch(
+        "tradingagents.agents.utils.fundamental_data_tools.route_to_vendor",
+        return_value="BS",
+    ) as rv:
+        data_server.get_company_balance_sheet("AAPL", curr_date="2026-01-10")
+    rv.assert_called_once_with("get_balance_sheet", "AAPL", "quarterly", "2026-01-10")
+
+
+@pytest.mark.unit
+def test_market_snapshot_delegates_to_validator():
+    with mock.patch(
+        "tradingagents.agents.utils.market_data_validation_tools."
+        "build_verified_market_snapshot",
+        return_value="SNAP",
+    ) as bv:
+        out = data_server.get_market_snapshot("AAPL", "2026-01-10", 20)
+    assert out == "SNAP"
+    bv.assert_called_once_with("AAPL", "2026-01-10", 20)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_instrument: anchoring context built from resolved identity.
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_resolve_instrument_builds_context_with_identity():
+    with mock.patch(
+        "tradingagents.mcp.data_server.resolve_instrument_identity",
+        return_value={"company_name": "Apple Inc.", "sector": "Technology"},
+    ):
+        ctx = data_server.resolve_instrument("AAPL")
+    assert "AAPL" in ctx
+    assert "Apple Inc." in ctx
+
+
+@pytest.mark.unit
+def test_resolve_instrument_crypto_falls_back_without_identity():
+    with mock.patch(
+        "tradingagents.mcp.data_server.resolve_instrument_identity",
+        return_value={},
+    ):
+        ctx = data_server.resolve_instrument("BTC-USD", asset_type="crypto")
+    assert "BTC-USD" in ctx
+    assert "crypto asset" in ctx
+
+
+# --------------------------------------------------------------------------- #
+# Realized return / benchmark math (pure, yfinance mocked).
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_resolve_benchmark_uses_suffix_map():
+    assert _returns.resolve_benchmark("7203.T") == "^N225"
+    assert _returns.resolve_benchmark("0700.HK") == "^HSI"
+    # US ticker with no recognised suffix -> SPY default.
+    assert _returns.resolve_benchmark("AAPL") == "SPY"
+
+
+@pytest.mark.unit
+def test_resolve_benchmark_explicit_override(monkeypatch):
+    from tradingagents.dataflows import config as cfg
+
+    cfg.set_config({"benchmark_ticker": "QQQ"})
+    assert _returns.resolve_benchmark("7203.T") == "QQQ"
+
+
+class _FakeHistory:
+    """Minimal stand-in for a yfinance history DataFrame."""
+
+    def __init__(self, closes):
+        self._closes = closes
+
+    def __len__(self):
+        return len(self._closes)
+
+    def __getitem__(self, key):
+        assert key == "Close"
+        return _FakeCol(self._closes)
+
+
+class _FakeCol:
+    def __init__(self, values):
+        self.iloc = values
+
+
+@pytest.mark.unit
+def test_fetch_realized_return_computes_alpha():
+    stock = _FakeHistory([100.0, 101, 102, 103, 104, 110.0])  # +10% over 5 days
+    bench = _FakeHistory([400.0, 401, 402, 403, 404, 408.0])  # +2% over 5 days
+
+    def fake_ticker(sym):
+        m = mock.Mock()
+        m.history.return_value = stock if sym != "SPY" else bench
+        return m
+
+    with mock.patch("tradingagents.mcp._returns.yf.Ticker", side_effect=fake_ticker):
+        out = _returns.fetch_realized_return("AAPL", "2026-01-05", holding_days=5)
+
+    assert out["available"] is True
+    assert out["benchmark"] == "SPY"
+    assert out["raw_return"] == pytest.approx(0.10, abs=1e-9)
+    assert out["benchmark_return"] == pytest.approx(0.02, abs=1e-9)
+    assert out["alpha_return"] == pytest.approx(0.08, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_fetch_realized_return_unavailable_when_too_recent():
+    short = _FakeHistory([100.0])  # < 2 rows -> not enough data
+
+    def fake_ticker(sym):
+        m = mock.Mock()
+        m.history.return_value = short
+        return m
+
+    with mock.patch("tradingagents.mcp._returns.yf.Ticker", side_effect=fake_ticker):
+        out = _returns.fetch_realized_return("AAPL", "2026-06-14")
+
+    assert out["available"] is False
+    assert "reason" in out
+
+
+@pytest.mark.unit
+def test_get_realized_return_tool_returns_json_serialisable_dict():
+    with mock.patch(
+        "tradingagents.mcp.data_server.fetch_realized_return",
+        return_value={"ticker": "AAPL", "available": False, "reason": "x"},
+    ):
+        out = data_server.get_realized_return("AAPL", "2026-06-14")
+    # The tool returns a dict; it must round-trip through JSON for MCP transport.
+    assert json.loads(json.dumps(out))["ticker"] == "AAPL"

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,0 +1,101 @@
+"""Tests for the trade-decision decision-log CLI (tradingagents.mcp.memory_cli).
+
+Exercises the store -> pending -> resolve -> get-context round trip against a
+temporary log path, and asserts the on-disk format stays compatible with
+``TradingMemoryLog`` (the native pipeline reads the same file).
+"""
+
+import json
+
+import pytest
+
+from tradingagents.agents.utils.memory import TradingMemoryLog
+from tradingagents.mcp import memory_cli
+
+
+@pytest.fixture()
+def temp_log(tmp_path, monkeypatch):
+    """Point memory_cli at a temp log by patching the config it loads."""
+    log_path = tmp_path / "trading_memory.md"
+
+    def fake_memory_log():
+        return TradingMemoryLog({"memory_log_path": str(log_path)})
+
+    monkeypatch.setattr(memory_cli, "_memory_log", fake_memory_log)
+    return log_path
+
+
+def _run(argv, capsys):
+    rc = memory_cli.main(argv)
+    out = capsys.readouterr().out
+    return rc, out
+
+
+@pytest.mark.unit
+def test_store_then_pending_lists_entry(temp_log, tmp_path, capsys):
+    decision = tmp_path / "decision.md"
+    decision.write_text("**Rating**: Buy\n\n**Executive Summary**: ok.", encoding="utf-8")
+
+    rc, _ = _run(["store", "NVDA", "2026-01-15", "--decision-file", str(decision)], capsys)
+    assert rc == 0
+
+    rc, out = _run(["pending", "NVDA"], capsys)
+    assert rc == 0
+    pending = json.loads(out)
+    assert pending == [{"date": "2026-01-15", "rating": "Buy"}]
+
+
+@pytest.mark.unit
+def test_pending_is_ticker_scoped(temp_log, tmp_path, capsys):
+    for tkr in ("NVDA", "AAPL"):
+        d = tmp_path / f"{tkr}.md"
+        d.write_text("**Rating**: Hold", encoding="utf-8")
+        _run(["store", tkr, "2026-01-15", "--decision-file", str(d)], capsys)
+
+    rc, out = _run(["pending", "AAPL"], capsys)
+    assert [e["date"] for e in json.loads(out)] == ["2026-01-15"]
+    assert all(e["rating"] == "Hold" for e in json.loads(out))
+
+
+@pytest.mark.unit
+def test_resolve_adds_returns_and_reflection_to_context(temp_log, tmp_path, capsys):
+    decision = tmp_path / "decision.md"
+    decision.write_text("**Rating**: Buy\n\n**Executive Summary**: ok.", encoding="utf-8")
+    _run(["store", "NVDA", "2026-01-15", "--decision-file", str(decision)], capsys)
+
+    reflection = tmp_path / "refl.md"
+    reflection.write_text("Modest alpha; thesis held.", encoding="utf-8")
+    rc, _ = _run(
+        [
+            "resolve", "NVDA", "2026-01-15",
+            "--raw", "0.034", "--alpha", "-0.012", "--holding", "5",
+            "--reflection-file", str(reflection),
+        ],
+        capsys,
+    )
+    assert rc == 0
+
+    # Resolved entries (not pending) now surface in get-context.
+    rc, out = _run(["get-context", "NVDA"], capsys)
+    assert "Past analyses of NVDA" in out
+    assert "+3.4%" in out and "-1.2%" in out and "5d" in out
+    assert "Modest alpha; thesis held." in out
+
+    # And the resolved entry is no longer pending.
+    rc, out = _run(["pending", "NVDA"], capsys)
+    assert json.loads(out) == []
+
+
+@pytest.mark.unit
+def test_on_disk_format_is_readable_by_native_memory_log(temp_log, tmp_path, capsys):
+    decision = tmp_path / "decision.md"
+    decision.write_text("**Rating**: Overweight\n\n**Thesis**: x.", encoding="utf-8")
+    _run(["store", "TSLA", "2026-02-01", "--decision-file", str(decision)], capsys)
+
+    # The native log parser must understand what the CLI wrote.
+    native = TradingMemoryLog({"memory_log_path": str(temp_log)})
+    entries = native.load_entries()
+    assert len(entries) == 1
+    assert entries[0]["ticker"] == "TSLA"
+    assert entries[0]["rating"] == "Overweight"
+    assert entries[0]["pending"] is True

--- a/tradingagents/mcp/__init__.py
+++ b/tradingagents/mcp/__init__.py
@@ -1,0 +1,8 @@
+"""Local MCP (Model Context Protocol) server for the TradingAgents data layer.
+
+This package exposes the framework's data tools (market, news, fundamentals,
+macro, prediction markets) over an MCP ``stdio`` transport so a Claude client
+(Claude Code / Claude Desktop) can fetch data while *Claude itself* plays every
+analyst/researcher/trader/PM role. The server makes **no LLM calls** — it only
+returns data — so running the full pipeline costs zero LLM API spend.
+"""

--- a/tradingagents/mcp/_returns.py
+++ b/tradingagents/mcp/_returns.py
@@ -1,0 +1,109 @@
+"""Realized-return / alpha computation for the MCP ``get_realized_return`` tool.
+
+This mirrors the pure-data math in
+:meth:`tradingagents.graph.trading_graph.TradingAgentsGraph._fetch_returns`
+and ``_resolve_benchmark`` but lives here as standalone functions because the
+graph versions are methods on a class whose construction creates LLM clients
+(and would therefore need API keys). The MCP server needs none of that — this
+is yfinance arithmetic only — so the logic is reproduced rather than imported.
+Kept in sync with the graph by reusing the same ``benchmark_map`` from config.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+import yfinance as yf
+
+from tradingagents.dataflows.config import get_config
+from tradingagents.dataflows.symbol_utils import normalize_symbol
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_benchmark(ticker: str) -> str:
+    """Pick the alpha-baseline benchmark for ``ticker`` from config.
+
+    ``benchmark_ticker`` (when set) overrides everything; otherwise the
+    exchange-suffix map is consulted (e.g. ``.T`` -> Nikkei). US tickers with
+    no recognised suffix fall through to the empty-suffix entry (SPY). Mirrors
+    :meth:`TradingAgentsGraph._resolve_benchmark`.
+    """
+    config = get_config()
+    explicit = config.get("benchmark_ticker")
+    if explicit:
+        return explicit
+    benchmark_map = config.get("benchmark_map", {})
+    ticker_upper = ticker.upper()
+    for suffix, benchmark in benchmark_map.items():
+        if suffix and ticker_upper.endswith(suffix.upper()):
+            return benchmark
+    return benchmark_map.get("", "SPY")
+
+
+def fetch_realized_return(
+    ticker: str,
+    trade_date: str,
+    holding_days: int = 5,
+    benchmark: str | None = None,
+) -> dict:
+    """Return realized raw/alpha return for ``ticker`` over a holding window.
+
+    ``benchmark`` defaults to the config-resolved index for the ticker's
+    market. Returns a dict with ``available`` False when price data is not yet
+    available (too recent, delisted, or a network error) so the caller can
+    report cleanly instead of failing. Mirrors ``_fetch_returns``.
+    """
+    if benchmark is None:
+        benchmark = resolve_benchmark(ticker)
+
+    try:
+        start = datetime.strptime(trade_date, "%Y-%m-%d")
+        end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
+        end_str = end.strftime("%Y-%m-%d")
+
+        stock = yf.Ticker(normalize_symbol(ticker)).history(start=trade_date, end=end_str)
+        bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+
+        if len(stock) < 2 or len(bench) < 2:
+            return {
+                "ticker": ticker,
+                "trade_date": trade_date,
+                "benchmark": benchmark,
+                "available": False,
+                "reason": "Price data not yet available (too recent, delisted, or no data).",
+            }
+
+        actual_days = min(holding_days, len(stock) - 1, len(bench) - 1)
+        raw = float(
+            (stock["Close"].iloc[actual_days] - stock["Close"].iloc[0])
+            / stock["Close"].iloc[0]
+        )
+        bench_ret = float(
+            (bench["Close"].iloc[actual_days] - bench["Close"].iloc[0])
+            / bench["Close"].iloc[0]
+        )
+        alpha = raw - bench_ret
+        return {
+            "ticker": ticker,
+            "trade_date": trade_date,
+            "benchmark": benchmark,
+            "available": True,
+            "holding_days": actual_days,
+            "raw_return": raw,
+            "benchmark_return": bench_ret,
+            "alpha_return": alpha,
+        }
+    except Exception as e:  # noqa: BLE001 — fail open, this feeds best-effort reflection
+        logger.warning(
+            "Could not resolve realized return for %s on %s vs %s: %s",
+            ticker, trade_date, benchmark, e,
+        )
+        return {
+            "ticker": ticker,
+            "trade_date": trade_date,
+            "benchmark": benchmark,
+            "available": False,
+            "reason": f"Lookup failed: {e}",
+        }

--- a/tradingagents/mcp/data_server.py
+++ b/tradingagents/mcp/data_server.py
@@ -1,0 +1,312 @@
+"""TradingAgents data MCP server (stdio).
+
+Exposes the framework's data layer as MCP tools so a Claude client (Claude
+Code / Claude Desktop) can fetch market, news, fundamental, macro, and
+prediction-market data. Each tool is a thin wrapper that calls the *existing*
+``@tool`` implementations from
+:mod:`tradingagents.agents.utils.agent_utils` via their underlying ``.func``
+(single source of truth — same vendor routing, config, and formatting as the
+native pipeline), so this server adds an interface but no data logic.
+
+The server makes **no LLM calls**. Claude (the MCP client) performs all agent
+reasoning, so running the whole multi-agent pipeline through this server costs
+zero LLM API spend — only the (mostly free / keyless) data sources are hit.
+
+Run with: ``tradingagents-data-mcp`` (installed script) or
+``python -m tradingagents.mcp.data_server``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+
+# Load .env (free data-source keys: FRED_API_KEY, ALPHA_VANTAGE_API_KEY, ...)
+# before the config snapshot is taken, so vendors that need a key see it.
+load_dotenv()
+
+from tradingagents.agents.utils.agent_utils import (  # noqa: E402  (after load_dotenv)
+    build_instrument_context,
+    get_balance_sheet,
+    get_cashflow,
+    get_fundamentals,
+    get_global_news,
+    get_income_statement,
+    get_indicators,
+    get_insider_transactions,
+    get_macro_indicators,
+    get_news,
+    get_prediction_markets,
+    get_stock_data,
+    get_verified_market_snapshot,
+    resolve_instrument_identity,
+)
+from tradingagents.dataflows.config import set_config  # noqa: E402
+from tradingagents.dataflows.reddit import fetch_reddit_posts  # noqa: E402
+from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages  # noqa: E402
+from tradingagents.default_config import DEFAULT_CONFIG  # noqa: E402
+from tradingagents.mcp._returns import fetch_realized_return  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Initialise the dataflows config exactly like the CLI/graph do, so vendor
+# routing (yfinance by default) and limits match the native pipeline. Honours
+# TRADINGAGENTS_* env overrides baked into DEFAULT_CONFIG.
+set_config(DEFAULT_CONFIG.copy())
+
+mcp = FastMCP("tradingagents-data")
+
+
+# --------------------------------------------------------------------------- #
+# Market / price / technical tools
+# --------------------------------------------------------------------------- #
+@mcp.tool()
+def get_stock_price_data(symbol: str, start_date: str, end_date: str) -> str:
+    """Retrieve OHLCV stock price data for a ticker over a date range.
+
+    Args:
+        symbol: Ticker symbol, e.g. AAPL, 0700.HK, BTC-USD.
+        start_date: Start date in yyyy-mm-dd format.
+        end_date: End date in yyyy-mm-dd format.
+    """
+    return get_stock_data.func(symbol, start_date, end_date)
+
+
+@mcp.tool()
+def get_technical_indicators(
+    symbol: str, indicator: str, curr_date: str, look_back_days: int = 30
+) -> str:
+    """Retrieve technical indicator(s) for a ticker (e.g. rsi, macd, boll, sma).
+
+    Args:
+        symbol: Ticker symbol, e.g. AAPL.
+        indicator: Indicator name(s); a comma-separated list is allowed.
+        curr_date: Current trading date in yyyy-mm-dd format.
+        look_back_days: Trailing window length in days (default 30).
+    """
+    return get_indicators.func(symbol, indicator, curr_date, look_back_days)
+
+
+@mcp.tool()
+def get_market_snapshot(symbol: str, curr_date: str, look_back_days: int = 30) -> str:
+    """Deterministic verification snapshot for exact market-data claims.
+
+    Returns the latest OHLCV row on or before ``curr_date``, common indicators,
+    and recent closes. Use this as the source of truth before asserting exact
+    price levels, RSI/MACD, Bollinger bands, moving averages, or support/
+    resistance.
+
+    Args:
+        symbol: Ticker symbol.
+        curr_date: Current trading date in yyyy-mm-dd format.
+        look_back_days: Recent trading rows to include for sanity-checking.
+    """
+    return get_verified_market_snapshot.func(symbol, curr_date, look_back_days)
+
+
+# --------------------------------------------------------------------------- #
+# News / macro / prediction-market tools
+# --------------------------------------------------------------------------- #
+@mcp.tool()
+def get_ticker_news(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve recent news headlines/articles for a ticker over a date range.
+
+    Args:
+        ticker: Ticker symbol.
+        start_date: Start date in yyyy-mm-dd format.
+        end_date: End date in yyyy-mm-dd format.
+    """
+    return get_news.func(ticker, start_date, end_date)
+
+
+@mcp.tool()
+def get_macro_news(
+    curr_date: str, look_back_days: int | None = None, limit: int | None = None
+) -> str:
+    """Retrieve global/macroeconomic news headlines.
+
+    Args:
+        curr_date: Current date in yyyy-mm-dd format.
+        look_back_days: Days to look back (omit for the configured default).
+        limit: Max articles to return (omit for the configured default).
+    """
+    return get_global_news.func(curr_date, look_back_days, limit)
+
+
+@mcp.tool()
+def get_company_insider_transactions(ticker: str) -> str:
+    """Retrieve insider-transaction information for a company.
+
+    Args:
+        ticker: Ticker symbol of the company.
+    """
+    return get_insider_transactions.func(ticker)
+
+
+@mcp.tool()
+def get_stocktwits_messages(ticker: str, limit: int = 30) -> str:
+    """Retrieve recent StockTwits messages for a ticker (retail sentiment).
+
+    Returns retail-trader posts indexed by cashtag, each carrying a
+    user-labeled Bullish / Bearish tag (or none) plus the message body — a
+    fast-moving retail-sentiment signal. Degrades gracefully to a placeholder
+    when the source is unavailable.
+
+    Args:
+        ticker: Ticker symbol (the cashtag, e.g. AAPL).
+        limit: Max messages to return (default 30).
+    """
+    return fetch_stocktwits_messages(ticker, limit=limit)
+
+
+@mcp.tool()
+def get_reddit_posts(ticker: str) -> str:
+    """Retrieve recent Reddit posts mentioning a ticker (community sentiment).
+
+    Searches r/wallstreetbets, r/stocks, and r/investing over the past ~7 days
+    and returns posts with engagement signal (upvotes, comment counts) and body
+    excerpts. Degrades gracefully to a placeholder when no posts are found.
+
+    Args:
+        ticker: Ticker symbol.
+    """
+    return fetch_reddit_posts(ticker)
+
+
+@mcp.tool()
+def get_macro_indicator(
+    indicator: str, curr_date: str, look_back_days: int | None = None
+) -> str:
+    """Retrieve a macroeconomic indicator time series from FRED.
+
+    Covers policy rates, Treasury yields, inflation, labor, and growth. Returns
+    the series title, units, frequency, latest value, change over the window,
+    and a recent observation table. Requires FRED_API_KEY in the environment.
+
+    Args:
+        indicator: Friendly alias ('cpi', 'fed_funds_rate', '10y_treasury',
+            'unemployment', 'vix', 'yield_curve', 'real_gdp', ...) or a raw
+            FRED series ID such as 'CPIAUCSL'.
+        curr_date: Current date in yyyy-mm-dd format (end of the window).
+        look_back_days: Trailing window length (omit for a 1-year window).
+    """
+    return get_macro_indicators.func(indicator, curr_date, look_back_days)
+
+
+@mcp.tool()
+def get_event_prediction_markets(topic: str, limit: int | None = None) -> str:
+    """Retrieve live market-implied probabilities for forward-looking events.
+
+    Sources Polymarket for the most-traded open markets matching the topic,
+    each with implied probability, volume, resolution date, and recent move.
+
+    Args:
+        topic: Event keyword(s), e.g. 'Fed rate cut', 'recession 2026'.
+        limit: Max markets to return (omit for a default of 6).
+    """
+    return get_prediction_markets.func(topic, limit)
+
+
+# --------------------------------------------------------------------------- #
+# Fundamentals tools
+# --------------------------------------------------------------------------- #
+@mcp.tool()
+def get_company_fundamentals(ticker: str, curr_date: str) -> str:
+    """Retrieve comprehensive fundamental data for a ticker.
+
+    Args:
+        ticker: Ticker symbol of the company.
+        curr_date: Current trading date in yyyy-mm-dd format.
+    """
+    return get_fundamentals.func(ticker, curr_date)
+
+
+@mcp.tool()
+def get_company_balance_sheet(
+    ticker: str, freq: str = "quarterly", curr_date: str | None = None
+) -> str:
+    """Retrieve balance sheet data for a ticker.
+
+    Args:
+        ticker: Ticker symbol of the company.
+        freq: Reporting frequency, 'annual' or 'quarterly' (default quarterly).
+        curr_date: Current trading date in yyyy-mm-dd format.
+    """
+    return get_balance_sheet.func(ticker, freq, curr_date)
+
+
+@mcp.tool()
+def get_company_cashflow(
+    ticker: str, freq: str = "quarterly", curr_date: str | None = None
+) -> str:
+    """Retrieve cash-flow-statement data for a ticker.
+
+    Args:
+        ticker: Ticker symbol of the company.
+        freq: Reporting frequency, 'annual' or 'quarterly' (default quarterly).
+        curr_date: Current trading date in yyyy-mm-dd format.
+    """
+    return get_cashflow.func(ticker, freq, curr_date)
+
+
+@mcp.tool()
+def get_company_income_statement(
+    ticker: str, freq: str = "quarterly", curr_date: str | None = None
+) -> str:
+    """Retrieve income-statement data for a ticker.
+
+    Args:
+        ticker: Ticker symbol of the company.
+        freq: Reporting frequency, 'annual' or 'quarterly' (default quarterly).
+        curr_date: Current trading date in yyyy-mm-dd format.
+    """
+    return get_income_statement.func(ticker, freq, curr_date)
+
+
+# --------------------------------------------------------------------------- #
+# Identity / reflection helpers
+# --------------------------------------------------------------------------- #
+@mcp.tool()
+def resolve_instrument(ticker: str, asset_type: str = "stock") -> str:
+    """Resolve the real instrument identity and return an anchoring context.
+
+    Call this first. It does a deterministic yfinance lookup (company name,
+    sector/industry, exchange) and returns a context string that every agent
+    should be anchored to, so the analysis never substitutes a different
+    company than the one the ticker refers to.
+
+    Args:
+        ticker: Ticker symbol, preserving any exchange suffix.
+        asset_type: 'stock' (default) or 'crypto'.
+    """
+    identity = resolve_instrument_identity(ticker)
+    return build_instrument_context(ticker, asset_type, identity)
+
+
+@mcp.tool()
+def get_realized_return(
+    ticker: str, trade_date: str, holding_days: int = 5
+) -> dict:
+    """Compute the realized raw and alpha return after a past decision.
+
+    Used by the reflection step: given a prior decision's trade date, returns
+    the raw return and the alpha versus the market-appropriate benchmark over
+    the holding window. ``available`` is False when prices aren't out yet.
+
+    Args:
+        ticker: Ticker symbol.
+        trade_date: The decision/trade date in yyyy-mm-dd format.
+        holding_days: Holding window in trading days (default 5).
+    """
+    return fetch_realized_return(ticker, trade_date, holding_days)
+
+
+def main() -> None:
+    """Console-script entry point: run the server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tradingagents/mcp/memory_cli.py
+++ b/tradingagents/mcp/memory_cli.py
@@ -1,0 +1,138 @@
+"""Decision-log CLI for the Claude Code trade-decision workflow.
+
+The multi-agent reasoning runs inside Claude (via the workflow), but the
+append-only decision log at ``~/.tradingagents/memory/trading_memory.md`` has a
+precise, regex-parsed on-disk format (see
+:class:`tradingagents.agents.utils.memory.TradingMemoryLog`). Rather than have
+Claude hand-edit that format, the ``/trade`` slash command shells out to this
+CLI for the read/write/resolve operations and keeps only the *reasoning*
+(the reflection paragraph) for itself.
+
+Subcommands::
+
+    get-context TICKER
+        Print the past-decisions context block to inject into the run
+        (same-ticker history + recent cross-ticker lessons). Empty if none.
+
+    pending TICKER
+        Print a JSON list of this ticker's unresolved decisions, as
+        [{"date": "...", "rating": "..."}], so Claude knows which prior runs
+        to reflect on with realized returns.
+
+    store TICKER DATE --decision-file PATH
+        Append a new pending decision entry (rating parsed from the decision
+        text). Idempotent per (date, ticker).
+
+    resolve TICKER DATE --raw R --alpha A --holding D --reflection-file PATH
+        Resolve a pending entry with realized returns and a reflection.
+
+This module makes no LLM calls. It shares the format with the native pipeline,
+so logs written here remain readable by the Python CLI and vice versa.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from dotenv import load_dotenv
+
+from tradingagents.agents.utils.memory import TradingMemoryLog
+from tradingagents.dataflows.config import set_config
+from tradingagents.default_config import DEFAULT_CONFIG
+
+
+def _memory_log() -> TradingMemoryLog:
+    load_dotenv()
+    config = DEFAULT_CONFIG.copy()
+    set_config(config)
+    return TradingMemoryLog(config)
+
+
+def _read_file(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def _cmd_get_context(args: argparse.Namespace) -> int:
+    log = _memory_log()
+    sys.stdout.write(log.get_past_context(args.ticker))
+    return 0
+
+
+def _cmd_pending(args: argparse.Namespace) -> int:
+    log = _memory_log()
+    pending = [
+        {"date": e["date"], "rating": e["rating"]}
+        for e in log.get_pending_entries()
+        if e["ticker"] == args.ticker
+    ]
+    sys.stdout.write(json.dumps(pending))
+    return 0
+
+
+def _cmd_store(args: argparse.Namespace) -> int:
+    log = _memory_log()
+    decision = _read_file(args.decision_file)
+    log.store_decision(ticker=args.ticker, trade_date=args.date, final_trade_decision=decision)
+    sys.stdout.write(f"stored pending decision for {args.ticker} @ {args.date}")
+    return 0
+
+
+def _cmd_resolve(args: argparse.Namespace) -> int:
+    log = _memory_log()
+    reflection = _read_file(args.reflection_file)
+    log.update_with_outcome(
+        ticker=args.ticker,
+        trade_date=args.date,
+        raw_return=args.raw,
+        alpha_return=args.alpha,
+        holding_days=args.holding,
+        reflection=reflection,
+    )
+    sys.stdout.write(f"resolved {args.ticker} @ {args.date}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tradingagents-memory",
+        description="Decision-log read/write for the Claude Code trade-decision workflow.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_ctx = sub.add_parser("get-context", help="Print past-decisions context for a ticker.")
+    p_ctx.add_argument("ticker")
+    p_ctx.set_defaults(func=_cmd_get_context)
+
+    p_pend = sub.add_parser("pending", help="Print JSON list of unresolved decisions for a ticker.")
+    p_pend.add_argument("ticker")
+    p_pend.set_defaults(func=_cmd_pending)
+
+    p_store = sub.add_parser("store", help="Append a pending decision entry.")
+    p_store.add_argument("ticker")
+    p_store.add_argument("date", help="Trade date, yyyy-mm-dd")
+    p_store.add_argument("--decision-file", required=True, help="Path to the final decision markdown.")
+    p_store.set_defaults(func=_cmd_store)
+
+    p_res = sub.add_parser("resolve", help="Resolve a pending entry with realized returns + reflection.")
+    p_res.add_argument("ticker")
+    p_res.add_argument("date", help="Trade date, yyyy-mm-dd")
+    p_res.add_argument("--raw", type=float, required=True, help="Realized raw return (e.g. 0.034).")
+    p_res.add_argument("--alpha", type=float, required=True, help="Alpha vs benchmark (e.g. -0.012).")
+    p_res.add_argument("--holding", type=int, required=True, help="Holding days.")
+    p_res.add_argument("--reflection-file", required=True, help="Path to the reflection paragraph.")
+    p_res.set_defaults(func=_cmd_resolve)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
…spend)

Run the full TradingAgents multi-agent pipeline from Claude Code, with Claude playing every agent via the subscription instead of paid LLM API keys.

- Data layer: local stdio MCP server (tradingagents-data-mcp) exposing 16 data tools that reuse the existing dataflows; makes no LLM calls. Adds get_realized_return for reflection and a memory CLI (tradingagents-memory) that reads/writes the existing trading_memory.md format.
- Reasoning layer: 12 role subagents (.claude/agents/), a deterministic orchestration workflow (.claude/workflows/trade-decision.js), and a /trade slash command. Mirrors the native graph (analysts -> bull/bear debate -> research manager -> trader -> 3-way risk debate -> portfolio manager).
- Packaging: [mcp] extra + console scripts; project-scoped .mcp.json.
- Tests: 19 new unit tests (data server + memory CLI), full suite green, ruff clean.
- Docs: docs/CLAUDE_CODE.md, README section + derivative notice, CHANGELOG entry.

Core LangGraph CLI and Python API are unchanged. Derivative of TauricResearch/TradingAgents under Apache-2.0.