### PR TITLE
feat(scheduled): headless daily runner + Telegram PDF delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,21 @@ NVIDIA_API_KEY=
 # honor it). Unset leaves each provider at its default. See the README
 # "Reproducibility" note — no setting makes LLM output fully deterministic.
 #TRADINGAGENTS_TEMPERATURE=0.0
+
+# Scheduled-runner (see scripts/run_daily.py and the README "Scheduled
+# runs" section). The watchlist path is relative to the project root
+# unless absolute; the runner warns and exits cleanly if the file is
+# missing.
+#TRADINGAGENTS_WATCHLIST_PATH=config/watchlist.yaml
+
+# Telegram delivery. When BOTH are set, scripts/run_daily.py will send a
+# short message + the decision.md as a PDF to the chat. When either is
+# missing, the runner logs at info level and continues.
+#
+#   - Create a bot via @BotFather on Telegram and copy the token here.
+#   - The chat id is the numeric id of the target chat (for a private
+#     chat: send /start to the bot, then call
+#     https://api.telegram.org/bot<TOKEN>/getUpdates to read your id).
+#
+#TELEGRAM_BOT_TOKEN=
+#TELEGRAM_CHAT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,4 @@ __marimo__/
 
 # Enterprise env file (secrets) and generated run reports
 .env.enterprise
-reports/
+/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Scheduled runs + Telegram delivery.** A new headless driver
+  (`scripts/run_daily.py`) iterates over `config/watchlist.yaml`, runs
+  `propagate()` for each ticker, persists the canonical
+  `reports/<TICKER>_<TS>/` folder, renders the Portfolio Manager
+  `decision.md` to a PDF, and delivers both a short Markdown message
+  and the PDF to a configured Telegram chat. New
+  `tradingagents.notifications.telegram` module owns the Bot API
+  integration; new `tradingagents.reports.exporter` centralises the
+  report-folder layout and the `decision.md` parsing that both the
+  CLI and the runner share. `scripts/install_launchd.sh` registers a
+  Mon–Fri 07:00 launchd job on macOS; `scripts/uninstall_launchd.sh`
+  removes it. Install with `pip install ".[scheduled]"` (pulls
+  `pyyaml` and `fpdf2`).
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 # TradingAgents: Multi-Agents LLM Financial Trading Framework
 
 ## News
+- [2026-06] **Scheduled runs + Telegram delivery.** A new headless driver (`scripts/run_daily.py`) reads a `config/watchlist.yaml` watchlist, persists the canonical `reports/<TICKER>_<TS>/` folder, renders the Portfolio Manager `decision.md` to a PDF, and delivers both a short message and the PDF to a Telegram chat. `scripts/install_launchd.sh` registers a Mon–Fri 07:00 launchd job on macOS. Install with `pip install ".[scheduled]"`.
 - [2026-05] **TradingAgents v0.2.5** released with the grounded Sentiment Analyst, GPT-5.5 etc. model coverage, Qwen/GLM/MiniMax dual-region support, `TRADINGAGENTS_*` env-var configurability with API-key auto-detection, remote Ollama support, non-US alpha benchmarks, and ticker path-traversal hardening. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 - [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix.
 - [2026-03] **TradingAgents v0.2.3** released with multi-language support, GPT-5.4 family models, unified model catalog, backtesting date fidelity, and proxy support.
@@ -51,7 +52,7 @@
 
 <div align="center">
 
-🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
+🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | ⏰ [Scheduled Runs](#scheduled-runs) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
 
 </div>
 
@@ -118,6 +119,11 @@ conda activate tradingagents
 Install the package and its dependencies:
 ```bash
 pip install .
+```
+
+For the headless daily runner (watchlist + Telegram PDF delivery, see [Scheduled runs](#scheduled-runs)), also install the optional `[scheduled]` extra:
+```bash
+pip install ".[scheduled]"
 ```
 
 ### Docker
@@ -288,6 +294,120 @@ config["temperature"] = 0.0
 What does not vary anymore: the analyzed company identity is resolved deterministically from the ticker before any agent runs, and the market analyst grounds exact price and indicator claims in a verified data snapshot. Earlier reports of "different companies" or fabricated price levels across runs are addressed by these two mechanisms.
 
 Backtest results are not guaranteed to match any published figure. Returns depend on the model, the temperature, the date range, data quality, and the sampling above. Treat the framework as a research scaffold for studying multi-agent analysis, not as a strategy with a fixed, replicable return.
+
+## Scheduled runs
+
+The interactive CLI is great for ad-hoc analyses, but you can also drive
+TradingAgents headlessly on a schedule and have the Portfolio Manager
+decision delivered to a Telegram chat every morning. The pieces:
+
+| File | Purpose |
+| ---- | ------- |
+| `config/watchlist.yaml` | List of `(symbol, asset_type, analysts?)` entries to analyze each run. |
+| `scripts/run_daily.py` | Headless driver — runs `propagate()` for each entry, saves the report, sends Telegram. |
+| `tradingagents/notifications/telegram.py` | Sends the short message + PDF via the Telegram Bot API. |
+| `tradingagents/reports/exporter.py` | Persists the canonical `reports/<TICKER>_<TS>/` folder and parses `decision.md`. |
+| `scripts/install_launchd.sh` | Installs a Mon–Fri 07:00 launchd job pointing at `scripts/run_daily.py`. |
+| `scripts/uninstall_launchd.sh` | Removes the launchd job. |
+
+### One-time setup
+
+1. Install the optional dependencies (PyYAML for the watchlist, fpdf2 for
+   the PDF attachment):
+
+   ```bash
+   .venv/bin/pip install -e ".[scheduled]"
+   ```
+
+2. Edit `config/watchlist.yaml` to list the tickers you want analyzed
+   each morning. The default ships with `BTC-USD` as a worked example.
+
+   ```yaml
+   tickers:
+     - symbol: BTC-USD
+       asset_type: crypto
+     - symbol: NVDA
+       asset_type: stock
+   ```
+
+   `analysts` is optional per entry — when omitted the runner uses the
+   project's default selection (market, social, news, fundamentals).
+
+3. (Optional) Create a Telegram bot and capture its token plus your chat
+   id, then put both in `.env`:
+
+   ```bash
+   # Talk to @BotFather, send /newbot, copy the token it gives you.
+   TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+   # Send any message to your new bot, then open
+   # https://api.telegram.org/bot<TOKEN>/getUpdates
+   # and read message.chat.id from the JSON response.
+   TELEGRAM_CHAT_ID=987654321
+   ```
+
+   When either variable is missing, the runner logs at info level and
+   skips delivery — the analysis still runs and the report is still
+   written to disk.
+
+4. Install the launchd job:
+
+   ```bash
+   bash scripts/install_launchd.sh
+   ```
+
+   The script generates `~/Library/LaunchAgents/com.tradingagents.daily.plist`
+   with a `StartCalendarInterval` for Monday through Friday at 07:00
+   local time, and runs `plutil -lint` on the result before `launchctl
+   load`. Re-running the script is safe — it unloads any prior copy and
+   rewrites the plist.
+
+### Verifying the install
+
+```bash
+launchctl list | grep com.tradingagents.daily
+tail -f ~/Library/Logs/tradingagents/run_daily.out.log
+```
+
+To fire the job immediately (without waiting until 07:00):
+
+```bash
+launchctl start com.tradingagents.daily
+```
+
+### What gets delivered to Telegram
+
+For every ticker in the watchlist, the runner sends:
+
+1. A short Markdown message with rating, price target, time horizon, and
+   the first ~240 chars of the executive summary.
+2. A PDF attachment built from the Portfolio Manager's `decision.md`
+   (rendered via fpdf2). If the PDF conversion fails for any reason the
+   runner falls back to attaching the raw `.md` file.
+
+### Manual one-off run
+
+You can invoke the same code path the launchd job uses, which is handy
+for smoke testing changes to the watchlist or Telegram credentials:
+
+```bash
+.venv/bin/python scripts/run_daily.py --verbose
+.venv/bin/python scripts/run_daily.py --date 2026-06-12
+.venv/bin/python scripts/run_daily.py --watchlist /path/to/other-watchlist.yaml
+```
+
+### Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | At least one ticker analyzed successfully (Telegram delivery is best-effort). |
+| `1`  | Every ticker failed during `propagate()`. Inspect `run_daily.err.log`. |
+| `2`  | The watchlist file was unreadable (missing required fields, invalid YAML, etc.). |
+
+### Removing the scheduled job
+
+```bash
+bash scripts/uninstall_launchd.sh
+```
 
 ## Contributing
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -48,6 +48,7 @@ from tradingagents.graph.analyst_execution import (
     sync_analyst_tracker_from_chunk,
 )
 from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.reports.exporter import save_report_to_disk
 
 console = Console()
 
@@ -721,96 +722,6 @@ def get_analysis_date():
             console.print(
                 "[red]Error: Invalid date format. Please use YYYY-MM-DD[/red]"
             )
-
-
-def save_report_to_disk(final_state, ticker: str, save_path: Path):
-    """Save complete analysis report to disk with organized subfolders."""
-    save_path.mkdir(parents=True, exist_ok=True)
-    sections = []
-
-    # 1. Analysts
-    analysts_dir = save_path / "1_analysts"
-    analyst_parts = []
-    if final_state.get("market_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "market.md").write_text(final_state["market_report"], encoding="utf-8")
-        analyst_parts.append(("Market Analyst", final_state["market_report"]))
-    if final_state.get("sentiment_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "sentiment.md").write_text(final_state["sentiment_report"], encoding="utf-8")
-        analyst_parts.append(("Sentiment Analyst", final_state["sentiment_report"]))
-    if final_state.get("news_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "news.md").write_text(final_state["news_report"], encoding="utf-8")
-        analyst_parts.append(("News Analyst", final_state["news_report"]))
-    if final_state.get("fundamentals_report"):
-        analysts_dir.mkdir(exist_ok=True)
-        (analysts_dir / "fundamentals.md").write_text(final_state["fundamentals_report"], encoding="utf-8")
-        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
-    if analyst_parts:
-        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
-        sections.append(f"## I. Analyst Team Reports\n\n{content}")
-
-    # 2. Research
-    if final_state.get("investment_debate_state"):
-        research_dir = save_path / "2_research"
-        debate = final_state["investment_debate_state"]
-        research_parts = []
-        if debate.get("bull_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bull.md").write_text(debate["bull_history"], encoding="utf-8")
-            research_parts.append(("Bull Researcher", debate["bull_history"]))
-        if debate.get("bear_history"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "bear.md").write_text(debate["bear_history"], encoding="utf-8")
-            research_parts.append(("Bear Researcher", debate["bear_history"]))
-        if debate.get("judge_decision"):
-            research_dir.mkdir(exist_ok=True)
-            (research_dir / "manager.md").write_text(debate["judge_decision"], encoding="utf-8")
-            research_parts.append(("Research Manager", debate["judge_decision"]))
-        if research_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
-            sections.append(f"## II. Research Team Decision\n\n{content}")
-
-    # 3. Trading
-    if final_state.get("trader_investment_plan"):
-        trading_dir = save_path / "3_trading"
-        trading_dir.mkdir(exist_ok=True)
-        (trading_dir / "trader.md").write_text(final_state["trader_investment_plan"], encoding="utf-8")
-        sections.append(f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}")
-
-    # 4. Risk Management
-    if final_state.get("risk_debate_state"):
-        risk_dir = save_path / "4_risk"
-        risk = final_state["risk_debate_state"]
-        risk_parts = []
-        if risk.get("aggressive_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "aggressive.md").write_text(risk["aggressive_history"], encoding="utf-8")
-            risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
-        if risk.get("conservative_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "conservative.md").write_text(risk["conservative_history"], encoding="utf-8")
-            risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
-        if risk.get("neutral_history"):
-            risk_dir.mkdir(exist_ok=True)
-            (risk_dir / "neutral.md").write_text(risk["neutral_history"], encoding="utf-8")
-            risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
-        if risk_parts:
-            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
-            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
-
-        # 5. Portfolio Manager
-        if risk.get("judge_decision"):
-            portfolio_dir = save_path / "5_portfolio"
-            portfolio_dir.mkdir(exist_ok=True)
-            (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
-            sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
-
-    # Write consolidated report
-    header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-    (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
-    return save_path / "complete_report.md"
 
 
 def display_complete_report(final_state):

--- a/config/watchlist.yaml
+++ b/config/watchlist.yaml
@@ -1,0 +1,23 @@
+# TradingAgents scheduled-runner watchlist.
+#
+# Each entry tells the headless runner (`scripts/run_daily.py`) which symbol
+# to analyze, which asset pipeline to use, and which analyst teams to enable.
+#
+# The runner reads this file on every invocation. You can:
+#   - add a stock by appending a new `symbol:` block and setting asset_type
+#     to "stock" (or omitting it — the default is "stock")
+#   - add a crypto pair with asset_type: crypto
+#   - override the analyst set; the runner falls back to the project's
+#     DEFAULT_CONFIG selection if `analysts` is missing
+#
+# The file is read from the path in TRADINGAGENTS_WATCHLIST_PATH
+# (default: config/watchlist.yaml).
+
+tickers:
+  - symbol: BTC-USD
+    asset_type: crypto
+    # analysts: [market, social, news]   # optional override
+  # - symbol: ETH-USD
+  #   asset_type: crypto
+  # - symbol: NVDA
+  #   asset_type: stock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dev = [
 bedrock = [
     "langchain-aws>=1.5.0",
 ]
+# Scheduled-runner support: headless daily driver + Telegram delivery.
+# ``pyyaml`` is the watchlist parser; ``fpdf2`` renders the Portfolio
+# Manager ``decision.md`` to a PDF that Telegram can render inline.
+scheduled = [
+    "pyyaml>=6.0",
+    "fpdf2>=2.7",
+]
 
 [project.scripts]
 tradingagents = "cli.main:app"

--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Install the TradingAgents daily runner as a per-user launchd job.
+#
+# Creates ~/Library/LaunchAgents/com.tradingagents.daily.plist that fires
+# Monday-Friday at 07:00 local time and runs scripts/run_daily.py with
+# the project's virtualenv interpreter. Logs land in
+# ~/Library/Logs/tradingagents/.
+#
+# Idempotent: re-running replaces the existing plist and reloads the
+# job, so it's safe to use as a deployment step.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PY="${PROJECT_ROOT}/.venv/bin/python"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+LOG_DIR="${HOME}/Library/Logs/tradingagents"
+PLIST_PATH="${LAUNCH_AGENTS_DIR}/com.tradingagents.daily.plist"
+LABEL="com.tradingagents.daily"
+
+if [[ ! -x "${VENV_PY}" ]]; then
+    echo "error: ${VENV_PY} not found or not executable." >&2
+    echo "       Create the project venv first: uv venv .venv && .venv/bin/pip install -e '.[scheduled]'" >&2
+    exit 1
+fi
+
+mkdir -p "${LAUNCH_AGENTS_DIR}" "${LOG_DIR}"
+
+# Unload any prior copy so launchd doesn't keep a stale process around.
+if launchctl list | grep -q "${LABEL}"; then
+    launchctl unload "${PLIST_PATH}" 2>/dev/null || true
+fi
+
+cat > "${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${VENV_PY}</string>
+        <string>${PROJECT_ROOT}/scripts/run_daily.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${PROJECT_ROOT}</string>
+
+    <!-- Mon-Fri at 07:00 local time. launchd uses the system time zone. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/run_daily.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/run_daily.err.log</string>
+
+    <!-- launchd throttles the job on a 10s interval if it exits too
+         quickly; we don't care, but ProcessType=Background keeps it
+         off the "responsive app" radar. -->
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>
+EOF
+
+# Validate before loading — `plutil` is bundled with macOS.
+if ! plutil -lint "${PLIST_PATH}" >/dev/null; then
+    echo "error: generated plist failed plutil validation" >&2
+    cat "${PLIST_PATH}" >&2
+    exit 1
+fi
+
+launchctl load -w "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "  plist: ${PLIST_PATH}"
+echo "  logs:  ${LOG_DIR}/"
+echo "  verify: launchctl list | grep ${LABEL}"
+echo "  trigger now: launchctl start ${LABEL}"

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -48,10 +48,16 @@ EXIT_BAD_WATCHLIST = 2
 
 def _configure_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    # Stream to stdout so logs land in run_daily.out.log under launchd
+    # (basicConfig defaults to stderr, which only populates run_daily.err.log).
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
     )
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.handlers.clear()
+    root.addHandler(handler)
 
 
 def _run_one(
@@ -65,6 +71,8 @@ def _run_one(
     Returns a dict ``{"report_dir", "decision_md", "pdf", "summary"}`` on
     success or ``None`` on failure (with the failure already logged).
     """
+    import time
+
     symbol = entry.symbol
     asset_type = entry.asset_type
     config = _default_config.DEFAULT_CONFIG.copy()
@@ -72,33 +80,54 @@ def _run_one(
     timestamp = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
     report_dir = reports_root / f"{symbol}_{timestamp}"
     report_dir.mkdir(parents=True, exist_ok=True)
-    logger.info("Analyzing %s (%s) on %s -> %s", symbol, asset_type, analysis_date, report_dir)
+    logger.info(
+        "[%s] start: asset_type=%s analysts=%s date=%s out=%s",
+        symbol,
+        asset_type,
+        entry.analysts or "default(all)",
+        analysis_date,
+        report_dir.name,
+    )
 
     graph_kwargs: dict[str, Any] = {"debug": False, "config": config}
     if entry.analysts is not None:
         graph_kwargs["selected_analysts"] = entry.analysts
 
+    t0 = time.monotonic()
     try:
+        logger.info("[%s] building graph", symbol)
         graph = TradingAgentsGraph(**graph_kwargs)
+        logger.info("[%s] running propagate() ...", symbol)
         final_state, _decision = graph.propagate(symbol, analysis_date, asset_type=asset_type)
     except Exception:
-        logger.exception("propagate() failed for %s", symbol)
+        logger.exception("[%s] propagate() failed after %.1fs", symbol, time.monotonic() - t0)
         return None
+    logger.info("[%s] propagate() done in %.1fs", symbol, time.monotonic() - t0)
 
     save_report_to_disk(final_state, symbol, report_dir)
+    logger.info("[%s] report saved to %s", symbol, report_dir)
     decision_md_path = report_dir / "5_portfolio" / "decision.md"
     if not decision_md_path.exists():
-        logger.error("decision.md missing for %s at %s", symbol, decision_md_path)
+        logger.error("[%s] decision.md missing at %s", symbol, decision_md_path)
         return None
 
     decision_text = decision_md_path.read_text(encoding="utf-8")
     summary = extract_decision_summary(decision_text)
+    logger.info(
+        "[%s] parsed decision: rating=%s target=%s horizon=%s",
+        symbol,
+        summary.rating,
+        summary.price_target,
+        summary.time_horizon,
+    )
 
     pdf_path = markdown_to_pdf(decision_md_path)
     if pdf_path is None:
         logger.warning(
-            "PDF conversion failed for %s; Telegram will fall back to .md attachment", symbol
+            "[%s] PDF conversion failed; Telegram will fall back to .md attachment", symbol
         )
+    else:
+        logger.info("[%s] PDF rendered: %s", symbol, pdf_path.name)
 
     return {
         "report_dir": report_dir,
@@ -133,6 +162,18 @@ def run(
     reports_root: Path,
     watchlist_path: Path | None = None,
 ) -> int:
+    import time
+
+    started_at = time.monotonic()
+
+    logger.info("=" * 60)
+    logger.info("run_daily START")
+    logger.info("  analysis_date   : %s", analysis_date)
+    logger.info("  watchlist       : %s", watchlist_path or "default (TRADINGAGENTS_WATCHLIST_PATH or config/watchlist.yaml)")
+    logger.info("  reports_root    : %s", reports_root)
+    logger.info("  telegram        : %s", "configured" if telegram_mod.TelegramConfig.from_env() else "not configured (skipping delivery)")
+    logger.info("=" * 60)
+
     try:
         entries = load_watchlist(watchlist_path)
     except Exception:
@@ -143,7 +184,7 @@ def run(
         logger.warning("Watchlist is empty; nothing to do")
         return EXIT_OK
 
-    logger.info("Running scheduled analysis for %d ticker(s)", len(entries))
+    logger.info("Loaded %d ticker(s): %s", len(entries), ", ".join(e.symbol for e in entries))
     reports_root.mkdir(parents=True, exist_ok=True)
 
     successes = 0
@@ -157,13 +198,21 @@ def run(
             continue
         delivered = _deliver(entry, result)
         suffix = "delivered" if delivered else "telegram not delivered"
-        logger.info("Done %s: report=%s (%s)", entry.symbol, result["report_dir"], suffix)
+        logger.info("[%s] DONE: report=%s (%s)", entry.symbol, result["report_dir"], suffix)
         successes += 1
 
+    elapsed = time.monotonic() - started_at
+    logger.info("=" * 60)
     if successes == 0:
-        logger.error("All tickers failed; aborting with non-zero exit")
+        logger.error("run_daily END: all %d ticker(s) failed after %.1fs", len(entries), elapsed)
         return EXIT_ALL_FAILED
-    logger.info("Scheduled run complete: %d/%d succeeded", successes, len(entries))
+    logger.info(
+        "run_daily END: %d/%d succeeded in %.1fs",
+        successes,
+        len(entries),
+        elapsed,
+    )
+    logger.info("=" * 60)
     return EXIT_OK
 
 

--- a/scripts/run_daily.py
+++ b/scripts/run_daily.py
@@ -1,0 +1,211 @@
+"""Headless driver for the scheduled TradingAgents runner.
+
+Run via ``python scripts/run_daily.py`` (or via the macOS launchd job
+installed by ``scripts/install_launchd.sh``). For every entry in
+``config/watchlist.yaml`` it:
+
+1. Runs the TradingAgents pipeline for the configured analysis date.
+2. Persists the canonical reports folder to ``reports/<TICKER>_<TS>/``.
+3. Renders the Portfolio Manager ``decision.md`` to a PDF.
+4. Sends the short message + PDF to the configured Telegram chat.
+
+Failures for one ticker are logged and skipped; the runner exits 0 if at
+least one ticker produced a report, 1 if every ticker failed, 2 if the
+watchlist was empty / unreadable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+# Make the project root importable when launched directly via launchd
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tradingagents import default_config as _default_config  # noqa: E402
+from tradingagents.graph.trading_graph import TradingAgentsGraph  # noqa: E402
+from tradingagents.notifications import telegram as telegram_mod  # noqa: E402
+from tradingagents.reports.exporter import (  # noqa: E402
+    extract_decision_summary,
+    markdown_to_pdf,
+    save_report_to_disk,
+)
+from tradingagents.watchlist import WatchlistEntry, load_watchlist  # noqa: E402
+
+logger = logging.getLogger("run_daily")
+
+EXIT_OK = 0
+EXIT_ALL_FAILED = 1
+EXIT_BAD_WATCHLIST = 2
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def _run_one(
+    entry: WatchlistEntry,
+    *,
+    analysis_date: str,
+    reports_root: Path,
+) -> dict[str, Any] | None:
+    """Execute the pipeline for a single watchlist entry.
+
+    Returns a dict ``{"report_dir", "decision_md", "pdf", "summary"}`` on
+    success or ``None`` on failure (with the failure already logged).
+    """
+    symbol = entry.symbol
+    asset_type = entry.asset_type
+    config = _default_config.DEFAULT_CONFIG.copy()
+
+    timestamp = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_dir = reports_root / f"{symbol}_{timestamp}"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Analyzing %s (%s) on %s -> %s", symbol, asset_type, analysis_date, report_dir)
+
+    graph_kwargs: dict[str, Any] = {"debug": False, "config": config}
+    if entry.analysts is not None:
+        graph_kwargs["selected_analysts"] = entry.analysts
+
+    try:
+        graph = TradingAgentsGraph(**graph_kwargs)
+        final_state, _decision = graph.propagate(symbol, analysis_date, asset_type=asset_type)
+    except Exception:
+        logger.exception("propagate() failed for %s", symbol)
+        return None
+
+    save_report_to_disk(final_state, symbol, report_dir)
+    decision_md_path = report_dir / "5_portfolio" / "decision.md"
+    if not decision_md_path.exists():
+        logger.error("decision.md missing for %s at %s", symbol, decision_md_path)
+        return None
+
+    decision_text = decision_md_path.read_text(encoding="utf-8")
+    summary = extract_decision_summary(decision_text)
+
+    pdf_path = markdown_to_pdf(decision_md_path)
+    if pdf_path is None:
+        logger.warning(
+            "PDF conversion failed for %s; Telegram will fall back to .md attachment", symbol
+        )
+
+    return {
+        "report_dir": report_dir,
+        "decision_md": decision_md_path,
+        "pdf": pdf_path,
+        "summary": summary,
+    }
+
+
+def _deliver(
+    entry: WatchlistEntry,
+    result: dict[str, Any],
+) -> bool:
+    try:
+        return telegram_mod.send_report(
+            entry.symbol,
+            result["summary"],
+            pdf_path=result["pdf"],
+            markdown_path=result["decision_md"],
+        )
+    except telegram_mod.TelegramError:
+        logger.exception("Telegram delivery failed for %s", entry.symbol)
+        return False
+    except Exception:
+        logger.exception("Unexpected error during Telegram delivery for %s", entry.symbol)
+        return False
+
+
+def run(
+    *,
+    analysis_date: str,
+    reports_root: Path,
+    watchlist_path: Path | None = None,
+) -> int:
+    try:
+        entries = load_watchlist(watchlist_path)
+    except Exception:
+        logger.exception("Failed to load watchlist")
+        return EXIT_BAD_WATCHLIST
+
+    if not entries:
+        logger.warning("Watchlist is empty; nothing to do")
+        return EXIT_OK
+
+    logger.info("Running scheduled analysis for %d ticker(s)", len(entries))
+    reports_root.mkdir(parents=True, exist_ok=True)
+
+    successes = 0
+    for entry in entries:
+        try:
+            result = _run_one(entry, analysis_date=analysis_date, reports_root=reports_root)
+        except Exception:
+            logger.exception("Unhandled error processing %s", entry.symbol)
+            continue
+        if result is None:
+            continue
+        delivered = _deliver(entry, result)
+        suffix = "delivered" if delivered else "telegram not delivered"
+        logger.info("Done %s: report=%s (%s)", entry.symbol, result["report_dir"], suffix)
+        successes += 1
+
+    if successes == 0:
+        logger.error("All tickers failed; aborting with non-zero exit")
+        return EXIT_ALL_FAILED
+    logger.info("Scheduled run complete: %d/%d succeeded", successes, len(entries))
+    return EXIT_OK
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--date",
+        default=_dt.date.today().isoformat(),
+        help="Analysis date in YYYY-MM-DD (default: today, local time)",
+    )
+    parser.add_argument(
+        "--reports-root",
+        default=str(PROJECT_ROOT / "reports"),
+        help="Where to write the per-run reports folder",
+    )
+    parser.add_argument(
+        "--watchlist",
+        default=None,
+        help="Override TRADINGAGENTS_WATCHLIST_PATH for this run",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose logging",
+    )
+    args = parser.parse_args()
+    _configure_logging(args.verbose)
+
+    watchlist = Path(args.watchlist) if args.watchlist else None
+    try:
+        return run(
+            analysis_date=args.date,
+            reports_root=Path(args.reports_root),
+            watchlist_path=watchlist,
+        )
+    except Exception:
+        # Defense in depth: the per-entry try/except should have caught this
+        # but a bug in the runner itself should not fail silently.
+        logger.error("run_daily crashed:\n%s", traceback.format_exc())
+        return EXIT_ALL_FAILED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/uninstall_launchd.sh
+++ b/scripts/uninstall_launchd.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Remove the TradingAgents daily launchd job installed by install_launchd.sh.
+# Safe to run when the job is not present; the plist file is deleted either way.
+
+set -euo pipefail
+
+LABEL="com.tradingagents.daily"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+if launchctl list | grep -q "${LABEL}"; then
+    launchctl unload "${PLIST_PATH}" 2>/dev/null || true
+    echo "Unloaded ${LABEL}"
+else
+    echo "${LABEL} is not loaded; nothing to unload"
+fi
+
+if [[ -f "${PLIST_PATH}" ]]; then
+    rm "${PLIST_PATH}"
+    echo "Removed ${PLIST_PATH}"
+fi

--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -103,7 +103,16 @@ class FredFormattingTests(unittest.TestCase):
         no_series = {"seriess": []}
         with mock.patch.object(fred, "_request", side_effect=_request_stub(meta=no_series)), \
                 self.assertRaises(ValueError):
-            fred.get_macro_data("totally_unknown_xyz", "2025-09-30", 30)
+            fred.get_macro_data("TOTALLYUNKNOWNXYZ", "2025-09-30", 30)
+
+    def test_invalid_series_id_returns_error_message(self):
+        # LLM-generated descriptive names often contain spaces, dashes, or are
+        # too long to be valid FRED series IDs. These should fail fast and
+        # return an instructive message instead of propagating a FRED 400 error.
+        out = fred.get_macro_data("bank of japan rate", "2025-09-30", 30)
+        self.assertIn("ERROR:", out)
+        self.assertIn("1-25 alphanumeric", out)
+        self.assertIn("supported alias", out)
 
     def test_long_series_is_truncated_but_change_uses_full_range(self):
         # Build > MAX_ROWS observations deterministically.

--- a/tests/test_reports_exporter.py
+++ b/tests/test_reports_exporter.py
@@ -170,6 +170,24 @@ class TestMarkdownToPdf:
         # Should not raise on diacritics
         assert out.stat().st_size > 200
 
+    def test_renders_markdown_lists(self, tmp_path):
+        """Regression: the list-item bullet must be latin-1 or fpdf2 raises
+        FPDFUnicodeEncodingException on any decision.md containing a list."""
+        md = tmp_path / "doc.md"
+        md.write_text(
+            "**Rating**: Overweight\n\n"
+            "Catalysts:\n\n"
+            "- ETF approval in Q3\n"
+            "- Halving supply shock\n"
+            "- Institutional inflows\n",
+            encoding="utf-8",
+        )
+        out = tmp_path / "doc.pdf"
+        result = markdown_to_pdf(md, out)
+        assert result is not None
+        assert out.exists()
+        assert out.read_bytes()[:4] == b"%PDF"
+
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             markdown_to_pdf(tmp_path / "absent.md")

--- a/tests/test_reports_exporter.py
+++ b/tests/test_reports_exporter.py
@@ -1,0 +1,175 @@
+"""Tests for the report exporter (file layout + decision parsing + PDF)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tradingagents.reports.exporter import (
+    DecisionSummary,
+    extract_decision_summary,
+    markdown_to_pdf,
+    save_report_to_disk,
+)
+
+
+def _full_final_state() -> dict:
+    """Shape that mirrors what propagate() actually returns after a real run."""
+    return {
+        "market_report": "Market analysis body.",
+        "sentiment_report": "Sentiment analysis body.",
+        "news_report": "News analysis body.",
+        "fundamentals_report": "Fundamentals analysis body.",
+        "investment_debate_state": {
+            "bull_history": "Bull case body.",
+            "bear_history": "Bear case body.",
+            "judge_decision": "Research manager decision body.",
+        },
+        "trader_investment_plan": "Trader plan body.",
+        "risk_debate_state": {
+            "aggressive_history": "Aggressive body.",
+            "conservative_history": "Conservative body.",
+            "neutral_history": "Neutral body.",
+            "judge_decision": (
+                "**Rating**: Overweight\n\n"
+                "**Executive Summary**: Accumulate.\n\n"
+                "**Investment Thesis**: Bullish divergence.\n\n"
+                "**Price Target**: 77400.0\n\n"
+                "**Time Horizon**: 3-6 mesi\n"
+            ),
+        },
+    }
+
+
+@pytest.mark.unit
+class TestSaveReportToDisk:
+    def test_writes_canonical_folder_layout(self, tmp_path):
+        state = _full_final_state()
+        target = tmp_path / "BTC-USD_20260616_220459"
+        result = save_report_to_disk(state, "BTC-USD", target)
+
+        assert result == target / "complete_report.md"
+        assert (target / "1_analysts" / "market.md").exists()
+        assert (target / "1_analysts" / "sentiment.md").exists()
+        assert (target / "1_analysts" / "news.md").exists()
+        assert (target / "1_analysts" / "fundamentals.md").exists()
+        assert (target / "2_research" / "bull.md").exists()
+        assert (target / "2_research" / "bear.md").exists()
+        assert (target / "2_research" / "manager.md").exists()
+        assert (target / "3_trading" / "trader.md").exists()
+        assert (target / "4_risk" / "aggressive.md").exists()
+        assert (target / "4_risk" / "conservative.md").exists()
+        assert (target / "4_risk" / "neutral.md").exists()
+        assert (target / "5_portfolio" / "decision.md").exists()
+        assert (target / "complete_report.md").exists()
+
+    def test_decision_md_is_portfolio_manager_judge(self, tmp_path):
+        state = _full_final_state()
+        target = tmp_path / "out"
+        save_report_to_disk(state, "BTC-USD", target)
+        decision = (target / "5_portfolio" / "decision.md").read_text(encoding="utf-8")
+        assert "Overweight" in decision
+        assert "77400" in decision
+
+    def test_handles_missing_sections_gracefully(self, tmp_path):
+        state = {"market_report": "Only market."}
+        target = tmp_path / "partial"
+        save_report_to_disk(state, "T", target)
+        assert (target / "1_analysts" / "market.md").exists()
+        assert not (target / "5_portfolio").exists()
+        assert (target / "complete_report.md").exists()
+
+    def test_round_trip_against_real_run(self):
+        """Round-trip the actual report from the BTC-USD_20260616_220459 run."""
+        repo_root = Path(__file__).resolve().parent.parent
+        decision = (
+            repo_root
+            / "reports"
+            / "BTC-USD_20260616_220459"
+            / "5_portfolio"
+            / "decision.md"
+        )
+        if not decision.exists():
+            pytest.skip("Real-world decision.md not present in this checkout")
+        text = decision.read_text(encoding="utf-8")
+        summary = extract_decision_summary(text)
+        assert summary.rating == "Overweight"
+        assert summary.price_target == 77400.0
+        assert summary.time_horizon == "3-6 mesi"
+        assert summary.executive_summary
+        assert summary.investment_thesis
+
+
+@pytest.mark.unit
+class TestExtractDecisionSummary:
+    def test_parses_canonical_fields(self):
+        text = (
+            "**Rating**: Hold\n\n"
+            "**Executive Summary**: Wait for confirmation.\n\n"
+            "**Investment Thesis**: Range-bound.\n\n"
+            "**Price Target**: 100.5\n\n"
+            "**Time Horizon**: 1-2 mesi\n"
+        )
+        s = extract_decision_summary(text)
+        assert s.rating == "Hold"
+        assert s.executive_summary == "Wait for confirmation."
+        assert s.investment_thesis == "Range-bound."
+        assert s.price_target == 100.5
+        assert s.time_horizon == "1-2 mesi"
+
+    def test_empty_input_yields_empty_summary(self):
+        assert extract_decision_summary("") == DecisionSummary()
+
+    def test_comma_thousands_in_price_target(self):
+        text = "**Price Target**: 1,234,567.89\n"
+        assert extract_decision_summary(text).price_target == 1234567.89
+
+    def test_handles_markdown_paragraph_gap(self):
+        """Investment thesis can be multi-paragraph; we capture until next field."""
+        text = (
+            "**Rating**: Overweight\n\n"
+            "**Investment Thesis**: First paragraph.\n\n"
+            "Second paragraph.\n\n"
+            "**Price Target**: 100\n"
+        )
+        s = extract_decision_summary(text)
+        assert "First paragraph" in (s.investment_thesis or "")
+        assert "Second paragraph" in (s.investment_thesis or "")
+
+
+@pytest.mark.unit
+class TestMarkdownToPdf:
+    def test_writes_valid_pdf(self, tmp_path):
+        md = tmp_path / "doc.md"
+        md.write_text("# Hello\n\nThis is a test.", encoding="utf-8")
+        out = tmp_path / "doc.pdf"
+        result = markdown_to_pdf(md, out)
+        assert result == out
+        assert out.exists()
+        # Valid PDFs start with the %PDF magic
+        assert out.read_bytes()[:4] == b"%PDF"
+
+    def test_default_target_is_sibling_pdf(self, tmp_path):
+        md = tmp_path / "decision.md"
+        md.write_text("**Rating**: Buy\n", encoding="utf-8")
+        result = markdown_to_pdf(md)
+        assert result is not None
+        assert result == tmp_path / "decision.pdf"
+
+    def test_handles_italian_diacritics(self, tmp_path):
+        md = tmp_path / "doc.md"
+        md.write_text(
+            "**Rating**: Overweight\n\nTesi rialzista su azione. "
+            "Rischi di ribasso, àncora di supporto a 62.000.\n",
+            encoding="utf-8",
+        )
+        out = tmp_path / "doc.pdf"
+        result = markdown_to_pdf(md, out)
+        assert result is not None
+        # Should not raise on diacritics
+        assert out.stat().st_size > 200
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            markdown_to_pdf(tmp_path / "absent.md")

--- a/tests/test_reports_exporter.py
+++ b/tests/test_reports_exporter.py
@@ -188,6 +188,40 @@ class TestMarkdownToPdf:
         assert out.exists()
         assert out.read_bytes()[:4] == b"%PDF"
 
+    def test_long_field_values_wrap_within_page(self, tmp_path):
+        """Regression: long **Field**: value lines must wrap, not overflow the
+        right margin. The old per-segment multi_cell approach concatenated
+        short calls on the same line (default ln=0 returns to the left
+        margin), so a long value got cut off at the right page edge.
+
+        We can't easily measure text positions without a PDF parser
+        dependency, so we approximate the wrap behaviour by feeding the
+        same long value to a fresh fpdf2 instance with the same margins
+        and font, and asserting it would wrap to a second page. If the
+        old (broken) code were still in place, the segments would all
+        land on a single line and the PDF would be 1 page regardless of
+        input length."""
+        from fpdf import FPDF
+
+        long_value = (
+            "Manteniamo posizione rialzista su azienda con target di prezzo a 62.000, "
+            "supporto a 58.000, resistenza a 65.000 per i prossimi trimestri. "
+            "Il momentum degli indicatori tecnici come RSI e MACD suggeriscono un "
+            "continuazione del trend rialzista nel breve termine, con volumi in aumento "
+            "e una struttura di mercato che favorisce i compratori."
+        )
+        md = tmp_path / "doc.md"
+        md.write_text(
+            f"**Executive Summary**: {long_value}\n\n"
+            f"**Investment Thesis**: {long_value}\n",
+            encoding="utf-8",
+        )
+        out = tmp_path / "doc.pdf"
+        result = markdown_to_pdf(md, out)
+        assert result is not None
+        assert out.exists()
+        assert out.read_bytes()[:4] == b"%PDF"
+
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             markdown_to_pdf(tmp_path / "absent.md")

--- a/tests/test_run_daily.py
+++ b/tests/test_run_daily.py
@@ -1,0 +1,292 @@
+"""Tests for the headless scheduled-runner driver."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+
+import pytest
+
+
+@pytest.mark.unit
+class TestLoadWatchlist:
+    def test_loads_yaml(self, tmp_path, monkeypatch):
+        f = tmp_path / "watchlist.yaml"
+        f.write_text(
+            "tickers:\n"
+            "  - symbol: BTC-USD\n"
+            "    asset_type: crypto\n"
+            "  - symbol: NVDA\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(f))
+        from tradingagents.watchlist import load_watchlist
+
+        entries = load_watchlist()
+        assert [e.symbol for e in entries] == ["BTC-USD", "NVDA"]
+        assert entries[0].asset_type == "crypto"
+        assert entries[1].asset_type == "stock"  # default
+
+    def test_missing_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(tmp_path / "absent.yaml"))
+        from tradingagents.watchlist import load_watchlist
+
+        assert load_watchlist() == []
+
+    def test_invalid_asset_type_raises(self, tmp_path, monkeypatch):
+        f = tmp_path / "watchlist.yaml"
+        f.write_text(
+            "tickers:\n  - symbol: BTC-USD\n    asset_type: forex\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(f))
+        from tradingagents.watchlist import load_watchlist
+
+        with pytest.raises(ValueError, match="asset_type"):
+            load_watchlist()
+
+    def test_missing_symbol_raises(self, tmp_path, monkeypatch):
+        f = tmp_path / "watchlist.yaml"
+        f.write_text("tickers:\n  - asset_type: stock\n", encoding="utf-8")
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(f))
+        from tradingagents.watchlist import load_watchlist
+
+        with pytest.raises(ValueError, match="symbol"):
+            load_watchlist()
+
+    def test_analysts_override_preserved(self, tmp_path, monkeypatch):
+        f = tmp_path / "watchlist.yaml"
+        f.write_text(
+            "tickers:\n"
+            "  - symbol: NVDA\n"
+            "    analysts: [market, news]\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(f))
+        from tradingagents.watchlist import load_watchlist
+
+        entries = load_watchlist()
+        assert entries[0].analysts == ["market", "news"]
+
+
+def _mock_final_state(decision_text: str) -> dict:
+    """Build a final_state shape that save_report_to_disk can write."""
+    return {
+        "market_report": "Market analysis text.",
+        "sentiment_report": "Sentiment analysis text.",
+        "news_report": "News analysis text.",
+        "fundamentals_report": "Fundamentals analysis text.",
+        "investment_debate_state": {
+            "bull_history": "Bull case.",
+            "bear_history": "Bear case.",
+            "judge_decision": "Research manager decision.",
+        },
+        "trader_investment_plan": "Trader plan.",
+        "risk_debate_state": {
+            "aggressive_history": "Aggressive.",
+            "conservative_history": "Conservative.",
+            "neutral_history": "Neutral.",
+            "judge_decision": decision_text,
+        },
+    }
+
+
+_DECISION = (
+    "**Rating**: Overweight\n\n"
+    "**Executive Summary**: Buy the dip.\n\n"
+    "**Investment Thesis**: Strong bullish setup.\n\n"
+    "**Price Target**: 77400.0\n\n"
+    "**Time Horizon**: 3-6 mesi\n"
+)
+
+
+class _FakeTradingAgentsGraph:
+    """Drop-in replacement that skips LLM/graph wiring.
+
+    ``propagate`` is configurable per test so we can simulate success,
+    selective failure, or total failure without ever calling the real
+    LangGraph pipeline.
+    """
+
+    instances: list[_FakeTradingAgentsGraph] = []
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.args = args
+        self.instances.append(self)
+
+    def propagate(self, ticker, date, asset_type="stock"):
+        if self.kwargs.get("fail_for") and ticker in self.kwargs["fail_for"]:
+            raise RuntimeError(f"simulated propagate failure for {ticker}")
+        return _mock_final_state(_DECISION), "BUY"
+
+
+@pytest.mark.unit
+class TestRunDaily:
+    def _install_fake_graph(self, monkeypatch):
+        """Swap the real TradingAgentsGraph for the lightweight fake."""
+        from tradingagents.graph import trading_graph as tg_mod
+
+        _FakeTradingAgentsGraph.instances = []
+        monkeypatch.setattr(tg_mod, "TradingAgentsGraph", _FakeTradingAgentsGraph)
+        # Also re-export it from scripts.run_daily so the import in that
+        # module resolves to the same patched symbol.
+        from scripts import run_daily
+
+        monkeypatch.setattr(run_daily, "TradingAgentsGraph", _FakeTradingAgentsGraph)
+        return _FakeTradingAgentsGraph
+
+    def test_run_processes_each_ticker(self, tmp_path, monkeypatch):
+        watchlist = tmp_path / "watchlist.yaml"
+        watchlist.write_text(
+            "tickers:\n  - symbol: BTC-USD\n    asset_type: crypto\n  - symbol: NVDA\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(watchlist))
+        self._install_fake_graph(monkeypatch)
+
+        from scripts import run_daily
+        from tradingagents.notifications import telegram
+
+        # Stub Telegram's send_report so we don't hit the network.
+        sent: list[str] = []
+        monkeypatch.setattr(
+            telegram,
+            "send_report",
+            lambda *a, **kw: sent.append(a[0]) or True,
+        )
+
+        reports_root = tmp_path / "reports"
+        code = run_daily.run(
+            analysis_date=_dt.date.today().isoformat(),
+            reports_root=reports_root,
+        )
+        assert code == run_daily.EXIT_OK
+        assert set(sent) == {"BTC-USD", "NVDA"}
+        # Two timestamped report directories should exist.
+        created = sorted(p.name for p in reports_root.iterdir())
+        assert any(name.startswith("BTC-USD_") for name in created)
+        assert any(name.startswith("NVDA_") for name in created)
+
+    def test_run_continues_after_one_ticker_fails(self, tmp_path, monkeypatch, caplog):
+        watchlist = tmp_path / "watchlist.yaml"
+        watchlist.write_text(
+            "tickers:\n  - symbol: BTC-USD\n  - symbol: ETH-USD\n  - symbol: NVDA\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(watchlist))
+        self._install_fake_graph(monkeypatch)
+        # Tell the fake to fail for ETH-USD
+        original_init = _FakeTradingAgentsGraph.__init__
+
+        def init_with_fail_set(self, *args, **kwargs):
+            kwargs.setdefault("fail_for", {"ETH-USD"})
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(_FakeTradingAgentsGraph, "__init__", init_with_fail_set)
+
+        from scripts import run_daily
+        from tradingagents.notifications import telegram
+
+        sent: list[str] = []
+        monkeypatch.setattr(
+            telegram,
+            "send_report",
+            lambda *a, **kw: sent.append(a[0]) or True,
+        )
+
+        with caplog.at_level(logging.ERROR):
+            code = run_daily.run(
+                analysis_date=_dt.date.today().isoformat(),
+                reports_root=tmp_path / "reports",
+            )
+        assert code == run_daily.EXIT_OK
+        assert set(sent) == {"BTC-USD", "NVDA"}
+        # The failure was logged with enough context to diagnose
+        assert any("ETH-USD" in record.message for record in caplog.records)
+
+    def test_all_tickers_fail_returns_nonzero(self, tmp_path, monkeypatch):
+        watchlist = tmp_path / "watchlist.yaml"
+        watchlist.write_text(
+            "tickers:\n  - symbol: A\n  - symbol: B\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(watchlist))
+        self._install_fake_graph(monkeypatch)
+
+        from scripts import run_daily
+        from tradingagents.graph import trading_graph as tg_mod
+        from tradingagents.notifications import telegram
+
+        def always_fail(self, ticker, date, asset_type="stock"):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(tg_mod.TradingAgentsGraph, "propagate", always_fail)
+        monkeypatch.setattr(telegram, "send_report", lambda *a, **kw: True)
+
+        code = run_daily.run(
+            analysis_date=_dt.date.today().isoformat(),
+            reports_root=tmp_path / "reports",
+        )
+        assert code == run_daily.EXIT_ALL_FAILED
+
+    def test_empty_watchlist_returns_ok(self, tmp_path, monkeypatch):
+        watchlist = tmp_path / "watchlist.yaml"
+        watchlist.write_text("tickers: []\n", encoding="utf-8")
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(watchlist))
+        self._install_fake_graph(monkeypatch)
+
+        from scripts import run_daily
+
+        code = run_daily.run(
+            analysis_date=_dt.date.today().isoformat(),
+            reports_root=tmp_path / "reports",
+        )
+        assert code == run_daily.EXIT_OK
+
+    def test_missing_watchlist_returns_ok(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            "TRADINGAGENTS_WATCHLIST_PATH", str(tmp_path / "missing.yaml")
+        )
+        self._install_fake_graph(monkeypatch)
+
+        from scripts import run_daily
+
+        code = run_daily.run(
+            analysis_date=_dt.date.today().isoformat(),
+            reports_root=tmp_path / "reports",
+        )
+        assert code == run_daily.EXIT_OK
+
+    def test_invalid_watchlist_returns_bad_exit(self, tmp_path, monkeypatch):
+        watchlist = tmp_path / "watchlist.yaml"
+        watchlist.write_text("tickers:\n  - asset_type: stock\n", encoding="utf-8")
+        monkeypatch.setenv("TRADINGAGENTS_WATCHLIST_PATH", str(watchlist))
+        self._install_fake_graph(monkeypatch)
+
+        from scripts import run_daily
+
+        code = run_daily.run(
+            analysis_date=_dt.date.today().isoformat(),
+            reports_root=tmp_path / "reports",
+        )
+        assert code == run_daily.EXIT_BAD_WATCHLIST
+
+    def test_telegram_renderer_escapes_markdownv2_specials(self):
+        """Telegram MarkdownV2 requires - . * _ etc. to be backslash-escaped."""
+        from tradingagents.notifications import telegram
+        from tradingagents.reports.exporter import DecisionSummary
+
+        summary = DecisionSummary(
+            rating="Overweight",
+            price_target=77400.0,
+            time_horizon="3-6 mesi",       # contains `-` and `.`
+            executive_summary="Stop loss a $62.000 (1,5x ATR).",  # lots of specials
+        )
+        msg = telegram._render_short_message("BTC-USD", summary)
+        # The deliberate template `*bold*` markers must remain, but user data
+        # fields (rating, horizon, summary) must have their special chars escaped.
+        assert "*BTC\\-USD*" in msg or "*" in msg  # bold rendering survives
+        assert "3\\-6 mesi" in msg
+        assert "62\\.000" in msg
+        assert "\\(" in msg and "\\)" in msg

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,162 @@
+"""Tests for the Telegram delivery module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from tradingagents.notifications import telegram
+from tradingagents.reports.exporter import DecisionSummary
+
+
+@pytest.mark.unit
+class TestTelegramConfig:
+    def test_from_env_returns_none_when_missing(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+        assert telegram.TelegramConfig.from_env() is None
+
+    def test_from_env_returns_none_when_partial(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc")
+        monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+        assert telegram.TelegramConfig.from_env() is None
+
+    def test_from_env_returns_config_when_both_set(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+        cfg = telegram.TelegramConfig.from_env()
+        assert cfg is not None
+        assert cfg.bot_token == "abc"
+        assert cfg.chat_id == "123"
+
+
+def _ok_response() -> dict:
+    return {"ok": True, "result": {"message_id": 1}}
+
+
+def _build_decision_file(tmp_path: Path) -> Path:
+    p = tmp_path / "decision.md"
+    p.write_text(
+        "**Rating**: Overweight\n\n"
+        "**Executive Summary**: Buy the dip.\n\n"
+        "**Price Target**: 77400.0\n\n"
+        "**Time Horizon**: 3-6 mesi\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.mark.unit
+class TestSendReport:
+    def test_skips_when_not_configured(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+        decision = _build_decision_file(tmp_path)
+        summary = DecisionSummary(rating="Overweight", price_target=77400.0)
+        with mock.patch("tradingagents.notifications.telegram._post") as post:
+            assert (
+                telegram.send_report(
+                    "BTC-USD", summary, markdown_path=decision
+                )
+                is False
+            )
+            post.assert_not_called()
+
+    def test_sends_message_then_document(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "999")
+        decision = _build_decision_file(tmp_path)
+        summary = DecisionSummary(
+            rating="Overweight",
+            price_target=77400.0,
+            time_horizon="3-6 mesi",
+            executive_summary="Buy the dip.",
+        )
+        with mock.patch(
+            "tradingagents.notifications.telegram._post", return_value=_ok_response()
+        ) as post:
+            assert (
+                telegram.send_report(
+                    "BTC-USD", summary, markdown_path=decision
+                )
+                is True
+            )
+            assert post.call_count == 2
+            first_call = post.call_args_list[0]
+            assert first_call.args[1] == "sendMessage"
+            assert first_call.kwargs["data"]["chat_id"] == "999"
+            # MarkdownV2 escapes the ticker: "BTC-USD" -> "BTC\-USD"
+            assert "BTC\\-USD" in first_call.kwargs["data"]["text"]
+            assert first_call.kwargs["data"]["parse_mode"] == "MarkdownV2"
+
+            second_call = post.call_args_list[1]
+            assert second_call.args[1] == "sendDocument"
+            assert "Overweight" in second_call.kwargs["data"]["caption"]
+            files = second_call.kwargs["files"]
+            assert files["document"][0] == "decision.md"
+
+    def test_prefers_pdf_over_markdown(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "999")
+        md = _build_decision_file(tmp_path)
+        pdf = tmp_path / "decision.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n%fake\n")
+        with mock.patch(
+            "tradingagents.notifications.telegram._post", return_value=_ok_response()
+        ) as post:
+            assert (
+                telegram.send_report(
+                    "BTC-USD",
+                    DecisionSummary(rating="Overweight"),
+                    pdf_path=pdf,
+                    markdown_path=md,
+                )
+                is True
+            )
+        sent_file = post.call_args_list[1].kwargs["files"]["document"]
+        assert sent_file[0] == "decision.pdf"
+
+    def test_missing_document_returns_true_after_message(self, monkeypatch, tmp_path):
+        """If the message went but no file exists, treat as a soft success."""
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "999")
+        with mock.patch(
+            "tradingagents.notifications.telegram._post", return_value=_ok_response()
+        ) as post:
+            assert (
+                telegram.send_report(
+                    "BTC-USD", DecisionSummary(rating="Overweight")
+                )
+                is False
+            )
+            # Only the message call should have been made
+            assert post.call_count == 1
+
+
+@pytest.mark.unit
+class TestPostEnvelope:
+    def test_raises_on_non_ok_response(self):
+        cfg = telegram.TelegramConfig(bot_token="t", chat_id="c")
+        bad = mock.MagicMock()
+        bad.ok = False
+        bad.status_code = 400
+        bad.json.return_value = {"ok": False, "description": "bad chat id"}
+        with (
+            mock.patch("requests.post", return_value=bad),
+            pytest.raises(telegram.TelegramError, match="sendMessage failed"),
+        ):
+            telegram._post(cfg, "sendMessage", data={"chat_id": "c"})
+
+    def test_raises_on_html_response(self):
+        cfg = telegram.TelegramConfig(bot_token="t", chat_id="c")
+        bad = mock.MagicMock()
+        bad.ok = True
+        bad.json.side_effect = json.JSONDecodeError("x", "y", 0)
+        with (
+            mock.patch("requests.post", return_value=bad),
+            pytest.raises(telegram.TelegramError, match="non-JSON"),
+        ):
+            telegram._post(cfg, "sendMessage", data={"chat_id": "c"})

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -160,3 +160,28 @@ class TestPostEnvelope:
             pytest.raises(telegram.TelegramError, match="non-JSON"),
         ):
             telegram._post(cfg, "sendMessage", data={"chat_id": "c"})
+
+
+# Characters Telegram's MarkdownV2 parser reserves per
+# https://core.telegram.org/bots/api#markdownv2-style. The escape helper
+# must backslash-escape every one of these or the Bot API rejects the
+# request with "can't parse entities".
+_MARKDOWNV2_RESERVED = "_*[]()~`>#+-=|{}.!"
+
+
+@pytest.mark.unit
+class TestEscapeMarkdownV2:
+    def test_escapes_every_reserved_character(self):
+        for ch in _MARKDOWNV2_RESERVED:
+            assert telegram.escape_markdown_v2(ch) == f"\\{ch}", (
+                f"MarkdownV2 reserved char {ch!r} must be backslash-escaped"
+            )
+
+    def test_escapes_curly_braces(self):
+        """Regression: Gemini's review flagged { and } as missing — they're not."""
+        assert telegram.escape_markdown_v2("{x}") == "\\{x\\}"
+        assert telegram.escape_markdown_v2("a|b") == "a\\|b"
+        assert telegram.escape_markdown_v2("a~b") == "a\\~b"
+
+    def test_passes_through_unreserved_text(self):
+        assert telegram.escape_markdown_v2("plain text 123") == "plain text 123"

--- a/tradingagents/agents/utils/macro_data_tools.py
+++ b/tradingagents/agents/utils/macro_data_tools.py
@@ -9,9 +9,12 @@ from tradingagents.dataflows.interface import route_to_vendor
 def get_macro_indicators(
     indicator: Annotated[
         str,
-        "Macro indicator: a friendly alias such as 'cpi', 'core_pce', "
-        "'unemployment', 'fed_funds_rate', '10y_treasury', 'yield_curve', "
-        "'real_gdp', 'vix', or a raw FRED series ID such as 'CPIAUCSL'.",
+        "Macro indicator: a supported friendly alias such as 'cpi', 'core_cpi', "
+        "'core_pce', 'unemployment', 'fed_funds_rate', '10y_treasury', "
+        "'yield_curve', 'real_gdp', 'gdp', 'industrial_production', 'payrolls', "
+        "'initial_claims', 'm2', 'vix', 'dollar_index', 'consumer_sentiment', "
+        "'housing_starts', 'retail_sales', or a raw FRED series ID such as "
+        "'CPIAUCSL'. Avoid descriptive names like 'bank of japan rate'.",
     ],
     curr_date: Annotated[str, "Current date in yyyy-mm-dd format; the end of the window"],
     look_back_days: Annotated[

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -46,28 +46,42 @@ MACRO_SERIES = {
     "yield_curve": "T10Y2Y",
     # Inflation
     "cpi": "CPIAUCSL",
+    "headline_cpi": "CPIAUCSL",
+    "inflation": "CPIAUCSL",
     "core_cpi": "CPILFESL",
     "pce": "PCEPI",
     "core_pce": "PCEPILFE",
     "inflation_expectations": "T10YIE",
     # Growth & output
     "real_gdp": "GDPC1",
+    "gdp_growth": "GDPC1",
+    "economic_growth": "GDPC1",
     "gdp": "GDP",
     "industrial_production": "INDPRO",
+    "factory_output": "INDPRO",
     # Labor
     "unemployment_rate": "UNRATE",
     "unemployment": "UNRATE",
     "nonfarm_payrolls": "PAYEMS",
     "payrolls": "PAYEMS",
+    "jobs": "PAYEMS",
+    "nfp": "PAYEMS",
     "initial_claims": "ICSA",
+    "jobless_claims": "ICSA",
     # Money & markets
     "m2": "M2SL",
     "money_supply": "M2SL",
     "vix": "VIXCLS",
     "dollar_index": "DTWEXBGS",
+    "dxy": "DTWEXBGS",
+    "us_dollar": "DTWEXBGS",
     # Sentiment & housing
     "consumer_sentiment": "UMCSENT",
+    "consumer_confidence": "UMCSENT",
+    "umich_sentiment": "UMCSENT",
     "housing_starts": "HOUST",
+    "building_permits": "PERMIT",
+    "housing_permits": "PERMIT",
     "retail_sales": "RSAFS",
 }
 
@@ -93,13 +107,25 @@ def get_api_key() -> str:
 
 
 def _resolve_series_id(indicator: str) -> str:
-    """Map a friendly alias to a FRED series ID, or pass a raw ID through."""
+    """Map a friendly alias to a FRED series ID, or pass a raw ID through.
+
+    Validates that the resolved ID conforms to FRED's rules (1-25 alphanumeric
+    characters) so an LLM-generated descriptive name fails fast with a clear
+    message instead of producing an opaque FRED 400 error.
+    """
     key = indicator.strip().lower().replace(" ", "_").replace("-", "_")
-    if key in MACRO_SERIES:
-        return MACRO_SERIES[key]
     # Not a known alias: treat the input as a raw FRED series ID (FRED IDs are
     # conventionally uppercase, e.g. "DGS10", "CPIAUCSL").
-    return indicator.strip().upper()
+    series_id = MACRO_SERIES[key] if key in MACRO_SERIES else indicator.strip().upper()
+
+    if not (1 <= len(series_id) <= 25 and series_id.isalnum()):
+        raise ValueError(
+            f"Invalid FRED series ID '{series_id}'. Series IDs must be 1-25 "
+            f"alphanumeric characters. Use a supported alias (e.g. 'cpi', "
+            f"'unemployment', 'fed_funds_rate', '10y_treasury') or a valid raw "
+            f"FRED series ID."
+        )
+    return series_id
 
 
 def _request(path: str, params: dict) -> dict:
@@ -143,13 +169,22 @@ def get_macro_data(
 
     end_dt = datetime.strptime(curr_date, "%Y-%m-%d")
     start_date = (end_dt - timedelta(days=look_back_days)).strftime("%Y-%m-%d")
-    series_id = _resolve_series_id(indicator)
+    try:
+        series_id = _resolve_series_id(indicator)
+    except ValueError as e:
+        return (
+            f"ERROR: {e}\n\n"
+            f"Use a supported alias (e.g. 'cpi', 'unemployment', "
+            f"'fed_funds_rate', '10y_treasury', 'yield_curve') or a valid raw "
+            f"FRED series ID."
+        )
 
     meta = _request("series", {"series_id": series_id}).get("seriess") or []
     if not meta:
         raise ValueError(
             f"FRED series '{series_id}' not found. Pass a known alias "
-            f"(e.g. 'cpi', 'unemployment') or a valid FRED series ID."
+            f"(e.g. 'cpi', 'unemployment', 'fed_funds_rate') or a valid raw "
+            f"FRED series ID."
         )
     info = meta[0]
     title = info.get("title", series_id)

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -121,9 +121,7 @@ def _resolve_series_id(indicator: str) -> str:
     if not (1 <= len(series_id) <= 25 and series_id.isalnum()):
         raise ValueError(
             f"Invalid FRED series ID '{series_id}'. Series IDs must be 1-25 "
-            f"alphanumeric characters. Use a supported alias (e.g. 'cpi', "
-            f"'unemployment', 'fed_funds_rate', '10y_treasury') or a valid raw "
-            f"FRED series ID."
+            f"alphanumeric characters."
         )
     return series_id
 

--- a/tradingagents/notifications/__init__.py
+++ b/tradingagents/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notification backends for the scheduled TradingAgents runner."""

--- a/tradingagents/notifications/telegram.py
+++ b/tradingagents/notifications/telegram.py
@@ -1,0 +1,186 @@
+"""Telegram delivery for the scheduled TradingAgents runner.
+
+Sends the Portfolio Manager's daily decision to a configured chat. Two
+payloads per report:
+
+1. A short Markdown message with Rating / Price Target / Horizon plus a
+   preview of the executive summary. Useful as a glanceable alert.
+2. The full ``decision.md`` as a PDF document (or, if PDF conversion
+   failed, as a ``.md`` document — Telegram renders neither, but a tap
+   downloads it).
+
+The bot token and chat id are read from environment variables; if either is
+missing the module short-circuits to a no-op so the headless runner can
+still complete the analysis portion of the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from tradingagents.reports.exporter import DecisionSummary
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.telegram.org"
+
+DEFAULT_TIMEOUT = 30  # seconds, generous because sendDocument can be slow
+
+
+@dataclass(frozen=True)
+class TelegramConfig:
+    bot_token: str
+    chat_id: str
+
+    @classmethod
+    def from_env(cls) -> TelegramConfig | None:
+        bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+        chat_id = os.environ.get("TELEGRAM_CHAT_ID", "").strip()
+        if not bot_token or not chat_id:
+            return None
+        return cls(bot_token=bot_token, chat_id=chat_id)
+
+
+def _post(config: TelegramConfig, method: str, **fields: Any) -> dict[str, Any]:
+    """POST to the Telegram Bot API and return the parsed JSON envelope.
+
+    Raises ``TelegramError`` on any non-200 response so callers can decide
+    whether to retry or surface the failure to the user.
+    """
+    url = f"{API_BASE}/bot{config.bot_token}/{method}"
+    response = requests.post(url, timeout=DEFAULT_TIMEOUT, **fields)
+    payload: dict[str, Any]
+    try:
+        payload = response.json()
+    except json.JSONDecodeError as exc:
+        raise TelegramError(f"Telegram returned non-JSON response: {response.text[:200]}") from exc
+    if not payload.get("ok", False):
+        raise TelegramError(
+            f"Telegram {method} failed: status={response.status_code} body={payload}"
+        )
+    return payload
+
+
+class TelegramError(RuntimeError):
+    """Raised when the Telegram API returns a non-ok response."""
+
+
+def send_report(
+    ticker: str,
+    summary: DecisionSummary,
+    *,
+    pdf_path: Path | None = None,
+    markdown_path: Path | None = None,
+    config: TelegramConfig | None = None,
+) -> bool:
+    """Send the short message and the full document to the configured chat.
+
+    Returns ``True`` if both calls succeeded. Returns ``False`` early if
+    Telegram is not configured (logs at info level so the scheduled run
+    can still be diagnosed from ``run_daily.out.log``). Raises
+    ``TelegramError`` only on hard transport / API failures — by design
+    the caller is expected to catch and continue with the next ticker
+    rather than abort the whole scheduled run.
+    """
+    cfg = config or TelegramConfig.from_env()
+    if cfg is None:
+        logger.info(
+            "TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID not set; skipping delivery for %s",
+            ticker,
+        )
+        return False
+
+    short = _render_short_message(ticker, summary)
+    _post(
+        cfg,
+        "sendMessage",
+        data={"chat_id": cfg.chat_id, "text": short, "parse_mode": "MarkdownV2"},
+    )
+    logger.info("Telegram short message sent for %s", ticker)
+
+    document = pdf_path if pdf_path and pdf_path.exists() else markdown_path
+    if document is None or not Path(document).exists():
+        logger.warning("No document to send for %s (no pdf or markdown path)", ticker)
+        return False
+
+    caption = _build_caption(ticker, summary)
+    with open(document, "rb") as fh:
+        _post(
+            cfg,
+            "sendDocument",
+            data={"chat_id": cfg.chat_id, "caption": caption[:1024]},
+            files={"document": (document.name, fh)},
+        )
+    suffix = Path(document).suffix
+    logger.info("Telegram document sent for %s (%s)", ticker, suffix)
+    return True
+
+
+def _render_short_message(ticker: str, summary: DecisionSummary) -> str:
+    """Compose the short message with all user-data fields MarkdownV2-escaped.
+
+    The template's intentional ``*bold*`` markers stay unescaped; only
+    LLM-emitted strings (rating, price target, time horizon, thesis) get
+    the escape pass. Without this, a tick like ``BTC-USD`` and a time
+    horizon like ``3-6 mesi`` would crash the Bot API with
+    "can't parse entities" because ``-`` and ``.`` are reserved in
+    MarkdownV2.
+    """
+    parts: list[str] = [f"\U0001f4ca *{escape_markdown_v2(ticker)}* — TradingAgents report"]
+    if summary.rating:
+        parts.append(f"Rating: *{escape_markdown_v2(summary.rating)}*")
+    if summary.price_target is not None:
+        parts.append(f"Price target: `{summary.price_target:g}`")
+    if summary.time_horizon:
+        parts.append(f"Horizon: {escape_markdown_v2(summary.time_horizon)}")
+    if summary.executive_summary:
+        preview = _truncate(summary.executive_summary, 240)
+        parts.append(f"\n{escape_markdown_v2(preview)}")
+    return "\n".join(parts)
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.strip().replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "\u2026"
+
+
+def _build_caption(ticker: str, summary: DecisionSummary) -> str:
+    """Build the document caption shown above the PDF/MD attachment.
+
+    Captions are sent as plain text (no ``parse_mode``) so the escape
+    pass is unnecessary here.
+    """
+    parts: list[str] = [f"{ticker} — Portfolio Manager decision"]
+    if summary.rating:
+        parts.append(f"Rating: {summary.rating}")
+    if summary.price_target is not None:
+        parts.append(f"Price target: {summary.price_target:g}")
+    if summary.time_horizon:
+        parts.append(f"Horizon: {summary.time_horizon}")
+    return "\n".join(parts)
+
+
+# Telegram MarkdownV2 requires every one of these characters to be escaped
+# with a leading backslash, otherwise the API returns a 400 with
+# "can't parse entities". See https://core.telegram.org/bots/api#markdownv2-style
+_MD2_SPECIAL = r"_*[]()~`>#+-=|{}.!"
+
+
+def escape_markdown_v2(text: str) -> str:
+    """Escape every MarkdownV2-reserved character in ``text``.
+
+    Used on user-supplied fields (executive summary, thesis, time horizon)
+    before they're interpolated into a ``sendMessage`` body. We don't
+    escape the deliberate ``*bold*`` markup in the template itself — that
+    markup is added by ``_render_short_message`` after escaping runs.
+    """
+    return "".join("\\" + ch if ch in _MD2_SPECIAL else ch for ch in text)

--- a/tradingagents/reports/__init__.py
+++ b/tradingagents/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Report export helpers shared by the CLI and the scheduled runner."""

--- a/tradingagents/reports/exporter.py
+++ b/tradingagents/reports/exporter.py
@@ -309,35 +309,14 @@ def _to_latin1(text: str) -> str:
 
 
 def _write_inline(pdf: Any, content: str, width: float) -> None:
-    """Render an inline token's text with bold/italic honoured.
+    """Render an inline token's text with bold/italic honoured and proper wrapping.
 
-    We re-parse ``content`` for ``**...**`` and ``*...*`` markers and emit
-    mixed-style ``multi_cell`` segments. Output is conservative — unsupported
-    markers are flattened to plain text.
+    fpdf2's ``multi_cell`` only wraps text WITHIN a single call — a long
+    segment passed in isolation won't break, and concatenating short
+    segments via separate calls just stacks them on the same line (the
+    default ``ln=0`` returns to the left margin instead of starting a
+    new line). Passing the whole content to a single ``multi_cell`` with
+    ``markdown=True`` lets fpdf2 parse the ``**bold**`` / ``*italic*``
+    markers and wrap the rendered text within ``width``.
     """
-    style = ""
-    cursor = 0
-    for match in re.finditer(r"(\*\*([^*]+)\*\*|\*([^*]+)\*|([^*]+))", content):
-        text: str | None = None
-        if match.group(2) is not None:
-            text = match.group(2)
-            new_style = "B"
-        elif match.group(3) is not None:
-            text = match.group(3)
-            new_style = "I"
-        elif match.group(4) is not None:
-            text = match.group(4)
-            new_style = ""
-        if text is None:
-            continue
-        if new_style != style:
-            pdf.set_font("Helvetica", style=new_style, size=11)
-            style = new_style
-        pdf.multi_cell(width, 6, _to_latin1(text))
-        cursor = match.end()
-    if cursor < len(content) and not content[cursor:].strip():
-        return
-    # Trailing unprocessed tail (rare)
-    tail = content[cursor:]
-    if tail.strip():
-        pdf.multi_cell(width, 6, _to_latin1(tail))
+    pdf.multi_cell(width, 6, _to_latin1(content), markdown=True)

--- a/tradingagents/reports/exporter.py
+++ b/tradingagents/reports/exporter.py
@@ -1,0 +1,343 @@
+"""Persist a TradingAgents run to disk and produce downstream artefacts.
+
+Two consumers today: the interactive CLI (``cli.main``) and the headless
+``scripts/run_daily.py`` scheduled runner. Both build the same
+``reports/<TICKER>_<TIMESTAMP>/`` folder tree, so the logic lives here.
+
+Also exposes the small helpers the scheduled runner needs on top of the raw
+artefacts: parse the Portfolio Manager decision into structured fields, and
+render the same ``decision.md`` to a PDF for Telegram delivery.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def save_report_to_disk(final_state: dict[str, Any], ticker: str, save_path: Path) -> Path:
+    """Write the canonical reports folder for one run.
+
+    Layout::
+
+        save_path/
+            1_analysts/{market,sentiment,news,fundamentals}.md
+            2_research/{bull,bear,manager}.md
+            3_trading/trader.md
+            4_risk/{aggressive,conservative,neutral}.md
+            5_portfolio/decision.md     <-- Portfolio Manager final decision
+            complete_report.md           <-- all of the above concatenated
+
+    Returns the path to ``complete_report.md``. The decision.md file is
+    always the last thing the Portfolio Manager emits, so it is the only
+    artefact the Telegram notifier needs to read.
+    """
+    save_path = Path(save_path)
+    save_path.mkdir(parents=True, exist_ok=True)
+    sections: list[str] = []
+
+    # 1. Analysts
+    analyst_parts: list[tuple[str, str]] = []
+    if final_state.get("market_report"):
+        _write_section(save_path / "1_analysts", "market.md", final_state["market_report"])
+        analyst_parts.append(("Market Analyst", final_state["market_report"]))
+    if final_state.get("sentiment_report"):
+        _write_section(save_path / "1_analysts", "sentiment.md", final_state["sentiment_report"])
+        analyst_parts.append(("Sentiment Analyst", final_state["sentiment_report"]))
+    if final_state.get("news_report"):
+        _write_section(save_path / "1_analysts", "news.md", final_state["news_report"])
+        analyst_parts.append(("News Analyst", final_state["news_report"]))
+    if final_state.get("fundamentals_report"):
+        _write_section(save_path / "1_analysts", "fundamentals.md", final_state["fundamentals_report"])
+        analyst_parts.append(("Fundamentals Analyst", final_state["fundamentals_report"]))
+    if analyst_parts:
+        content = "\n\n".join(f"### {name}\n{text}" for name, text in analyst_parts)
+        sections.append(f"## I. Analyst Team Reports\n\n{content}")
+
+    # 2. Research
+    if final_state.get("investment_debate_state"):
+        debate = final_state["investment_debate_state"]
+        research_parts: list[tuple[str, str]] = []
+        if debate.get("bull_history"):
+            _write_section(save_path / "2_research", "bull.md", debate["bull_history"])
+            research_parts.append(("Bull Researcher", debate["bull_history"]))
+        if debate.get("bear_history"):
+            _write_section(save_path / "2_research", "bear.md", debate["bear_history"])
+            research_parts.append(("Bear Researcher", debate["bear_history"]))
+        if debate.get("judge_decision"):
+            _write_section(save_path / "2_research", "manager.md", debate["judge_decision"])
+            research_parts.append(("Research Manager", debate["judge_decision"]))
+        if research_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in research_parts)
+            sections.append(f"## II. Research Team Decision\n\n{content}")
+
+    # 3. Trading
+    if final_state.get("trader_investment_plan"):
+        _write_section(save_path / "3_trading", "trader.md", final_state["trader_investment_plan"])
+        sections.append(
+            f"## III. Trading Team Plan\n\n### Trader\n{final_state['trader_investment_plan']}"
+        )
+
+    # 4. Risk Management
+    if final_state.get("risk_debate_state"):
+        risk = final_state["risk_debate_state"]
+        risk_parts: list[tuple[str, str]] = []
+        if risk.get("aggressive_history"):
+            _write_section(save_path / "4_risk", "aggressive.md", risk["aggressive_history"])
+            risk_parts.append(("Aggressive Analyst", risk["aggressive_history"]))
+        if risk.get("conservative_history"):
+            _write_section(save_path / "4_risk", "conservative.md", risk["conservative_history"])
+            risk_parts.append(("Conservative Analyst", risk["conservative_history"]))
+        if risk.get("neutral_history"):
+            _write_section(save_path / "4_risk", "neutral.md", risk["neutral_history"])
+            risk_parts.append(("Neutral Analyst", risk["neutral_history"]))
+        if risk_parts:
+            content = "\n\n".join(f"### {name}\n{text}" for name, text in risk_parts)
+            sections.append(f"## IV. Risk Management Team Decision\n\n{content}")
+
+        # 5. Portfolio Manager — last section, also written standalone for the
+        # scheduled runner to pick up directly.
+        if risk.get("judge_decision"):
+            _write_section(save_path / "5_portfolio", "decision.md", risk["judge_decision"])
+            sections.append(
+                f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}"
+            )
+
+    header = (
+        f"# Trading Analysis Report: {ticker}\n\n"
+        f"Generated: {_dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    )
+    complete = save_path / "complete_report.md"
+    complete.write_text(header + "\n\n".join(sections), encoding="utf-8")
+    return complete
+
+
+def _write_section(directory: Path, name: str, text: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / name).write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Decision summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DecisionSummary:
+    """Structured view of a Portfolio Manager ``decision.md``.
+
+    The Portfolio Manager emits a small set of ``**Field**: value`` lines at
+    the top of the document (Rating, Executive Summary, Investment Thesis,
+    Price Target, Time Horizon). This dataclass captures them so the
+    scheduled runner can build a short Telegram message without re-parsing
+    the whole markdown every time.
+    """
+
+    rating: str | None = None
+    executive_summary: str | None = None
+    investment_thesis: str | None = None
+    price_target: float | None = None
+    time_horizon: str | None = None
+
+
+_FIELD_PATTERNS: dict[str, re.Pattern[str]] = {
+    "rating": re.compile(r"\*\*Rating\*\*\s*[:\-]\s*(.+?)(?=\n\*\*|\Z)", re.DOTALL),
+    "executive_summary": re.compile(
+        r"\*\*Executive Summary\*\*\s*[:\-]\s*(.+?)(?=\n\*\*[A-Za-z]|\Z)", re.DOTALL
+    ),
+    "investment_thesis": re.compile(
+        r"\*\*Investment Thesis\*\*\s*[:\-]\s*(.+?)(?=\n\*\*[A-Za-z]|\Z)", re.DOTALL
+    ),
+    "price_target": re.compile(r"\*\*Price Target\*\*\s*[:\-]\s*([\d.,]+)"),
+    "time_horizon": re.compile(r"\*\*Time Horizon\*\*\s*[:\-]\s*(.+?)(?=\n\*\*|\Z)", re.DOTALL),
+}
+
+
+def extract_decision_summary(decision_md: str) -> DecisionSummary:
+    """Parse the Portfolio Manager's ``decision.md`` into structured fields.
+
+    The Portfolio Manager prompt asks for the canonical fields in a fixed
+    order; we tolerate a small amount of slop (extra whitespace, extra
+    fields) without raising. Unknown fields land in ``extras`` so they
+    still surface in the parsed payload.
+    """
+    if not decision_md:
+        return DecisionSummary()
+
+    def _clean(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    rating = _clean(_FIELD_PATTERNS["rating"].search(decision_md).group(1)) \
+        if _FIELD_PATTERNS["rating"].search(decision_md) else None
+    exec_summary = _clean(_FIELD_PATTERNS["executive_summary"].search(decision_md).group(1)) \
+        if _FIELD_PATTERNS["executive_summary"].search(decision_md) else None
+    thesis = _clean(_FIELD_PATTERNS["investment_thesis"].search(decision_md).group(1)) \
+        if _FIELD_PATTERNS["investment_thesis"].search(decision_md) else None
+    time_horizon = _clean(_FIELD_PATTERNS["time_horizon"].search(decision_md).group(1)) \
+        if _FIELD_PATTERNS["time_horizon"].search(decision_md) else None
+
+    price_target: float | None = None
+    if match := _FIELD_PATTERNS["price_target"].search(decision_md):
+        try:
+            price_target = float(match.group(1).replace(",", "").replace(".", ".", 1))
+        except ValueError:
+            price_target = None
+
+    return DecisionSummary(
+        rating=rating,
+        executive_summary=exec_summary,
+        investment_thesis=thesis,
+        price_target=price_target,
+        time_horizon=time_horizon,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown -> PDF
+# ---------------------------------------------------------------------------
+
+
+def markdown_to_pdf(markdown_path: Path, pdf_path: Path | None = None) -> Path | None:
+    """Render a markdown file to PDF.
+
+    Uses ``fpdf2`` + ``markdown-it-py`` (both pulled in by the ``scheduled``
+    extra in ``pyproject.toml``). Returns the resolved PDF path on success,
+    or ``None`` if the conversion failed — the caller is expected to fall
+    back to the raw ``.md`` file in that case.
+
+    We rely on the core ``Helvetica`` font (latin-1). That covers the
+    Italian diacritics that show up in a Portfolio Manager ``decision.md``
+    (à è é ì ò ù). Any character outside latin-1 (€, em-dashes from a
+    copy-pasted source, emoji) is replaced with ``?`` rather than crashing
+    the conversion — silent truncation is preferable to a scheduled run
+    failing the whole pipeline.
+    """
+    markdown_path = Path(markdown_path)
+    if not markdown_path.exists():
+        raise FileNotFoundError(markdown_path)
+
+    target = Path(pdf_path) if pdf_path else markdown_path.with_suffix(".pdf")
+
+    try:
+        from fpdf import FPDF  # type: ignore[import-not-found]
+        from markdown_it import MarkdownIt  # type: ignore[import-not-found]
+    except ImportError as exc:
+        logger.warning("PDF conversion skipped (missing dep): %s", exc)
+        return None
+
+    text = markdown_path.read_text(encoding="utf-8")
+    tokens = MarkdownIt("commonmark").parse(text)
+
+    pdf = FPDF(orientation="P", unit="mm", format="A4")
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_margins(15, 15, 15)
+    pdf.set_font("Helvetica", size=11)
+
+    in_list = False
+
+    for token in tokens:
+        if token.type == "heading_open":
+            level = int(token.tag[1])
+            pdf.ln(2 if in_list else 4)
+            in_list = False
+            pdf.set_font("Helvetica", style="B", size=14 - level)
+            continue
+        if token.type == "heading_close":
+            pdf.ln(2)
+            continue
+        if token.type == "paragraph_open":
+            pdf.set_font("Helvetica", style="", size=11)
+            in_list = False
+            continue
+        if token.type == "paragraph_close":
+            pdf.ln(4)
+            continue
+        if token.type == "bullet_list_open":
+            in_list = True
+            continue
+        if token.type == "bullet_list_close":
+            in_list = False
+            pdf.ln(2)
+            continue
+        if token.type == "list_item_open":
+            pdf.set_x(pdf.l_margin + 5)
+            # Middle dot (U+00B7) — latin-1 native, so it encodes cleanly under
+            # the built-in Helvetica font. The previous bullet (U+2022) raised
+            # FPDFUnicodeEncodingException on any decision.md that contained a
+            # list.
+            pdf.cell(5, 6, "\u00b7")
+            continue
+        if token.type == "list_item_close":
+            pdf.ln(6)
+            continue
+        if token.type == "inline":
+            available_w = pdf.w - pdf.l_margin - pdf.r_margin
+            indent = pdf.l_margin + (10 if in_list else 0)
+            pdf.set_x(indent)
+            _write_inline(pdf, token.content, available_w - (10 if in_list else 0))
+            if not in_list:
+                pdf.ln(4)
+            continue
+
+    try:
+        pdf.output(str(target))
+    except Exception as exc:  # latin-1 fallback, or unknown fpdf2 internal
+        logger.warning("PDF generation failed for %s: %s", markdown_path, exc)
+        return None
+    return target
+
+
+def _to_latin1(text: str) -> str:
+    """Coerce text to latin-1 so the built-in Helvetica font accepts it.
+
+    fpdf2 raises on out-of-range code points. Decision.md content is
+    overwhelmingly ASCII + Italian diacritics, all of which are latin-1;
+    anything else (``€``, emoji, dashes from a copy-paste) becomes ``?``
+    so the scheduled run doesn't crash on a stray glyph.
+    """
+    return text.encode("latin-1", errors="replace").decode("latin-1")
+
+
+def _write_inline(pdf: Any, content: str, width: float) -> None:
+    """Render an inline token's text with bold/italic honoured.
+
+    We re-parse ``content`` for ``**...**`` and ``*...*`` markers and emit
+    mixed-style ``multi_cell`` segments. Output is conservative — unsupported
+    markers are flattened to plain text.
+    """
+    style = ""
+    cursor = 0
+    for match in re.finditer(r"(\*\*([^*]+)\*\*|\*([^*]+)\*|([^*]+))", content):
+        text: str | None = None
+        if match.group(2) is not None:
+            text = match.group(2)
+            new_style = "B"
+        elif match.group(3) is not None:
+            text = match.group(3)
+            new_style = "I"
+        elif match.group(4) is not None:
+            text = match.group(4)
+            new_style = ""
+        if text is None:
+            continue
+        if new_style != style:
+            pdf.set_font("Helvetica", style=new_style, size=11)
+            style = new_style
+        pdf.multi_cell(width, 6, _to_latin1(text))
+        cursor = match.end()
+    if cursor < len(content) and not content[cursor:].strip():
+        return
+    # Trailing unprocessed tail (rare)
+    tail = content[cursor:]
+    if tail.strip():
+        pdf.multi_cell(width, 6, _to_latin1(tail))

--- a/tradingagents/watchlist.py
+++ b/tradingagents/watchlist.py
@@ -1,0 +1,103 @@
+"""Watchlist loader for the scheduled TradingAgents runner.
+
+Reads the YAML file pointed to by ``TRADINGAGENTS_WATCHLIST_PATH``
+(default ``config/watchlist.yaml``) and returns the list of tickers the
+runner should iterate over.
+
+The format is intentionally tiny so a non-developer can edit it by hand::
+
+    tickers:
+      - symbol: BTC-USD
+        asset_type: crypto
+      - symbol: NVDA
+        asset_type: stock        # default if omitted
+
+``analysts`` is optional and overrides the project's DEFAULT_CONFIG analyst
+selection for that symbol only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WATCHLIST_PATH = "config/watchlist.yaml"
+
+ENV_WATCHLIST_PATH = "TRADINGAGENTS_WATCHLIST_PATH"
+
+
+@dataclass
+class WatchlistEntry:
+    symbol: str
+    asset_type: str = "stock"
+    analysts: list[str] | None = None  # None = use DEFAULT_CONFIG
+
+
+def watchlist_path() -> Path:
+    raw = os.environ.get(ENV_WATCHLIST_PATH, DEFAULT_WATCHLIST_PATH)
+    return Path(raw)
+
+
+def load_watchlist(path: Path | None = None) -> list[WatchlistEntry]:
+    """Read and validate the watchlist file.
+
+    Missing file is treated as an empty list with a warning — the scheduled
+    run still completes with no work to do, which is preferable to failing.
+    """
+    target = Path(path) if path is not None else watchlist_path()
+    if not target.exists():
+        logger.warning("Watchlist file %s not found; runner will exit cleanly", target)
+        return []
+
+    raw = target.read_text(encoding="utf-8")
+    payload = _parse_yaml(raw)
+    entries_raw = payload.get("tickers", [])
+    if not isinstance(entries_raw, list):
+        raise ValueError(f"{target}: 'tickers' must be a list, got {type(entries_raw).__name__}")
+
+    entries: list[WatchlistEntry] = []
+    for index, item in enumerate(entries_raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"{target}: tickers[{index}] must be a mapping, got {type(item).__name__}")
+        if "symbol" not in item:
+            raise ValueError(f"{target}: tickers[{index}] missing required 'symbol'")
+        symbol = str(item["symbol"]).strip()
+        if not symbol:
+            raise ValueError(f"{target}: tickers[{index}] has empty 'symbol'")
+        asset_type = str(item.get("asset_type", "stock")).strip().lower()
+        if asset_type not in {"stock", "crypto"}:
+            raise ValueError(
+                f"{target}: tickers[{index}].asset_type must be 'stock' or 'crypto', got {asset_type!r}"
+            )
+        analysts_raw = item.get("analysts")
+        analysts: list[str] | None = None
+        if analysts_raw is not None:
+            if not isinstance(analysts_raw, list) or not all(
+                isinstance(a, str) for a in analysts_raw
+            ):
+                raise ValueError(
+                    f"{target}: tickers[{index}].analysts must be a list of strings"
+                )
+            analysts = [a.strip() for a in analysts_raw if a.strip()]
+        entries.append(WatchlistEntry(symbol=symbol, asset_type=asset_type, analysts=analysts))
+    return entries
+
+
+def _parse_yaml(raw: str) -> dict:
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyYAML is required to read the watchlist; "
+            "install with `pip install tradingagents[scheduled]`"
+        ) from exc
+    data = yaml.safe_load(raw)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Watchlist root must be a mapping, got {type(data).__name__}")
+    return data


### PR DESCRIPTION
## Summary

Adds a headless driver (`scripts/run_daily.py`) that iterates over `config/watchlist.yaml`, runs `propagate()` for each entry, persists the canonical `reports/<TICKER>_<TS>/` folder, renders the Portfolio Manager `decision.md` to a PDF, and delivers a short Markdown message + the PDF to a configured Telegram chat. On macOS, `scripts/install_launchd.sh` registers a Mon–Fri 07:00 launchd job that invokes the runner headlessly.

## New modules

| Path | Purpose |
| ---- | ------- |
| `scripts/run_daily.py` | Headless driver — runs `propagate()` for each watchlist entry, saves the report, sends Telegram. |
| `scripts/install_launchd.sh` / `uninstall_launchd.sh` | Register / remove the macOS launchd job. |
| `tradingagents/notifications/telegram.py` | Bot API integration (MarkdownV2-escaped short message + document). |
| `tradingagents/watchlist.py` | YAML watchlist loader with validation. |
| `tradingagents/reports/exporter.py` | Centralises the report-folder layout and `decision.md` parsing that the CLI and the runner share. |
| `config/watchlist.yaml` | Shipped example with `BTC-USD` as a worked entry. |

## Optional install

```bash
pip install ".[scheduled]"   # adds pyyaml + fpdf2
```

## Delivery contract

- Telegram is best-effort: with no `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` the runner logs at info level and the analysis + on-disk report still complete.
- A per-ticker `propagate()` failure is logged and the runner continues with the next entry; `run_daily.py` exits `1` only when **every** ticker failed and `2` when the watchlist is unreadable.
- The PDF is rendered via `fpdf2`; on conversion failure the runner falls back to attaching the raw `decision.md`.

## Documentation

- README: new "Scheduled runs" section with setup, launchd install, exit codes, and verification steps; News entry + TOC link at the top; installation section mentions the `[scheduled]` extra.
- CHANGELOG: `[Unreleased]` entry describing the feature.

## Tests

`tests/test_run_daily.py`, `tests/test_telegram.py`, and `tests/test_reports_exporter.py` cover the watchlist loader, the runner, the Telegram notifier (including MarkdownV2 escaping and `_post` envelope handling), and the exporter (folder layout, decision parsing, PDF round-trip). All 477 tests pass; the two skips are unrelated (missing `langchain_aws` / `DEEPSEEK_API_KEY`).