### PR TITLE
fix: suppress local compatible tool choice objects

### DIFF
--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -6,6 +6,7 @@ model name is accepted, and the env backend URL precedence (#978).
 """
 
 import pytest
+from pydantic import BaseModel
 
 from tradingagents.llm_clients.api_key_env import get_api_key_env
 from tradingagents.llm_clients.factory import create_llm_client
@@ -36,13 +37,33 @@ def test_keyless_local_uses_placeholder_and_chat_completions(monkeypatch):
     llm = create_llm_client(
         provider="openai_compatible", model="qwen2.5", base_url="http://localhost:8000/v1"
     ).get_llm()
-    assert type(llm).__name__ == "NormalizedChatOpenAI"
+    assert type(llm).__name__ == "LocalCompatibleChatOpenAI"
     assert str(llm.openai_api_base) == "http://localhost:8000/v1"
     # keyless local servers: a placeholder key is sent
     key = llm.openai_api_key.get_secret_value() if hasattr(llm.openai_api_key, "get_secret_value") else llm.openai_api_key
     assert key == "EMPTY"
     # must use Chat Completions, not OpenAI's Responses API
     assert getattr(llm, "use_responses_api", False) in (False, None)
+
+
+@pytest.mark.unit
+def test_local_structured_output_suppresses_object_tool_choice(monkeypatch):
+    class Pick(BaseModel):
+        action: str
+
+    monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+    llm = create_llm_client(
+        provider="openai_compatible", model="qwen3-coder-30b", base_url="http://localhost:1234/v1"
+    ).get_llm()
+    bound = llm.with_structured_output(Pick)
+    first = bound.steps[0] if hasattr(bound, "steps") else bound
+    kwargs = getattr(first, "kwargs", {})
+
+    assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
+    assert any(
+        tool.get("function", {}).get("name") == "Pick"
+        for tool in kwargs.get("tools", [])
+    ), f"schema not bound: {kwargs.get('tools', [])}"
 
 
 @pytest.mark.unit

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -50,6 +50,22 @@ class NormalizedChatOpenAI(ChatOpenAI):
         return super().with_structured_output(schema, method=method, **kwargs)
 
 
+class LocalCompatibleChatOpenAI(NormalizedChatOpenAI):
+    """OpenAI-compatible local servers that reject object-form tool_choice.
+
+    Generic local endpoints such as LM Studio can accept function tools but
+    reject LangChain's function-spec object as ``tool_choice``. Suppress that
+    forced choice by default while still binding the schema as a tool.
+    """
+
+    def with_structured_output(self, schema, *, method=None, **kwargs):
+        caps = get_capabilities(self.model_name)
+        resolved_method = method or caps.preferred_structured_method
+        if resolved_method == "function_calling":
+            kwargs.setdefault("tool_choice", None)
+        return super().with_structured_output(schema, method=method, **kwargs)
+
+
 def _input_to_messages(input_: Any) -> list:
     """Normalise a langchain LLM input to a list of message objects.
 
@@ -197,7 +213,11 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderSpec] = {
     "ollama":     ProviderSpec(base_url="http://localhost:11434/v1", base_url_env="OLLAMA_BASE_URL",
                                key_optional=True, placeholder_key="ollama"),
     # Generic endpoint: user supplies base_url; key optional (keyless local).
-    "openai_compatible": ProviderSpec(require_base_url=True, key_optional=True),
+    "openai_compatible": ProviderSpec(
+        chat_class=LocalCompatibleChatOpenAI,
+        require_base_url=True,
+        key_optional=True,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add a `LocalCompatibleChatOpenAI` subclass for generic OpenAI-compatible local endpoints
- use it for the `openai_compatible` provider so structured-output binding suppresses LangChain's object-form `tool_choice`
- add a regression test that verifies local structured output still binds the schema as a tool

## Problem
LM Studio and similar local OpenAI-compatible servers can reject LangChain's function-spec object form of `tool_choice` even though they support function tools. Because arbitrary local model IDs fall through to the default capability row, structured-output calls can 400 and then fall back to free text.

Closes #1057.

## Before / After
Before: `openai_compatible` used `NormalizedChatOpenAI`, so unknown local model IDs kept the default `supports_tool_choice=True` behavior and could send object-form `tool_choice`.

After: `openai_compatible` uses `LocalCompatibleChatOpenAI`, which suppresses object-form `tool_choice` for function-calling structured output while still binding the schema as a tool.

## Verification
- `python -m compileall tradingagents/llm_clients/openai_client.py tests/test_openai_compatible_provider.py`
- `git diff --check`
- `python -m pytest tests/test_openai_compatible_provider.py tests/test_capabilities.py -q` (`28 passed`)