### PR TITLE
fix(llm): suppress object-form tool_choice for local OpenAI-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Fixed
+
+- **Local OpenAI-compatible servers no longer 400 on structured output.**
+  LM Studio, llama.cpp, older vLLM, and Ollama reject the function-spec
+  `tool_choice` object that langchain's `function_calling` path sends by
+  default. Because these servers run arbitrary, user-named models the
+  per-model capability table can't key off, the client now suppresses
+  `tool_choice` at the endpoint level for the local/generic `openai_compatible`
+  and `ollama` providers. The schema is still bound as a tool, matching the
+  existing DeepSeek/MiniMax handling, so structured output keeps working. (#1057)
+
 ## [0.2.5] — 2026-05-11
 
 ### Added

--- a/tests/test_local_server_tool_choice.py
+++ b/tests/test_local_server_tool_choice.py
@@ -77,9 +77,9 @@ class TestLocalServerToolChoiceSuppression:
             t.get("function", {}).get("name") == "_Sample" for t in tools
         ), f"schema not bound as a tool: {tools}"
 
-    def test_hosted_provider_still_sends_tool_choice(self):
+    def test_hosted_provider_still_sends_tool_choice(self, monkeypatch):
         """Suppression must not leak to hosted OpenAI-compatible providers
         (e.g. xAI) that accept the object-form tool_choice."""
-        os.environ.setdefault("XAI_API_KEY", "placeholder")
+        monkeypatch.setenv("XAI_API_KEY", "placeholder")
         bound = self._structured(model="grok-2", provider="xai")
         assert _bound_kwargs(bound).get("tool_choice") is not None

--- a/tests/test_local_server_tool_choice.py
+++ b/tests/test_local_server_tool_choice.py
@@ -1,0 +1,85 @@
+"""Local OpenAI-compatible servers must not receive object-form tool_choice.
+
+LM Studio, llama.cpp, older vLLM, and Ollama implement the Chat Completions
+API but reject the function-spec *object* that langchain's ``function_calling``
+structured-output path sends as ``tool_choice`` by default, returning::
+
+    400 Invalid tool_choice type: 'object'.
+        Supported string values: none, auto, required
+
+(issue #1057). These servers run arbitrary, user-named models, so the
+per-model capability table (which keys off the model name) can never catch
+them. Suppression therefore has to key off the *provider/endpoint* being a
+local/generic OpenAI-compatible server, not the model name.
+
+The schema is still bound as a tool — exactly the DeepSeek/MiniMax pattern
+already used for cloud models that reject tool_choice — so structured output
+keeps working, just without the rejected parameter.
+"""
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from tradingagents.llm_clients.openai_client import OpenAIClient
+
+
+def _bound_kwargs(runnable):
+    """Extract bind() kwargs from a with_structured_output result.
+
+    Mirrors the helper in test_deepseek_reasoning.py.
+    """
+    first = runnable.steps[0] if hasattr(runnable, "steps") else runnable
+    return getattr(first, "kwargs", {})
+
+
+def _tool_choice_suppressed(kwargs) -> bool:
+    """A suppressed tool_choice is either absent or explicitly None — both
+    signal that langchain's bind_tools will skip the parameter on the wire."""
+    return kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
+
+
+class _Sample(BaseModel):
+    answer: str
+
+
+@pytest.mark.unit
+class TestLocalServerToolChoiceSuppression:
+    def _structured(self, **client_kwargs):
+        llm = OpenAIClient(**client_kwargs).get_llm()
+        return llm.with_structured_output(_Sample)
+
+    def test_openai_compatible_endpoint_suppresses_tool_choice(self):
+        """The generic local endpoint (vLLM / LM Studio via backend_url)
+        must not send the object-form tool_choice."""
+        bound = self._structured(
+            model="some-local-model",
+            provider="openai_compatible",
+            base_url="http://localhost:1234/v1",
+        )
+        assert _tool_choice_suppressed(_bound_kwargs(bound))
+
+    def test_ollama_endpoint_suppresses_tool_choice(self):
+        bound = self._structured(model="qwen2.5", provider="ollama")
+        assert _tool_choice_suppressed(_bound_kwargs(bound))
+
+    def test_schema_is_still_bound_as_tool(self):
+        """Suppressing tool_choice must not drop the schema: it still ships
+        as a tool so structured output keeps working."""
+        bound = self._structured(
+            model="some-local-model",
+            provider="openai_compatible",
+            base_url="http://localhost:1234/v1",
+        )
+        tools = _bound_kwargs(bound).get("tools", [])
+        assert any(
+            t.get("function", {}).get("name") == "_Sample" for t in tools
+        ), f"schema not bound as a tool: {tools}"
+
+    def test_hosted_provider_still_sends_tool_choice(self):
+        """Suppression must not leak to hosted OpenAI-compatible providers
+        (e.g. xAI) that accept the object-form tool_choice."""
+        os.environ.setdefault("XAI_API_KEY", "placeholder")
+        bound = self._structured(model="grok-2", provider="xai")
+        assert _bound_kwargs(bound).get("tool_choice") is not None

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -31,6 +31,15 @@ class NormalizedChatOpenAI(ChatOpenAI):
     stays small.
     """
 
+    # Force-suppress the object-form ``tool_choice`` in structured-output
+    # binding, regardless of the per-model capability table. Set by the client
+    # for local/generic OpenAI-compatible servers (LM Studio, llama.cpp, older
+    # vLLM, Ollama): those run arbitrary, user-named models that the per-model
+    # table can't key off, and they 400 on the function-spec ``tool_choice``
+    # object (#1057). Declared as a field so langchain treats it as a known
+    # init kwarg, not an extra model param forwarded to the API.
+    suppress_tool_choice: bool = False
+
     def invoke(self, input, config=None, **kwargs):
         return normalize_content(super().invoke(input, config, **kwargs))
 
@@ -42,10 +51,13 @@ class NormalizedChatOpenAI(ChatOpenAI):
                 f"agent factories will fall back to free-text generation."
             )
         method = method or caps.preferred_structured_method
-        # When the model rejects tool_choice, suppress langchain's hardcoded
-        # value. The schema is still bound as a tool — exactly what
-        # DeepSeek's official tool-calling examples do.
-        if method == "function_calling" and not caps.supports_tool_choice:
+        # Suppress langchain's hardcoded tool_choice when either the model
+        # (capability table) or the endpoint (local server, suppress_tool_choice)
+        # rejects the object form. The schema is still bound as a tool — exactly
+        # what DeepSeek's official tool-calling examples do.
+        if method == "function_calling" and (
+            self.suppress_tool_choice or not caps.supports_tool_choice
+        ):
             kwargs.setdefault("tool_choice", None)
         return super().with_structured_output(schema, method=method, **kwargs)
 
@@ -201,6 +213,14 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderSpec] = {
 }
 
 
+# Providers that represent a *local or self-hosted* OpenAI-compatible server:
+# the generic ``openai_compatible`` endpoint (LM Studio, llama.cpp, older vLLM)
+# and Ollama. They speak Chat Completions but run arbitrary, user-named models
+# and reject the function-spec ``tool_choice`` object, so the client forces
+# tool_choice suppression for them regardless of model name (#1057).
+LOCAL_OPENAI_COMPATIBLE_PROVIDERS: frozenset[str] = frozenset({"ollama", "openai_compatible"})
+
+
 def is_openai_compatible(provider: str) -> bool:
     """Whether ``provider`` is served by the OpenAI-compatible registry."""
     return provider.lower() in OPENAI_COMPATIBLE_PROVIDERS
@@ -250,6 +270,13 @@ class OpenAIClient(BaseLLMClient):
 
         if spec is not None:
             chat_cls = spec.chat_class
+
+            # Local/generic OpenAI-compatible servers reject the object-form
+            # tool_choice; force suppression at the endpoint level since the
+            # per-model capability table can't key off arbitrary local model
+            # names (#1057).
+            if self.provider in LOCAL_OPENAI_COMPATIBLE_PROVIDERS:
+                llm_kwargs["suppress_tool_choice"] = True
 
             # base_url precedence: explicit client base_url (carries the config /
             # TRADINGAGENTS_LLM_BACKEND_URL value) > provider env override (e.g.


### PR DESCRIPTION
…e servers

Local OpenAI-compatible servers (LM Studio, llama.cpp, older vLLM, Ollama) reject the function-spec tool_choice object that langchain's function_calling structured-output path sends by default, returning HTTP 400. They run arbitrary model names the per-model capability table can't key off, so suppress tool_choice at the endpoint level for the openai_compatible and ollama providers. The schema is still bound as a tool, matching the existing DeepSeek/MiniMax handling.

Adds tests/test_local_server_tool_choice.py and a CHANGELOG entry.

Refs #1057