### PR TITLE
fix: return reddit fallback message when rss is unavailable

### DIFF
--- a/tests/test_reddit_rss_empty_fallback.py
+++ b/tests/test_reddit_rss_empty_fallback.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import tradingagents.dataflows.reddit as reddit
+
+
+def test_fetch_reddit_posts_returns_message_when_all_sources_empty(monkeypatch):
+    def fake_fetch_subreddit(ticker, sub, limit, timeout):
+        return []
+
+    monkeypatch.setattr(reddit, "_fetch_subreddit", fake_fetch_subreddit)
+    monkeypatch.setattr(reddit.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = reddit.fetch_reddit_posts(
+        "ULVR.L",
+        subreddits=("stocks", "investing"),
+        limit_per_sub=5,
+        timeout=1.0,
+        inter_request_delay=0.0,
+    )
+
+    assert result.strip()
+    assert "No Reddit discussion posts were available for ULVR.L" in result
+    assert "rate-limited" in result
+    assert "temporarily unavailable" in result
+
+
+def test_fetch_reddit_posts_marks_empty_subreddit_blocks(monkeypatch):
+    calls = []
+
+    def fake_fetch_subreddit(ticker, sub, limit, timeout):
+        calls.append(sub)
+        if sub == "stocks":
+            return []
+        return [
+            {
+                "title": "ULVR discussion",
+                "score": None,
+                "num_comments": None,
+                "created_utc": None,
+                "selftext": "Some discussion body",
+                "source": "rss",
+            }
+        ]
+
+    monkeypatch.setattr(reddit, "_fetch_subreddit", fake_fetch_subreddit)
+    monkeypatch.setattr(reddit.time, "sleep", lambda *_args, **_kwargs: None)
+
+    result = reddit.fetch_reddit_posts(
+        "ULVR.L",
+        subreddits=("stocks", "investing"),
+        limit_per_sub=5,
+        timeout=1.0,
+        inter_request_delay=0.0,
+    )
+
+    assert "r/stocks: no Reddit posts returned for ULVR.L" in result
+    assert "r/investing — 1 recent posts mentioning ULVR.L" in result
+    assert calls == ["stocks", "investing"]

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -208,7 +208,10 @@ def fetch_reddit_posts(
         posts = _fetch_subreddit(ticker, sub, limit_per_sub, timeout)
         total_posts += len(posts)
         if not posts:
-            blocks.append(f"r/{sub}: <no posts found mentioning {ticker.upper()} in the past 7 days>")
+            blocks.append(
+                f"r/{sub}: no Reddit posts returned for {ticker.upper()} "
+                "(the public RSS feed may be rate-limited or temporarily unavailable)."
+            )
             continue
 
         via_rss = any(p.get("source") == "rss" for p in posts)
@@ -239,7 +242,7 @@ def fetch_reddit_posts(
 
     if total_posts == 0:
         return (
-            f"<no Reddit posts found mentioning {ticker.upper()} across "
-            f"{', '.join(f'r/{s}' for s in subreddits)} in the past 7 days>"
+            f"No Reddit discussion posts were available for {ticker.upper()}. "
+            "Reddit JSON/RSS endpoints may be blocked, rate-limited, or temporarily unavailable."
         )
     return "\n\n".join(blocks)


### PR DESCRIPTION
Fixes #1046

This PR improves the Reddit fallback behavior when Reddit JSON/RSS sources are blocked or rate-limited.

The issue was that Reddit JSON scraping can fail with `403 Blocked`, and then the RSS fallback can also fail or return no usable posts because of `429 Too Many Requests`.

In that case, the current flow could end up giving an empty Reddit section. That is confusing because from the user side it looks like nothing happened, and the agent also gets no clear signal about Reddit being unavailable.

### What changed

I updated the Reddit post fetch flow so it returns a clear fallback message when no Reddit posts are available.

Now if all subreddit sources return no posts, the function returns a message like:

```text
No Reddit discussion posts were available for ULVR.L. Reddit JSON/RSS endpoints may be blocked, rate-limited, or temporarily unavailable.
```

I also changed the per-subreddit empty block so instead of leaving something blank like:

```text
r/stocks:
```

it now explains that no posts were returned for that ticker and that RSS may be rate-limited or temporarily unavailable.

### Why this helps

This does not try to bypass Reddit rate limits or work around their blocking.

It just makes the failure mode safer and more clear.

So instead of silently passing an empty sentiment/news section downstream, the workflow now gives the agent and the user a readable reason why Reddit data was missing.

This should be better for cases where Reddit JSON returns `403` and RSS returns `429`.

### Tests added

I added tests for:

* returning a non-empty fallback message when all Reddit sources return no posts
* making sure the message mentions rate-limited / temporarily unavailable behavior
* making sure an empty subreddit block is still shown clearly when another subreddit returns valid posts

### Validation

I ran:

```bash
python -m compileall tradingagents/dataflows/reddit.py
python -m pytest tests/test_reddit_rss_empty_fallback.py -q
```

Result:

```bash
2 passed
```
