### PR TITLE
refactor: remove setuptools from runtime deps and replace config deepcopy with read-only view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "requests>=2.32.4",
     "rich>=14.0.0",
     "typer>=0.21.0",
-    "setuptools>=80.9.0",
     "stockstats>=0.6.5",
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",

--- a/tests/test_dataflows_config.py
+++ b/tests/test_dataflows_config.py
@@ -2,6 +2,7 @@
 
 import copy
 import unittest
+from types import MappingProxyType
 
 import pytest
 
@@ -14,14 +15,22 @@ class DataflowsConfigIsolationTests(unittest.TestCase):
     def setUp(self):
         set_config(copy.deepcopy(default_config.DEFAULT_CONFIG))
 
-    def test_get_config_returns_deep_copy(self):
+    def test_get_config_returns_read_only_view(self):
         cfg = get_config()
-        cfg["data_vendors"]["core_stock_apis"] = "alpha_vantage"
-        cfg["tool_vendors"]["get_stock_data"] = "alpha_vantage"
+        # Must be a MappingProxyType — mutations raise TypeError
+        self.assertIsInstance(cfg, MappingProxyType)
 
-        fresh = get_config()
-        self.assertEqual(fresh["data_vendors"]["core_stock_apis"], "yfinance")
-        self.assertNotIn("get_stock_data", fresh["tool_vendors"])
+        # The nested dict values are also frozen
+        self.assertIsInstance(cfg["data_vendors"], MappingProxyType)
+        self.assertIsInstance(cfg["tool_vendors"], MappingProxyType)
+
+        # Top-level mutation must raise
+        with self.assertRaises(TypeError):
+            cfg["output_language"] = "Chinese"
+
+        # Nested dict mutation must also raise
+        with self.assertRaises(TypeError):
+            cfg["data_vendors"]["core_stock_apis"] = "alpha_vantage"
 
     def test_set_config_does_not_alias_caller_nested_dicts(self):
         custom = copy.deepcopy(default_config.DEFAULT_CONFIG)

--- a/tradingagents/dataflows/config.py
+++ b/tradingagents/dataflows/config.py
@@ -1,19 +1,41 @@
+from __future__ import annotations
+
 from copy import deepcopy
+from types import MappingProxyType
+from typing import Any
 
 import tradingagents.default_config as default_config
 
 # Use default config but allow it to be overridden
-_config: dict | None = None
+_config: dict[str, Any] | None = None
 
 
-def initialize_config():
+def _deep_freeze(mapping: dict[str, Any]) -> MappingProxyType[str, Any]:
+    """Recursively freeze a dict so all nested levels are read-only.
+
+    Lists are converted to tuples so they also become immutable.
+    This avoids the cost of ``deepcopy`` on every read while guaranteeing
+    that callers cannot accidentally mutate the shared configuration.
+    """
+    frozen: dict[str, Any] = {}
+    for key, value in mapping.items():
+        if isinstance(value, dict):
+            frozen[key] = _deep_freeze(value)
+        elif isinstance(value, list):
+            frozen[key] = tuple(value)
+        else:
+            frozen[key] = value
+    return MappingProxyType(frozen)
+
+
+def initialize_config() -> None:
     """Initialize the configuration with default values."""
     global _config
     if _config is None:
         _config = deepcopy(default_config.DEFAULT_CONFIG)
 
 
-def set_config(config: dict):
+def set_config(config: dict[str, Any]) -> None:
     """Update the configuration with custom values.
 
     Dict-valued keys (e.g. ``data_vendors``) are merged one level deep so a
@@ -30,11 +52,16 @@ def set_config(config: dict):
             _config[key] = value
 
 
-def get_config() -> dict:
-    """Get the current configuration."""
+def get_config() -> MappingProxyType[str, Any]:
+    """Get a read-only view of the current configuration.
+
+    Returns a recursively frozen mapping — any attempt to modify the returned
+    value (or any nested dict/list inside it) raises ``TypeError``. This is
+    both safer and faster than the previous ``deepcopy``-based approach.
+    """
     if _config is None:
         initialize_config()
-    return deepcopy(_config)
+    return _deep_freeze(_config)
 
 
 # Initialize with default config


### PR DESCRIPTION
## Summary

Two high-priority improvements identified in the project analysis report:

### 1. `pyproject.toml` — Move `setuptools` out of runtime dependencies

`setuptools>=80.9.0` was listed under `[project] dependencies` but it is a build-time tool, not a runtime library. It was already correctly declared in `[build-system] requires = ["setuptools>=61.0"]`, so this line was redundant.

**Impact**: `pip install tradingagents` no longer pulls in `setuptools` unnecessarily, reducing installation footprint and avoiding potential version conflicts.

### 2. `config.py` — Replace `deepcopy` with a deep-frozen read-only view

`get_config()` previously called `deepcopy(_config)` on every read — an O(n) copy of the entire configuration dictionary. This has been replaced with a recursive `MappingProxyType` freeze via the new `_deep_freeze()` helper.

**Benefits**:
- **Safety**: The returned view is deeply immutable — any attempt to mutate it (or any nested dict/list) raises `TypeError` immediately, catching bugs early instead of silently modifying a throwaway copy
- **Performance**: Avoids the overhead of `deepcopy` on every read (the freeze is still O(n) but avoids recursive object copying)
- **Type safety**: All functions now have full `dict[str, Any]` / `MappingProxyType[str, Any]` annotations

### Testing

All **491 tests pass**, 0 failures, 1 skipped (unrelated missing `langchain_aws` module).

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Remove `setuptools>=80.9.0` from `[project] dependencies` |
| `tradingagents/dataflows/config.py` | Add `_deep_freeze()`, switch `get_config()` to `MappingProxyType`, add type annotations |
| `tests/test_dataflows_config.py` | Update test for read-only view semantics (verify `TypeError` on mutation) |