### PR TITLE
feat(engine): retry an undecodable JSON response body instead of aborting the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Engine: a 2xx response with an undecodable JSON body is retried instead of
+  aborting the run.** The OpenAI SDK already retries the connection / timeout /
+  5xx / 429 family internally, but it parses each response body only once —
+  *after* that retry loop — so a successful 2xx whose `application/json` body is
+  truncated or garbled (`json.JSONDecodeError`) would propagate out of a node and
+  crash a long graph run (checkpointing bounds the loss, it doesn't prevent the
+  crash). `NormalizedChatOpenAI.invoke` now retries that one case, bounded by
+  `max_retries` (default 2) with capped exponential backoff; the HTTP-transient
+  family is left to the SDK (so retries aren't multiplied) and permanent 4xx
+  errors still fail fast. New config knobs `llm_max_retries` / `llm_timeout` (env
+  `TRADINGAGENTS_LLM_MAX_RETRIES` / `TRADINGAGENTS_LLM_TIMEOUT`). (Malformed LLM
+  *structured-output* content is a separate layer, recovered by the per-agent
+  free-text fallback.)
+
 ## [0.3.0] — 2026-06-22
 
 Stabilization and extensibility release: a CI gate, a unified verified

--- a/README.md
+++ b/README.md
@@ -268,6 +268,21 @@ ta = TradingAgentsGraph(config=config)
 _, decision = ta.propagate("NVDA", "2026-01-15")
 ```
 
+### Transient-failure retries
+
+The OpenAI SDK already retries dropped connections, timeouts, and 5xx/429 — but it
+parses each response body only once, *after* that retry loop, so a successful 2xx
+whose `application/json` body is truncated or garbled (`json.JSONDecodeError`) would
+otherwise abort a whole run. `NormalizedChatOpenAI.invoke` retries that one case,
+bounded by `max_retries` with capped exponential backoff; the HTTP-transient family
+is left to the SDK (no multiplied retries) and permanent errors (auth, bad request)
+still fail fast. Tune it with `llm_max_retries` / `llm_timeout` in your config, or
+`TRADINGAGENTS_LLM_MAX_RETRIES` / `TRADINGAGENTS_LLM_TIMEOUT` in `.env` (defaults: 2
+retries, no explicit timeout). (A model emitting malformed structured-output content
+is handled separately, by the per-agent free-text fallback.) This complements
+`--checkpoint`: checkpointing limits how much you lose on a crash; this prevents the
+crash in the first place.
+
 ## Reproducibility
 
 TradingAgents is LLM-driven, so two runs of the same ticker and date can differ. This is expected for a research tool built on language models, not a defect. The variation comes from a few distinct sources, and it helps to separate them.

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -1,0 +1,89 @@
+"""Unit tests for ``NormalizedChatOpenAI.invoke`` transient-failure retry.
+
+The retry loop wraps ``super().invoke()`` and retries only an undecodable JSON
+response body (``json.JSONDecodeError``) — the one transient failure the OpenAI
+SDK does not retry itself. The HTTP-transient family is delegated to the SDK,
+and permanent errors surface immediately. These tests exercise that loop
+directly by stubbing the parent ``invoke``.
+"""
+
+import json
+
+import httpx
+import openai
+import pytest
+
+import tradingagents.llm_clients.openai_client as oc
+
+
+@pytest.fixture(autouse=True)
+def _fast_and_isolated(monkeypatch):
+    # Don't actually sleep between retries, and don't require a real message
+    # object back from the (stubbed) parent invoke.
+    monkeypatch.setattr(oc.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(oc, "normalize_content", lambda value: value)
+
+
+def _client(max_retries):
+    # Build an instance without network/credentials; we only exercise the retry
+    # loop, which reads ``self.max_retries`` and calls ``super().invoke()``.
+    return oc.NormalizedChatOpenAI.model_construct(max_retries=max_retries)
+
+
+def test_transient_failure_is_retried_then_succeeds(monkeypatch):
+    calls = []
+
+    def flaky(self, *args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise json.JSONDecodeError("Expecting value", "", 0)
+        return "recovered"
+
+    monkeypatch.setattr(oc.ChatOpenAI, "invoke", flaky)
+    assert _client(max_retries=2).invoke("prompt") == "recovered"
+    assert len(calls) == 2  # one transient failure, then success
+
+
+def test_permanent_error_is_not_retried(monkeypatch):
+    calls = []
+
+    def boom(self, *args, **kwargs):
+        calls.append(1)
+        raise ValueError("permanent 4xx-style failure")
+
+    monkeypatch.setattr(oc.ChatOpenAI, "invoke", boom)
+    with pytest.raises(ValueError):
+        _client(max_retries=5).invoke("prompt")
+    assert len(calls) == 1  # surfaced immediately, never retried
+
+
+def test_persistent_transient_exhausts_budget_then_raises(monkeypatch):
+    calls = []
+
+    def always_transient(self, *args, **kwargs):
+        calls.append(1)
+        raise json.JSONDecodeError("Expecting value", "", 0)
+
+    monkeypatch.setattr(oc.ChatOpenAI, "invoke", always_transient)
+    with pytest.raises(json.JSONDecodeError):
+        _client(max_retries=2).invoke("prompt")
+    assert len(calls) == 3  # initial attempt + max_retries
+
+
+def test_http_transient_is_delegated_to_the_sdk_not_outer_retried(monkeypatch):
+    # The OpenAI SDK retries the connection / timeout / 5xx / 429 family itself
+    # (max_retries is forwarded to it), so the invoke loop must NOT also catch
+    # those — that would multiply requests. An HTTP-family error therefore
+    # propagates on the first attempt instead of being re-retried here.
+    calls = []
+
+    def http_transient(self, *args, **kwargs):
+        calls.append(1)
+        raise openai.APITimeoutError(
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        )
+
+    monkeypatch.setattr(oc.ChatOpenAI, "invoke", http_transient)
+    with pytest.raises(openai.APITimeoutError):
+        _client(max_retries=3).invoke("prompt")
+    assert len(calls) == 1  # delegated to the SDK, not re-retried at invoke level

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -24,6 +24,8 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_GOOGLE_THINKING_LEVEL":   "google_thinking_level",
     "TRADINGAGENTS_OPENAI_REASONING_EFFORT": "openai_reasoning_effort",
     "TRADINGAGENTS_ANTHROPIC_EFFORT":        "anthropic_effort",
+    "TRADINGAGENTS_LLM_MAX_RETRIES":      "llm_max_retries",
+    "TRADINGAGENTS_LLM_TIMEOUT":          "llm_timeout",
 }
 
 
@@ -95,6 +97,15 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # variation on models that honor it; reasoning models largely ignore it
     # and no setting makes LLM output bit-identical across runs (see README).
     "temperature": None,
+    # LLM resilience: retry budget and per-request timeout. `llm_max_retries` is
+    # both the openai SDK's HTTP retry count AND the budget for
+    # NormalizedChatOpenAI's invoke-level retry of transient parse/timeout
+    # failures (so a single malformed/non-JSON response is retried, not fatal);
+    # `llm_timeout` (seconds) bounds each request. None leaves the SDK defaults
+    # (max_retries=2, no explicit timeout). Env: TRADINGAGENTS_LLM_MAX_RETRIES /
+    # TRADINGAGENTS_LLM_TIMEOUT.
+    "llm_max_retries": None,
+    "llm_timeout": None,
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -156,6 +156,17 @@ class TradingAgentsGraph:
         if temperature is not None and temperature != "":
             kwargs["temperature"] = float(temperature)
 
+        # Resilience knobs (cross-provider): per-request HTTP timeout and the retry
+        # budget. max_retries also drives NormalizedChatOpenAI's invoke-level retry
+        # of transient parse/timeout failures. Coerced here so env-string values
+        # ("2", "120") work the same as programmatic ints/floats.
+        max_retries = self.config.get("llm_max_retries")
+        if max_retries is not None and max_retries != "":
+            kwargs["max_retries"] = int(max_retries)
+        timeout = self.config.get("llm_timeout")
+        if timeout is not None and timeout != "":
+            kwargs["timeout"] = float(timeout)
+
         return kwargs
 
     def _create_tool_nodes(self) -> dict[str, ToolNode]:

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,5 +1,8 @@
+import json
+import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -11,6 +14,23 @@ from .api_key_env import get_api_key_env
 from .base_client import BaseLLMClient, normalize_content
 from .capabilities import get_capabilities
 from .validators import validate_model
+
+logger = logging.getLogger(__name__)
+
+# At the invoke level we retry only the one transient failure the OpenAI SDK
+# does NOT: a successful 2xx whose application/json body fails to decode
+# (json.JSONDecodeError). The SDK already retries the connection / timeout /
+# 5xx / 429 family internally (up to max_retries) but parses the body only
+# once, after that retry loop — so a truncated or garbled body would otherwise
+# propagate out of a node and abort the whole graph run (checkpointing bounds
+# the loss, it doesn't prevent the crash). The HTTP-transient family is left to
+# the SDK so retries aren't multiplied, and permanent 4xx errors (auth, bad
+# request) still fail fast.
+#
+# Not handled here (different layer): a model emitting malformed *structured-
+# output* content surfaces in the downstream parser, outside invoke, and is
+# recovered by the agents' free-text fallback (agents/utils/structured.py).
+_TRANSIENT_LLM_ERRORS: tuple[type[Exception], ...] = (json.JSONDecodeError,)
 
 
 class NormalizedChatOpenAI(ChatOpenAI):
@@ -33,7 +53,23 @@ class NormalizedChatOpenAI(ChatOpenAI):
     """
 
     def invoke(self, input, config=None, **kwargs):
-        return normalize_content(super().invoke(input, config, **kwargs))
+        # Retry an undecodable-JSON response body instead of letting it abort the
+        # graph (see _TRANSIENT_LLM_ERRORS). `max_retries` (the ChatOpenAI field,
+        # default 2) bounds the attempts and `timeout` bounds each request; both
+        # come from the `llm_max_retries` / `llm_timeout` config keys (TRADINGAGENTS_LLM_*).
+        attempts = max(self.max_retries or 0, 0) + 1
+        for attempt in range(attempts):
+            try:
+                return normalize_content(super().invoke(input, config, **kwargs))
+            except _TRANSIENT_LLM_ERRORS as exc:
+                if attempt + 1 >= attempts:
+                    raise
+                delay = min(2.0 ** attempt, 8.0)
+                logger.warning(
+                    "transient %s on attempt %d/%d; retrying in %.0fs",
+                    type(exc).__name__, attempt + 1, attempts, delay,
+                )
+                time.sleep(delay)
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
         caps = get_capabilities(self.model_name)


### PR DESCRIPTION
## What & why

A single transient response from a provider — a dropped connection, a timeout, a 5xx/429, or a **malformed / non-JSON body** — currently propagates out of a graph node and aborts the entire run. On a long multi-agent run that's expensive, and `checkpoint_enabled` only bounds the loss (resume from the last step) — it doesn't prevent the crash.

This wraps `NormalizedChatOpenAI.invoke` in a small retry loop over a curated transient-error set, so one bad response is retried instead of fatal.

## What it does

- Retries a curated transient set: `APITimeoutError`, `APIConnectionError`, `InternalServerError`, `RateLimitError`, `APIResponseValidationError`, and `json.JSONDecodeError`.
  - The OpenAI SDK already retries the connection/timeout/5xx/429 family *inside a single call*, but **not** response-parse failures — the malformed/non-JSON body is the main case this adds at the invoke level.
- **Permanent 4xx** errors (auth, bad request, not found) are deliberately excluded — they still fail fast.
- Bounded by the existing `max_retries` field (default 2) with capped exponential backoff; each retry logs to stderr.
- Two optional config knobs, forwarded via `_get_provider_kwargs`:
  - `llm_max_retries` / `TRADINGAGENTS_LLM_MAX_RETRIES`
  - `llm_timeout` / `TRADINGAGENTS_LLM_TIMEOUT`
  - Unset → SDK defaults (behavior unchanged).

## Tests

`tests/test_llm_retry.py` covers: a transient parse failure retries and recovers; a permanent error surfaces immediately without retry; a persistent transient exhausts `max_retries` before re-raising.

## Scope

Engine-only, opt-in, backward-compatible. 6 files, +155/-1.
