### PR TITLE
Normalize benchmark ticker before fetching return history

### DIFF
--- a/tests/test_symbol_normalization_paths.py
+++ b/tests/test_symbol_normalization_paths.py
@@ -55,6 +55,27 @@ def test_fetch_returns_normalizes_symbol(monkeypatch):
     assert raw is not None and days is not None
 
 
+def test_fetch_returns_normalizes_benchmark(monkeypatch):
+    queried = []
+
+    class FakeTicker:
+        def __init__(self, symbol):
+            queried.append(symbol)
+
+        def history(self, *args, **kwargs):
+            return pd.DataFrame({"Close": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0]})
+
+    monkeypatch.setattr(tg.yf, "Ticker", FakeTicker)
+
+    raw, alpha, days = TradingAgentsGraph._fetch_returns(
+        None, "AAPL", "2025-01-02", holding_days=5, benchmark="SPX500"
+    )
+
+    assert queried[0] == "AAPL"
+    assert queried[1] == "^GSPC"
+    assert raw is not None and alpha is not None and days is not None
+
+
 def test_news_lookup_normalizes_symbol(monkeypatch):
     seen = {}
 

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -240,10 +240,10 @@ class TradingAgentsGraph:
             end_str = end.strftime("%Y-%m-%d")
 
             # Normalize so the realized-return lookup hits the same instrument
-            # the analysis priced (e.g. XAUUSD -> GC=F) (#984). The benchmark is
-            # already a canonical Yahoo symbol from ``_resolve_benchmark``.
+            # the analysis priced (e.g. XAUUSD -> GC=F) (#984). Apply the same
+            # normalization to user-configured benchmarks such as SPX500.
             stock = yf.Ticker(normalize_symbol(ticker)).history(start=trade_date, end=end_str)
-            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+            bench = yf.Ticker(normalize_symbol(benchmark)).history(start=trade_date, end=end_str)
 
             if len(stock) < 2 or len(bench) < 2:
                 return None, None, None


### PR DESCRIPTION
## Summary
- Normalize configured benchmark tickers before fetching return history in `_fetch_returns`
- Add a regression test covering broker/CFD benchmark aliases such as `SPX500 -> ^GSPC`

## Why
`_fetch_returns` already normalizes the analyzed ticker before querying yfinance, but it passed the configured benchmark directly to `yf.Ticker(...)`. When users set `benchmark_ticker` to an alias such as `SPX500`, yfinance receives the raw alias instead of the canonical Yahoo symbol `^GSPC`, so realized alpha can fail or be computed against missing benchmark data.

This keeps canonical benchmarks like `SPY` unchanged while allowing user-configured aliases to follow the same normalization path as traded symbols.

## Tests
- `python -m pytest tests/test_symbol_normalization_paths.py tests/test_symbol_utils.py tests/test_reporting.py -q`
- `python -m ruff check tradingagents/graph/trading_graph.py tests/test_symbol_normalization_paths.py`
- `git diff --check`