### PR TITLE
feat(desk): engine host/streaming APIs + a FastAPI/SSE backend for a GUI frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Breaking changes within the 0.x line are called out explicitly.
   host can realize previously-pending decisions on a schedule without a full run.
   Setting `TRADINGAGENTS_NO_DOTENV=1` skips the package-import `.env` load for
   hosts that inject secrets themselves.
+- **TradingDesk backend (`desk_server/`, `desk_adapter/`).** A FastAPI + SSE
+  server, packaged into the engine's Docker image (`pip install ".[server]"`,
+  `desk-server` entrypoint), that drives the engine for a host UI: it streams a
+  run's events over SSE (`POST /runs`, `GET /runs/{id}/events`,
+  `POST /runs/{id}/cancel`) and exposes `/health`, `/capabilities`, `/journal`,
+  `/reports`, `/search`, `/prices`, `/openrouter/models`, and connectivity tests
+  (`/test`, `/test_fred`). `desk_adapter/` is the host glue that diffs the
+  engine's `stream_run` snapshots into a typed NDJSON event stream and
+  introspects provider/model capabilities. Runs on loopback only
+  (`127.0.0.1:8765`); secrets are injected by the host, never read from disk
+  (`TRADINGAGENTS_NO_DOTENV=1`).
 
 ## [0.3.0] — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Engine host / embedding APIs.** `TradingAgentsGraph.stream_run()` yields each
+  whole-state snapshot as the graph advances — a streaming sibling of
+  `propagate()` for live-progress hosts — while preserving the same state-log and
+  decision side effects. `resolve_pending_entries(ticker)` and
+  `resolve_all_pending()` expose outcome resolution as public entry points, so a
+  host can realize previously-pending decisions on a schedule without a full run.
+  Setting `TRADINGAGENTS_NO_DOTENV=1` skips the package-import `.env` load for
+  hosts that inject secrets themselves.
+
 ## [0.3.0] — 2026-06-22
 
 Stabilization and extensibility release: a CI gate, a unified verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /build
 COPY . .
-RUN pip install --no-cache-dir .
+# ".[server]" adds FastAPI + uvicorn so the same image can serve the TradingDesk
+# macOS app's backend (desk-server) in addition to the interactive CLI.
+RUN pip install --no-cache-dir ".[server]"
 
 FROM python:3.12-slim
 
@@ -25,4 +27,10 @@ WORKDIR /home/appuser/app
 
 COPY --from=builder --chown=appuser:appuser /build .
 
+# Backend server port (overridable via DESK_SERVER_PORT). The macOS app maps
+# this to 127.0.0.1 on the host so it is never exposed off-box.
+EXPOSE 8765
+
+# Default entrypoint is the interactive CLI; the `desk-server` compose service
+# overrides the entrypoint to run the HTTP/SSE backend instead.
 ENTRYPOINT ["tradingagents"]

--- a/desk_adapter/__init__.py
+++ b/desk_adapter/__init__.py
@@ -1,0 +1,18 @@
+"""Host glue between the native macOS app (TradingDesk) and the TradingAgents engine.
+
+This package is intentionally thin. Two modules are dependency-free and import
+nothing from ``tradingagents`` so they can be unit-tested on any interpreter:
+
+- ``desk_adapter.protocol`` — the NDJSON event channel (envelope + fd-1 discipline).
+- ``desk_adapter.diff`` — turns consecutive ``stream_mode="values"`` whole-state
+  snapshots into the typed event stream the app consumes.
+
+The remaining modules (``run``, ``introspect``, ``env``, ``__main__``) drive the
+engine and therefore require the full ``tradingagents`` dependency tree (Python
+>=3.10). Keep this ``__init__`` import-light so importing the pure modules never
+pulls the engine in.
+"""
+
+from desk_adapter.protocol import SCHEMA_VERSION
+
+__all__ = ["SCHEMA_VERSION"]

--- a/desk_adapter/__main__.py
+++ b/desk_adapter/__main__.py
@@ -1,0 +1,67 @@
+"""Command-line entry point: ``python -m desk_adapter <run|capabilities|resolve>``.
+
+Order matters: reserve fd 1 and prepare the environment BEFORE importing
+``tradingagents`` (the engine reads dir env vars and loads ``.env`` at import).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import uuid
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="desk_adapter")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_run = sub.add_parser("run", help="stream one analysis run as NDJSON")
+    p_run.add_argument("--config", required=True, help="path to the resolved run-config JSON")
+    p_run.add_argument("--base-dir", default=None, help="app data dir for results/cache/memory")
+
+    sub.add_parser("capabilities", help="dump provider/model/vendor surface as one JSON object")
+
+    p_res = sub.add_parser("resolve", help="realize pending outcomes (no analysis)")
+    p_res.add_argument("--config", default=None)
+    p_res.add_argument("--ticker", default=None)
+    p_res.add_argument("--all", action="store_true")
+    p_res.add_argument("--base-dir", default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Reserve the protocol channel first; everything else may write to stderr.
+    from desk_adapter.protocol import SCHEMA_VERSION, Emitter, reserve_stdout
+
+    real_out = reserve_stdout()
+    logging.basicConfig(stream=sys.stderr, level=os.environ.get("DESK_LOG_LEVEL", "WARNING"))
+    logging.captureWarnings(True)
+
+    args = _build_parser().parse_args(argv)
+
+    from desk_adapter.env import prepare_environment
+
+    prepare_environment(getattr(args, "base_dir", None))
+
+    run_id = os.environ.get("DESK_RUN_ID") or uuid.uuid4().hex
+    emitter = Emitter(real_out, run_id)
+    emitter.emit("handshake", schema_version=SCHEMA_VERSION, pid=os.getpid())
+
+    if args.cmd == "capabilities":
+        from desk_adapter.introspect import capabilities_command
+
+        return capabilities_command(emitter)
+
+    from desk_adapter import run as run_mod
+
+    if args.cmd == "run":
+        return run_mod.run_command(args, emitter)
+    if args.cmd == "resolve":
+        return run_mod.resolve_command(args, emitter)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desk_adapter/diff.py
+++ b/desk_adapter/diff.py
@@ -1,0 +1,419 @@
+"""Turn consecutive ``stream_mode="values"`` whole-state snapshots into a typed,
+append-only event stream.
+
+The TradingAgents graph streams full accumulated state on every step (verified:
+``tradingagents/graph/propagation.py`` ``get_graph_args`` -> ``stream_mode="values"``).
+This module holds the previous view of the world and emits only what is new,
+porting the CLI's proven derivation logic (``cli/main.py``: ``update_analyst_statuses``,
+``classify_message_type``, ``extract_content_string``, and the investment/risk
+debate handling) into structured events instead of Rich panels.
+
+Dependency-free and duck-typed: it never imports ``tradingagents`` or
+``langchain`` so it runs and is unit-testable on any interpreter. LangChain
+message objects are read via ``.type`` / ``.content`` / ``.tool_calls`` /
+``.tool_call_id`` / ``.id`` (with attribute-sniffing fallbacks for test fakes).
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from typing import Any
+
+# --- Static maps (mirror cli/main.py MessageBuffer) ---
+
+ANALYST_ORDER = ["market", "social", "news", "fundamentals"]
+ANALYST_AGENT = {
+    "market": "Market Analyst",
+    "social": "Sentiment Analyst",
+    "news": "News Analyst",
+    "fundamentals": "Fundamentals Analyst",
+}
+ANALYST_REPORT = {
+    "market": "market_report",
+    "social": "sentiment_report",
+    "news": "news_report",
+    "fundamentals": "fundamentals_report",
+}
+RESEARCH_AGENTS = ["Bull Researcher", "Bear Researcher", "Research Manager"]
+RISK_AGENTS = ["Aggressive Analyst", "Conservative Analyst", "Neutral Analyst"]
+
+REPORT_TITLES = {
+    "market_report": "Market analysis",
+    "sentiment_report": "Sentiment analysis",
+    "news_report": "News analysis",
+    "fundamentals_report": "Fundamentals analysis",
+    "investment_plan": "Research decision",
+    "trader_investment_plan": "Trader plan",
+    "final_trade_decision": "Portfolio decision",
+}
+REPORT_FINALIZER = {
+    "market_report": "Market Analyst",
+    "sentiment_report": "Sentiment Analyst",
+    "news_report": "News Analyst",
+    "fundamentals_report": "Fundamentals Analyst",
+    "investment_plan": "Research Manager",
+    "trader_investment_plan": "Trader",
+    "final_trade_decision": "Portfolio Manager",
+}
+
+_GROUP = {}
+for _a in ANALYST_AGENT.values():
+    _GROUP[_a] = "analyst"
+for _a in RESEARCH_AGENTS:
+    _GROUP[_a] = "research"
+_GROUP["Trader"] = "trader"
+for _a in RISK_AGENTS:
+    _GROUP[_a] = "risk"
+_GROUP["Portfolio Manager"] = "portfolio"
+
+# The non-analyst pipeline tail, shared by ``_PIPELINE`` and the initial status map.
+_NON_ANALYST_PIPELINE = RESEARCH_AGENTS + ["Trader"] + RISK_AGENTS + ["Portfolio Manager"]
+
+# Pipeline order used to resolve the single "active" agent for step attribution.
+_PIPELINE = list(ANALYST_AGENT.values()) + _NON_ANALYST_PIPELINE
+
+# Each debate turn is appended to its OWN speaker's history field as
+# "\n<Speaker> Analyst: <text>" (bull_researcher.py:53, aggressive_debator.py:45,
+# etc.). Deriving turns from the per-speaker histories — rather than scanning the
+# shared combined ``history`` — means content that quotes another speaker by name
+# (risk debators are prompted to rebut "the conservative and neutral analysts")
+# can't manufacture a phantom turn or corrupt the round numbering.
+_DEBATE_SPEAKERS: dict[str, list[tuple[str, str]]] = {
+    "investment": [("Bull Analyst", "bull_history"), ("Bear Analyst", "bear_history")],
+    "risk": [
+        ("Aggressive Analyst", "aggressive_history"),
+        ("Conservative Analyst", "conservative_history"),
+        ("Neutral Analyst", "neutral_history"),
+    ],
+}
+_SENTIMENT_SCORE_RE = re.compile(r"Score:\s*([0-9]+(?:\.[0-9]+)?)\s*/\s*10")
+
+NO_DATA_PREFIX = "NO_DATA_AVAILABLE"
+
+
+def extract_content_string(content: Any) -> str | None:
+    """Extract displayable text from a LangChain message ``content`` field.
+
+    Ported verbatim in behavior from ``cli/main.py:extract_content_string`` so
+    GUI and CLI agree on what counts as real text. Returns ``None`` for empty.
+    """
+
+    def is_empty(val: Any) -> bool:
+        if val is None or val == "":
+            return True
+        if isinstance(val, str):
+            s = val.strip()
+            if not s:
+                return True
+            try:
+                return not bool(ast.literal_eval(s))
+            except (ValueError, SyntaxError):
+                return False
+        return not bool(val)
+
+    if is_empty(content):
+        return None
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        text = content.get("text", "")
+        return text.strip() if not is_empty(text) else None
+    if isinstance(content, list):
+        parts = [
+            item.get("text", "").strip()
+            if isinstance(item, dict) and item.get("type") == "text"
+            else (item.strip() if isinstance(item, str) else "")
+            for item in content
+        ]
+        result = " ".join(p for p in parts if p and not is_empty(p))
+        return result or None
+    return str(content).strip() if not is_empty(content) else None
+
+
+def _split_speaker_history(history: str, speaker: str) -> list[str]:
+    """Split one speaker's accumulated debate history into that speaker's turn texts.
+
+    Splits on the speaker's OWN line-start prefix only, so a turn whose content
+    quotes a different speaker's name can never create a phantom turn.
+    """
+    if not history:
+        return []
+    prefix = re.compile(rf"^{re.escape(speaker)}:[ \t]*", re.MULTILINE)
+    matches = list(prefix.finditer(history))
+    turns: list[str] = []
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(history)
+        turns.append(history[m.end() : end].strip())
+    return turns
+
+
+def extract_sentiment_score(report: str) -> float | None:
+    """Pull the 0-10 score out of the Sentiment Analyst's structured header."""
+    if not report:
+        return None
+    m = _SENTIMENT_SCORE_RE.search(report)
+    return float(m.group(1)) if m else None
+
+
+def _msg_type(msg: Any) -> str:
+    """Duck-typed message kind: ai | tool | human | system | remove | other."""
+    t = getattr(msg, "type", None)
+    if isinstance(t, str) and t:
+        return t
+    if getattr(msg, "tool_call_id", None) is not None:
+        return "tool"
+    if getattr(msg, "tool_calls", None):
+        return "ai"
+    return "other"
+
+
+def _toolcall_fields(tc: Any) -> tuple[str, Any, str]:
+    """Normalize a tool call (dict or object) to (name, args, call_id)."""
+    if isinstance(tc, dict):
+        return tc.get("name", ""), tc.get("args", {}), tc.get("id", "")
+    return getattr(tc, "name", ""), getattr(tc, "args", {}), getattr(tc, "id", "")
+
+
+class SnapshotDiffer:
+    """Stateful diff: feed it whole-state snapshots, get back new events.
+
+    Construct once per run with the selected analyst keys, then call
+    ``process(snapshot)`` for each streamed chunk. Returned events are dicts
+    carrying a ``type`` key plus that event's fields (no envelope — the
+    ``Emitter`` adds ``v``/``run_id``/``seq``/``ts``).
+    """
+
+    def __init__(self, selected_analysts: list[str]):
+        self.selected = [a.lower() for a in selected_analysts]
+        self.status: dict[str, str] = {}
+        for k in ANALYST_ORDER:
+            if k in self.selected:
+                self.status[ANALYST_AGENT[k]] = "pending"
+        for agent in _NON_ANALYST_PIPELINE:
+            self.status[agent] = "pending"
+        self.active: str | None = None
+        self.reports: dict[str, str] = {}
+        self.processed_ids: set = set()
+        self.tool_index: dict[str, str] = {}
+        self._emitted_turns: dict[str, dict[str, int]] = {"investment": {}, "risk": {}}
+        self._debate_count = {"investment": 0, "risk": 0}
+        self._judge_emitted = {"investment": False, "risk": False}
+
+    # -- public API --
+
+    def process(self, snapshot: dict) -> list[dict]:
+        events: list[dict] = []
+        events += self._status_events(snapshot)  # first: lights up the rail + sets self.active
+        events += self._message_events(snapshot)
+        events += self._report_events(snapshot)
+        events += self._debate_events(snapshot, "investment", "investment_debate_state")
+        events += self._debate_events(snapshot, "risk", "risk_debate_state")
+        return events
+
+    # -- status (ported from cli/main.py:update_analyst_statuses + debate transitions) --
+
+    def _status_events(self, snap: dict) -> list[dict]:
+        desired = dict(self.status)
+        found_active = False
+        for k in ANALYST_ORDER:
+            if k not in self.selected:
+                continue
+            agent = ANALYST_AGENT[k]
+            has_report = bool(snap.get(ANALYST_REPORT[k])) or bool(self.reports.get(ANALYST_REPORT[k]))
+            if has_report:
+                desired[agent] = "completed"
+            elif not found_active:
+                desired[agent] = "in_progress"
+                found_active = True
+            else:
+                desired[agent] = "pending"
+        if not found_active and self.selected and desired.get("Bull Researcher") == "pending":
+            desired["Bull Researcher"] = "in_progress"
+
+        inv = snap.get("investment_debate_state") or {}
+        if (inv.get("bull_history") or "").strip() and desired.get("Bull Researcher") != "completed":
+            desired["Bull Researcher"] = "in_progress"
+        if (inv.get("bear_history") or "").strip() and desired.get("Bear Researcher") != "completed":
+            desired["Bear Researcher"] = "in_progress"
+        if (inv.get("judge_decision") or "").strip() or snap.get("investment_plan"):
+            desired["Bull Researcher"] = "completed"
+            desired["Bear Researcher"] = "completed"
+            desired["Research Manager"] = "completed"
+            if desired.get("Trader") == "pending":
+                desired["Trader"] = "in_progress"
+
+        if snap.get("trader_investment_plan"):
+            desired["Trader"] = "completed"
+            if desired.get("Aggressive Analyst") == "pending":
+                desired["Aggressive Analyst"] = "in_progress"
+
+        risk = snap.get("risk_debate_state") or {}
+        for hist_key, agent in (
+            ("aggressive_history", "Aggressive Analyst"),
+            ("conservative_history", "Conservative Analyst"),
+            ("neutral_history", "Neutral Analyst"),
+        ):
+            if (risk.get(hist_key) or "").strip() and desired.get(agent) != "completed":
+                desired[agent] = "in_progress"
+        if (risk.get("judge_decision") or "").strip() or snap.get("final_trade_decision"):
+            for agent in RISK_AGENTS:
+                desired[agent] = "completed"
+            desired["Portfolio Manager"] = "completed"
+
+        events = []
+        for agent, state in desired.items():
+            if self.status.get(agent) != state:
+                self.status[agent] = state
+                events.append(
+                    {"type": "node_status", "node": agent, "group": _GROUP.get(agent, ""), "state": state}
+                )
+        self.active = self._active_agent()
+        return events
+
+    def _active_agent(self) -> str | None:
+        for agent in _PIPELINE:
+            if self.status.get(agent) == "in_progress":
+                return agent
+        last_completed = None
+        for agent in _PIPELINE:
+            if self.status.get(agent) == "completed":
+                last_completed = agent
+        return last_completed
+
+    # -- messages -> agent_step / tool_call / tool_result --
+
+    def _message_events(self, snap: dict) -> list[dict]:
+        events = []
+        for msg in snap.get("messages") or []:
+            key = self._dedupe_key(msg)
+            if key in self.processed_ids:
+                continue
+            self.processed_ids.add(key)
+            mtype = _msg_type(msg)
+            content = extract_content_string(getattr(msg, "content", None))
+            if mtype == "ai":
+                if content:
+                    events.append(
+                        {
+                            "type": "agent_step",
+                            "node": self.active or "",
+                            "role": self.active or "",
+                            "text": content,
+                            "text_kind": "reasoning",
+                            "is_final": False,
+                        }
+                    )
+                for tc in getattr(msg, "tool_calls", None) or []:
+                    name, args, call_id = _toolcall_fields(tc)
+                    if call_id:
+                        self.tool_index[call_id] = name
+                    events.append(
+                        {
+                            "type": "tool_call",
+                            "node": self.active or "",
+                            "call_id": call_id,
+                            "name": name,
+                            "args": args if isinstance(args, (dict, list)) else str(args),
+                        }
+                    )
+            elif mtype == "tool":
+                call_id = getattr(msg, "tool_call_id", None)
+                name = self.tool_index.get(call_id, getattr(msg, "name", "") or "")
+                text = content or ""
+                no_data = text.startswith(NO_DATA_PREFIX)
+                events.append(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "name": name,
+                        "ok": not no_data,
+                        "preview": text[:280],
+                        "full": text,
+                        "data_status": "no_data" if no_data else "ok",
+                    }
+                )
+        return events
+
+    def _dedupe_key(self, msg: Any):
+        mid = getattr(msg, "id", None)
+        if mid is not None:
+            return mid
+        # id-less fakes/messages: best-effort stable key. sha256 (not built-in
+        # hash()) so the key is deterministic across processes and effectively
+        # collision-free, without holding full message bodies in the seen-set.
+        content = extract_content_string(getattr(msg, "content", None)) or ""
+        return (
+            "anon",
+            _msg_type(msg),
+            getattr(msg, "tool_call_id", None),
+            hashlib.sha256(content.encode("utf-8", "replace")).hexdigest(),
+        )
+
+    # -- report sections --
+
+    def _report_events(self, snap: dict) -> list[dict]:
+        events = []
+        for section, title in REPORT_TITLES.items():
+            val = snap.get(section)
+            if val and val != self.reports.get(section):
+                self.reports[section] = val
+                event = {
+                    "type": "report_section",
+                    "section": section,
+                    "title": title,
+                    "markdown": val,
+                    "finalized": self.status.get(REPORT_FINALIZER[section]) == "completed",
+                }
+                if section == "sentiment_report":
+                    score = extract_sentiment_score(val)
+                    if score is not None:
+                        event["sentiment_score"] = score
+                events.append(event)
+        return events
+
+    # -- debates -> ordered, speaker-attributed turns --
+
+    def _debate_events(self, snap: dict, name: str, key: str) -> list[dict]:
+        state = snap.get(key) or {}
+        speakers = _DEBATE_SPEAKERS[name]
+        per_round = len(speakers)
+        emitted = self._emitted_turns[name]
+        events = []
+        # Emit each speaker's new turns in fixed graph order. In a live run exactly
+        # one speaker's history grows per snapshot, so the global index — and thus
+        # the round (index // per_round + 1) — follows the real debate order.
+        for label, field in speakers:
+            turns = _split_speaker_history(state.get(field) or "", label)
+            for j in range(emitted.get(label, 0), len(turns)):
+                idx = self._debate_count[name]
+                events.append(
+                    {
+                        "type": "debate_turn",
+                        "debate": name,
+                        "round": idx // per_round + 1,
+                        "index": idx + 1,
+                        "speaker": label,
+                        "text": turns[j],
+                        "is_judge": False,
+                    }
+                )
+                self._debate_count[name] = idx + 1
+            emitted[label] = len(turns)
+
+        judge = (state.get("judge_decision") or "").strip()
+        if judge and not self._judge_emitted[name]:
+            self._judge_emitted[name] = True
+            events.append(
+                {
+                    "type": "debate_turn",
+                    "debate": name,
+                    "round": 0,
+                    "index": self._debate_count[name] + 1,
+                    "speaker": "Research Manager" if name == "investment" else "Portfolio Manager",
+                    "text": judge,
+                    "is_judge": True,
+                }
+            )
+        return events

--- a/desk_adapter/env.py
+++ b/desk_adapter/env.py
@@ -1,0 +1,70 @@
+"""Environment + config preparation for an adapter subprocess.
+
+Everything here runs BEFORE ``tradingagents`` is imported, because the engine
+reads its directory env vars and loads ``.env`` at import time
+(``tradingagents/default_config.py`` and ``tradingagents/__init__.py``).
+Dependency-free (stdlib only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def prepare_environment(base_dir: str | None) -> None:
+    """Pin engine I/O into the app's domain and disable the engine's dotenv load.
+
+    - ``TRADINGAGENTS_NO_DOTENV=1`` stops the bundled engine from auto-loading a
+      stray ``.env`` (honored by the ``tradingagents/__init__.py`` guard).
+    - Redirect results / cache / memory under ``base_dir`` (the app passes a
+      per-run results dir and a shared memory/cache dir). When ``base_dir`` is
+      None the engine defaults (``~/.tradingagents``) stand.
+    """
+    os.environ.setdefault("TRADINGAGENTS_NO_DOTENV", "1")
+    if not base_dir:
+        return
+    base = Path(base_dir).expanduser()
+    results = base / "results"
+    cache = base / "cache"
+    memory = base / "memory" / "trading_memory.md"
+    for p in (results, cache, memory.parent):
+        p.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("TRADINGAGENTS_RESULTS_DIR", str(results))
+    os.environ.setdefault("TRADINGAGENTS_CACHE_DIR", str(cache))
+    os.environ.setdefault("TRADINGAGENTS_MEMORY_LOG_PATH", str(memory))
+
+
+def load_run_config(path: str) -> dict[str, Any]:
+    """Load the resolved Profile->config JSON the app wrote for this run.
+
+    Secrets are NOT in this file — they arrive as provider key env vars injected
+    into the subprocess environment by the coordinator.
+    """
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_engine_config(run_config: dict[str, Any]) -> dict[str, Any]:
+    """Merge a run config onto ``DEFAULT_CONFIG`` (imported lazily, 3.10+ only).
+
+    Mirrors the CLI's assignment (``cli/main.py:1027``) and ``set_config``'s
+    one-level-deep merge for the nested ``data_vendors`` dict.
+    """
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG.copy()
+    nested = run_config.get("data_vendors")
+    tool_nested = run_config.get("tool_vendors")
+    skip = {"data_vendors", "tool_vendors", "analysts", "ticker", "trade_date", "asset_type", "profile_name", "keys"}
+    for key, value in run_config.items():
+        if key in skip:
+            continue
+        cfg[key] = value
+    if isinstance(nested, dict):
+        cfg["data_vendors"] = {**cfg.get("data_vendors", {}), **nested}
+    if isinstance(tool_nested, dict):
+        cfg["tool_vendors"] = {**cfg.get("tool_vendors", {}), **tool_nested}
+    return cfg

--- a/desk_adapter/introspect.py
+++ b/desk_adapter/introspect.py
@@ -1,0 +1,105 @@
+"""Read-only ``capabilities`` subcommand.
+
+Dumps the provider / model / capability / vendor / language surface as one JSON
+object so the native Settings UI sources its lists from the engine and never
+drifts from it. Runs in the same bundled interpreter as runs do.
+
+Imports ``tradingagents`` (Python >=3.10).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from desk_adapter.protocol import Emitter
+
+# Native (non OpenAI-compatible) providers route through dedicated clients in
+# tradingagents/llm_clients/factory.py.
+_NATIVE = {"anthropic", "google", "azure", "bedrock"}
+
+# Static UI value lists (the engine consumes these but exposes no enum to read).
+_REASONING_KNOBS = {
+    "openai_reasoning_effort": ["low", "medium", "high"],
+    "anthropic_effort": ["low", "medium", "high"],
+    "google_thinking_level": ["minimal", "high"],
+}
+_OUTPUT_LANGUAGES = [
+    "English", "Chinese", "Japanese", "Korean", "Hindi", "Spanish",
+    "Portuguese", "French", "German", "Arabic", "Russian", "Custom",
+]
+_DATA_VENDORS = {
+    "core_stock_apis": ["yfinance", "alpha_vantage"],
+    "technical_indicators": ["yfinance", "alpha_vantage"],
+    "fundamental_data": ["yfinance", "alpha_vantage"],
+    "news_data": ["yfinance", "alpha_vantage"],
+    "macro_data": ["fred"],
+    "prediction_markets": ["polymarket"],
+}
+_DATA_KEYS = {"fred": "FRED_API_KEY", "alpha_vantage": "ALPHA_VANTAGE_API_KEY"}
+
+
+def _models(provider: str, mode: str) -> list[dict[str, str]]:
+    from tradingagents.llm_clients.model_catalog import get_model_options
+
+    try:
+        opts = get_model_options(provider, mode)
+    except Exception:  # noqa: BLE001 - native providers have no catalog entry
+        return []
+    out = []
+    for opt in opts:
+        if isinstance(opt, (tuple, list)) and len(opt) == 2:
+            out.append({"label": opt[0], "model_id": opt[1]})
+        else:
+            out.append({"label": str(opt), "model_id": str(opt)})
+    return out
+
+
+def build_capabilities() -> dict[str, Any]:
+    from tradingagents.llm_clients.api_key_env import PROVIDER_API_KEY_ENV
+    from tradingagents.llm_clients.capabilities import get_capabilities
+    from tradingagents.llm_clients.model_catalog import get_known_models
+    from tradingagents.llm_clients.openai_client import OPENAI_COMPATIBLE_PROVIDERS
+
+    providers = []
+    for name, key_env in PROVIDER_API_KEY_ENV.items():
+        spec = OPENAI_COMPATIBLE_PROVIDERS.get(name)
+        providers.append(
+            {
+                "name": name,
+                "api_key_env": key_env,
+                "native": name in _NATIVE,
+                "base_url": getattr(spec, "base_url", None) if spec else None,
+                "base_url_env": getattr(spec, "base_url_env", None) if spec else None,
+                "key_optional": getattr(spec, "key_optional", False) if spec else (key_env is None),
+                "require_base_url": getattr(spec, "require_base_url", False) if spec else False,
+                "quick_models": _models(name, "quick"),
+                "deep_models": _models(name, "deep"),
+            }
+        )
+
+    capabilities = {}
+    try:
+        for _provider, model_ids in get_known_models().items():
+            for model_id in model_ids:
+                try:
+                    capabilities[model_id] = dataclasses.asdict(get_capabilities(model_id))
+                except Exception:  # noqa: BLE001
+                    continue
+    except Exception:  # noqa: BLE001
+        pass
+
+    return {
+        "schema": "capabilities",
+        "providers": providers,
+        "model_capabilities": capabilities,
+        "reasoning_knobs": _REASONING_KNOBS,
+        "output_languages": _OUTPUT_LANGUAGES,
+        "data_vendors": _DATA_VENDORS,
+        "data_keys": _DATA_KEYS,
+    }
+
+
+def capabilities_command(emitter: Emitter) -> int:
+    emitter.write_object(build_capabilities())
+    return 0

--- a/desk_adapter/protocol.py
+++ b/desk_adapter/protocol.py
@@ -1,0 +1,82 @@
+"""NDJSON event protocol + fd-1 discipline.
+
+The adapter speaks to the native app over the child process's stdout, one
+compact JSON object per line. fd 1 is reserved exclusively for this channel:
+stray ``print()`` calls in the dependency tree and library warnings are pushed
+to stderr so they can never corrupt a line.
+
+Dependency-free on purpose (no ``tradingagents`` import) so it is importable and
+testable on any interpreter.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from collections.abc import Callable
+from typing import Any, TextIO
+
+# Bump when the event shape changes in a way the Swift decoder must know about.
+SCHEMA_VERSION = 1
+
+
+def reserve_stdout() -> TextIO:
+    """Reserve fd 1 for the protocol and return a text stream bound to it.
+
+    Duplicates the original stdout, then redirects fd 1 (and ``sys.stdout``) to
+    stderr so anything that writes to "stdout" downstream lands on stderr. The
+    returned stream is the ONLY writer that should ever touch the real fd 1.
+    Call this once, first thing, before importing ``tradingagents``.
+    """
+    sys.stdout.flush()
+    saved_fd = os.dup(1)
+    real_out = os.fdopen(saved_fd, "w", buffering=1, encoding="utf-8", newline="\n")
+    # Point fd 1 at stderr's destination and route python-level prints there too.
+    os.dup2(2, 1)
+    sys.stdout = sys.stderr
+    return real_out
+
+
+class Emitter:
+    """Serializes events to a single NDJSON stream with a monotonic ``seq``."""
+
+    def __init__(self, stream: TextIO, run_id: str, clock: Callable[[], float] = time.time):
+        self._stream = stream
+        self._run_id = run_id
+        self._seq = 0
+        self._clock = clock
+
+    @property
+    def seq(self) -> int:
+        return self._seq
+
+    def emit(self, event_type: str, **fields: Any) -> dict:
+        """Write one event line. Returns the emitted object (handy for tests)."""
+        self._seq += 1
+        obj = {
+            "v": SCHEMA_VERSION,
+            "run_id": self._run_id,
+            "seq": self._seq,
+            "ts": round(self._clock(), 3),
+            "type": event_type,
+        }
+        obj.update(fields)
+        self._stream.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False, default=str) + "\n")
+        self._stream.flush()
+        return obj
+
+    def emit_event(self, event: dict) -> dict:
+        """Emit an event dict that carries its own ``type`` key (from ``diff``)."""
+        fields = {k: v for k, v in event.items() if k != "type"}
+        return self.emit(event["type"], **fields)
+
+    def write_object(self, obj: dict) -> None:
+        """Write a single bare JSON object + newline (no envelope).
+
+        Used by the read-only ``capabilities`` subcommand, which returns one
+        document rather than a run's event stream.
+        """
+        self._stream.write(json.dumps(obj, ensure_ascii=False, default=str) + "\n")
+        self._stream.flush()

--- a/desk_adapter/run.py
+++ b/desk_adapter/run.py
@@ -1,0 +1,124 @@
+"""The streaming run driver and the resolve-only pass.
+
+Imports ``tradingagents`` (Python >=3.10). Drives the engine's new
+``TradingAgentsGraph.stream_run`` generator, diffs each whole-state snapshot
+into events via ``desk_adapter.diff``, and emits them as NDJSON.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import signal
+import time
+import traceback
+from typing import Any
+
+from desk_adapter.diff import SnapshotDiffer
+from desk_adapter.env import build_engine_config, load_run_config
+from desk_adapter.protocol import Emitter
+
+
+def _emit_stats(emitter: Emitter, stats_handler: Any, start: float) -> None:
+    try:
+        stats = stats_handler.get_stats()
+    except Exception:
+        stats = {}
+    emitter.emit(
+        "stats",
+        llm_calls=stats.get("llm_calls", 0),
+        tool_calls=stats.get("tool_calls", 0),
+        tokens_in=stats.get("tokens_in", 0),
+        tokens_out=stats.get("tokens_out", 0),
+        elapsed_s=round(time.time() - start, 2),
+    )
+
+
+def run_command(args: Any, emitter: Emitter) -> int:
+    """Execute one analysis run, streaming events. Returns a process exit code."""
+    run_config = load_run_config(args.config)
+    ticker = run_config["ticker"]
+    trade_date = run_config["trade_date"]
+    asset_type = run_config.get("asset_type", "stock")
+    analysts = run_config.get("analysts") or ["market", "social", "news", "fundamentals"]
+    profile_name = run_config.get("profile_name", "")
+
+    # Cancel = SIGTERM -> emit a clean final line then exit. Process-kill is the
+    # real cancel; this just gives the app a tidy terminal event when catchable.
+    def _on_term(signum, frame):
+        emitter.emit("cancelled", at_node=getattr(differ, "active", None))
+        raise SystemExit(143)
+
+    differ = SnapshotDiffer(analysts)
+    signal.signal(signal.SIGTERM, _on_term)
+
+    emitter.emit("warming", phase="import")
+    from cli.stats_handler import StatsCallbackHandler
+    from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+    cfg = build_engine_config(run_config)
+    cfg["max_debate_rounds"] = run_config.get("max_debate_rounds", cfg.get("max_debate_rounds", 1))
+    cfg["max_risk_discuss_rounds"] = run_config.get(
+        "max_risk_discuss_rounds", cfg.get("max_risk_discuss_rounds", 1)
+    )
+
+    emitter.emit("warming", phase="graph_build")
+    stats_handler = StatsCallbackHandler()
+    graph = TradingAgentsGraph(
+        selected_analysts=analysts, debug=False, config=cfg, callbacks=[stats_handler]
+    )
+
+    emitter.emit(
+        "started",
+        ticker=ticker,
+        asset_type=asset_type,
+        trade_date=str(trade_date),
+        analysts=analysts,
+        profile_name=profile_name,
+        max_debate_rounds=cfg["max_debate_rounds"],
+        max_risk_discuss_rounds=cfg["max_risk_discuss_rounds"],
+        benchmark=graph._resolve_benchmark(ticker),
+    )
+
+    start = time.time()
+    final_state: dict = {}
+    try:
+        for snapshot in graph.stream_run(ticker, trade_date, asset_type=asset_type):
+            final_state = snapshot
+            for event in differ.process(snapshot):
+                emitter.emit_event(event)
+            _emit_stats(emitter, stats_handler, start)
+    except SystemExit:
+        return 143
+    except Exception as exc:  # noqa: BLE001 - surface any engine failure to the UI
+        traceback.print_exc()  # -> stderr (fd 1 is reserved for the protocol)
+        emitter.emit("error", scope="fatal", message=str(exc))
+        return 1
+
+    rating = ""
+    with contextlib.suppress(Exception):
+        rating = graph.process_signal(final_state.get("final_trade_decision", ""))
+    _emit_stats(emitter, stats_handler, start)
+    emitter.emit("done", rating=rating, run_dir=cfg.get("results_dir", ""))
+    return 0
+
+
+def resolve_command(args: Any, emitter: Emitter) -> int:
+    """Realize pending outcomes (realized return + alpha + reflection) without a
+    full paid re-analysis, via the engine's public resolve methods."""
+    run_config = load_run_config(args.config) if args.config else {}
+    from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+    cfg = build_engine_config(run_config) if run_config else None
+    graph = TradingAgentsGraph(config=cfg) if cfg else TradingAgentsGraph()
+    try:
+        if args.ticker and not args.all:
+            graph.resolve_pending_entries(args.ticker)
+            resolved = [args.ticker]
+        else:
+            resolved = graph.resolve_all_pending()
+    except Exception as exc:  # noqa: BLE001
+        traceback.print_exc()
+        emitter.emit("error", scope="fatal", message=str(exc))
+        return 1
+    emitter.emit("resolved", tickers=resolved)
+    return 0

--- a/desk_server/__init__.py
+++ b/desk_server/__init__.py
@@ -1,0 +1,7 @@
+"""FastAPI server that runs inside the TradingDesk backend Docker container.
+
+Wraps the TradingAgents engine and streams a run's events to the macOS app over
+Server-Sent Events. The event objects are exactly the ones produced by
+``desk_adapter.diff.SnapshotDiffer`` (the NDJSON payloads), now delivered as SSE
+``data:`` frames — so the engine-side derivation logic is shared, not duplicated.
+"""

--- a/desk_server/__main__.py
+++ b/desk_server/__main__.py
@@ -1,0 +1,29 @@
+"""Container entry point: ``desk-server`` (runs uvicorn).
+
+Host/port/data-dir come from env so the compose service and the macOS app can
+configure them. Binds 0.0.0.0 inside the container; the published port is mapped
+to 127.0.0.1 on the host so it is never exposed off-box.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def main() -> int:
+    # Prepare engine env (no dotenv; redirect data dirs) before anything imports
+    # tradingagents transitively via the app module.
+    from desk_adapter.env import prepare_environment
+
+    prepare_environment(os.environ.get("DESK_BASE_DIR"))
+
+    import uvicorn
+
+    host = os.environ.get("DESK_SERVER_HOST", "127.0.0.1")
+    port = int(os.environ.get("DESK_SERVER_PORT", "8765"))
+    uvicorn.run("desk_server.app:app", host=host, port=port, log_level="info")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desk_server/app.py
+++ b/desk_server/app.py
@@ -1,0 +1,365 @@
+"""FastAPI application exposing the engine to the macOS app over localhost.
+
+Endpoints:
+  GET  /health                 liveness + schema version (used by the Docker healthcheck and the app)
+  GET  /capabilities           provider/model/vendor surface (Settings UI source of truth)
+  GET  /journal[?ticker]       decisions journal parsed from the engine memory log
+  GET  /reports[?ticker[&date]] list saved run documents, or return one full document
+  GET  /search?q=              live ticker/company search (Yahoo Finance public search)
+  GET  /prices?ticker=&days=   recent daily closes for the watchlist sparklines
+  GET  /openrouter/models      live OpenRouter model catalog (Settings dropdown)
+  POST /test                   model availability check (build client + ping)
+  POST /test_fred              FRED API key connectivity check
+  POST /runs                   start a run; body = resolved run-config JSON; -> {run_id}
+  GET  /runs/{id}/events       SSE stream of the run's events (supports Last-Event-ID resume)
+  POST /runs/{id}/cancel       request cancellation (checked between graph nodes)
+  GET  /runs/{id}/state        terminal status snapshot
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from desk_adapter.protocol import SCHEMA_VERSION
+from desk_server.events import sse_format
+from desk_server.runner import RunHandle, run_blocking
+
+app = FastAPI(title="TradingDesk engine", version="0.0.1")
+
+_runs: dict[str, RunHandle] = {}
+
+# Runs execute on a dedicated single-worker pool, NOT the event loop's default
+# executor. This (a) serializes runs so two concurrent runs never race on the
+# shared ``os.environ`` provider keys, and (b) keeps multi-minute runs off the
+# default pool that the short /search, /prices, /test endpoints use via
+# ``asyncio.to_thread`` — so the UI stays responsive while a run is in flight.
+# (A queued run sits at "warming" until the active one finishes.) /test never
+# touches this process's env at all — its probe runs in a subprocess with the
+# candidate keys in the child env only (see test_model) — so the run worker is
+# the sole writer of os.environ and no cross-thread env race exists.
+_RUN_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="desk-run")
+
+# Evict a finished run from ``_runs`` this long after it completes, so an SSE
+# client still has time to drain the tail but the per-run buffer (full report
+# markdown + tool output) doesn't accumulate for the container's lifetime.
+_RUN_RETENTION_S = 600
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok", "schema_version": SCHEMA_VERSION, "runs": len(_runs)}
+
+
+@app.get("/capabilities")
+async def capabilities() -> JSONResponse:
+    # Imported lazily so /health stays cheap and import errors surface per-call.
+    from desk_adapter.introspect import build_capabilities
+
+    return JSONResponse(build_capabilities())
+
+
+@app.get("/journal")
+async def journal(ticker: str | None = None) -> dict:
+    """The decisions journal: parsed entries from the engine's memory log.
+
+    Each entry has date, ticker, rating, pending, raw, alpha, holding, decision,
+    reflection. Pending entries (raw/alpha None) resolve on a later same-ticker
+    run. Powers the app's Ticker Desk journal and watchlist.
+    """
+    from tradingagents.agents.utils.memory import TradingMemoryLog
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    entries = TradingMemoryLog(DEFAULT_CONFIG).load_entries()
+    if ticker:
+        entries = [e for e in entries if str(e.get("ticker", "")).upper() == ticker.upper()]
+    entries.sort(key=lambda e: e.get("date", ""), reverse=True)
+    return {"entries": entries}
+
+
+@app.get("/reports")
+async def reports(ticker: str | None = None, date: str | None = None) -> dict:
+    """Saved run documents (the per-run full_states_log JSON).
+
+    With ``ticker`` + ``date``: returns that run's full document (7 report
+    sections + bull/bear and 3-way risk transcripts + final decision). With only
+    ``ticker`` (or nothing): lists available runs as {ticker, date, rating}.
+    """
+    import json as _json
+    import re as _re
+    from pathlib import Path
+
+    from tradingagents.agents.utils.rating import parse_rating
+    from tradingagents.dataflows.utils import safe_ticker_component
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    results_dir = Path(DEFAULT_CONFIG["results_dir"])
+
+    if ticker and date:
+        # ``date`` is interpolated into a filename: accept only the date shape
+        # runs can produce, so path metacharacters ("../", "/") can't traverse
+        # out of results_dir. Month/day are 1-2 digits because the CLI's
+        # strptime("%Y-%m-%d") accepts unpadded dates and writes them into the
+        # filename. (``ticker`` is validated by safe_ticker_component, which
+        # raises on any path-unsafe value.)
+        if not _re.fullmatch(r"[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}", date):
+            raise HTTPException(status_code=400, detail="invalid date")
+        path = results_dir / safe_ticker_component(ticker) / "TradingAgentsStrategy_logs" / f"full_states_log_{date}.json"
+        if not path.exists():
+            raise HTTPException(status_code=404, detail="report not found")
+        return _json.loads(path.read_text(encoding="utf-8"))
+
+    out = []
+    for path in results_dir.glob("*/TradingAgentsStrategy_logs/full_states_log_*.json"):
+        folder = path.parent.parent.name
+        if ticker and folder.upper() != safe_ticker_component(ticker).upper():
+            continue
+        run_date = path.stem.replace("full_states_log_", "")
+        rating = ""
+        with contextlib.suppress(Exception):
+            rating = parse_rating(_json.loads(path.read_text(encoding="utf-8")).get("final_trade_decision", ""))
+        out.append({"ticker": folder, "date": run_date, "rating": rating})
+    out.sort(key=lambda r: r["date"], reverse=True)
+    return {"reports": out}
+
+
+@app.get("/search")
+async def search(q: str = "") -> dict:
+    """Live ticker/company search via Yahoo Finance's public search endpoint.
+
+    Powers the app's top-bar command search: real symbols + company names, so
+    the user can find and add any listed instrument (no key needed). Returns
+    ``{results: [{symbol, name, exchange, type}]}`` ordered by Yahoo relevance.
+    """
+    import json as _json
+    import urllib.parse
+    import urllib.request
+
+    query = (q or "").strip()
+    if not query:
+        return {"results": []}
+
+    def _fetch():
+        params = urllib.parse.urlencode({"q": query, "quotesCount": 10, "newsCount": 0})
+        url = f"https://query2.finance.yahoo.com/v1/finance/search?{params}"
+        # Yahoo rejects the default urllib UA; present a browser-like one.
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (Macintosh) TradingDesk"})
+        with urllib.request.urlopen(req, timeout=8) as resp:
+            payload = _json.load(resp)
+        out = []
+        for quote in payload.get("quotes", []):
+            symbol = quote.get("symbol")
+            if not symbol:
+                continue
+            out.append(
+                {
+                    "symbol": symbol,
+                    "name": quote.get("shortname") or quote.get("longname") or quote.get("name") or "",
+                    "exchange": quote.get("exchDisp") or quote.get("exchange") or "",
+                    "type": quote.get("typeDisp") or quote.get("quoteType") or "",
+                }
+            )
+        return out
+
+    try:
+        return {"results": await asyncio.to_thread(_fetch)}
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"search failed: {exc}") from exc
+
+
+@app.get("/prices")
+async def prices(ticker: str = "", days: int = 30) -> dict:
+    """Recent daily closing prices for a symbol (watchlist sparklines).
+
+    Uses yfinance (already a dependency); returns ``{points: [close, ...]}``
+    oldest→newest. Best-effort: an unknown/illiquid symbol just yields an empty
+    list (200), so the row simply shows no sparkline. No key needed.
+    """
+    symbol = (ticker or "").strip()
+    if not symbol:
+        return {"points": []}
+
+    def _fetch():
+        import yfinance as yf
+
+        hist = yf.Ticker(symbol).history(period=f"{max(days, 5)}d")
+        return [float(c) for c in hist["Close"].dropna().tolist()]
+
+    try:
+        return {"points": await asyncio.to_thread(_fetch)}
+    except Exception:  # noqa: BLE001
+        return {"points": []}
+
+
+@app.get("/openrouter/models")
+async def openrouter_models() -> dict:
+    """Live OpenRouter model catalog (public endpoint, no key needed)."""
+    import json as _json
+    import urllib.request
+
+    def _fetch():
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/models", headers={"User-Agent": "TradingDesk"}
+        )
+        with urllib.request.urlopen(req, timeout=12) as resp:
+            payload = _json.load(resp)
+        out = []
+        for m in payload.get("data", []):
+            mid = m.get("id")
+            if mid:
+                out.append({"label": m.get("name") or mid, "model_id": mid})
+        out.sort(key=lambda x: x["model_id"])
+        return out
+
+    try:
+        return {"models": await asyncio.to_thread(_fetch)}
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=502, detail=f"could not fetch OpenRouter models: {exc}") from exc
+
+
+@app.post("/test")
+async def test_model(request: Request) -> dict:
+    """Quick availability check: build the LLM client and make a tiny call.
+
+    Body: {llm_provider, model, backend_url?, keys?}. Returns {ok} or {ok:false, error}.
+    """
+    body = await request.json()
+    provider = body.get("llm_provider", "")
+    model = body.get("model", "")
+    base_url = body.get("backend_url")
+    keys = {k: v for k, v in (body.get("keys") or {}).items() if v}
+
+    def _ping():
+        import subprocess
+        import sys
+
+        # Probe in a short-lived subprocess with the candidate keys in the CHILD
+        # env only. This process's os.environ is never touched, so a /test can
+        # never race an active run's provider keys (runs are serialized on
+        # _RUN_EXECUTOR, making the run worker the sole env writer) and a
+        # half-typed key from the Settings field can never bleed into a run
+        # mid-flight. A lock would instead block /test for the whole multi-minute
+        # run — this stays correct AND non-blocking.
+        script = (
+            "import sys\n"
+            "from tradingagents.llm_clients import create_llm_client\n"
+            "client = create_llm_client(provider=sys.argv[1], model=sys.argv[2],"
+            " base_url=sys.argv[3] or None)\n"
+            "client.get_llm().invoke('Reply with: OK')\n"
+        )
+        try:
+            # 50s: under the app's 60s request timeout, so a hung provider
+            # surfaces as this structured error, not a client-side cutoff.
+            proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                [sys.executable, "-c", script, provider, model, base_url or ""],
+                env={**os.environ, **keys},
+                capture_output=True,
+                text=True,
+                timeout=50,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # str(TimeoutExpired) leads with the argv repr; raise a readable one.
+            raise RuntimeError("model probe timed out after 50s") from exc
+        if proc.returncode != 0:
+            tail = (proc.stderr or proc.stdout or "").strip().splitlines()
+            raise RuntimeError(tail[-1] if tail else f"probe exited {proc.returncode}")
+        return True
+
+    try:
+        await asyncio.to_thread(_ping)
+        return {"ok": True}
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)[:300]}
+
+
+@app.post("/test_fred")
+async def test_fred(request: Request) -> dict:
+    """Validate a FRED API key by making one minimal FRED API call."""
+    body = await request.json()
+    key = body.get("key", "")
+
+    def _ping():
+        import json as _json
+        import urllib.parse
+        import urllib.request
+
+        query = urllib.parse.urlencode({"series_id": "GDP", "api_key": key, "file_type": "json"})
+        url = f"https://api.stlouisfed.org/fred/series?{query}"
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            _json.load(resp)
+        return True
+
+    if not key:
+        return {"ok": False, "error": "no key"}
+    try:
+        await asyncio.to_thread(_ping)
+        return {"ok": True}
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": str(exc)[:200]}
+
+
+@app.post("/runs")
+async def create_run(request: Request) -> dict:
+    cfg = await request.json()
+    if not cfg.get("ticker") or not cfg.get("trade_date"):
+        raise HTTPException(status_code=400, detail="ticker and trade_date are required")
+    run_id = uuid.uuid4().hex
+    loop = asyncio.get_running_loop()
+    handle = RunHandle(run_id, loop)
+    _runs[run_id] = handle
+    task = loop.run_in_executor(_RUN_EXECUTOR, run_blocking, handle, cfg)
+    # Drop the run from _runs a while after it finishes. The done-callback runs
+    # on the loop thread, so scheduling call_later from it is thread-safe.
+    task.add_done_callback(lambda _t: loop.call_later(_RUN_RETENTION_S, _runs.pop, run_id, None))
+    return {"run_id": run_id, "schema_version": SCHEMA_VERSION}
+
+
+@app.post("/runs/{run_id}/cancel")
+async def cancel_run(run_id: str) -> dict:
+    handle = _runs.get(run_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="unknown run")
+    handle.cancelled = True
+    return {"cancelled": True}
+
+
+@app.get("/runs/{run_id}/state")
+async def run_state(run_id: str) -> dict:
+    handle = _runs.get(run_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="unknown run")
+    return {"run_id": run_id, "status": handle.status, "done": handle.done, "events": handle.seq}
+
+
+@app.get("/runs/{run_id}/events")
+async def run_events(run_id: str, request: Request) -> StreamingResponse:
+    handle = _runs.get(run_id)
+    if handle is None:
+        raise HTTPException(status_code=404, detail="unknown run")
+
+    last = request.headers.get("Last-Event-ID")
+    start_idx = int(last) if last and last.isdigit() else 0
+
+    async def gen():
+        idx = start_idx
+        while True:
+            handle.updated.clear()
+            while idx < len(handle.events):
+                yield sse_format(handle.events[idx])
+                idx += 1
+            if handle.done and idx >= len(handle.events):
+                break
+            if await request.is_disconnected():
+                break
+            try:
+                await asyncio.wait_for(handle.updated.wait(), timeout=15)
+            except asyncio.TimeoutError:
+                yield ": keepalive\n\n"
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/desk_server/events.py
+++ b/desk_server/events.py
@@ -1,0 +1,33 @@
+"""Event envelope + SSE framing. Dependency-free (no FastAPI / tradingagents),
+so it is unit-testable on any interpreter and shares the schema version with
+``desk_adapter.protocol``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from desk_adapter.protocol import SCHEMA_VERSION
+
+
+def build_event(run_id: str, seq: int, event_type: str, fields: dict[str, Any],
+                clock=time.time) -> dict:
+    """Wrap an event in the shared envelope (mirrors desk_adapter.protocol.Emitter)."""
+    obj = {
+        "v": SCHEMA_VERSION,
+        "run_id": run_id,
+        "seq": seq,
+        "ts": round(clock(), 3),
+        "type": event_type,
+    }
+    obj.update(fields)
+    return obj
+
+
+def sse_format(event: dict) -> str:
+    """Render one event as an SSE frame. ``id:`` carries ``seq`` so a reconnecting
+    client can resume via the ``Last-Event-ID`` header."""
+    payload = json.dumps(event, separators=(",", ":"), ensure_ascii=False, default=str)
+    return f"id: {event['seq']}\ndata: {payload}\n\n"

--- a/desk_server/runner.py
+++ b/desk_server/runner.py
@@ -1,0 +1,177 @@
+"""Per-run execution: drive the engine on a worker thread and push events onto
+the asyncio loop for the SSE endpoint to drain.
+
+``graph.stream_run`` is synchronous and blocking, so it runs in the loop's
+executor; every event is handed back to the loop with ``call_soon_threadsafe``
+so all mutation of the run's buffer happens on the loop thread (no locks needed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import time
+import traceback
+from typing import Any
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+from desk_adapter.diff import SnapshotDiffer
+from desk_adapter.env import build_engine_config
+from desk_server.events import build_event
+
+
+class RunCancelled(Exception):
+    """Raised (via a callback) to interrupt the engine promptly on cancel."""
+
+
+class CancelCallbackHandler(BaseCallbackHandler):
+    """Raises ``RunCancelled`` at the next LLM / tool / chain boundary once the
+    run is cancelled, so a Stop interrupts within one call instead of waiting for
+    the whole in-flight node (which can be minutes of LLM + tool calls) to finish.
+
+    ``raise_error`` makes LangChain propagate the exception instead of swallowing
+    it, which aborts the graph; the call already in flight finishes, but no new
+    LLM/tool call starts.
+    """
+
+    raise_error = True
+
+    def __init__(self, handle: RunHandle) -> None:
+        super().__init__()
+        self._handle = handle
+
+    def _check(self) -> None:
+        if self._handle.cancelled:
+            raise RunCancelled
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        self._check()
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+        self._check()
+
+    def on_tool_start(self, *args: Any, **kwargs: Any) -> None:
+        self._check()
+
+    def on_chain_start(self, *args: Any, **kwargs: Any) -> None:
+        self._check()
+
+
+class RunHandle:
+    """Buffers a run's events and signals the SSE generator when new ones land."""
+
+    def __init__(self, run_id: str, loop: asyncio.AbstractEventLoop):
+        self.run_id = run_id
+        self.loop = loop
+        self.events: list[dict] = []
+        self.seq = 0
+        self.done = False
+        self.cancelled = False
+        self.status = "warming"
+        self.updated = asyncio.Event()
+
+    # -- loop-thread only --
+    def _append(self, event_type: str, fields: dict[str, Any]) -> None:
+        self.seq += 1
+        self.events.append(build_event(self.run_id, self.seq, event_type, fields))
+        if event_type in ("started", "done", "error", "cancelled"):
+            self.status = event_type
+        self.updated.set()
+
+    def _finish(self) -> None:
+        self.done = True
+        self.updated.set()
+
+    # -- worker-thread safe --
+    def emit(self, event_type: str, **fields: Any) -> None:
+        self.loop.call_soon_threadsafe(self._append, event_type, fields)
+
+    def emit_event(self, event: dict) -> None:
+        fields = {k: v for k, v in event.items() if k != "type"}
+        self.emit(event["type"], **fields)
+
+    def finish(self) -> None:
+        self.loop.call_soon_threadsafe(self._finish)
+
+
+def run_blocking(handle: RunHandle, run_config: dict) -> None:
+    """Executed in a worker thread. Streams the engine and emits events."""
+    saved_env: dict[str, str | None] = {}
+    try:
+        from cli.stats_handler import StatsCallbackHandler
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        # Inject the provider/data keys the app supplied (from Keychain) into the
+        # process env so the engine's clients (which read os.getenv) pick them up.
+        # Loopback-only; never written to disk. The prior values are restored in
+        # ``finally`` so a run's keys never leak into a run that omits them.
+        # Thread-safety: runs are serialized on a single-worker executor and
+        # /test probes run in a subprocess with their own env copy (see
+        # desk_server/app.py), so this worker thread is the ONLY writer of
+        # os.environ — no lock is needed.
+        for env_name, value in (run_config.get("keys") or {}).items():
+            if value:
+                saved_env[env_name] = os.environ.get(env_name)
+                os.environ[env_name] = value
+
+        analysts = run_config.get("analysts") or ["market", "social", "news", "fundamentals"]
+        cfg = build_engine_config(run_config)
+        differ = SnapshotDiffer(analysts)
+        stats = StatsCallbackHandler()
+        cancel_cb = CancelCallbackHandler(handle)
+
+        handle.emit("warming", phase="graph_build")
+        graph = TradingAgentsGraph(
+            selected_analysts=analysts, debug=False, config=cfg, callbacks=[stats, cancel_cb]
+        )
+
+        ticker = run_config["ticker"]
+        trade_date = run_config["trade_date"]
+        asset_type = run_config.get("asset_type", "stock")
+        handle.emit(
+            "started",
+            ticker=ticker,
+            asset_type=asset_type,
+            trade_date=str(trade_date),
+            analysts=analysts,
+            profile_name=run_config.get("profile_name", ""),
+            max_debate_rounds=cfg.get("max_debate_rounds", 1),
+            max_risk_discuss_rounds=cfg.get("max_risk_discuss_rounds", 1),
+            benchmark=graph._resolve_benchmark(ticker),
+        )
+
+        start = time.time()
+        final: dict = {}
+        completed = True
+        try:
+            for snapshot in graph.stream_run(ticker, trade_date, asset_type=asset_type):
+                if handle.cancelled:  # belt-and-braces; the callback usually fires first
+                    completed = False
+                    break
+                final = snapshot
+                for event in differ.process(snapshot):
+                    handle.emit_event(event)
+                handle.emit("stats", elapsed_s=round(time.time() - start, 2), **stats.get_stats())
+        except RunCancelled:
+            # The cancel callback aborted an in-flight node mid-stream.
+            completed = False
+
+        if completed:
+            rating = ""
+            with contextlib.suppress(Exception):
+                rating = graph.process_signal(final.get("final_trade_decision", ""))
+            handle.emit("done", rating=rating, run_dir=cfg.get("results_dir", ""))
+        else:
+            handle.emit("cancelled", at_node=getattr(differ, "active", None))
+    except Exception as exc:  # noqa: BLE001 - surface any engine failure to the client
+        traceback.print_exc()
+        handle.emit("error", scope="fatal", message=str(exc))
+    finally:
+        for env_name, prior in saved_env.items():
+            if prior is None:
+                os.environ.pop(env_name, None)
+            else:
+                os.environ[env_name] = prior
+        handle.finish()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,53 @@ services:
   tradingagents:
     build: .
     env_file:
-      - .env
+      # Optional so a fresh clone (no .env) can still load the compose file —
+      # e.g. `docker compose build/up desk-server`, which the macOS app runs on
+      # launch. Without `required: false`, Compose validates every service's
+      # env_file at load time and aborts when .env is absent.
+      - path: .env
+        required: false
     volumes:
       - tradingagents_data:/home/appuser/.tradingagents
     tty: true
     stdin_open: true
+
+  # Backend for the TradingDesk macOS app. The app starts this on launch and
+  # talks to it at http://127.0.0.1:8765 over SSE. Built locally for dev; for
+  # release the image is shipped inside the .app and docker-loaded on first run.
+  # API keys are injected at runtime by the app (not via env_file), so no key
+  # configuration is needed here.
+  desk-server:
+    build: .
+    image: tradingdesk-engine:dev
+    entrypoint: ["desk-server"]
+    environment:
+      DESK_SERVER_HOST: 0.0.0.0
+      DESK_SERVER_PORT: "8765"
+      DESK_BASE_DIR: /home/appuser/.tradingagents
+      TRADINGAGENTS_NO_DOTENV: "1"
+      # Provider/data keys are injected by the host (the macOS app sets these
+      # from the Keychain before `compose up`; in dev they come from the shell
+      # or a sourced .env). Unset keys interpolate to empty and are ignored.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+      FRED_API_KEY: ${FRED_API_KEY:-}
+      ALPHA_VANTAGE_API_KEY: ${ALPHA_VANTAGE_API_KEY:-}
+    ports:
+      - "127.0.0.1:8765:8765"
+    volumes:
+      - tradingagents_data:/home/appuser/.tradingagents
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+    restart: unless-stopped
 
   ollama:
     image: ollama/ollama:latest
@@ -18,7 +60,12 @@ services:
   tradingagents-ollama:
     build: .
     env_file:
-      - .env
+      # Optional so a fresh clone (no .env) can still load the compose file —
+      # e.g. `docker compose build/up desk-server`, which the macOS app runs on
+      # launch. Without `required: false`, Compose validates every service's
+      # env_file at load time and aborts when .env is absent.
+      - path: .env
+        required: false
     environment:
       - TRADINGAGENTS_LLM_PROVIDER=ollama
       - OLLAMA_BASE_URL=http://ollama:11434/v1

--- a/packaging/build-and-save-image.sh
+++ b/packaging/build-and-save-image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build the engine backend image and save it as a tarball that ships INSIDE the
+# macOS app. On first launch the app `docker load`s it — so the user pulls
+# nothing and configures nothing (Docker Desktop is the only prerequisite).
+#
+# Dev: the tar lands in macos/TradingDesk/.build (gitignored). The Xcode app
+# target's build phase copies it into TradingDesk.app/Contents/Resources, where
+# DockerBackendController.bundledImageTar() finds it. To test the load path in
+# dev without an Xcode bundle, point the app at the tar:
+#   DESK_IMAGE_TAR=<abs path to engine-image.tar.gz> open .build/TradingDesk.app
+set -euo pipefail
+
+cd "$(dirname "$0")/.."          # repo root
+TAG="${1:-tradingdesk-engine:dev}"
+OUT="${2:-macos/TradingDesk/.build/engine-image.tar.gz}"
+
+echo "Building $TAG …"
+docker compose build desk-server
+
+mkdir -p "$(dirname "$OUT")"
+echo "Saving $TAG -> $OUT …"
+docker save "$TAG" | gzip > "$OUT"
+echo "Done: $OUT ($(du -h "$OUT" | cut -f1))"

--- a/packaging/requirements-bundle.txt
+++ b/packaging/requirements-bundle.txt
@@ -1,0 +1,38 @@
+# Pruned dependency set for the bundled macOS app interpreter (TradingDesk).
+#
+# This is the runtime tree shipped inside <App>.app/Contents/Resources/python.
+# It deliberately OMITS dependencies that the analysis run path never imports,
+# to keep the signed/notarized bundle smaller:
+#   - backtrader  (declared in pyproject for the standalone backtesting CLI;
+#                  grep-verified: not imported anywhere under tradingagents/ or
+#                  cli/ on the run path)
+#   - redis       (declared but unused on the run path)
+#
+# Pinning is delegated to uv against uv.lock at bundle-build time; the M0
+# packaging job runs `uv pip install` with these names so the resolver brings
+# the exact locked versions. langchain-aws is added only for a Bedrock build.
+#
+# Verify after populating site-packages:
+#   grep -rl "import backtrader\|import redis" <site-packages>   # -> empty
+#   python -m desk_adapter capabilities                          # -> valid JSON
+
+langchain-core>=0.3.81
+langchain-anthropic>=0.3.15
+langchain-experimental>=0.3.4
+langchain-google-genai>=4.0.0
+langchain-openai>=0.3.23
+langgraph>=0.4.8
+langgraph-checkpoint-sqlite>=2.0.0
+pandas>=2.3.0
+parsel>=1.10.0
+python-dotenv>=1.0.0
+pytz>=2025.2
+questionary>=2.1.0
+requests>=2.32.4
+rich>=14.0.0
+typer>=0.21.0
+setuptools>=80.9.0
+stockstats>=0.6.5
+tqdm>=4.67.1
+typing-extensions>=4.14.0
+yfinance>=1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,23 @@ dev = [
 bedrock = [
     "langchain-aws>=1.5.0",
 ]
+# HTTP/SSE server for the TradingDesk macOS app's Docker backend. Installed in
+# the backend image (pip install ".[server]"); not needed for the CLI/library.
+server = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+]
 
 [project.scripts]
 tradingagents = "cli.main:app"
+# Host glue for the native macOS app (TradingDesk): NDJSON run streaming,
+# capabilities introspection, and the resolve-only pass. See desk_adapter/.
+desk-adapter = "desk_adapter.__main__:main"
+# Backend HTTP/SSE server run inside the TradingDesk Docker container.
+desk-server = "desk_server.__main__:main"
 
 [tool.setuptools.packages.find]
-include = ["tradingagents*", "cli*"]
+include = ["tradingagents*", "cli*", "desk_adapter*", "desk_server*"]
 
 [tool.setuptools.package-data]
 cli = ["static/*"]

--- a/tests/test_desk_adapter_diff.py
+++ b/tests/test_desk_adapter_diff.py
@@ -1,0 +1,178 @@
+"""Unit tests for the dependency-free snapshot->events diff (desk_adapter.diff).
+
+These import only ``desk_adapter.diff`` (no ``tradingagents``), so they run on
+any interpreter. Under CI they run via pytest; locally they can also be run
+directly: ``PYTHONPATH=. python3 tests/test_desk_adapter_diff.py``.
+"""
+
+from __future__ import annotations
+
+from desk_adapter.diff import (
+    SnapshotDiffer,
+    extract_content_string,
+    extract_sentiment_score,
+)
+
+
+class _Msg:
+    """Minimal duck-typed stand-in for a LangChain message."""
+
+    def __init__(self, type, content="", id=None, tool_calls=None, tool_call_id=None, name=None):
+        self.type = type
+        self.content = content
+        self.id = id
+        if tool_calls is not None:
+            self.tool_calls = tool_calls
+        if tool_call_id is not None:
+            self.tool_call_id = tool_call_id
+        if name is not None:
+            self.name = name
+
+
+def _types(events):
+    return [e["type"] for e in events]
+
+
+def _of(events, type_):
+    return [e for e in events if e["type"] == type_]
+
+
+def test_extract_content_string_variants():
+    assert extract_content_string("  hi  ") == "hi"
+    assert extract_content_string("") is None
+    assert extract_content_string("   ") is None
+    assert extract_content_string([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a b"
+    assert extract_content_string({"text": "x"}) == "x"
+    # A bare "[]" is empty per literal_eval; real prose is kept.
+    assert extract_content_string("[]") is None
+
+
+def test_debate_quoted_opponent_does_not_create_phantom_turn():
+    # A bear turn that quotes the bull by name at line start must NOT be split into
+    # a phantom Bull turn or shift the round numbering (the previous combined-history
+    # parser did exactly that).
+    d = SnapshotDiffer(["market"])
+    s = {"messages": [], "investment_debate_state": {
+        "bull_history": "\nBull Analyst: growth is strong",
+        "bear_history": "\nBear Analyst: rebuttal\nBull Analyst: claimed growth is strong but margins are thin",
+        "count": 2,
+    }}
+    turns = _of(d.process(s), "debate_turn")
+    assert [t["speaker"] for t in turns] == ["Bull Analyst", "Bear Analyst"]
+    assert turns[1]["text"].startswith("rebuttal")
+    assert "claimed growth is strong" in turns[1]["text"]  # quote stays inside the bear's turn
+    assert turns[0]["round"] == 1 and turns[1]["round"] == 1
+
+
+def test_sentiment_score_extraction():
+    assert extract_sentiment_score("**Overall Sentiment: Bullish (Score: 7.5/10)**") == 7.5
+    assert extract_sentiment_score("no score here") is None
+
+
+def test_report_section_emitted_once_and_marks_finalized():
+    d = SnapshotDiffer(["market"])
+    ev1 = d.process({"messages": [], "market_report": "MKT"})
+    rs = _of(ev1, "report_section")
+    assert len(rs) == 1
+    assert rs[0]["section"] == "market_report"
+    assert rs[0]["finalized"] is True  # only analyst selected -> Market Analyst completed
+    # Same content again -> no duplicate report_section.
+    ev2 = d.process({"messages": [], "market_report": "MKT"})
+    assert _of(ev2, "report_section") == []
+
+
+def test_node_status_transitions_across_analysts():
+    d = SnapshotDiffer(["market", "news"])
+    # First snapshot: market becomes in_progress (news stays pending).
+    ev1 = d.process({"messages": []})
+    market = [e for e in _of(ev1, "node_status") if e["node"] == "Market Analyst"]
+    assert market and market[0]["state"] == "in_progress"
+    assert market[0]["group"] == "analyst"
+    # Market report arrives -> market completed, news in_progress.
+    ev2 = d.process({"messages": [], "market_report": "done"})
+    states = {e["node"]: e["state"] for e in _of(ev2, "node_status")}
+    assert states.get("Market Analyst") == "completed"
+    assert states.get("News Analyst") == "in_progress"
+
+
+def test_tool_call_result_join_and_no_data_flag():
+    d = SnapshotDiffer(["news"])
+    ai = _Msg("ai", content="checking news", id="a1", tool_calls=[{"name": "get_news", "args": {"q": "AAPL"}, "id": "c1"}])
+    tool_ok = _Msg("tool", content="headline A\nheadline B", id="t1", tool_call_id="c1")
+    events = d.process({"messages": [ai, tool_ok]})
+    calls = _of(events, "tool_call")
+    results = _of(events, "tool_result")
+    assert calls[0]["name"] == "get_news" and calls[0]["args"] == {"q": "AAPL"}
+    assert results[0]["name"] == "get_news"  # joined via tool_call_id
+    assert results[0]["data_status"] == "ok" and results[0]["ok"] is True
+    # agent_step carries the reasoning text attributed to the active node.
+    steps = _of(events, "agent_step")
+    assert steps and steps[0]["text"] == "checking news"
+
+    # NO_DATA sentinel flips the flag.
+    ai2 = _Msg("ai", id="a2", tool_calls=[{"name": "get_news", "args": {}, "id": "c2"}])
+    tool_nd = _Msg("tool", content="NO_DATA_AVAILABLE: reddit down", id="t2", tool_call_id="c2")
+    ev2 = d.process({"messages": [ai2, tool_nd]})
+    r2 = _of(ev2, "tool_result")[0]
+    assert r2["data_status"] == "no_data" and r2["ok"] is False
+
+
+def test_message_dedup_by_id():
+    d = SnapshotDiffer(["market"])
+    ai = _Msg("ai", content="hello", id="dup1")
+    first = d.process({"messages": [ai]})
+    second = d.process({"messages": [ai]})  # same id in a later snapshot
+    assert len(_of(first, "agent_step")) == 1
+    assert _of(second, "agent_step") == []
+
+
+def test_investment_debate_turns_then_judge():
+    d = SnapshotDiffer(["market"])
+    s1 = {"messages": [], "investment_debate_state": {
+        "bull_history": "\nBull Analyst: up", "bear_history": "\nBear Analyst: down", "count": 2}}
+    turns = _of(d.process(s1), "debate_turn")
+    assert [t["speaker"] for t in turns] == ["Bull Analyst", "Bear Analyst"]
+    assert turns[0]["round"] == 1 and turns[1]["round"] == 1
+    assert all(t["debate"] == "investment" for t in turns)
+    # A new bull turn appended -> only the new one is emitted (round 2).
+    s2 = {"messages": [], "investment_debate_state": {
+        "bull_history": "\nBull Analyst: up\nBull Analyst: still up", "bear_history": "\nBear Analyst: down", "count": 3}}
+    new = _of(d.process(s2), "debate_turn")
+    assert len(new) == 1 and new[0]["index"] == 3 and new[0]["round"] == 2
+    # Judge decision emits one is_judge turn from the Research Manager.
+    s3 = {"messages": [], "investment_debate_state": {
+        "bull_history": s2["investment_debate_state"]["bull_history"],
+        "bear_history": "\nBear Analyst: down", "judge_decision": "BUY", "count": 3}}
+    judge = _of(d.process(s3), "debate_turn")
+    assert len(judge) == 1 and judge[0]["is_judge"] is True and judge[0]["speaker"] == "Research Manager"
+
+
+def test_risk_debate_three_way_rounds():
+    d = SnapshotDiffer(["market"])
+    s = {"messages": [], "risk_debate_state": {
+        "aggressive_history": "\nAggressive Analyst: a",
+        "conservative_history": "\nConservative Analyst: c",
+        "neutral_history": "\nNeutral Analyst: n",
+        "latest_speaker": "Neutral", "count": 3}}
+    turns = _of(d.process(s), "debate_turn")
+    assert [t["speaker"] for t in turns] == ["Aggressive Analyst", "Conservative Analyst", "Neutral Analyst"]
+    assert all(t["round"] == 1 for t in turns)  # 3 speakers per round
+    assert all(t["debate"] == "risk" for t in turns)
+
+
+if __name__ == "__main__":
+    import sys
+    import traceback
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/tests/test_desk_adapter_protocol.py
+++ b/tests/test_desk_adapter_protocol.py
@@ -1,0 +1,76 @@
+"""Unit tests for the NDJSON emitter (desk_adapter.protocol).
+
+Dependency-free; runnable directly: ``PYTHONPATH=. python3 tests/test_desk_adapter_protocol.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from desk_adapter.protocol import SCHEMA_VERSION, Emitter
+
+
+def _lines(buf):
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_emit_envelope_and_monotonic_seq():
+    buf = io.StringIO()
+    em = Emitter(buf, run_id="r1", clock=lambda: 123.456)
+    em.emit("warming", phase="import")
+    em.emit("node_status", node="Market Analyst", state="in_progress")
+    rows = _lines(buf)
+    assert [r["seq"] for r in rows] == [1, 2]
+    assert all(r["v"] == SCHEMA_VERSION and r["run_id"] == "r1" for r in rows)
+    assert rows[0]["type"] == "warming" and rows[0]["phase"] == "import"
+    assert rows[0]["ts"] == 123.456
+    assert rows[1]["node"] == "Market Analyst"
+
+
+def test_emit_event_dict_roundtrip():
+    buf = io.StringIO()
+    em = Emitter(buf, run_id="r2", clock=lambda: 0.0)
+    em.emit_event({"type": "tool_call", "name": "get_news", "args": {"q": "AAPL"}})
+    row = _lines(buf)[0]
+    assert row["type"] == "tool_call" and row["name"] == "get_news"
+    assert row["args"] == {"q": "AAPL"}
+    assert "type" in row and row["seq"] == 1
+
+
+def test_each_line_is_valid_standalone_json():
+    buf = io.StringIO()
+    em = Emitter(buf, run_id="r3", clock=lambda: 1.0)
+    # Text with embedded newlines must stay on one physical line (JSON-escaped).
+    em.emit("agent_step", text="line one\nline two", role="News Analyst")
+    raw = buf.getvalue()
+    assert raw.count("\n") == 1  # exactly one record terminator
+    row = json.loads(raw)
+    assert row["text"] == "line one\nline two"
+
+
+def test_write_object_is_bare_no_envelope():
+    buf = io.StringIO()
+    em = Emitter(buf, run_id="r4", clock=lambda: 1.0)
+    em.write_object({"schema": "capabilities", "providers": []})
+    row = _lines(buf)[0]
+    assert row == {"schema": "capabilities", "providers": []}
+    assert "seq" not in row and "v" not in row
+
+
+if __name__ == "__main__":
+    import sys
+    import traceback
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/tests/test_desk_server_events.py
+++ b/tests/test_desk_server_events.py
@@ -1,0 +1,54 @@
+"""Unit tests for the SSE event envelope/framing (desk_server.events).
+
+Dependency-free; runnable directly: ``PYTHONPATH=. python3 tests/test_desk_server_events.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from desk_adapter.protocol import SCHEMA_VERSION
+from desk_server.events import build_event, sse_format
+
+
+def test_build_event_envelope():
+    ev = build_event("run-1", 3, "node_status", {"node": "Market Analyst", "state": "running"}, clock=lambda: 9.9)
+    assert ev == {
+        "v": SCHEMA_VERSION,
+        "run_id": "run-1",
+        "seq": 3,
+        "ts": 9.9,
+        "type": "node_status",
+        "node": "Market Analyst",
+        "state": "running",
+    }
+
+
+def test_sse_format_has_id_and_data():
+    ev = build_event("r", 7, "agent_step", {"text": "hi\nthere"}, clock=lambda: 0.0)
+    frame = sse_format(ev)
+    lines = frame.split("\n")
+    assert lines[0] == "id: 7"
+    assert lines[1].startswith("data: ")
+    assert frame.endswith("\n\n")
+    # The data line is single-line valid JSON (embedded newline is escaped).
+    payload = json.loads(lines[1][len("data: "):])
+    assert payload["type"] == "agent_step" and payload["text"] == "hi\nthere"
+
+
+if __name__ == "__main__":
+    import sys
+    import traceback
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/tradingagents/__init__.py
+++ b/tradingagents/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import warnings
 
 # Load .env files at package import so DEFAULT_CONFIG's env-var overlay
@@ -8,13 +9,18 @@ import warnings
 # the project's .env instead of stepping up from site-packages.
 # load_dotenv defaults to override=False, so it never clobbers values
 # the caller has already exported.
-try:
-    from dotenv import find_dotenv, load_dotenv
+#
+# Hosts that inject secrets themselves (e.g. an app that passes OS-keychain
+# values as env vars and must never pick up a stray on-disk .env) set
+# TRADINGAGENTS_NO_DOTENV=1 to skip this entirely.
+if not os.environ.get("TRADINGAGENTS_NO_DOTENV"):
+    try:
+        from dotenv import find_dotenv, load_dotenv
 
-    load_dotenv(find_dotenv(usecwd=True))
-    load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
-except ImportError:
-    pass
+        load_dotenv(find_dotenv(usecwd=True))
+        load_dotenv(find_dotenv(".env.enterprise", usecwd=True), override=False)
+    except ImportError:
+        pass
 
 # langchain-core 1.3.3 calls surface_langchain_deprecation_warnings() in
 # its own __init__, which prepends default-action filters for its

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -288,12 +288,22 @@ class TradingAgentsGraph:
             )
             if raw is None:
                 continue  # price not available yet — try again next run
-            reflection = self.reflector.reflect_on_final_decision(
-                final_decision=entry.get("decision", ""),
-                raw_return=raw,
-                alpha_return=alpha,
-                benchmark_name=benchmark,
-            )
+            try:
+                reflection = self.reflector.reflect_on_final_decision(
+                    final_decision=entry.get("decision", ""),
+                    raw_return=raw,
+                    alpha_return=alpha,
+                    benchmark_name=benchmark,
+                )
+            except Exception:  # noqa: BLE001
+                # One transient reflection (LLM) failure must not abort the caller —
+                # this also runs at the start of propagate()/stream_run(), so a blip
+                # here would otherwise kill a brand-new analysis. Leave the entry
+                # pending and retry it next run.
+                logger.warning(
+                    "Reflection failed for %s %s; leaving pending", ticker, entry["date"], exc_info=True
+                )
+                continue
             updates.append({
                 "ticker": ticker,
                 "trade_date": entry["date"],
@@ -305,6 +315,34 @@ class TradingAgentsGraph:
 
         if updates:
             self.memory_log.batch_update_with_outcomes(updates)
+
+    def resolve_pending_entries(self, ticker: str) -> None:
+        """Public entry point to realize pending decisions for ``ticker``.
+
+        Fetches realized returns + alpha and writes reflections for any pending
+        memory-log entries on ``ticker`` without running a full analysis. Hosts
+        (e.g. a UI's periodic "refresh outcomes" action) call this on a schedule
+        so decisions that were too recent to score at analysis time get resolved
+        later. Thin wrapper over :meth:`_resolve_pending_entries`.
+        """
+        self._resolve_pending_entries(ticker)
+
+    def resolve_all_pending(self) -> list[str]:
+        """Resolve pending entries for every ticker that has any.
+
+        Returns the sorted list of tickers that were successfully resolved. One
+        ticker's failure (e.g. a transient LLM error) does not abort the batch —
+        the rest are still processed and the failed ticker is retried next run.
+        """
+        tickers = sorted({e["ticker"] for e in self.memory_log.get_pending_entries()})
+        resolved = []
+        for ticker in tickers:
+            try:
+                self._resolve_pending_entries(ticker)
+                resolved.append(ticker)
+            except Exception:  # noqa: BLE001 - one ticker must not poison the batch
+                logger.warning("Could not resolve pending for %s; will retry next run", ticker, exc_info=True)
+        return resolved
 
     def resolve_instrument_context(self, ticker: str, asset_type: str = "stock") -> str:
         """Resolve ticker identity once and return the full instrument context.
@@ -373,6 +411,60 @@ class TradingAgentsGraph:
                 / f"{safe_ticker_component(ticker)}_{stamp}"
             )
         return write_report_tree(final_state, ticker, save_path)
+
+    def stream_run(self, company_name, trade_date, asset_type: str = "stock"):
+        """Streaming sibling of :meth:`propagate` for live host UIs.
+
+        Yields each whole-state snapshot from ``graph.stream(stream_mode="values")``
+        as it is produced, while preserving the same side effects ``_run_graph``
+        performs: it resolves prior pending outcomes before the run and writes the
+        state log + decision entry after the final snapshot. ``propagate`` remains
+        the blocking one-shot path; this one exists so a host can render progress
+        as the graph advances.
+
+        Checkpoint/resume is intentionally not enabled on this path in v1 (the
+        SqliteSaver recompile flow is owned by ``propagate``); callers needing
+        resume should use ``propagate``.
+        """
+        self.ticker = company_name
+
+        # Realize prior pending outcomes first (parity with propagate()).
+        self._resolve_pending_entries(company_name)
+
+        past_context = self.memory_log.get_past_context(company_name)
+        instrument_context = self.resolve_instrument_context(company_name, asset_type)
+        init_agent_state = self.propagator.create_initial_state(
+            company_name,
+            trade_date,
+            asset_type=asset_type,
+            past_context=past_context,
+            instrument_context=instrument_context,
+        )
+        # Pass the graph's callbacks so tool-execution stats are tracked, mirroring
+        # the CLI streaming path (LLM stats come via the LLM constructor callbacks).
+        args = self.propagator.get_graph_args(callbacks=self.callbacks or None)
+
+        final_state: dict[str, Any] = {}
+        for chunk in self.graph.stream(init_agent_state, **args):
+            # stream_mode="values" yields the full accumulated state each step.
+            final_state = chunk
+            yield chunk
+
+        self.curr_state = final_state
+
+        # Side effects the raw stream path would otherwise skip (see _run_graph).
+        # Guarded on key PRESENCE (not truthiness) for exact parity with
+        # _run_graph: a stream that ended without reaching a decision (nothing
+        # yielded, or the graph terminated early) skips the epilogue rather than
+        # raising KeyError out of the generator's final ``next()``, while a
+        # completed run with an empty decision still logs, as propagate() does.
+        if "final_trade_decision" in final_state:
+            self._log_state(trade_date, final_state)
+            self.memory_log.store_decision(
+                ticker=company_name,
+                trade_date=trade_date,
+                final_trade_decision=final_state["final_trade_decision"],
+            )
 
     def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
         """Execute the graph and write the resulting state to disk and memory log."""


### PR DESCRIPTION
## What

The host-side service layer that lets a GUI or external process drive the TradingAgents engine **without touching the agent graph**. This is the backend the native macOS app (a stacked follow-up PR) talks to; it's also usable standalone as a thin HTTP/SSE surface over the engine.

**1. Engine host APIs** (additive, opt-in — nothing changes for existing callers):
- `TradingAgentsGraph.stream_run()` — a streaming sibling of `propagate()` that yields each whole-state snapshot as the graph advances, preserving the same side effects.
- `resolve_pending_entries(ticker)` / `resolve_all_pending()` — realize previously-pending decisions on demand (one ticker's transient failure doesn't abort the batch).
- `TRADINGAGENTS_NO_DOTENV=1` — skip the package-import `.env` load for hosts that inject their own secrets.

**2. `desk_server/` + `desk_adapter/`** — a FastAPI + SSE backend, packaged into the engine's Docker image (`pip install ".[server]"`, `desk-server` entrypoint). `POST /runs` starts a run, `GET /runs/{id}/events` streams it over SSE, `POST /runs/{id}/cancel` stops it; plus `/health`, `/capabilities`, `/journal`, `/reports`, `/search`, `/prices`, `/openrouter/models`, and connectivity tests. `desk_adapter/` diffs the engine's `stream_run` snapshots into a typed NDJSON event stream. Loopback-only (`127.0.0.1:8765`); provider keys are injected per run, never read from disk.

## Notes
- `docker-compose.yml`'s `env_file: .env` entries are now optional (`required: false`) so a fresh clone with no `.env` can still `docker compose build`/`up`.
- Runs execute on a dedicated single-worker pool (isolates per-run provider keys + keeps multi-minute runs off the short endpoints' pool); finished runs are evicted after a retention window.

## Tests / verification
`tests/test_desk_adapter_diff.py`, `test_desk_adapter_protocol.py`, `test_desk_server_events.py` — 15 pure-stdlib cases. `ruff` clean. The Docker image builds and `desk-server` serves `/health` + `/capabilities`.

## Scope
Engine-only + additive. The native macOS app that consumes this backend is a stacked follow-up PR (so it can be reviewed on its own, and pulled + run with the backend included).
