### PR TITLE
feat(trader): add probability + risk/reward review to every proposal

### DIFF
--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -36,10 +36,20 @@ from tradingagents.agents.trader.trader import create_trader
 @pytest.mark.unit
 class TestRenderTraderProposal:
     def test_minimal_required_fields(self):
-        p = TraderProposal(action=TraderAction.HOLD, reasoning="Balanced setup; no edge.")
+        p = TraderProposal(
+            action=TraderAction.HOLD,
+            reasoning="Balanced setup; no edge.",
+            bull_case="Margins resilient.",
+            bear_case="Cash flow deteriorating.",
+            win_probability=50,
+        )
         md = render_trader_proposal(p)
         assert "**Action**: Hold" in md
         assert "**Reasoning**: Balanced setup; no edge." in md
+        # Bull/bear cases and the probability review are always present.
+        assert "**Bull Case**: Margins resilient." in md
+        assert "**Bear Case**: Cash flow deteriorating." in md
+        assert "**Win Probability**: 50%" in md
         # The trailing FINAL TRANSACTION PROPOSAL line is preserved for the
         # analyst stop-signal text and any external code that greps for it.
         assert "FINAL TRANSACTION PROPOSAL: **HOLD**" in md
@@ -48,8 +58,12 @@ class TestRenderTraderProposal:
         p = TraderProposal(
             action=TraderAction.BUY,
             reasoning="Strong technicals + fundamentals.",
+            bull_case="Breakout on volume.",
+            bear_case="Valuation stretched.",
+            win_probability=62,
             entry_price=189.5,
             stop_loss=178.0,
+            target_price=212.5,
             position_sizing="6% of portfolio",
         )
         md = render_trader_proposal(p)
@@ -57,15 +71,62 @@ class TestRenderTraderProposal:
         assert "**Entry Price**: 189.5" in md
         assert "**Stop Loss**: 178.0" in md
         assert "**Position Sizing**: 6% of portfolio" in md
+        # Risk/reward is computed deterministically: reward 23.0 / risk 11.5 = 2.00.
+        assert "**Risk/Reward Ratio**: 2.00 : 1" in md
+        assert "**Expected Value**:" in md
         assert "FINAL TRANSACTION PROPOSAL: **BUY**" in md
 
     def test_optional_fields_omitted_when_absent(self):
-        p = TraderProposal(action=TraderAction.SELL, reasoning="Guidance cut.")
+        p = TraderProposal(
+            action=TraderAction.SELL,
+            reasoning="Guidance cut.",
+            bull_case="Oversold bounce possible.",
+            bear_case="Demand collapsing.",
+            win_probability=58,
+        )
         md = render_trader_proposal(p)
         assert "Entry Price" not in md
         assert "Stop Loss" not in md
         assert "Position Sizing" not in md
+        # Without price levels the R/R is reported as not-applicable.
+        assert "**Risk/Reward Ratio**: n/a" in md
         assert "FINAL TRANSACTION PROPOSAL: **SELL**" in md
+
+    def test_risk_reward_math_is_deterministic(self):
+        # entry 100, stop 90, target 130 -> reward 30 / risk 10 = 3.00 R/R.
+        # win prob 60% -> EV = 0.6*3 - 0.4 = 1.40R; breakeven = 100/(1+3) = 25%.
+        p = TraderProposal(
+            action=TraderAction.BUY,
+            reasoning="Clean breakout.",
+            bull_case="Trend + volume.",
+            bear_case="Thin liquidity.",
+            win_probability=60,
+            entry_price=100.0,
+            stop_loss=90.0,
+            target_price=130.0,
+        )
+        md = render_trader_proposal(p)
+        assert "**Risk/Reward Ratio**: 3.00 : 1" in md
+        assert "**Expected Value**: +1.40R (favorable)" in md
+        assert "**Breakeven Win-Rate**: 25%" in md
+        assert "above breakeven" in md
+
+    def test_negative_expected_value_flagged(self):
+        # Low win prob below breakeven -> unfavorable EV.
+        # entry 100, stop 90, target 110 -> R/R 1.00, breakeven 50%; prob 35% < 50%.
+        p = TraderProposal(
+            action=TraderAction.BUY,
+            reasoning="Marginal setup.",
+            bull_case="Possible bounce.",
+            bear_case="Downtrend intact.",
+            win_probability=35,
+            entry_price=100.0,
+            stop_loss=90.0,
+            target_price=110.0,
+        )
+        md = render_trader_proposal(p)
+        assert "(unfavorable)" in md
+        assert "below breakeven" in md
 
 
 @pytest.mark.unit
@@ -78,14 +139,26 @@ class TestNullishFloatCoercion:
             p = TraderProposal(
                 action=TraderAction.HOLD,
                 reasoning="x",
+                bull_case="b",
+                bear_case="c",
+                win_probability=50,
                 entry_price=sentinel,
                 stop_loss=sentinel,
+                target_price=sentinel,
             )
             assert p.entry_price is None
             assert p.stop_loss is None
+            assert p.target_price is None
 
     def test_trader_real_numeric_string_still_parses(self):
-        p = TraderProposal(action=TraderAction.BUY, reasoning="x", entry_price="189.5")
+        p = TraderProposal(
+            action=TraderAction.BUY,
+            reasoning="x",
+            bull_case="b",
+            bear_case="c",
+            win_probability=60,
+            entry_price="189.5",
+        )
         assert p.entry_price == 189.5
 
     def test_pm_nullish_price_target_coerces_to_none(self):
@@ -142,6 +215,9 @@ def _structured_trader_llm(captured: dict, proposal: TraderProposal | None = Non
         proposal = TraderProposal(
             action=TraderAction.BUY,
             reasoning="Strong setup.",
+            bull_case="Momentum building.",
+            bear_case="Macro headwinds.",
+            win_probability=60,
         )
     structured = MagicMock()
     structured.invoke.side_effect = lambda prompt: (
@@ -177,8 +253,12 @@ class TestTraderAgent:
         proposal = TraderProposal(
             action=TraderAction.BUY,
             reasoning="AI capex cycle intact; institutional flows constructive.",
+            bull_case="Datacenter demand accelerating.",
+            bear_case="Export-control overhang.",
+            win_probability=64,
             entry_price=189.5,
             stop_loss=178.0,
+            target_price=212.0,
             position_sizing="6% of portfolio",
         )
         llm = _structured_trader_llm(captured, proposal)

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -136,6 +136,29 @@ class TraderProposal(BaseModel):
             "the research plan. Two to four sentences."
         ),
     )
+    bull_case: str = Field(
+        description=(
+            "Bull case: the 2-4 strongest arguments FOR upside / taking this "
+            "position, each grounded in specific evidence (fundamentals, "
+            "technicals, sentiment, catalysts)."
+        ),
+    )
+    bear_case: str = Field(
+        description=(
+            "Bear case: the 2-4 strongest arguments AGAINST the position / "
+            "pointing to downside, each grounded in specific evidence. Be "
+            "genuinely critical; do not strawman the opposing view."
+        ),
+    )
+    win_probability: float = Field(
+        ge=0.0,
+        le=100.0,
+        description=(
+            "Win probability (0-100): your estimated likelihood that the "
+            "directional thesis plays out, weighing the bull case against the "
+            "bear case. Do not default to 50 — commit to a considered estimate."
+        ),
+    )
     entry_price: float | None = Field(
         default=None,
         description="Optional entry price target in the instrument's quote currency.",
@@ -144,15 +167,67 @@ class TraderProposal(BaseModel):
         default=None,
         description="Optional stop-loss price in the instrument's quote currency.",
     )
+    target_price: float | None = Field(
+        default=None,
+        description=(
+            "Optional take-profit / target price in the instrument's quote "
+            "currency, used to compute the risk/reward ratio. Provide whenever "
+            "the action is Buy or Sell."
+        ),
+    )
     position_sizing: str | None = Field(
         default=None,
         description="Optional sizing guidance, e.g. '5% of portfolio'.",
     )
 
-    @field_validator("entry_price", "stop_loss", mode="before")
+    @field_validator("entry_price", "stop_loss", "target_price", mode="before")
     @classmethod
     def _nullish_float_to_none(cls, v):
         return _coerce_optional_float(v)
+
+
+def _render_trade_review(proposal: TraderProposal) -> str:
+    """Probability + risk/reward + expected-value review.
+
+    The win probability comes from the model; the risk/reward ratio, expected
+    value (in R-multiples), and breakeven win-rate are computed here from the
+    entry / stop / target levels so the numbers stay arithmetically consistent
+    rather than being hallucinated by the LLM.
+    """
+    lines = ["### Probability & Risk/Reward"]
+    prob = proposal.win_probability
+    lines.append(f"- **Win Probability**: {prob:.0f}%")
+
+    rr = None
+    if (
+        proposal.entry_price is not None
+        and proposal.stop_loss is not None
+        and proposal.target_price is not None
+    ):
+        reward = abs(proposal.target_price - proposal.entry_price)
+        risk = abs(proposal.entry_price - proposal.stop_loss)
+        if risk > 0:
+            rr = reward / risk
+            lines.append(
+                f"- **Risk/Reward Ratio**: {rr:.2f} : 1 "
+                f"(potential +{reward:.2f} vs risk -{risk:.2f})"
+            )
+
+    if rr is not None:
+        p = prob / 100.0
+        ev_r = p * rr - (1.0 - p)  # expected value in units of risk (R-multiple)
+        breakeven = 100.0 / (1.0 + rr)
+        verdict = "favorable" if ev_r > 0 else "unfavorable"
+        lines.append(f"- **Expected Value**: {ev_r:+.2f}R ({verdict})")
+        lines.append(
+            f"- **Breakeven Win-Rate**: {breakeven:.0f}% "
+            f"(current {prob:.0f}% is {'above' if prob > breakeven else 'below'} breakeven)"
+        )
+    else:
+        lines.append(
+            "- **Risk/Reward Ratio**: n/a (needs entry / stop / target prices)"
+        )
+    return "\n".join(lines)
 
 
 def render_trader_proposal(proposal: TraderProposal) -> str:
@@ -166,13 +241,20 @@ def render_trader_proposal(proposal: TraderProposal) -> str:
         f"**Action**: {proposal.action.value}",
         "",
         f"**Reasoning**: {proposal.reasoning}",
+        "",
+        f"**Bull Case**: {proposal.bull_case}",
+        "",
+        f"**Bear Case**: {proposal.bear_case}",
     ]
     if proposal.entry_price is not None:
         parts.extend(["", f"**Entry Price**: {proposal.entry_price}"])
     if proposal.stop_loss is not None:
         parts.extend(["", f"**Stop Loss**: {proposal.stop_loss}"])
+    if proposal.target_price is not None:
+        parts.extend(["", f"**Target Price**: {proposal.target_price}"])
     if proposal.position_sizing:
         parts.extend(["", f"**Position Sizing**: {proposal.position_sizing}"])
+    parts.extend(["", _render_trade_review(proposal)])
     parts.extend([
         "",
         f"FINAL TRANSACTION PROPOSAL: **{proposal.action.value.upper()}**",

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -31,7 +31,11 @@ def create_trader(llm):
                 "content": (
                     "You are a trading agent analyzing market data to make investment decisions. "
                     "Based on your analysis, provide a specific recommendation to buy, sell, or hold. "
-                    "Anchor your reasoning in the analysts' reports and the research plan."
+                    "Anchor your reasoning in the analysts' reports and the research plan. "
+                    "Always argue BOTH sides explicitly — a bull case (arguments for) and a bear "
+                    "case (arguments against) — then commit to a win probability, and when taking a "
+                    "Buy/Sell give entry / stop-loss / target prices so the risk/reward ratio can "
+                    "be computed."
                     + get_language_instruction()
                 ),
             },


### PR DESCRIPTION
## Summary

Every Trader proposal now ends with a **quantified, two-sided verdict** instead of a one-sided narrative:

- **Bull case + Bear case** (both required): the strongest arguments for and against, each grounded in specific evidence. The prompt explicitly tells the model to argue both sides and not to strawman the opposing view.
- **Win probability** (required, 0-100): the model commits to a likelihood estimate, with an instruction not to default to 50.
- **Deterministic risk/reward review**: the win probability comes from the model, but the **risk/reward ratio**, **expected value** (in R-multiples), and **breakeven win-rate** are computed in code from the entry/stop/target levels — so the numbers are always arithmetically consistent rather than hallucinated by the LLM.

### Example output

```
**Action**: Buy
**Reasoning**: ...
**Bull Case**: Datacenter demand accelerating; ...
**Bear Case**: Export-control overhang; ...
**Entry Price**: 189.5
**Stop Loss**: 178.0
**Target Price**: 212.0

### Probability & Risk/Reward
- **Win Probability**: 64%
- **Risk/Reward Ratio**: 2.00 : 1 (potential +22.50 vs risk -11.50)
- **Expected Value**: +0.92R (favorable)
- **Breakeven Win-Rate**: 33% (current 64% is above breakeven)

FINAL TRANSACTION PROPOSAL: **BUY**
```

When price levels are absent (e.g. a Hold), the risk/reward line degrades to `n/a` and the probability + bull/bear still render.

## Changes

- `tradingagents/agents/schemas.py`: extend `TraderProposal` with `bull_case` / `bear_case` / `win_probability` (required) and `target_price` (optional, covered by the existing nullish-float coercion validator); add `_render_trade_review()` and wire it into `render_trader_proposal()`.
- `tradingagents/agents/trader/trader.py`: prompt now instructs the model to argue both sides, commit a win probability, and supply entry/stop/target.
- `tests/test_structured_agents.py`: updated constructors for the new required fields; added tests for exact R/R, EV and breakeven math, favorable-vs-unfavorable EV flagging, the `n/a` path, and `target_price` nullish coercion.

## Test plan

- [x] `pytest tests/test_structured_agents.py` — 27 passed
- [x] `ruff check` on the changed files — clean
- [x] Structured-output JSON schema marks `bull_case` / `bear_case` / `win_probability` as required, so providers using json_schema mode (OpenAI/xAI/MiniMax) enforce them; the free-text fallback path is unchanged.

## Notes

The win-probability/R-R framing is deliberately model-agnostic and adds no new dependencies. Happy to adjust labels or make the review section opt-in via config if preferred.