### PR TITLE
fix(smoke): clarify structured output markdown checks

### DIFF
--- a/scripts/smoke_structured_output.py
+++ b/scripts/smoke_structured_output.py
@@ -105,6 +105,8 @@ def _print_section(title: str, content: object) -> None:
 
 def _as_text(content: object) -> str:
     """Coerce smoke outputs to text before marker checks."""
+    if content is None:
+        return ""
     return content if isinstance(content, str) else str(content)
 
 
@@ -116,9 +118,9 @@ def _missing_markers(content: object, required: list[str]) -> list[str]:
 def _run_structure_checks(checks: list[tuple[str, object, list[str]]]) -> int:
     failures = 0
     for name, content, required in checks:
-        missing = set(_missing_markers(content, required))
+        text = _as_text(content)
         for marker in required:
-            ok = marker not in missing
+            ok = marker in text
             print(f"  {'PASS' if ok else 'FAIL'}  {name}: contains {marker!r}")
             failures += int(not ok)
     return failures

--- a/scripts/smoke_structured_output.py
+++ b/scripts/smoke_structured_output.py
@@ -1,11 +1,12 @@
 """End-to-end smoke for structured-output agents against a real LLM provider.
 
 Runs the three decision-making agents (Research Manager, Trader, Portfolio
-Manager) directly with their structured-output bindings and prints the
-typed Pydantic instance + the rendered markdown for each.  Use this to
-verify a provider's native structured-output mode (json_schema for
+Manager) directly through their normal agent callables and prints the
+rendered markdown each agent returns. Use this to verify a provider's
+native structured-output mode (json_schema for
 OpenAI / xAI / DeepSeek / Qwen / GLM, response_schema for Gemini, tool-use
-for Anthropic) returns clean instances on the schemas we ship.
+for Anthropic) can produce clean schema-backed markdown through the same
+API used by the graph.
 
 Usage:
     OPENAI_API_KEY=... python scripts/smoke_structured_output.py openai
@@ -66,14 +67,14 @@ def _make_rm_state():
     }
 
 
-def _make_trader_state(investment_plan: str):
+def _make_trader_state(investment_plan: str) -> dict:
     return {
         "company_of_interest": "NVDA",
         "investment_plan": investment_plan,
     }
 
 
-def _make_pm_state(investment_plan: str, trader_plan: str):
+def _make_pm_state(investment_plan: str, trader_plan: str) -> dict:
     return {
         "company_of_interest": "NVDA",
         "past_context": "",
@@ -97,9 +98,30 @@ def _make_pm_state(investment_plan: str, trader_plan: str):
     }
 
 
-def _print_section(title: str, content: str) -> None:
+def _print_section(title: str, content: object) -> None:
     bar = "=" * 70
     print(f"\n{bar}\n{title}\n{bar}\n{content}")
+
+
+def _as_text(content: object) -> str:
+    """Coerce smoke outputs to text before marker checks."""
+    return content if isinstance(content, str) else str(content)
+
+
+def _missing_markers(content: object, required: list[str]) -> list[str]:
+    text = _as_text(content)
+    return [marker for marker in required if marker not in text]
+
+
+def _run_structure_checks(checks: list[tuple[str, object, list[str]]]) -> int:
+    failures = 0
+    for name, content, required in checks:
+        missing = set(_missing_markers(content, required))
+        for marker in required:
+            ok = marker not in missing
+            print(f"  {'PASS' if ok else 'FAIL'}  {name}: contains {marker!r}")
+            failures += int(not ok)
+    return failures
 
 
 def main() -> int:
@@ -151,16 +173,15 @@ def main() -> int:
     #    saved reports) keep working.
     checks = [
         ("Research Manager", investment_plan, ["**Recommendation**:"]),
-        ("Trader",           trader_plan,     ["**Action**:", "FINAL TRANSACTION PROPOSAL:"]),
-        ("Portfolio Manager", final_decision, ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:"]),
+        ("Trader", trader_plan, ["**Action**:", "FINAL TRANSACTION PROPOSAL:"]),
+        (
+            "Portfolio Manager",
+            final_decision,
+            ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:"],
+        ),
     ]
     print("\n" + "=" * 70 + "\nStructure checks\n" + "=" * 70)
-    failures = 0
-    for name, text, required in checks:
-        for marker in required:
-            ok = marker in text
-            print(f"  {'PASS' if ok else 'FAIL'}  {name}: contains {marker!r}")
-            failures += int(not ok)
+    failures = _run_structure_checks(checks)
 
     print()
     if failures:

--- a/tests/test_smoke_structured_output.py
+++ b/tests/test_smoke_structured_output.py
@@ -1,0 +1,29 @@
+import pytest
+
+from scripts.smoke_structured_output import _missing_markers, _run_structure_checks
+
+
+@pytest.mark.unit
+def test_missing_markers_handles_non_string_output_without_typeerror():
+    class StructuredLikeOutput:
+        def __str__(self) -> str:
+            return "recommendation='Hold' rationale='balanced'"
+
+    missing = _missing_markers(StructuredLikeOutput(), ["**Recommendation**:"])
+
+    assert missing == ["**Recommendation**:"]
+
+
+@pytest.mark.unit
+def test_run_structure_checks_counts_missing_markers(capsys):
+    failures = _run_structure_checks(
+        [
+            ("Research Manager", "**Recommendation**: Hold", ["**Recommendation**:"]),
+            ("Trader", "**Action**: Hold", ["**Action**:", "FINAL TRANSACTION PROPOSAL:"]),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert failures == 1
+    assert "PASS  Research Manager" in output
+    assert "FAIL  Trader" in output

--- a/tests/test_smoke_structured_output.py
+++ b/tests/test_smoke_structured_output.py
@@ -1,6 +1,11 @@
 import pytest
 
-from scripts.smoke_structured_output import _missing_markers, _run_structure_checks
+from scripts.smoke_structured_output import _as_text, _missing_markers, _run_structure_checks
+
+
+@pytest.mark.unit
+def test_as_text_treats_none_as_empty_string():
+    assert _as_text(None) == ""
 
 
 @pytest.mark.unit


### PR DESCRIPTION
﻿## Summary

Clarify the structured-output smoke script so it describes and checks the actual agent API output: rendered markdown produced through the normal agent callables.

## Why

Issue #997 points out that `scripts/smoke_structured_output.py` says it prints typed Pydantic instances plus rendered markdown, while the graph-facing agent API returns rendered markdown strings. The script also checked markers directly with `marker in text`, which would raise a raw `TypeError` if a future change returned a non-string object.

## What changed

- Update the smoke script docstring to describe schema-backed rendered markdown instead of promising typed Pydantic instances.
- Add small marker-check helpers that coerce smoke outputs to text before checking required headers.
- Keep the existing structure checks and exit-code behavior unchanged.
- Add regression coverage for non-string structured-like output and PASS/FAIL accounting.

## Duplicate check

I checked current open PRs and searched for `smoke_structured_output`, `_make_pm_state`, and structured-output smoke fixes; I found no overlapping open PR.

## Validation

- `python -m pytest tests/test_smoke_structured_output.py tests/test_structured_agents.py -q`
- `python -m pytest tests/test_smoke_structured_output.py -q`
- `python -m py_compile scripts/smoke_structured_output.py tests/test_smoke_structured_output.py`
- `python -m ruff check scripts/smoke_structured_output.py tests/test_smoke_structured_output.py`
- `python -m ruff format --check scripts/smoke_structured_output.py tests/test_smoke_structured_output.py`
- `git diff --check`

Fixes #997.
