### PR TITLE
feat(reflection): calibrate lessons with surprise ratio

### DIFF
--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -513,9 +513,18 @@ class TestDeferredReflection:
         final_decision = "**Rating**: Buy\n\n**Price Target**: 112.0"
         assert extract_expected_return(final_decision, trader_plan) == pytest.approx(0.12)
 
+        trader_plan_alt = "**Action**: Buy\n\n**Entry Price:** 100.0"
+        final_decision_alt = "**Rating**: Buy\n\n**Price Target:** 112.0"
+        assert extract_expected_return(final_decision_alt, trader_plan_alt) == pytest.approx(0.12)
+
     def test_extract_expected_return_from_explicit_percent(self):
         final_decision = "**Rating**: Buy\n\nExpected return: +8.5%"
         assert extract_expected_return(final_decision) == pytest.approx(0.085)
+
+    def test_extract_expected_return_rejects_non_positive_target(self):
+        trader_plan = "**Entry Price**: 100.0"
+        assert extract_expected_return("**Price Target**: 0.0", trader_plan) is None
+        assert extract_expected_return("**Price Target**: -10.0", trader_plan) is None
 
     # TradingAgentsGraph._fetch_returns
 

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -9,7 +9,7 @@ from tradingagents.agents.managers.portfolio_manager import create_portfolio_man
 from tradingagents.agents.schemas import PortfolioDecision, PortfolioRating
 from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.graph.propagation import Propagator
-from tradingagents.graph.reflection import Reflector
+from tradingagents.graph.reflection import Reflector, extract_expected_return
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 
 _SEP = TradingMemoryLog._SEPARATOR
@@ -123,6 +123,15 @@ class TestTradingMemoryLogCore:
         assert len(entries) == 2
         assert entries[0]["ticker"] == "NVDA"
         assert entries[1]["ticker"] == "AAPL"
+
+    def test_store_persists_expected_return(self, tmp_path):
+        log = make_log(tmp_path)
+        log.store_decision("NVDA", "2026-01-10", DECISION_BUY, expected_return=0.075)
+
+        raw_text = (tmp_path / "trading_memory.md").read_text(encoding="utf-8")
+        entries = log.load_entries()
+        assert "EXPECTED_RETURN: +7.5%" in raw_text
+        assert entries[0]["expected_return"] == pytest.approx(0.075)
 
     def test_store_decision_idempotent(self, tmp_path):
         """Calling store_decision twice with same (ticker, date) stores only one entry."""
@@ -484,6 +493,30 @@ class TestDeferredReflection:
         assert "-5.0%" in human_content
         assert "Exit position immediately." in human_content
 
+    def test_reflect_on_final_decision_includes_surprise_ratio(self):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value.content = "Outcome was luckier than planned."
+        reflector = Reflector(mock_llm)
+        reflector.reflect_on_final_decision(
+            final_decision=DECISION_BUY,
+            raw_return=0.10,
+            alpha_return=0.04,
+            expected_return=0.02,
+        )
+        messages = mock_llm.invoke.call_args[0][0]
+        human_content = next(content for role, content in messages if role == "human")
+        assert "Expected return at entry: +2.0%" in human_content
+        assert "Surprise ratio: 4.00" in human_content
+
+    def test_extract_expected_return_from_price_target(self):
+        trader_plan = "**Action**: Buy\n\n**Entry Price**: 100.0"
+        final_decision = "**Rating**: Buy\n\n**Price Target**: 112.0"
+        assert extract_expected_return(final_decision, trader_plan) == pytest.approx(0.12)
+
+    def test_extract_expected_return_from_explicit_percent(self):
+        final_decision = "**Rating**: Buy\n\nExpected return: +8.5%"
+        assert extract_expected_return(final_decision) == pytest.approx(0.085)
+
     # TradingAgentsGraph._fetch_returns
 
     def test_fetch_returns_valid_ticker(self):
@@ -664,6 +697,20 @@ class TestDeferredReflection:
         assert entries[0]["reflection"] == "Momentum confirmed."
         assert "+5.0%" in entries[0]["raw"]
         assert "+2.0%" in entries[0]["alpha"]
+
+    def test_resolve_passes_expected_return_to_reflector(self, tmp_path):
+        log = make_log(tmp_path)
+        log.store_decision("NVDA", "2026-01-05", DECISION_BUY, expected_return=0.03)
+        mock_reflector = MagicMock()
+        mock_reflector.reflect_on_final_decision.return_value = "Calibrated lesson."
+        mock_graph = MagicMock(spec=TradingAgentsGraph)
+        mock_graph.memory_log = log
+        mock_graph.reflector = mock_reflector
+        mock_graph._fetch_returns = MagicMock(return_value=(0.09, 0.04, 5))
+        TradingAgentsGraph._resolve_pending_entries(mock_graph, "NVDA")
+
+        call = mock_reflector.reflect_on_final_decision.call_args
+        assert call.kwargs["expected_return"] == pytest.approx(0.03)
 
 
 # ---------------------------------------------------------------------------

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -12,6 +12,7 @@ class TradingMemoryLog:
     # HTML comment: cannot appear in LLM prose output, safe as a hard delimiter
     _SEPARATOR = "\n\n<!-- ENTRY_END -->\n\n"
     # Precompiled patterns — avoids re-compilation on every load_entries() call
+    _EXPECTED_RETURN_RE = re.compile(r"EXPECTED_RETURN:\s*([+-]?\d+(?:\.\d+)?)%")
     _DECISION_RE = re.compile(r"DECISION:\n(.*?)(?=\nREFLECTION:|\Z)", re.DOTALL)
     _REFLECTION_RE = re.compile(r"REFLECTION:\n(.*?)$", re.DOTALL)
 
@@ -32,6 +33,7 @@ class TradingMemoryLog:
         ticker: str,
         trade_date: str,
         final_trade_decision: str,
+        expected_return: float | None = None,
     ) -> None:
         """Append pending entry at end of propagate(). No LLM call."""
         if not self._log_path:
@@ -44,7 +46,12 @@ class TradingMemoryLog:
                     return
         rating = parse_rating(final_trade_decision)
         tag = f"[{trade_date} | {ticker} | {rating} | pending]"
-        entry = f"{tag}\n\nDECISION:\n{final_trade_decision}{self._SEPARATOR}"
+        expected_block = (
+            f"EXPECTED_RETURN: {expected_return:+.1%}\n\n"
+            if expected_return is not None
+            else ""
+        )
+        entry = f"{tag}\n\n{expected_block}DECISION:\n{final_trade_decision}{self._SEPARATOR}"
         with open(self._log_path, "a", encoding="utf-8") as f:
             f.write(entry)
 
@@ -276,8 +283,12 @@ class TradingMemoryLog:
         body = "\n".join(lines[1:]).strip()
         decision_match = self._DECISION_RE.search(body)
         reflection_match = self._REFLECTION_RE.search(body)
+        expected_match = self._EXPECTED_RETURN_RE.search(body)
         entry["decision"] = decision_match.group(1).strip() if decision_match else ""
         entry["reflection"] = reflection_match.group(1).strip() if reflection_match else ""
+        entry["expected_return"] = (
+            float(expected_match.group(1)) / 100 if expected_match else None
+        )
         return entry
 
     def _format_full(self, e: dict) -> str:

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -11,7 +11,7 @@ _EXPECTED_RETURN_RE = re.compile(
 
 def _extract_labeled_float(text: str, label: str) -> float | None:
     pattern = re.compile(
-        rf"(?:\*\*)?{re.escape(label)}(?:\*\*)?\s*:\s*\$?\s*"
+        rf"\*?\*?{re.escape(label)}\*?\*?\s*:\s*\*?\*?\s*\$?\s*"
         r"([+-]?\d[\d,]*(?:\.\d+)?)",
         re.IGNORECASE,
     )
@@ -44,7 +44,7 @@ def extract_expected_return(final_decision: str, trader_plan: str = "") -> float
         or _extract_labeled_float(trader_plan or "", "Price Target")
         or _extract_labeled_float(trader_plan or "", "Target Price")
     )
-    if entry_price is None or target_price is None or entry_price <= 0:
+    if entry_price is None or target_price is None or entry_price <= 0 or target_price <= 0:
         return None
     return (target_price - entry_price) / entry_price
 

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -1,6 +1,64 @@
-# TradingAgents/graph/reflection.py
-
+import re
 from typing import Any
+
+_EXPECTED_RETURN_RE = re.compile(
+    r"\b(?:expected|projected|target)\s+"
+    r"(?:return|pnl|profit|upside|downside)\b\s*[:=]?\s*"
+    r"([+-]?\d+(?:\.\d+)?)\s*%",
+    re.IGNORECASE,
+)
+
+
+def _extract_labeled_float(text: str, label: str) -> float | None:
+    pattern = re.compile(
+        rf"(?:\*\*)?{re.escape(label)}(?:\*\*)?\s*:\s*\$?\s*"
+        r"([+-]?\d[\d,]*(?:\.\d+)?)",
+        re.IGNORECASE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return None
+    return float(match.group(1).replace(",", ""))
+
+
+def extract_expected_return(final_decision: str, trader_plan: str = "") -> float | None:
+    """Infer expected return from rendered decision/proposal markdown if present.
+
+    Structured runs usually expose an entry price in the Trader proposal and a
+    price target in the Portfolio Manager decision. Free-text runs may instead
+    mention an explicit expected/projected return percentage. This stays
+    best-effort: callers can omit the signal without changing reflection flow.
+    """
+    for text in (final_decision or "", trader_plan or ""):
+        match = _EXPECTED_RETURN_RE.search(text)
+        if match:
+            return float(match.group(1)) / 100
+
+    entry_price = (
+        _extract_labeled_float(trader_plan or "", "Entry Price")
+        or _extract_labeled_float(final_decision or "", "Entry Price")
+    )
+    target_price = (
+        _extract_labeled_float(final_decision or "", "Price Target")
+        or _extract_labeled_float(final_decision or "", "Target Price")
+        or _extract_labeled_float(trader_plan or "", "Price Target")
+        or _extract_labeled_float(trader_plan or "", "Target Price")
+    )
+    if entry_price is None or target_price is None or entry_price <= 0:
+        return None
+    return (target_price - entry_price) / entry_price
+
+
+def calculate_surprise_ratio(raw_return: float, expected_return: float) -> float:
+    """Return outcome surprise using percentage-point units.
+
+    Issue #718 defines the denominator as ``max(abs(expected_pnl), 1)``. Since
+    this code stores returns as fractions, convert to percentage points first so
+    the floor is one percentage point rather than 100%.
+    """
+    raw_pct = raw_return * 100
+    expected_pct = expected_return * 100
+    return abs(raw_pct - expected_pct) / max(abs(expected_pct), 1.0)
 
 
 class Reflector:
@@ -24,6 +82,9 @@ class Reflector:
             "1. Was the directional call correct? (cite the alpha figure)\n"
             "2. Which part of the investment thesis held or failed?\n"
             "3. One concrete lesson to apply to the next similar analysis.\n\n"
+            "If an expected return and surprise ratio are provided, use them to "
+            "calibrate the lesson: a high surprise ratio means the outcome may "
+            "reflect luck or regime noise, so do not over-credit direction alone.\n\n"
             "Be specific and terse. Your output will be stored verbatim in a decision log "
             "and re-read by future analysts, so every word must earn its place."
         )
@@ -34,6 +95,7 @@ class Reflector:
         raw_return: float,
         alpha_return: float,
         benchmark_name: str = "SPY",
+        expected_return: float | None = None,
     ) -> str:
         """Single reflection call on the final trade decision with outcome context.
 
@@ -43,15 +105,21 @@ class Reflector:
         for US tickers, ``"^N225"`` for ``.T`` listings); defaults to SPY for
         callers that haven't been updated to thread the benchmark through.
         """
+        outcome_lines = [
+            f"Raw return: {raw_return:+.1%}",
+            f"Alpha vs {benchmark_name}: {alpha_return:+.1%}",
+        ]
+        if expected_return is not None:
+            surprise_ratio = calculate_surprise_ratio(raw_return, expected_return)
+            outcome_lines.extend([
+                f"Expected return at entry: {expected_return:+.1%}",
+                f"Surprise ratio: {surprise_ratio:.2f}",
+            ])
         messages = [
             ("system", self.log_reflection_prompt),
             (
                 "human",
-                (
-                    f"Raw return: {raw_return:+.1%}\n"
-                    f"Alpha vs {benchmark_name}: {alpha_return:+.1%}\n\n"
-                    f"Final Decision:\n{final_decision}"
-                ),
+                "\n".join(outcome_lines) + f"\n\nFinal Decision:\n{final_decision}",
             ),
         ]
         return self.quick_thinking_llm.invoke(messages).content

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -37,7 +37,7 @@ from tradingagents.reporting import write_report_tree
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
 from .conditional_logic import ConditionalLogic
 from .propagation import Propagator
-from .reflection import Reflector
+from .reflection import Reflector, extract_expected_return
 from .setup import GraphSetup
 from .signal_processing import SignalProcessor
 
@@ -293,6 +293,7 @@ class TradingAgentsGraph:
                 raw_return=raw,
                 alpha_return=alpha,
                 benchmark_name=benchmark,
+                expected_return=entry.get("expected_return"),
             )
             updates.append({
                 "ticker": ticker,
@@ -427,6 +428,10 @@ class TradingAgentsGraph:
             ticker=company_name,
             trade_date=trade_date,
             final_trade_decision=final_state["final_trade_decision"],
+            expected_return=extract_expected_return(
+                final_state["final_trade_decision"],
+                final_state.get("trader_investment_plan", ""),
+            ),
         )
 
         # Clear checkpoint on successful completion to avoid stale state.


### PR DESCRIPTION
﻿Fixes #718.

## Summary

- Persist an optional expected return with each pending memory-log entry when it can be inferred from an explicit expected-return percentage or from Trader entry price plus Portfolio Manager price target.
- Add a surprise-ratio line to deferred reflection prompts so the LLM calibrates lessons against lucky or unexpectedly divergent outcomes.
- Keep the behavior best-effort: if no expected return is available, the existing reflection prompt shape is unchanged.

## Duplicate / overlap check

- Searched open PRs for `surprise_ratio`, `surprise ratio`, `lucky wins`, `over-learning`, expected-return reflection changes, and files touched here.
- No open PR directly implements #718 or the surprise-ratio reflection signal.
- File-level overlaps are different in scope: #645 touches `_resolve_pending_entries` for retry/error handling, while this PR threads expected return into reflection; older broad PRs (#438, #603, #372) touch reflection/memory files but do not implement #718.

## Tests

- `python -m pytest tests/test_memory_log.py -q`
- `python -m pytest tests/test_structured_agents.py -q`
- `python -m py_compile tradingagents/graph/reflection.py tradingagents/agents/utils/memory.py tradingagents/graph/trading_graph.py tests/test_memory_log.py`
- `python -m ruff check .`
- `git diff --check`
