### PR TITLE
feat(llm): make the LLM client max_retries configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ NVIDIA_API_KEY=
 #TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
 #TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 #TRADINGAGENTS_LLM_BACKEND_URL=
+# Optional override for the LLM client retry budget on transient errors (e.g.
+# HTTP 429 rate limits). Unset keeps the provider/SDK default (OpenAI/Azure = 2);
+# raise it to ride out bursty throttling (the SDK retries with exponential backoff).
+#TRADINGAGENTS_LLM_MAX_RETRIES=6
 #TRADINGAGENTS_OUTPUT_LANGUAGE=English
 #TRADINGAGENTS_MAX_DEBATE_ROUNDS=1
 #TRADINGAGENTS_MAX_RISK_ROUNDS=1

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -24,6 +24,7 @@ def test_no_env_uses_built_in_defaults(monkeypatch):
     assert dc.DEFAULT_CONFIG["deep_think_llm"] == "gpt-5.5"
     assert dc.DEFAULT_CONFIG["quick_think_llm"] == "gpt-5.4-mini"
     assert dc.DEFAULT_CONFIG["backend_url"] is None
+    assert dc.DEFAULT_CONFIG["llm_max_retries"] is None
     assert dc.DEFAULT_CONFIG["max_debate_rounds"] == 1
     assert dc.DEFAULT_CONFIG["checkpoint_enabled"] is False
 

--- a/tests/test_llm_max_retries.py
+++ b/tests/test_llm_max_retries.py
@@ -1,0 +1,98 @@
+"""Tests for the configurable LLM ``max_retries`` resilience knob.
+
+``max_retries`` is a cross-provider knob: when set it must reach the underlying
+chat client so transient provider errors (HTTP 429 rate limits) are retried with
+the SDK's exponential backoff; when unset the provider keeps its own default.
+"""
+
+import importlib
+
+import pytest
+
+from tradingagents.llm_clients.factory import create_llm_client
+
+
+@pytest.mark.unit
+class TestMaxRetriesForwarding:
+    @pytest.mark.parametrize(
+        "provider,model",
+        [
+            ("openai", "gpt-4.1"),
+            ("anthropic", "claude-sonnet-4-6"),
+            ("google", "gemini-2.5-flash"),
+            ("deepseek", "deepseek-chat"),
+        ],
+    )
+    def test_max_retries_reaches_client_when_set(self, provider, model):
+        llm = create_llm_client(
+            provider=provider, model=model, max_retries=8, api_key="placeholder"
+        ).get_llm()
+        assert llm.max_retries == 8
+
+    def test_max_retries_reaches_azure_client(self, monkeypatch):
+        # Azure's get_llm() reads its endpoint + API version from the env.
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+        monkeypatch.setenv("OPENAI_API_VERSION", "2024-10-21")
+        llm = create_llm_client(
+            provider="azure", model="my-deployment", max_retries=8, api_key="placeholder"
+        ).get_llm()
+        assert llm.max_retries == 8
+
+
+@pytest.mark.unit
+class TestProviderKwargsMaxRetries:
+    """_get_provider_kwargs int-coerces and forwards llm_max_retries, or omits it."""
+
+    def _kwargs_for(self, max_retries):
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+        # Call the method without constructing the full graph.
+        graph = TradingAgentsGraph.__new__(TradingAgentsGraph)
+        graph.config = {"llm_provider": "openai", "llm_max_retries": max_retries}
+        return TradingAgentsGraph._get_provider_kwargs(graph)
+
+    def test_int_passthrough(self):
+        assert self._kwargs_for(6)["max_retries"] == 6
+
+    def test_int_string_coerced(self):
+        assert self._kwargs_for("8")["max_retries"] == 8
+
+    def test_none_omitted(self):
+        assert "max_retries" not in self._kwargs_for(None)
+
+    def test_empty_string_omitted(self):
+        assert "max_retries" not in self._kwargs_for("")
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError, match="TRADINGAGENTS_LLM_MAX_RETRIES"):
+            self._kwargs_for("abc")
+
+    def test_negative_value_raises(self):
+        with pytest.raises(ValueError, match="TRADINGAGENTS_LLM_MAX_RETRIES"):
+            self._kwargs_for(-1)
+
+    def test_boolean_value_raises(self):
+        # bool is an int subclass; True/False must not become 1/0 retries.
+        with pytest.raises(ValueError, match="TRADINGAGENTS_LLM_MAX_RETRIES"):
+            self._kwargs_for(True)
+        with pytest.raises(ValueError, match="TRADINGAGENTS_LLM_MAX_RETRIES"):
+            self._kwargs_for(False)
+
+
+@pytest.mark.unit
+class TestMaxRetriesEnvOverlay:
+    """Default is None (provider keeps its own default); env var overrides it."""
+
+    def test_default_is_none(self, monkeypatch):
+        import tradingagents.default_config as dc
+        monkeypatch.delenv("TRADINGAGENTS_LLM_MAX_RETRIES", raising=False)
+        importlib.reload(dc)
+        assert dc.DEFAULT_CONFIG["llm_max_retries"] is None
+
+    def test_env_overrides(self, monkeypatch):
+        import tradingagents.default_config as dc
+        monkeypatch.setenv("TRADINGAGENTS_LLM_MAX_RETRIES", "8")
+        importlib.reload(dc)
+        # Stored as-is from env (string ok; consumed via int() at forward time).
+        assert int(dc.DEFAULT_CONFIG["llm_max_retries"]) == 8
+        monkeypatch.delenv("TRADINGAGENTS_LLM_MAX_RETRIES", raising=False)
+        importlib.reload(dc)

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -12,6 +12,7 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_DEEP_THINK_LLM":       "deep_think_llm",
     "TRADINGAGENTS_QUICK_THINK_LLM":      "quick_think_llm",
     "TRADINGAGENTS_LLM_BACKEND_URL":      "backend_url",
+    "TRADINGAGENTS_LLM_MAX_RETRIES":      "llm_max_retries",
     "TRADINGAGENTS_OUTPUT_LANGUAGE":      "output_language",
     "TRADINGAGENTS_MAX_DEBATE_ROUNDS":    "max_debate_rounds",
     "TRADINGAGENTS_MAX_RISK_ROUNDS":      "max_risk_discuss_rounds",
@@ -86,6 +87,14 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # provider-specific URL here would leak (e.g. OpenAI's /v1 was previously
     # being forwarded to Gemini, producing malformed request URLs).
     "backend_url": None,
+    # Optional override for the LLM client retry budget on transient provider
+    # errors (e.g. HTTP 429 rate limits). None keeps each provider/SDK's own
+    # default (the OpenAI/Azure SDK default is 2); set a higher value to ride
+    # out bursty throttling, since the SDK retries with exponential backoff and
+    # honors Retry-After. Forwarded to every provider client only when set
+    # (max_retries is in each one's passthrough list). Override via
+    # TRADINGAGENTS_LLM_MAX_RETRIES.
+    "llm_max_retries": None,
     # Provider-specific thinking configuration
     "google_thinking_level": None,      # "high", "minimal", etc.
     "openai_reasoning_effort": None,    # "medium", "high", "low"

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -156,6 +156,34 @@ class TradingAgentsGraph:
         if temperature is not None and temperature != "":
             kwargs["temperature"] = float(temperature)
 
+        # Retry budget for transient provider errors (HTTP 429 rate limits,
+        # brief 5xx). The OpenAI/Azure SDK retries with exponential backoff and
+        # honors Retry-After, so a higher count lets a run ride out bursty
+        # throttling. ``max_retries`` is in every client's passthrough list, so
+        # this forwards uniformly across providers.
+        max_retries = self.config.get("llm_max_retries")
+        if max_retries is not None and max_retries != "":
+            # bool is an int subclass: reject True/False explicitly so they
+            # don't silently become 1/0 retries.
+            if isinstance(max_retries, bool):
+                raise ValueError(
+                    "llm_max_retries (TRADINGAGENTS_LLM_MAX_RETRIES) must be a "
+                    f"non-negative integer, got {max_retries!r}"
+                )
+            try:
+                max_retries = int(max_retries)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "llm_max_retries (TRADINGAGENTS_LLM_MAX_RETRIES) must be a "
+                    f"non-negative integer, got {max_retries!r}"
+                ) from exc
+            if max_retries < 0:
+                raise ValueError(
+                    "llm_max_retries (TRADINGAGENTS_LLM_MAX_RETRIES) must be a "
+                    f"non-negative integer, got {max_retries}"
+                )
+            kwargs["max_retries"] = max_retries
+
         return kwargs
 
     def _create_tool_nodes(self) -> dict[str, ToolNode]:


### PR DESCRIPTION
Resolves #1091

## Summary Adds an opt-in `llm_max_retries` config knob (env: `TRADINGAGENTS_LLM_MAX_RETRIES`), forwarded to every provider's chat client. When unset (default `None`), each provider/SDK keeps its own retry default (OpenAI/Azure SDK = 2) — **no change to existing behavior**.  ## Motivation On long multi-agent runs against a rate-limited deployment, the pipeline aborts on a transient `RateLimitError: 429` (e.g. mid "Neutral Analyst"). The OpenAI/Azure SDK already retries with exponential backoff and honors `Retry-After`; this makes the retry budget configurable so a run can ride out bursty throttling instead of failing.  ## Changes - `default_config.py`: new `llm_max_retries` key (default `None`) + `TRADINGAGENTS_LLM_MAX_RETRIES` env override. - `graph/trading_graph.py`: `_get_provider_kwargs()` forwards `max_retries` only when set, int-coerced, with validation (friendly error, rejects negatives). Applies to both deep and quick LLMs across all providers (the kwarg is already in every client's passthrough list). - `.env.example`: documents the knob. - Tests: forwarding (incl. Azure), `_get_provider_kwargs` coercion/validation, and env-overlay coverage.  ## Test plan - `pytest` -> 503 passed, 2 pre-existing skips - `ruff check` -> clean - Default unchanged: nothing forwarded when the knob is unset (covered by a test) 
