### PR TITLE
fix(graph): route debate edges by source node

### DIFF
--- a/tests/test_conditional_logic.py
+++ b/tests/test_conditional_logic.py
@@ -1,0 +1,47 @@
+import pytest
+
+from tradingagents.graph.conditional_logic import ConditionalLogic
+
+
+def _state(investment_count=0, risk_count=0):
+    return {
+        "investment_debate_state": {
+            "count": investment_count,
+            "current_response": "unexpected speaker",
+        },
+        "risk_debate_state": {
+            "count": risk_count,
+            "latest_speaker": "unexpected speaker",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("method_name", "allowed_next_node"),
+    [
+        ("should_continue_after_bull_researcher", "Bear Researcher"),
+        ("should_continue_after_bear_researcher", "Bull Researcher"),
+    ],
+)
+def test_investment_debate_edges_only_return_mapped_nodes(method_name, allowed_next_node):
+    logic = ConditionalLogic(max_debate_rounds=1)
+    router = getattr(logic, method_name)
+
+    assert router(_state(investment_count=0)) == allowed_next_node
+    assert router(_state(investment_count=2)) == "Research Manager"
+
+
+@pytest.mark.parametrize(
+    ("method_name", "allowed_next_node"),
+    [
+        ("should_continue_after_aggressive_analyst", "Conservative Analyst"),
+        ("should_continue_after_conservative_analyst", "Neutral Analyst"),
+        ("should_continue_after_neutral_analyst", "Aggressive Analyst"),
+    ],
+)
+def test_risk_debate_edges_only_return_mapped_nodes(method_name, allowed_next_node):
+    logic = ConditionalLogic(max_risk_discuss_rounds=1)
+    router = getattr(logic, method_name)
+
+    assert router(_state(risk_count=0)) == allowed_next_node
+    assert router(_state(risk_count=3)) == "Portfolio Manager"

--- a/tradingagents/graph/conditional_logic.py
+++ b/tradingagents/graph/conditional_logic.py
@@ -52,22 +52,54 @@ class ConditionalLogic:
     def should_continue_debate(self, state: AgentState) -> str:
         """Determine if debate should continue."""
 
-        if (
-            state["investment_debate_state"]["count"] >= 2 * self.max_debate_rounds
-        ):  # 3 rounds of back-and-forth between 2 agents
+        if self._investment_debate_is_complete(state):
             return "Research Manager"
         if state["investment_debate_state"]["current_response"].startswith("Bull"):
             return "Bear Researcher"
         return "Bull Researcher"
 
+    def should_continue_after_bull_researcher(self, state: AgentState) -> str:
+        """Determine the next node after the Bull Researcher."""
+        if self._investment_debate_is_complete(state):
+            return "Research Manager"
+        return "Bear Researcher"
+
+    def should_continue_after_bear_researcher(self, state: AgentState) -> str:
+        """Determine the next node after the Bear Researcher."""
+        if self._investment_debate_is_complete(state):
+            return "Research Manager"
+        return "Bull Researcher"
+
+    def _investment_debate_is_complete(self, state: AgentState) -> bool:
+        return state["investment_debate_state"]["count"] >= 2 * self.max_debate_rounds
+
     def should_continue_risk_analysis(self, state: AgentState) -> str:
         """Determine if risk analysis should continue."""
-        if (
-            state["risk_debate_state"]["count"] >= 3 * self.max_risk_discuss_rounds
-        ):  # 3 rounds of back-and-forth between 3 agents
+        if self._risk_analysis_is_complete(state):
             return "Portfolio Manager"
         if state["risk_debate_state"]["latest_speaker"].startswith("Aggressive"):
             return "Conservative Analyst"
         if state["risk_debate_state"]["latest_speaker"].startswith("Conservative"):
             return "Neutral Analyst"
         return "Aggressive Analyst"
+
+    def should_continue_after_aggressive_analyst(self, state: AgentState) -> str:
+        """Determine the next node after the Aggressive Analyst."""
+        if self._risk_analysis_is_complete(state):
+            return "Portfolio Manager"
+        return "Conservative Analyst"
+
+    def should_continue_after_conservative_analyst(self, state: AgentState) -> str:
+        """Determine the next node after the Conservative Analyst."""
+        if self._risk_analysis_is_complete(state):
+            return "Portfolio Manager"
+        return "Neutral Analyst"
+
+    def should_continue_after_neutral_analyst(self, state: AgentState) -> str:
+        """Determine the next node after the Neutral Analyst."""
+        if self._risk_analysis_is_complete(state):
+            return "Portfolio Manager"
+        return "Aggressive Analyst"
+
+    def _risk_analysis_is_complete(self, state: AgentState) -> bool:
+        return state["risk_debate_state"]["count"] >= 3 * self.max_risk_discuss_rounds

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -42,9 +42,7 @@ class GraphSetup:
         self.tool_nodes = tool_nodes
         self.conditional_logic = conditional_logic
 
-    def setup_graph(
-        self, selected_analysts=("market", "social", "news", "fundamentals")
-    ):
+    def setup_graph(self, selected_analysts=("market", "social", "news", "fundamentals")):
         """Set up and compile the agent workflow graph.
 
         Args:
@@ -121,7 +119,7 @@ class GraphSetup:
         # Add remaining edges
         workflow.add_conditional_edges(
             "Bull Researcher",
-            self.conditional_logic.should_continue_debate,
+            self.conditional_logic.should_continue_after_bull_researcher,
             {
                 "Bear Researcher": "Bear Researcher",
                 "Research Manager": "Research Manager",
@@ -129,7 +127,7 @@ class GraphSetup:
         )
         workflow.add_conditional_edges(
             "Bear Researcher",
-            self.conditional_logic.should_continue_debate,
+            self.conditional_logic.should_continue_after_bear_researcher,
             {
                 "Bull Researcher": "Bull Researcher",
                 "Research Manager": "Research Manager",
@@ -139,7 +137,7 @@ class GraphSetup:
         workflow.add_edge("Trader", "Aggressive Analyst")
         workflow.add_conditional_edges(
             "Aggressive Analyst",
-            self.conditional_logic.should_continue_risk_analysis,
+            self.conditional_logic.should_continue_after_aggressive_analyst,
             {
                 "Conservative Analyst": "Conservative Analyst",
                 "Portfolio Manager": "Portfolio Manager",
@@ -147,7 +145,7 @@ class GraphSetup:
         )
         workflow.add_conditional_edges(
             "Conservative Analyst",
-            self.conditional_logic.should_continue_risk_analysis,
+            self.conditional_logic.should_continue_after_conservative_analyst,
             {
                 "Neutral Analyst": "Neutral Analyst",
                 "Portfolio Manager": "Portfolio Manager",
@@ -155,7 +153,7 @@ class GraphSetup:
         )
         workflow.add_conditional_edges(
             "Neutral Analyst",
-            self.conditional_logic.should_continue_risk_analysis,
+            self.conditional_logic.should_continue_after_neutral_analyst,
             {
                 "Aggressive Analyst": "Aggressive Analyst",
                 "Portfolio Manager": "Portfolio Manager",


### PR DESCRIPTION
## Summary
- replace shared debate routers in graph setup with source-node-specific router methods
- keep legacy shared router methods available while each conditional edge now only returns labels in its own path map
- add regression tests for unexpected speaker labels and completion routing

Closes #1088

## Tests
- .\\.venv\\Scripts\\python.exe -m pytest tests/test_conditional_logic.py
- .\\.venv\\Scripts\\python.exe -m ruff check tradingagents/graph/conditional_logic.py tradingagents/graph/setup.py tests/test_conditional_logic.py
- .\\.venv\\Scripts\\python.exe -m ruff format --check tradingagents/graph/conditional_logic.py tradingagents/graph/setup.py tests/test_conditional_logic.py