### PR TITLE
fix(graph): include run signature in checkpoint id

### DIFF
--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -76,6 +76,43 @@ class TestCheckpointResume(unittest.TestCase):
         # analyst added 1, trader added 10 → 11
         self.assertEqual(result["count"], 11)
 
+    def test_run_signature_changes_thread_id(self):
+        """Different graph-shaping signatures must not share a checkpoint thread."""
+        base = thread_id(self.ticker, self.date)
+        market_only = thread_id(self.ticker, self.date, "analysts=market")
+        news_only = thread_id(self.ticker, self.date, "analysts=news")
+
+        self.assertNotEqual(base, market_only)
+        self.assertNotEqual(market_only, news_only)
+
+    def test_different_run_signature_starts_fresh(self):
+        """A changed run signature must not resume a stale checkpoint."""
+        global _should_crash
+        builder = _build_graph()
+        sig1 = "analysts=market"
+        sig2 = "analysts=news"
+        tid1 = thread_id(self.ticker, self.date, sig1)
+
+        # Run with sig1 — crash to leave a checkpoint.
+        _should_crash = True
+        with get_checkpointer(self.tmpdir, self.ticker) as saver:
+            graph = builder.compile(checkpointer=saver)
+            with self.assertRaises(RuntimeError):
+                graph.invoke({"count": 0}, config={"configurable": {"thread_id": tid1}})
+
+        self.assertTrue(has_checkpoint(self.tmpdir, self.ticker, self.date, sig1))
+        self.assertFalse(has_checkpoint(self.tmpdir, self.ticker, self.date, sig2))
+
+        # Run with sig2 — should start fresh, not resume sig1's checkpoint.
+        _should_crash = False
+        tid2 = thread_id(self.ticker, self.date, sig2)
+        with get_checkpointer(self.tmpdir, self.ticker) as saver:
+            graph = builder.compile(checkpointer=saver)
+            result = graph.invoke({"count": 0}, config={"configurable": {"thread_id": tid2}})
+
+        self.assertEqual(result["count"], 11)
+        self.assertTrue(has_checkpoint(self.tmpdir, self.ticker, self.date, sig1))
+
     def test_clear_checkpoint_allows_fresh_start(self):
         """After clearing, the graph starts from scratch."""
         global _should_crash

--- a/tradingagents/graph/checkpointer.py
+++ b/tradingagents/graph/checkpointer.py
@@ -25,9 +25,12 @@ def _db_path(data_dir: str | Path, ticker: str) -> Path:
     return p / f"{safe}.db"
 
 
-def thread_id(ticker: str, date: str) -> str:
-    """Deterministic thread ID for a ticker+date pair."""
-    return hashlib.sha256(f"{ticker.upper()}:{date}".encode()).hexdigest()[:16]
+def thread_id(ticker: str, date: str, run_signature: str | None = None) -> str:
+    """Deterministic thread ID for a ticker/date/run-shape combination."""
+    parts = [ticker.upper(), date]
+    if run_signature:
+        parts.append(run_signature)
+    return hashlib.sha256(":".join(parts).encode()).hexdigest()[:16]
 
 
 @contextmanager
@@ -43,17 +46,27 @@ def get_checkpointer(data_dir: str | Path, ticker: str) -> Generator[SqliteSaver
         conn.close()
 
 
-def has_checkpoint(data_dir: str | Path, ticker: str, date: str) -> bool:
+def has_checkpoint(
+    data_dir: str | Path,
+    ticker: str,
+    date: str,
+    run_signature: str | None = None,
+) -> bool:
     """Check whether a resumable checkpoint exists for ticker+date."""
-    return checkpoint_step(data_dir, ticker, date) is not None
+    return checkpoint_step(data_dir, ticker, date, run_signature) is not None
 
 
-def checkpoint_step(data_dir: str | Path, ticker: str, date: str) -> int | None:
+def checkpoint_step(
+    data_dir: str | Path,
+    ticker: str,
+    date: str,
+    run_signature: str | None = None,
+) -> int | None:
     """Return the step number of the latest checkpoint, or None if none exists."""
     db = _db_path(data_dir, ticker)
     if not db.exists():
         return None
-    tid = thread_id(ticker, date)
+    tid = thread_id(ticker, date, run_signature)
     with get_checkpointer(data_dir, ticker) as saver:
         config = {"configurable": {"thread_id": tid}}
         cp = saver.get_tuple(config)
@@ -73,12 +86,17 @@ def clear_all_checkpoints(data_dir: str | Path) -> int:
     return len(dbs)
 
 
-def clear_checkpoint(data_dir: str | Path, ticker: str, date: str) -> None:
+def clear_checkpoint(
+    data_dir: str | Path,
+    ticker: str,
+    date: str,
+    run_signature: str | None = None,
+) -> None:
     """Remove checkpoint for a specific ticker+date by deleting the thread's rows."""
     db = _db_path(data_dir, ticker)
     if not db.exists():
         return
-    tid = thread_id(ticker, date)
+    tid = thread_id(ticker, date, run_signature)
     conn = sqlite3.connect(str(db))
     try:
         for table in ("writes", "checkpoints"):

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -65,6 +65,7 @@ class TradingAgentsGraph:
         self.debug = debug
         self.config = config or DEFAULT_CONFIG
         self.callbacks = callbacks or []
+        self.selected_analysts = tuple(selected_analysts)
 
         # Update the interface's config
         set_config(self.config)
@@ -125,9 +126,19 @@ class TradingAgentsGraph:
         self.log_states_dict = {}  # date to full state dict
 
         # Set up the graph: keep the workflow for recompilation with a checkpointer.
-        self.workflow = self.graph_setup.setup_graph(selected_analysts)
+        self.workflow = self.graph_setup.setup_graph(self.selected_analysts)
         self.graph = self.workflow.compile()
         self._checkpointer_ctx = None
+
+    def _checkpoint_run_signature(self, asset_type: str) -> str:
+        """Fingerprint graph-shaping choices for checkpoint resume identity."""
+        payload = {
+            "selected_analysts": list(self.selected_analysts),
+            "asset_type": asset_type,
+            "max_debate_rounds": self.config["max_debate_rounds"],
+            "max_risk_discuss_rounds": self.config["max_risk_discuss_rounds"],
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
     def _get_provider_kwargs(self) -> dict[str, Any]:
         """Get provider-specific kwargs for LLM client creation."""
@@ -335,6 +346,7 @@ class TradingAgentsGraph:
 
         # Recompile with a checkpointer if the user opted in.
         if self.config.get("checkpoint_enabled"):
+            run_signature = self._checkpoint_run_signature(asset_type)
             self._checkpointer_ctx = get_checkpointer(
                 self.config["data_cache_dir"], company_name
             )
@@ -342,7 +354,10 @@ class TradingAgentsGraph:
             self.graph = self.workflow.compile(checkpointer=saver)
 
             step = checkpoint_step(
-                self.config["data_cache_dir"], company_name, str(trade_date)
+                self.config["data_cache_dir"],
+                company_name,
+                str(trade_date),
+                run_signature,
             )
             if step is not None:
                 logger.info(
@@ -391,7 +406,8 @@ class TradingAgentsGraph:
 
         # Inject thread_id so same ticker+date resumes, different date starts fresh.
         if self.config.get("checkpoint_enabled"):
-            tid = thread_id(company_name, str(trade_date))
+            run_signature = self._checkpoint_run_signature(asset_type)
+            tid = thread_id(company_name, str(trade_date), run_signature)
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
 
         if self.debug:
@@ -431,8 +447,12 @@ class TradingAgentsGraph:
 
         # Clear checkpoint on successful completion to avoid stale state.
         if self.config.get("checkpoint_enabled"):
+            run_signature = self._checkpoint_run_signature(asset_type)
             clear_checkpoint(
-                self.config["data_cache_dir"], company_name, str(trade_date)
+                self.config["data_cache_dir"],
+                company_name,
+                str(trade_date),
+                run_signature,
             )
 
         return final_state, self.process_signal(final_state["final_trade_decision"])


### PR DESCRIPTION
## Problem

Checkpoint resume currently identifies runs only by `ticker + date`. The compiled graph also depends on graph-shaping choices such as the selected analysts, asset type, and debate/risk round settings, so a crashed run can be resumed under a different requested graph and silently continue stale state.

Closes #1089

## Before / after

Before:
- `thread_id(ticker, date)` was reused for every checkpointed run with the same ticker/date.
- Changing selected analysts or other graph-shaping settings could still resume the previous checkpoint.

After:
- `thread_id()` accepts an optional run signature while keeping the old two-argument form working.
- `TradingAgentsGraph` fingerprints selected analysts, asset type, and debate/risk round settings when checkpointing.
- Checkpoint lookup, graph invocation, and checkpoint clearing all use the same signed thread id.

## Verification

- `python -m pytest tests/test_checkpoint_resume.py`
- `python -m ruff check tradingagents/graph/checkpointer.py tradingagents/graph/trading_graph.py tests/test_checkpoint_resume.py`
- `git diff --check`
