### PR TITLE
Add low-token Y4Y trading desk wrapper

### DIFF
--- a/docs/y4y_low_token_trading_desk.md
+++ b/docs/y4y_low_token_trading_desk.md
@@ -1,0 +1,188 @@
+# Y4Y Low-Token Trading Desk on TradingAgents
+
+Goal: keep TauricResearch/TradingAgents' useful trading-firm structure, but stop paying for the full 11+ LLM call workflow on every ticker. The desk should spend LLM tokens only after cheap deterministic gates say a symbol is worth human/agent attention.
+
+## Executive design
+
+```
+Universe -> deterministic scanner -> evidence pack -> cheap desk -> gated full desk -> executor/report
+```
+
+### Tier 0 — deterministic scanner, no LLM
+Runs on a broad watchlist using market data only.
+
+Inputs:
+- OHLCV / intraday quote
+- ATR, RSI, MACD, moving averages, volume ratio
+- spread / liquidity / options volume if available
+- existing positions and risk budget
+- event calendar flags: earnings, FOMC, CPI, Fed speakers
+
+Output per symbol:
+```json
+{
+  "symbol": "NVDA",
+  "score": 0-100,
+  "direction_bias": "long|short|neutral",
+  "why": ["above VWAP", "volume_ratio>1.8", "RSI reset"],
+  "risk_flags": ["earnings<3d", "spread_wide"],
+  "eligible": true
+}
+```
+
+Hard gates before any LLM:
+- skip if spread too wide
+- skip if volume below threshold
+- skip if ATR/stop distance makes risk too large
+- skip if earnings/FOMC/event risk violates profile
+- skip if no clean stop/target plan
+- skip if already max positions
+
+### Tier 1 — cheap analyst desk, 1 cheap LLM call per finalist
+Only top 3-5 scanner names reach this.
+
+Use a cheap/fast model, not frontier:
+- Preferred API: `deepseek/deepseek-v4-flash` through OpenRouter or DeepSeek direct
+- Backup cheap: `stepfun/step-3.7-flash` if free in UI, otherwise worse value than DeepSeek V4 Flash
+- Local option: Ollama / LM Studio via repo's `openai_compatible` provider for summaries only
+
+Prompt shape must be compressed and structured:
+- max ~1,500-2,500 input tokens per symbol
+- only the deterministic evidence pack, not raw articles/logs
+- output strict JSON: pass/fail, direction, catalysts, stop, target, confidence
+
+Tier 1 does NOT run bull/bear/risk debates. It is a triage filter.
+
+### Tier 2 — focused TradingAgents run, 1-2 symbols only
+Use the actual repo graph, but restrict analysts based on the setup:
+
+| Setup | `selected_analysts` | Reason |
+|---|---|---|
+| intraday / scalping | `("market", "news")` | technicals + live catalyst only |
+| swing trade | `("market", "news", "fundamentals")` | adds valuation/earnings context |
+| sentiment/crowded retail name | `("market", "social", "news")` | meme/social risk matters |
+| earnings/FOMC/high-vol | full set | only when event risk justifies spend |
+
+Config:
+```python
+config["max_debate_rounds"] = 1
+config["max_risk_discuss_rounds"] = 1
+config["news_article_limit"] = 5
+config["global_news_article_limit"] = 3
+config["global_news_lookback_days"] = 3
+config["temperature"] = 0.0
+config["checkpoint_enabled"] = True
+```
+
+Model routing:
+```python
+config["llm_provider"] = "openrouter"
+config["quick_think_llm"] = "deepseek/deepseek-v4-flash"
+config["deep_think_llm"] = "deepseek/deepseek-v4-flash"   # default low-burn
+```
+
+Escalate `deep_think_llm` to Sonnet/GPT only if:
+- proposed trade score >= 80
+- real-money profile and position size > normal starter
+- event risk requires nuanced reasoning
+- cheap desk and deterministic gates disagree
+- final output would trigger actual order placement
+
+### Tier 3 — execution/risk gate, no creative LLM
+Final gate should be deterministic code, not vibes.
+
+Checks:
+- max dollars at risk
+- stop distance and quantity
+- position correlation / sector concentration
+- daily loss stop
+- option liquidity / bid-ask spread if options
+- no 0DTE unless explicitly allowed
+- market hours / no after-hours bracket unless supported
+
+Output:
+- `EXECUTE`, `WATCH`, or `REJECT`
+- reason code
+- exact position size
+- stop, target, invalidation
+
+## Token-burn reductions vs stock TradingAgents
+
+1. **Do not run full framework on the whole universe.** Scanner handles breadth.
+2. **Reduce analyst set dynamically.** Most names do not need social + fundamentals + macro every run.
+3. **Summarize data before LLM.** Feed compact evidence packs, not raw news/articles/tool dumps.
+4. **Cache daily slow data.** Fundamentals/news/global macro should not be refetched every 5 minutes.
+5. **Use cheap model for all routine nodes.** Frontier model only for rare escalation.
+6. **Keep debate rounds at 1.** Multi-round debate is expensive and usually redundant for screening.
+7. **Use structured outputs.** JSON avoids long narrative reports until a trade is actually actionable.
+8. **Only write full markdown report for actionable finalists.** Otherwise log compact JSON.
+
+## Practical model budget
+
+Default cheap route:
+- Quick + deep: DeepSeek V4 Flash
+- Reasoning effort: low / none unless provider supports cheap thinking mode
+- Output cap: 600-900 tokens for triage, 1,500 for final full report
+
+Escalation route:
+- Cheap model makes the case
+- Premium model acts as final committee chair only after deterministic gate passes
+- One premium call maximum per trade idea
+
+## Recommended desk roles
+
+### Deterministic Scanner
+Code-only. Produces ranked candidates and evidence packs.
+
+### Tape/Technical Analyst
+Usually TradingAgents `market` analyst. Cheap model. Verifies setup.
+
+### Catalyst Analyst
+TradingAgents `news` analyst with article limits reduced. Cheap model.
+
+### Fundamentals Analyst
+Only for swing trades / multi-day debit options / high conviction equities.
+
+### Sentiment Analyst
+Only for meme/high-retail names or when social squeeze risk matters.
+
+### Bull/Bear Research Pair
+Keep, but one round only. Use cheap model. Their job is to find disconfirming evidence, not write essays.
+
+### Risk Officer
+Mostly deterministic. LLM can summarize risk, but sizing/eligibility is code.
+
+### Portfolio Manager
+Default cheap model. Escalate only on real-money/actionable trades.
+
+## Output format for Discord
+
+Keep final report tiny:
+
+```
+SYMBOL — ACTION / WATCH / REJECT
+Bias: long/short/neutral | Score: 84/100 | Risk: low/med/high
+Entry: x.xx | Stop: x.xx | Target: x.xx | Size: $150 risk / N shares/contracts
+Why: 3 bullets max
+Reject/Watch reason: if not executing
+```
+
+## First implementation target
+
+Use the repo as a research engine, not an always-on auto-trader:
+
+1. Build `scripts/y4y_low_token_desk.py`
+2. It runs scanner across a watchlist
+3. It selects top N
+4. It runs TradingAgents only on those finalists with a reduced analyst set
+5. It writes `results/y4y_desk/latest.json`
+6. A separate executor can consume only `EXECUTE` records after deterministic risk checks
+
+## Safety stance
+
+Paper first. No direct live execution until:
+- 30+ trading days forward-tested
+- costs/slippage included
+- exact Alpaca/RH execution constraints wired
+- daily stop-loss and position watcher verified
+- premium-model escalation does not change deterministic risk limits

--- a/results/y4y_desk/.gitignore
+++ b/results/y4y_desk/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/y4y_low_token_desk.py
+++ b/scripts/y4y_low_token_desk.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Low-token TradingAgents desk wrapper for Y4Y.
+
+This script keeps the useful TradingAgents multi-agent desk, but puts a cheap
+code-only scanner in front of it so the expensive graph only runs on finalists.
+
+Usage examples:
+
+  # Scanner only; no LLM calls
+  python scripts/y4y_low_token_desk.py --symbols AAPL,NVDA,TSLA,SMH,SPY --scan-only
+
+  # Run TradingAgents only for top finalist(s), with a reduced analyst set
+  OPENROUTER_API_KEY=... python scripts/y4y_low_token_desk.py \
+      --symbols AAPL,NVDA,TSLA,SMH,SPY --run-agents --max-finalists 1
+
+Outputs JSON to results/y4y_desk/latest.json by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ScanResult:
+    symbol: str
+    score: float
+    direction_bias: str
+    eligible: bool
+    close: float | None = None
+    rsi14: float | None = None
+    volume_ratio: float | None = None
+    atr_pct: float | None = None
+    ma20: float | None = None
+    ma50: float | None = None
+    why: list[str] = field(default_factory=list)
+    risk_flags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DeskDecision:
+    symbol: str
+    status: str  # SCAN_ONLY | WATCH | REJECT | AGENT_DECISION | ERROR
+    scanner: ScanResult
+    selected_analysts: tuple[str, ...]
+    agent_decision: Any = None
+    error: str | None = None
+
+
+def _load_yfinance():
+    try:
+        import yfinance as yf  # type: ignore
+        return yf
+    except Exception as exc:  # pragma: no cover - environment dependent
+        raise SystemExit(
+            "yfinance is required for scanner mode. Install repo deps with `pip install .` "
+            "or at least `pip install yfinance`. Original error: " + repr(exc)
+        ) from exc
+
+
+def _rsi(values, period: int = 14) -> float | None:
+    if len(values) <= period:
+        return None
+    gains = []
+    losses = []
+    for prev, curr in zip(values[-period - 1 : -1], values[-period:], strict=False):
+        diff = curr - prev
+        gains.append(max(diff, 0.0))
+        losses.append(max(-diff, 0.0))
+    avg_gain = sum(gains) / period
+    avg_loss = sum(losses) / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def _sma(values, n: int) -> float | None:
+    if len(values) < n:
+        return None
+    return sum(values[-n:]) / n
+
+
+def _atr_pct(highs, lows, closes, period: int = 14) -> float | None:
+    if len(closes) <= period:
+        return None
+    trs = []
+    for i in range(len(closes) - period, len(closes)):
+        prev_close = closes[i - 1]
+        tr = max(highs[i] - lows[i], abs(highs[i] - prev_close), abs(lows[i] - prev_close))
+        trs.append(tr)
+    close = closes[-1]
+    if close <= 0:
+        return None
+    return (sum(trs) / len(trs)) / close * 100
+
+
+def scan_symbol(symbol: str, lookback: str = "6mo") -> ScanResult:
+    """Cheap deterministic scanner: zero LLM/API-token burn."""
+    yf = _load_yfinance()
+    hist = yf.Ticker(symbol).history(period=lookback, interval="1d", auto_adjust=True)
+    if hist is None or hist.empty or len(hist) < 55:
+        return ScanResult(
+            symbol=symbol,
+            score=0,
+            direction_bias="neutral",
+            eligible=False,
+            why=[],
+            risk_flags=["insufficient_price_history"],
+        )
+
+    closes = [float(x) for x in hist["Close"].tolist()]
+    highs = [float(x) for x in hist["High"].tolist()]
+    lows = [float(x) for x in hist["Low"].tolist()]
+    vols = [float(x) for x in hist["Volume"].tolist()]
+    close = closes[-1]
+    ma20 = _sma(closes, 20)
+    ma50 = _sma(closes, 50)
+    rsi14 = _rsi(closes, 14)
+    atr = _atr_pct(highs, lows, closes, 14)
+    avg_vol20 = sum(vols[-21:-1]) / 20 if len(vols) >= 21 else 0
+    volume_ratio = vols[-1] / avg_vol20 if avg_vol20 else None
+
+    score = 0.0
+    why: list[str] = []
+    flags: list[str] = []
+
+    if ma20 and close > ma20:
+        score += 15
+        why.append("close>20dma")
+    if ma50 and close > ma50:
+        score += 15
+        why.append("close>50dma")
+    if ma20 and ma50 and ma20 > ma50:
+        score += 10
+        why.append("20dma>50dma")
+    if rsi14 is not None:
+        if 45 <= rsi14 <= 68:
+            score += 15
+            why.append("rsi_constructive")
+        elif rsi14 > 78:
+            flags.append("rsi_overheated")
+            score -= 10
+        elif rsi14 < 35:
+            flags.append("rsi_weak_or_oversold")
+    if volume_ratio is not None:
+        if volume_ratio >= 1.5:
+            score += 15
+            why.append("volume_expansion")
+        elif volume_ratio < 0.65:
+            flags.append("low_relative_volume")
+            score -= 5
+    if atr is not None:
+        if 1.0 <= atr <= 5.5:
+            score += 10
+            why.append("tradable_atr")
+        elif atr > 8:
+            flags.append("atr_too_wide")
+            score -= 15
+
+    # Simple momentum: 5-day and 20-day returns.
+    ret5 = (closes[-1] / closes[-6] - 1) * 100 if len(closes) >= 6 else 0
+    ret20 = (closes[-1] / closes[-21] - 1) * 100 if len(closes) >= 21 else 0
+    if ret5 > 0 and ret20 > 0:
+        score += 15
+        why.append("positive_5d_20d_momentum")
+    elif ret5 < -4 and ret20 < 0:
+        flags.append("downtrend_pressure")
+        score -= 10
+
+    direction = "long" if score >= 55 and close > (ma20 or close) else "neutral"
+    eligible = score >= 60 and "atr_too_wide" not in flags and "low_relative_volume" not in flags
+
+    return ScanResult(
+        symbol=symbol.upper(),
+        score=round(max(0, min(100, score)), 2),
+        direction_bias=direction,
+        eligible=eligible,
+        close=round(close, 4),
+        rsi14=round(rsi14, 2) if rsi14 is not None and math.isfinite(rsi14) else None,
+        volume_ratio=round(volume_ratio, 2) if volume_ratio is not None and math.isfinite(volume_ratio) else None,
+        atr_pct=round(atr, 2) if atr is not None and math.isfinite(atr) else None,
+        ma20=round(ma20, 4) if ma20 else None,
+        ma50=round(ma50, 4) if ma50 else None,
+        why=why,
+        risk_flags=flags,
+    )
+
+
+def analysts_for(result: ScanResult, mode: str) -> tuple[str, ...]:
+    """Choose the smallest useful TradingAgents analyst set."""
+    if mode == "intraday":
+        return ("market", "news")
+    if mode == "swing":
+        return ("market", "news", "fundamentals")
+    if mode == "sentiment":
+        return ("market", "social", "news")
+    if mode == "full":
+        return ("market", "social", "news", "fundamentals")
+    # Auto: keep it cheap unless the scanner says it is high-conviction.
+    if result.score >= 80:
+        return ("market", "news", "fundamentals")
+    return ("market", "news")
+
+
+def low_token_config() -> dict[str, Any]:
+    """TradingAgents config tuned for low token burn."""
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG.copy()
+    cfg.update(
+        {
+            "llm_provider": os.getenv("Y4Y_LLM_PROVIDER", "openrouter"),
+            "quick_think_llm": os.getenv("Y4Y_QUICK_MODEL", "deepseek/deepseek-v4-flash"),
+            "deep_think_llm": os.getenv("Y4Y_DEEP_MODEL", "deepseek/deepseek-v4-flash"),
+            "max_debate_rounds": int(os.getenv("Y4Y_MAX_DEBATE_ROUNDS", "1")),
+            "max_risk_discuss_rounds": int(os.getenv("Y4Y_MAX_RISK_ROUNDS", "1")),
+            "news_article_limit": int(os.getenv("Y4Y_NEWS_ARTICLE_LIMIT", "5")),
+            "global_news_article_limit": int(os.getenv("Y4Y_GLOBAL_NEWS_LIMIT", "3")),
+            "global_news_lookback_days": int(os.getenv("Y4Y_GLOBAL_NEWS_DAYS", "3")),
+            "temperature": float(os.getenv("Y4Y_TEMPERATURE", "0")),
+            "checkpoint_enabled": True,
+        }
+    )
+    return cfg
+
+
+def run_tradingagents(symbol: str, trade_date: str, selected_analysts: tuple[str, ...]) -> Any:
+    """Run the repo's TradingAgents graph only after scanner gates pass."""
+    from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+    cfg = low_token_config()
+    ta = TradingAgentsGraph(selected_analysts=selected_analysts, debug=False, config=cfg)
+    _state, decision = ta.propagate(symbol, trade_date)
+    return decision
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Y4Y low-token TradingAgents desk")
+    parser.add_argument("--symbols", default="SPY,QQQ,NVDA,TSLA,SMH,AAPL,MSFT,AMZN,GOOGL,META")
+    parser.add_argument("--trade-date", default=str(date.today()))
+    parser.add_argument("--mode", choices=["auto", "intraday", "swing", "sentiment", "full"], default="auto")
+    parser.add_argument("--max-finalists", type=int, default=2)
+    parser.add_argument("--min-score", type=float, default=60.0)
+    parser.add_argument("--scan-only", action="store_true", help="never call LLMs")
+    parser.add_argument("--run-agents", action="store_true", help="run TradingAgents for finalists")
+    parser.add_argument("--out", default="results/y4y_desk/latest.json")
+    args = parser.parse_args()
+
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    scans = [scan_symbol(s) for s in symbols]
+    scans.sort(key=lambda x: x.score, reverse=True)
+    finalists = [s for s in scans if s.eligible and s.score >= args.min_score][: args.max_finalists]
+
+    decisions: list[DeskDecision] = []
+    for result in finalists:
+        selected = analysts_for(result, args.mode)
+        if args.run_agents and not args.scan_only:
+            try:
+                agent_decision = run_tradingagents(result.symbol, args.trade_date, selected)
+                decisions.append(
+                    DeskDecision(
+                        symbol=result.symbol,
+                        status="AGENT_DECISION",
+                        scanner=result,
+                        selected_analysts=selected,
+                        agent_decision=agent_decision,
+                    )
+                )
+            except Exception as exc:  # keep the desk from dying on one ticker
+                decisions.append(
+                    DeskDecision(
+                        symbol=result.symbol,
+                        status="ERROR",
+                        scanner=result,
+                        selected_analysts=selected,
+                        error=repr(exc),
+                    )
+                )
+        else:
+            decisions.append(
+                DeskDecision(
+                    symbol=result.symbol,
+                    status="SCAN_ONLY",
+                    scanner=result,
+                    selected_analysts=selected,
+                )
+            )
+
+    payload = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "trade_date": args.trade_date,
+        "model_budget": {
+            "default_provider": os.getenv("Y4Y_LLM_PROVIDER", "openrouter"),
+            "quick_model": os.getenv("Y4Y_QUICK_MODEL", "deepseek/deepseek-v4-flash"),
+            "deep_model": os.getenv("Y4Y_DEEP_MODEL", "deepseek/deepseek-v4-flash"),
+            "full_graph_calls": len([d for d in decisions if d.status == "AGENT_DECISION"]),
+        },
+        "scanner_ranked": [asdict(s) for s in scans],
+        "decisions": [asdict(d) for d in decisions],
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a low-token TradingAgents desk wrapper that uses a deterministic scanner before invoking the multi-agent graph only on finalists.

Changes:
- Adds docs/y4y_low_token_trading_desk.md with the desk architecture and token-budget rules.
- Adds scripts/y4y_low_token_desk.py scanner/wrapper.
- Keeps generated runtime JSON out of git via results/y4y_desk/.gitignore.

Validation performed locally:
- python3 -m py_compile scripts/y4y_low_token_desk.py
- scanner-only smoke run over SPY, QQQ, NVDA, TSLA, SMH, AAPL, MSFT
- JSON output validation
- TradingAgents import and reduced analyst plan validation