### PR TITLE
fix(dataflows): map Yahoo crypto pairs to StockTwits .X symbols

### DIFF
--- a/tests/test_stocktwits_resilience.py
+++ b/tests/test_stocktwits_resilience.py
@@ -40,3 +40,34 @@ class StockTwitsResilienceTests:
             out = stocktwits.fetch_stocktwits_messages("NVDA")
         assert "unavailable" in out.lower()
         assert out.startswith("<stocktwits unavailable")
+
+
+@pytest.mark.unit
+class TestStockTwitsCryptoSymbols:
+    """Yahoo-style crypto pairs must hit StockTwits' ``<BASE>.X`` symbols;
+    the ``<BASE>-USD`` form 404s on their API (equities pass through)."""
+
+    @pytest.mark.parametrize(
+        ("ticker", "expected"),
+        [
+            ("BTC-USD", "BTC.X"),
+            ("eth-usd", "ETH.X"),
+            ("SOL-USD", "SOL.X"),
+            ("AMD", "AMD"),
+            ("BRK-B", "BRK-B"),  # dashed equity class share: untouched
+            ("XYZ-USD", "XYZ-USD"),  # unknown base: not treated as crypto
+        ],
+    )
+    def test_symbol_mapping(self, ticker, expected):
+        assert stocktwits._stocktwits_symbol(ticker) == expected
+
+    def test_crypto_pair_requests_dot_x_endpoint(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            raise TimeoutError("stop after capturing the URL")
+
+        with patch.object(stocktwits, "urlopen", side_effect=fake_urlopen):
+            stocktwits.fetch_stocktwits_messages("BTC-USD")
+        assert "/symbol/BTC.X.json" in seen["url"]

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -25,6 +25,22 @@ _API = "https://api.stocktwits.com/api/2/streams/symbol/{ticker}.json"
 _UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
 
 
+def _stocktwits_symbol(ticker: str) -> str:
+    """Map a Yahoo-style crypto pair to StockTwits' crypto convention.
+
+    The pipeline normalizes crypto to Yahoo's ``<BASE>-USD`` form, but
+    StockTwits lists crypto as ``<BASE>.X`` (``BTC-USD`` 404s, ``BTC.X``
+    resolves to Bitcoin on exchange CRYPTO). Equity tickers pass through
+    unchanged.
+    """
+    from .symbol_utils import _CRYPTO_BASES
+
+    base, sep, quote = ticker.upper().partition("-")
+    if sep and quote == "USD" and base in _CRYPTO_BASES:
+        return f"{base}.X"
+    return ticker.upper()
+
+
 def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.0) -> str:
     """Fetch recent StockTwits messages for ``ticker`` and return them as a
     formatted plaintext block ready for prompt injection.
@@ -33,7 +49,7 @@ def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.
     symbol has no messages, or the response shape is unexpected — the
     caller never has to special-case None or exceptions.
     """
-    url = _API.format(ticker=ticker.upper())
+    url = _API.format(ticker=_stocktwits_symbol(ticker))
     req = Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
     try:
         with urlopen(req, timeout=timeout) as resp:

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -19,6 +19,8 @@ import json
 import logging
 from urllib.request import Request, urlopen
 
+from .symbol_utils import _CRYPTO_BASES
+
 logger = logging.getLogger(__name__)
 
 _API = "https://api.stocktwits.com/api/2/streams/symbol/{ticker}.json"
@@ -33,8 +35,6 @@ def _stocktwits_symbol(ticker: str) -> str:
     resolves to Bitcoin on exchange CRYPTO). Equity tickers pass through
     unchanged.
     """
-    from .symbol_utils import _CRYPTO_BASES
-
     base, sep, quote = ticker.upper().partition("-")
     if sep and quote == "USD" and base in _CRYPTO_BASES:
         return f"{base}.X"


### PR DESCRIPTION
## Problem

The pipeline normalizes crypto tickers to Yahoo's `<BASE>-USD` form (per `symbol_utils`), but StockTwits lists crypto under its own `<BASE>.X` convention. `fetch_stocktwits_messages` passes the ticker verbatim into the stream URL, so every crypto run logs:

```
StockTwits fetch failed for BTC-USD: HTTP Error 404: Not Found
```

and the Sentiment Analyst silently loses StockTwits sentiment for crypto — deterministically, not transiently. Verified against the live API: `/streams/symbol/BTC-USD.json` → 404; `/streams/symbol/BTC.X.json` → 200 (Bitcoin, exchange `CRYPTO`, sentiment-labeled messages).

## Fix

A small `_stocktwits_symbol()` mapper at the fetch boundary: `<BASE>-USD` → `<BASE>.X` for bases in the existing `symbol_utils._CRYPTO_BASES` set (single source of truth, no new list to maintain). Equities pass through unchanged, including dashed class shares like `BRK-B`; unknown `-USD` bases are left alone rather than guessed.

## Tests

Added `TestStockTwitsCryptoSymbols` to `tests/test_stocktwits_resilience.py`: parametrized mapping cases (crypto pairs, lowercase input, equities, dashed equity, unknown base) plus a mocked-transport test asserting the request URL actually targets `/symbol/BTC.X.json`.

One observation while adding these: the existing `StockTwitsResilienceTests` class doesn't match pytest's default `Test*` collection pattern, so its tests appear not to run in CI (`pytest --collect-only tests/test_stocktwits_resilience.py` collects nothing before this PR). I kept this PR minimal and didn't rename it, but happy to follow up with that one-line fix if wanted.

`pytest -q`: 497 passed, 2 skipped (missing optional API keys). `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)