### PR TITLE
fix(dataflows): actually apply the Alpha Vantage fundamentals look-ahead filter

### DIFF
--- a/tests/test_alpha_vantage_hardening.py
+++ b/tests/test_alpha_vantage_hardening.py
@@ -52,3 +52,26 @@ def test_invalid_key_not_mislabeled_as_rate_limit(monkeypatch):
     with pytest.raises(av.AlphaVantageRateLimitError):  # sanity: rate-limit path still distinct
         monkeypatch.setattr(av.requests, "get", _patched_get('{"Note": "API call frequency is 5 calls per minute."}'))
         av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+
+
+@pytest.mark.unit
+def test_fundamentals_filter_drops_future_fiscal_periods(monkeypatch):
+    # The look-ahead filter must actually run. _make_api_request returns a JSON
+    # *string*, so a filter guarded on isinstance(result, dict) never fires and
+    # future fiscal periods leak into a historical run. Regression for the #475
+    # look-ahead fix, which silently no-op'd on the str return.
+    import json
+
+    import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+
+    body = json.dumps({
+        "symbol": "AAPL",
+        "annualReports": [
+            {"fiscalDateEnding": "2025-12-31"},  # after curr_date -> must drop
+            {"fiscalDateEnding": "2023-12-31"},  # before          -> must keep
+        ],
+    })
+    monkeypatch.setattr(av.requests, "get", _patched_get(body))
+    out = avf.get_balance_sheet("AAPL", curr_date="2024-01-01")
+    dates = [r["fiscalDateEnding"] for r in json.loads(out)["annualReports"]]
+    assert dates == ["2023-12-31"]

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,21 +1,40 @@
+import json
+
 from .alpha_vantage_common import _make_api_request
 
 
 def _filter_reports_by_date(result, curr_date: str):
     """Filter annualReports/quarterlyReports to exclude entries after curr_date.
 
-    Prevents look-ahead bias by removing fiscal periods that end after
-    the simulation's current date.
+    Prevents look-ahead bias by removing fiscal periods that end after the
+    simulation's current date. ``_make_api_request`` returns the payload as a
+    JSON *string*, so parse it before filtering and re-serialize on the way out
+    (callers expect a str). Bodies that aren't JSON objects pass through
+    unchanged.
     """
-    if not curr_date or not isinstance(result, dict):
+    if not curr_date:
         return result
+
+    parsed = result
+    reserialize = False
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, ValueError):
+            return result
+        reserialize = True
+
+    if not isinstance(parsed, dict):
+        return result
+
     for key in ("annualReports", "quarterlyReports"):
-        if key in result:
-            result[key] = [
-                r for r in result[key]
+        if key in parsed:
+            parsed[key] = [
+                r for r in parsed[key]
                 if r.get("fiscalDateEnding", "") <= curr_date
             ]
-    return result
+
+    return json.dumps(parsed) if reserialize else parsed
 
 
 def get_fundamentals(ticker: str, curr_date: str = None) -> str:


### PR DESCRIPTION
## Summary

- `_filter_reports_by_date` guards on `isinstance(result, dict)`, but `_make_api_request` returns the fundamentals payload as a JSON **string**, so the guard falls through and the filter never runs. Annual/quarterly reports dated after `curr_date` leak into historical runs, silently undoing the look-ahead protection from #475.
- Parse the JSON string before filtering and re-serialize on the way out (callers still receive a `str`). Non-JSON / non-object bodies and `curr_date=None` behave exactly as before.
- Adds a regression test in the existing `tests/test_alpha_vantage_hardening.py` style — it fails on current `main` (`['2025-12-31', '2023-12-31']` survives a `curr_date='2024-01-01'` filter) and passes with this fix. No API key required: it monkeypatches `requests.get` like the neighboring tests.

Restores the CHANGELOG guarantee for #475 ("Backtesting fetchers no longer leak look-ahead data when `curr_date` is in the middle of a fetched window"), which the current code doesn't meet for the fundamentals endpoints (`get_balance_sheet`, `get_cashflow`, `get_income_statement`).

## Test plan

```
pytest tests/test_alpha_vantage_hardening.py -q
```

4 passed with the fix; the new test fails without it.