### PR TITLE
Add ChatGPT sign-in provider for OpenAI Codex

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ NVIDIA_API_KEY=
 # optional (local servers need none).
 #OPENAI_COMPATIBLE_API_KEY=
 
+# Optional: ChatGPT subscription auth through LangChain's experimental Codex
+# client. Select provider "openai_codex"; no OPENAI_API_KEY is used. The CLI
+# prompts for browser/device-code sign-in when needed and stores tokens at
+# ~/.langchain/chatgpt-auth.json.
+#TRADINGAGENTS_CODEX_ORIGINATOR=tradingagents
+#TRADINGAGENTS_CODEX_MODEL_LIST_TIMEOUT=8
+#TRADINGAGENTS_CODEX_INCLUDE_HIDDEN_MODELS=false
+
 # AWS Bedrock (provider "bedrock", install with: pip install ".[bedrock]").
 # Auth: either a Bedrock API key (bearer token, no AWS access keys) OR the AWS
 # credential chain (env keys / ~/.aws/credentials / IAM role / AWS_PROFILE). Set
@@ -63,6 +71,6 @@ NVIDIA_API_KEY=
 #TRADINGAGENTS_LLM_MAX_RETRIES=6
 # Provider-specific reasoning/thinking depth (optional; unset = provider
 # default). Setting one also skips the matching interactive prompt.
-#TRADINGAGENTS_OPENAI_REASONING_EFFORT=medium
+#TRADINGAGENTS_OPENAI_REASONING_EFFORT=xhigh
 #TRADINGAGENTS_GOOGLE_THINKING_LEVEL=high
 #TRADINGAGENTS_ANTHROPIC_EFFORT=high

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[codz]
 *$py.class
 
+# macOS
+.DS_Store
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 
 For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
 
+For ChatGPT subscription-backed OpenAI/Codex models, choose `llm_provider: "openai_codex"`. This uses LangChain's experimental ChatGPT OAuth Codex client, not the standard OpenAI Platform API, so it does not read `OPENAI_API_KEY` and does not bill through your API key account. The CLI checks your ChatGPT sign-in and prompts for browser or device-code sign-in when needed.
+
+The OAuth token is stored at `~/.langchain/chatgpt-auth.json`, separate from Codex CLI's `~/.codex/auth.json`. During model selection, TradingAgents first asks `codex app-server` for the live model catalog available to your signed-in Codex account; if app-server is unavailable, it falls back to the bundled model list plus a custom model ID option. This path is experimental and unofficial in LangChain; use it only where your account, workspace, plan, and applicable OpenAI terms permit ChatGPT-authenticated Codex access.
+
 For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_provider: "bedrock"`, configure AWS credentials (environment variables, `~/.aws/credentials`, or an IAM role) and `AWS_DEFAULT_REGION`, and use a Bedrock model ID, e.g. `us.anthropic.claude-opus-4-8-v1:0`.
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
@@ -205,7 +209,7 @@ An interface will appear showing results as they load, letting you track the age
 
 ### Implementation Details
 
-We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Ollama for local models, and Azure OpenAI for enterprise.
+We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, OpenAI Codex via ChatGPT sign-in, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Ollama for local models, and Azure OpenAI for enterprise.
 
 ### Python Usage
 
@@ -229,7 +233,7 @@ from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"        # e.g. openai, google, anthropic, deepseek, groq, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
+config["llm_provider"] = "openai"        # e.g. openai, openai_codex, google, anthropic, deepseek, groq, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
 config["deep_think_llm"] = "gpt-5.5"     # Model for complex reasoning
 config["quick_think_llm"] = "gpt-5.4-mini" # Model for quick tasks
 config["max_debate_rounds"] = 2

--- a/cli/main.py
+++ b/cli/main.py
@@ -31,6 +31,7 @@ from cli.utils import (
     confirm_ollama_endpoint,
     detect_asset_type,
     ensure_api_key,
+    ensure_openai_codex_auth,
     get_ticker,
     prompt_openai_compatible_url,
     resolve_backend_url,
@@ -622,6 +623,7 @@ def get_user_selections():
         console.print(f"[green]✓ Backend URL:[/green] {backend_url}")
         # Still confirm/persist the API key so the run doesn't fail later.
         ensure_api_key(selected_llm_provider)
+        ensure_openai_codex_auth(selected_llm_provider)
     else:
         console.print(
             create_question_box(
@@ -660,6 +662,7 @@ def get_user_selections():
         # one and persist it to .env if it's missing, so the analysis run
         # doesn't fail later at the first API call.
         ensure_api_key(selected_llm_provider)
+        ensure_openai_codex_auth(selected_llm_provider)
 
     # Step 7: Thinking agents (skipped when either model is set via environment)
     if os.environ.get("TRADINGAGENTS_QUICK_THINK_LLM") or os.environ.get("TRADINGAGENTS_DEEP_THINK_LLM"):
@@ -698,7 +701,7 @@ def get_user_selections():
             "Gemini thinking mode", "Step 8: Thinking Mode",
             "Configure Gemini thinking mode", ask_gemini_thinking_config,
         )
-    elif provider_lower == "openai":
+    elif provider_lower in ("openai", "openai_codex", "chatgpt_codex"):
         reasoning_effort = thinking_value_or_prompt(
             "TRADINGAGENTS_OPENAI_REASONING_EFFORT", "openai_reasoning_effort",
             "Reasoning effort", "Step 8: Reasoning Effort",

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -207,6 +207,7 @@ _OPENROUTER_MAINSTREAM = {
     "openai", "anthropic", "google", "deepseek", "qwen", "mistralai",
     "meta-llama", "x-ai", "z-ai", "minimax", "moonshotai",
 }
+_CODEX_MODEL_OPTIONS_CACHE: list[tuple[str, str]] | None = None
 
 
 def _fetch_openrouter_models() -> list[tuple[str, str]]:
@@ -284,6 +285,150 @@ def select_openrouter_model(mode: str) -> str:
     return choice
 
 
+def _is_openai_codex_provider(provider: str) -> bool:
+    return provider.lower() in ("openai_codex", "chatgpt_codex")
+
+
+def _codex_include_hidden_models() -> bool:
+    return os.environ.get("TRADINGAGENTS_CODEX_INCLUDE_HIDDEN_MODELS", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def ensure_openai_codex_auth(provider: str) -> None:
+    """Ensure ChatGPT OAuth is ready for the OpenAI Codex provider."""
+    if not _is_openai_codex_provider(provider):
+        return
+
+    from tradingagents.llm_clients.codex_oauth import (
+        CodexOAuthMissingTokenError,
+        CodexOAuthUnavailableError,
+        get_chatgpt_oauth_status,
+        login_chatgpt_oauth,
+    )
+
+    try:
+        status = get_chatgpt_oauth_status()
+        plan = f" ({status.plan_type})" if status.plan_type else ""
+        console.print(f"[green]✓ ChatGPT sign-in ready[/green]{plan}")
+        return
+    except CodexOAuthMissingTokenError:
+        pass
+    except CodexOAuthUnavailableError as exc:
+        console.print(f"\n[red]{exc}[/red]")
+        console.print(
+            "[yellow]Install/upgrade with: pip install -U "
+            "'langchain-openai>=1.3.3' 'langchain-core>=1.4.7' "
+            "'openai>=2.26.0'[/yellow]"
+        )
+        exit(1)
+    except Exception as exc:
+        console.print(f"\n[yellow]Could not refresh ChatGPT sign-in: {exc}[/yellow]")
+
+    console.print(
+        "\n[yellow]ChatGPT sign-in is required for the OpenAI Codex provider.[/yellow]"
+    )
+    choice = questionary.select(
+        "Sign in with ChatGPT now:",
+        choices=[
+            questionary.Choice("Browser sign-in (recommended)", "browser"),
+            questionary.Choice("Device code sign-in", "device"),
+        ],
+        style=questionary.Style([
+            ("selected", "fg:cyan noinherit"),
+            ("highlighted", "fg:cyan noinherit"),
+            ("pointer", "fg:cyan noinherit"),
+        ]),
+    ).ask()
+    if choice is None:
+        console.print("\n[red]ChatGPT sign-in cancelled. Exiting...[/red]")
+        exit(1)
+
+    try:
+        status = login_chatgpt_oauth(device_code=(choice == "device"))
+    except Exception as exc:
+        console.print(f"\n[red]ChatGPT sign-in failed: {exc}[/red]")
+        exit(1)
+
+    plan = f" ({status.plan_type})" if status.plan_type else ""
+    console.print(f"[green]✓ ChatGPT sign-in complete[/green]{plan}")
+
+
+def _fetch_codex_model_options() -> list[tuple[str, str]]:
+    """Fetch model labels/ids from Codex app-server, falling back on failure."""
+    global _CODEX_MODEL_OPTIONS_CACHE
+    if _CODEX_MODEL_OPTIONS_CACHE is not None:
+        return _CODEX_MODEL_OPTIONS_CACHE
+
+    from tradingagents.llm_clients.codex_app_server import list_codex_app_server_models
+
+    timeout = float(os.environ.get("TRADINGAGENTS_CODEX_MODEL_LIST_TIMEOUT", "8"))
+    models = list_codex_app_server_models(
+        include_hidden=_codex_include_hidden_models(),
+        timeout=timeout,
+    )
+    include_hidden = _codex_include_hidden_models()
+    visible = [model for model in models if include_hidden or not model.hidden]
+    options: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for model in visible:
+        if model.model in seen:
+            continue
+        seen.add(model.model)
+        suffixes = []
+        if model.is_default:
+            suffixes.append("default")
+        if model.default_reasoning_effort:
+            suffixes.append(f"effort: {model.default_reasoning_effort}")
+        suffix = f" ({', '.join(suffixes)})" if suffixes else ""
+        label = model.display_name
+        if model.model != model.display_name:
+            label = f"{label} [{model.model}]"
+        options.append((f"{label}{suffix}", model.model))
+    _CODEX_MODEL_OPTIONS_CACHE = options
+    return options
+
+
+def select_openai_codex_model(mode: str) -> str:
+    """Select a ChatGPT/Codex model, preferring live app-server catalog data."""
+    try:
+        options = _fetch_codex_model_options()
+    except Exception as exc:
+        console.print(
+            "\n[yellow]Could not fetch Codex model list from app-server; "
+            f"using bundled fallback list. Details: {exc}[/yellow]"
+        )
+        options = get_model_options("openai_codex", mode)
+
+    if not options:
+        options = get_model_options("openai_codex", mode)
+
+    choices = [questionary.Choice(display, value=value) for display, value in options]
+    if "custom" not in {value for _, value in options}:
+        choices.append(questionary.Choice("Custom model ID", value="custom"))
+
+    choice = questionary.select(
+        f"Select Your [{mode.title()}-Thinking] OpenAI Codex Model:",
+        choices=choices,
+        instruction="\n- Use arrow keys to navigate\n- Press Enter to select",
+        style=questionary.Style([
+            ("selected", "fg:magenta noinherit"),
+            ("highlighted", "fg:magenta noinherit"),
+            ("pointer", "fg:magenta noinherit"),
+        ]),
+    ).ask()
+
+    if choice is None:
+        console.print(f"\n[red]No {mode} thinking llm engine selected. Exiting...[/red]")
+        exit(1)
+    if choice == "custom":
+        return _prompt_custom_model_id()
+    return choice
+
+
 def _prompt_custom_model_id() -> str:
     """Prompt user to type a custom model ID."""
     return _require_text("Enter model ID:", "Please enter a model ID.")
@@ -291,6 +436,9 @@ def _prompt_custom_model_id() -> str:
 
 def _select_model(provider: str, mode: str) -> str:
     """Select a model for the given provider and mode (quick/deep)."""
+    if _is_openai_codex_provider(provider):
+        return select_openai_codex_model(mode)
+
     if provider.lower() == "openrouter":
         return select_openrouter_model(mode)
 
@@ -335,6 +483,7 @@ def select_deep_thinking_agent(provider) -> str:
     """Select deep thinking llm engine using an interactive selection."""
     return _select_model(provider, "deep")
 
+
 def _llm_provider_table() -> list[tuple[str, str, str | None]]:
     """(display_name, provider_key, base_url) for every supported provider.
 
@@ -347,6 +496,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
     ollama_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
     return [
         ("OpenAI", "openai", "https://api.openai.com/v1"),
+        ("OpenAI Codex (ChatGPT sign-in, experimental)", "openai_codex", None),
         ("Google", "google", None),
         ("Anthropic", "anthropic", "https://api.anthropic.com/"),
         ("xAI", "xai", "https://api.x.ai/v1"),
@@ -435,6 +585,7 @@ def ask_openai_reasoning_effort() -> str:
     choices = [
         questionary.Choice("Medium (Default)", "medium"),
         questionary.Choice("High (More thorough)", "high"),
+        questionary.Choice("XHigh (Maximum reasoning, slower)", "xhigh"),
         questionary.Choice("Low (Faster)", "low"),
     ]
     return questionary.select(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ dependencies = [
     "langchain-anthropic>=0.3.15",
     "langchain-experimental>=0.3.4",
     "langchain-google-genai>=4.0.0",
-    "langchain-openai>=0.3.23",
+    # langchain-openai 1.3.3 includes the experimental ChatGPT OAuth Codex
+    # client used by the openai_codex provider.
+    "langchain-openai>=1.3.3",
     "langgraph>=0.4.8",
     "langgraph-checkpoint-sqlite>=2.0.0",
     "pandas>=2.3.0",

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -22,7 +22,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         "qwen", "qwen-cn",
         "glm", "glm-cn",
         "minimax", "minimax-cn",
-        "openrouter", "azure", "ollama",
+        "openrouter", "azure", "openai_codex", "ollama",
     }
     assert expected.issubset(PROVIDER_API_KEY_ENV.keys())
 
@@ -51,6 +51,10 @@ def test_known_providers_resolve(provider, env_var):
 
 def test_ollama_has_no_key():
     assert get_api_key_env("ollama") is None
+
+
+def test_openai_codex_has_no_api_key():
+    assert get_api_key_env("openai_codex") is None
 
 
 def test_unknown_provider_returns_none():
@@ -85,6 +89,13 @@ def test_ensure_api_key_no_op_for_ollama(monkeypatch, cli_utils):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with patch.object(cli_utils, "questionary") as mock_q:
         result = cli_utils.ensure_api_key("ollama")
+    assert result is None
+    mock_q.password.assert_not_called()
+
+
+def test_ensure_api_key_no_op_for_openai_codex(cli_utils):
+    with patch.object(cli_utils, "questionary") as mock_q:
+        result = cli_utils.ensure_api_key("openai_codex")
     assert result is None
     mock_q.password.assert_not_called()
 

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -17,6 +17,7 @@ class TestProviderDefaultUrl(unittest.TestCase):
     def test_known_providers_resolve(self):
         from cli.utils import provider_default_url
         self.assertEqual(provider_default_url("openai"), "https://api.openai.com/v1")
+        self.assertIsNone(provider_default_url("openai_codex"))
         self.assertEqual(provider_default_url("DeepSeek"), "https://api.deepseek.com")
         self.assertIsNone(provider_default_url("google"))  # uses SDK default
 

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -72,11 +72,11 @@ def test_reasoning_thinking_overrides(monkeypatch):
     """The provider reasoning/thinking knobs are env-configurable (non-interactive runs)."""
     dc = _reload_with_env(
         monkeypatch,
-        TRADINGAGENTS_OPENAI_REASONING_EFFORT="high",
+        TRADINGAGENTS_OPENAI_REASONING_EFFORT="xhigh",
         TRADINGAGENTS_GOOGLE_THINKING_LEVEL="minimal",
         TRADINGAGENTS_ANTHROPIC_EFFORT="low",
     )
-    assert dc.DEFAULT_CONFIG["openai_reasoning_effort"] == "high"
+    assert dc.DEFAULT_CONFIG["openai_reasoning_effort"] == "xhigh"
     assert dc.DEFAULT_CONFIG["google_thinking_level"] == "minimal"
     assert dc.DEFAULT_CONFIG["anthropic_effort"] == "low"
 

--- a/tests/test_openai_codex_provider.py
+++ b/tests/test_openai_codex_provider.py
@@ -1,0 +1,324 @@
+"""ChatGPT OAuth-backed OpenAI Codex provider wiring."""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from tradingagents.llm_clients.api_key_env import get_api_key_env
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.validators import validate_model
+
+
+@pytest.mark.unit
+def test_factory_routes_to_codex_client():
+    client = create_llm_client(provider="openai_codex", model="gpt-5.3-codex")
+    assert type(client).__name__ == "OpenAICodexClient"
+
+
+@pytest.mark.unit
+def test_no_api_key_required_and_any_model_accepted():
+    assert get_api_key_env("openai_codex") is None
+    assert validate_model("openai_codex", "account-specific-model") is True
+
+
+@pytest.mark.unit
+def test_get_llm_uses_langchain_codex_client(monkeypatch):
+    captured = {}
+
+    class FakeCodex:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def invoke(self, input, config=None, **kwargs):
+            return SimpleNamespace(
+                content=[
+                    {"type": "reasoning", "summary": []},
+                    {"type": "text", "text": "normalized"},
+                ]
+            )
+
+    module = types.ModuleType("langchain_openai.chat_models.codex")
+    module._ChatOpenAICodex = FakeCodex
+    package = types.ModuleType("langchain_openai")
+    package.__path__ = []
+    chat_models_package = types.ModuleType("langchain_openai.chat_models")
+    chat_models_package.__path__ = []
+    monkeypatch.setitem(sys.modules, "langchain_openai", package)
+    monkeypatch.setitem(
+        sys.modules,
+        "langchain_openai.chat_models",
+        chat_models_package,
+    )
+    monkeypatch.setitem(sys.modules, "langchain_openai.chat_models.codex", module)
+    monkeypatch.setenv("TRADINGAGENTS_CODEX_ORIGINATOR", "tests")
+
+    llm = create_llm_client("openai_codex", "gpt-5.3-codex", max_retries=3).get_llm()
+
+    assert captured["model"] == "gpt-5.3-codex"
+    assert captured["originator"] == "tests"
+    assert captured["max_retries"] == 3
+    assert llm.invoke("hi").content == "normalized"
+
+
+@pytest.mark.unit
+def test_base_url_is_rejected():
+    with pytest.raises(ValueError, match="does not accept backend_url"):
+        create_llm_client(
+            "openai_codex", "gpt-5.3-codex", base_url="http://proxy/v1"
+        ).get_llm()
+
+
+@pytest.mark.unit
+def test_helpful_error_when_langchain_codex_client_absent(monkeypatch):
+    monkeypatch.setitem(sys.modules, "langchain_openai.chat_models.codex", None)
+    with pytest.raises(ImportError, match="langchain-openai>=1.3.3"):
+        create_llm_client("openai_codex", "gpt-5.3-codex").get_llm()
+
+
+@pytest.mark.unit
+def test_cli_model_options_include_codex_provider():
+    from tradingagents.llm_clients.model_catalog import get_model_options
+
+    quick_values = {value for _, value in get_model_options("openai_codex", "quick")}
+    deep_values = {value for _, value in get_model_options("openai_codex", "deep")}
+    assert "gpt-5.3-codex-spark" in quick_values
+    assert "gpt-5.3-codex" in deep_values
+    assert "custom" in quick_values
+
+
+@pytest.mark.unit
+def test_app_server_model_response_is_normalized(monkeypatch):
+    from tradingagents.llm_clients.codex_app_server import CodexAppServerClient
+
+    responses = [
+        {
+            "data": [
+                {
+                    "id": "gpt-5.3-codex",
+                    "model": "gpt-5.3-codex",
+                    "displayName": "GPT-5.3 Codex",
+                    "description": "Strong coding model",
+                    "isDefault": True,
+                    "hidden": False,
+                    "defaultReasoningEffort": "high",
+                }
+            ],
+            "nextCursor": "page-2",
+        },
+        {
+            "data": [
+                {
+                    "id": "gpt-5.3-codex-spark",
+                    "model": "gpt-5.3-codex-spark",
+                    "displayName": "GPT-5.3 Codex Spark",
+                    "description": "Fast coding model",
+                    "hidden": False,
+                    "defaultReasoningEffort": "medium",
+                }
+            ],
+            "nextCursor": None,
+        },
+    ]
+
+    client = CodexAppServerClient()
+    monkeypatch.setattr(client, "_request", lambda *_args, **_kwargs: responses.pop(0))
+
+    models = client.list_models()
+
+    assert [model.model for model in models] == [
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+    ]
+    assert models[0].display_name == "GPT-5.3 Codex"
+    assert models[0].is_default is True
+
+
+@pytest.mark.unit
+def test_app_server_stderr_buffer_is_bounded():
+    from tradingagents.llm_clients.codex_app_server import CodexAppServerClient
+
+    client = CodexAppServerClient()
+    for index in range(25):
+        client._stderr_lines.append(f"line-{index}")
+
+    assert len(client._stderr_lines) == 20
+    assert client._stderr_summary() == "line-22 line-23 line-24"
+
+
+@pytest.mark.unit
+def test_app_server_enter_closes_when_initialize_fails(monkeypatch):
+    from tradingagents.llm_clients.codex_app_server import CodexAppServerClient
+
+    client = CodexAppServerClient()
+    calls = []
+
+    def fail_initialize():
+        raise RuntimeError("init failed")
+
+    monkeypatch.setattr(client, "_start", lambda: calls.append("start"))
+    monkeypatch.setattr(client, "_initialize", fail_initialize)
+    monkeypatch.setattr(client, "close", lambda: calls.append("close"))
+
+    with pytest.raises(RuntimeError, match="init failed"):
+        client.__enter__()
+
+    assert calls == ["start", "close"]
+
+
+@pytest.mark.unit
+def test_app_server_send_wraps_closed_stdin():
+    from tradingagents.llm_clients.codex_app_server import (
+        CodexAppServerClient,
+        CodexAppServerError,
+    )
+
+    class ClosedStdin:
+        @staticmethod
+        def write(_value):
+            raise ValueError("I/O operation on closed file")
+
+        @staticmethod
+        def flush():
+            raise AssertionError("flush should not be called after write failure")
+
+    client = CodexAppServerClient()
+    client._proc = SimpleNamespace(stdin=ClosedStdin())
+    client._stderr_lines.append("app-server exited")
+
+    with pytest.raises(CodexAppServerError, match="Failed to write to Codex app-server"):
+        client._send({"method": "model/list"})
+
+
+@pytest.mark.unit
+def test_app_server_close_closes_stdio_streams():
+    from tradingagents.llm_clients.codex_app_server import CodexAppServerClient
+
+    class Pipe:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class Process:
+        def __init__(self):
+            self.stdin = Pipe()
+            self.stdout = Pipe()
+            self.stderr = Pipe()
+
+        @staticmethod
+        def poll():
+            return 0
+
+    process = Process()
+    client = CodexAppServerClient()
+    client._proc = process
+
+    client.close()
+
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+    assert process.stderr.closed is True
+    assert client._proc is None
+
+
+@pytest.mark.unit
+def test_cli_fetches_codex_models_from_app_server(monkeypatch):
+    import cli.utils as cli_utils
+    from tradingagents.llm_clients.codex_app_server import CodexModelInfo
+
+    monkeypatch.setattr(cli_utils, "_CODEX_MODEL_OPTIONS_CACHE", None)
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.codex_app_server.list_codex_app_server_models",
+        lambda **_kwargs: [
+            CodexModelInfo(
+                id="gpt-5.3-codex",
+                model="gpt-5.3-codex",
+                display_name="GPT-5.3 Codex",
+                description="Strong coding model",
+                is_default=True,
+                default_reasoning_effort="high",
+            ),
+            CodexModelInfo(
+                id="hidden-model",
+                model="hidden-model",
+                display_name="Hidden",
+                description="Hidden model",
+                hidden=True,
+            ),
+        ],
+    )
+
+    options = cli_utils._fetch_codex_model_options()
+
+    assert options == [
+        ("GPT-5.3 Codex [gpt-5.3-codex] (default, effort: high)", "gpt-5.3-codex")
+    ]
+
+
+@pytest.mark.unit
+def test_ensure_openai_codex_auth_uses_existing_token(monkeypatch):
+    import cli.utils as cli_utils
+    from tradingagents.llm_clients.codex_oauth import ChatGPTOAuthStatus
+
+    monkeypatch.setattr(
+        "tradingagents.llm_clients.codex_oauth.get_chatgpt_oauth_status",
+        lambda: ChatGPTOAuthStatus(account_id="acct", plan_type="plus", user_id="user"),
+    )
+    monkeypatch.setattr(cli_utils.questionary, "select", pytest.fail)
+
+    cli_utils.ensure_openai_codex_auth("openai_codex")
+
+
+@pytest.mark.unit
+def test_ensure_openai_codex_auth_runs_login_when_missing(monkeypatch):
+    import cli.utils as cli_utils
+    import tradingagents.llm_clients.codex_oauth as oauth
+    from tradingagents.llm_clients.codex_oauth import ChatGPTOAuthStatus
+
+    calls = {"login": None}
+
+    def missing_status():
+        raise oauth.CodexOAuthMissingTokenError("missing")
+
+    def login(*, device_code):
+        calls["login"] = device_code
+        return ChatGPTOAuthStatus(account_id="acct", plan_type="pro", user_id="user")
+
+    class Prompt:
+        @staticmethod
+        def ask():
+            return "device"
+
+    monkeypatch.setattr(oauth, "get_chatgpt_oauth_status", missing_status)
+    monkeypatch.setattr(oauth, "login_chatgpt_oauth", login)
+    monkeypatch.setattr(cli_utils.questionary, "select", lambda *_, **__: Prompt())
+
+    cli_utils.ensure_openai_codex_auth("openai_codex")
+
+    assert calls["login"] is True
+
+
+@pytest.mark.unit
+def test_openai_reasoning_effort_menu_includes_xhigh(monkeypatch):
+    import cli.utils as cli_utils
+
+    captured = {}
+
+    class Prompt:
+        @staticmethod
+        def ask():
+            return "xhigh"
+
+    def fake_select(_message, *, choices, **_kwargs):
+        captured["values"] = [choice.value for choice in choices]
+        return Prompt()
+
+    monkeypatch.setattr(cli_utils.questionary, "select", fake_select)
+
+    assert cli_utils.ask_openai_reasoning_effort() == "xhigh"
+    assert captured["values"] == ["medium", "high", "xhigh", "low"]

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -19,15 +19,29 @@ so that:
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, WithJsonSchema, field_validator
 
 # LLMs sometimes write a placeholder string ("None", "N/A", ...) into an optional
 # numeric field instead of omitting it. Coerce those to None so the structured
 # call validates instead of erroring (#1058). Pydantic still parses real numeric
 # strings ("189.5") to float.
 _NULLISH_FLOAT = {"", "none", "n/a", "na", "null", "nil", "-", "tbd", "unknown"}
+
+def _inline_enum(enum_cls: type[Enum]) -> WithJsonSchema:
+    """Inline an enum into the property schema instead of a $defs $ref.
+
+    OpenAI's structured-output validator rejects a $ref with sibling
+    keywords, and every enum field here carries a description, so the
+    default pydantic $ref schema 400s and silently degrades the call to
+    free text. Inlining keeps the description AND the closed value set.
+    """
+    return WithJsonSchema(
+        {"type": "string", "enum": [member.value for member in enum_cls]}
+    )
+
+
 
 
 def _coerce_optional_float(value):
@@ -79,7 +93,7 @@ class ResearchPlan(BaseModel):
     instructions the trader can execute against.
     """
 
-    recommendation: PortfolioRating = Field(
+    recommendation: Annotated[PortfolioRating, _inline_enum(PortfolioRating)] = Field(
         description=(
             "The investment recommendation. Exactly one of Buy / Overweight / "
             "Hold / Underweight / Sell. Reserve Hold for situations where the "
@@ -127,7 +141,7 @@ class TraderProposal(BaseModel):
     entry, stop-loss, and sizing.
     """
 
-    action: TraderAction = Field(
+    action: Annotated[TraderAction, _inline_enum(TraderAction)] = Field(
         description="The transaction direction. Exactly one of Buy / Hold / Sell.",
     )
     reasoning: str = Field(
@@ -194,7 +208,7 @@ class PortfolioDecision(BaseModel):
     the rating-scale guidance.
     """
 
-    rating: PortfolioRating = Field(
+    rating: Annotated[PortfolioRating, _inline_enum(PortfolioRating)] = Field(
         description=(
             "The final position rating. Exactly one of Buy / Overweight / Hold / "
             "Underweight / Sell, picked based on the analysts' debate."
@@ -281,7 +295,7 @@ class SentimentReport(BaseModel):
     deterministic header so the saved report stays human-readable.
     """
 
-    overall_band: SentimentBand = Field(
+    overall_band: Annotated[SentimentBand, _inline_enum(SentimentBand)] = Field(
         description=(
             "Overall sentiment direction. Exactly one of: "
             "Bullish / Mildly Bullish / Neutral / Mixed / Mildly Bearish / Bearish. "

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -89,7 +89,7 @@ DEFAULT_CONFIG = _apply_env_overrides({
     "backend_url": None,
     # Provider-specific thinking configuration
     "google_thinking_level": None,      # "high", "minimal", etc.
-    "openai_reasoning_effort": None,    # "medium", "high", "low"
+    "openai_reasoning_effort": None,    # "xhigh", "high", "medium", "low"
     "anthropic_effort": None,           # "high", "medium", "low"
     # Sampling temperature, forwarded to every provider when set. None leaves
     # each provider at its own default. Lower values reduce run-to-run

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -160,7 +160,7 @@ class TradingAgentsGraph:
             if thinking_level:
                 kwargs["thinking_level"] = thinking_level
 
-        elif provider == "openai":
+        elif provider in ("openai", "openai_codex", "chatgpt_codex"):
             reasoning_effort = self.config.get("openai_reasoning_effort")
             if reasoning_effort:
                 kwargs["reasoning_effort"] = reasoning_effort

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -16,6 +16,11 @@ PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "anthropic":  "ANTHROPIC_API_KEY",
     "google":     "GOOGLE_API_KEY",
     "azure":      "AZURE_OPENAI_API_KEY",
+    # ChatGPT OAuth via LangChain's experimental Codex client. Authentication
+    # lives in ~/.langchain/chatgpt-auth.json after login_chatgpt(), not in an
+    # OpenAI Platform API key.
+    "openai_codex": None,
+    "chatgpt_codex": None,
     # Bedrock authenticates via the AWS credential chain, not a single key env.
     "bedrock":    None,
     "xai":        "XAI_API_KEY",

--- a/tradingagents/llm_clients/codex_app_server.py
+++ b/tradingagents/llm_clients/codex_app_server.py
@@ -1,0 +1,226 @@
+"""Small JSON-RPC client for Codex app-server model discovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import threading
+import time
+from collections import deque
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+
+class CodexAppServerError(RuntimeError):
+    """Raised when Codex app-server cannot satisfy a request."""
+
+
+@dataclass(frozen=True)
+class CodexModelInfo:
+    """One model entry advertised by Codex app-server."""
+
+    id: str
+    model: str
+    display_name: str
+    description: str
+    is_default: bool = False
+    hidden: bool = False
+    default_reasoning_effort: str | None = None
+
+
+class CodexAppServerClient:
+    """Minimal stdio JSON-RPC client for read-only app-server requests."""
+
+    def __init__(self, command: str | None = None, timeout: float = 10.0):
+        self.command = command or os.environ.get("TRADINGAGENTS_CODEX_APP_SERVER_BIN") or "codex"
+        self.timeout = timeout
+        self._next_id = 0
+        self._messages: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr_lines: deque[str] = deque(maxlen=20)
+        self._proc: subprocess.Popen[str] | None = None
+        self._reader: threading.Thread | None = None
+        self._stderr_reader: threading.Thread | None = None
+
+    def __enter__(self) -> CodexAppServerClient:
+        self._start()
+        try:
+            self._initialize()
+        except Exception:
+            self.close()
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def _start(self) -> None:
+        try:
+            self._proc = subprocess.Popen(
+                [self.command, "app-server", "--stdio"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+        except OSError as exc:
+            raise CodexAppServerError(
+                f"Could not start `{self.command} app-server`: {exc}"
+            ) from exc
+
+        if self._proc.stdout is None or self._proc.stdin is None:
+            raise CodexAppServerError("Codex app-server did not expose stdio pipes.")
+
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+        self._stderr_reader = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stderr_reader.start()
+
+    def _read_stdout(self) -> None:
+        assert self._proc is not None and self._proc.stdout is not None
+        for line in self._proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(message, dict):
+                self._messages.put(message)
+
+    def _read_stderr(self) -> None:
+        assert self._proc is not None and self._proc.stderr is not None
+        for line in self._proc.stderr:
+            line = line.strip()
+            if line:
+                self._stderr_lines.append(line)
+
+    def _stderr_summary(self) -> str:
+        if not self._stderr_lines:
+            return ""
+        return " ".join(list(self._stderr_lines)[-3:])
+
+    def _send(self, message: dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise CodexAppServerError("Codex app-server is not running.")
+        try:
+            self._proc.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+            self._proc.stdin.flush()
+        except (OSError, ValueError) as exc:
+            detail = self._stderr_summary()
+            suffix = f": {detail}" if detail else "."
+            raise CodexAppServerError(f"Failed to write to Codex app-server{suffix}") from exc
+
+    def _request(self, method: str, params: Any, timeout: float | None = None) -> Any:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send({"id": request_id, "method": method, "params": params})
+        deadline = time.monotonic() + (timeout or self.timeout)
+
+        while True:
+            if time.monotonic() >= deadline:
+                detail = self._stderr_summary()
+                suffix = f" Last stderr: {detail}" if detail else ""
+                raise CodexAppServerError(
+                    f"Timed out waiting for Codex app-server response to {method}.{suffix}"
+                )
+            if self._proc is not None and self._proc.poll() is not None:
+                detail = self._stderr_summary()
+                suffix = f": {detail}" if detail else "."
+                raise CodexAppServerError(f"Codex app-server exited before {method}{suffix}")
+            try:
+                remaining = max(0.01, min(0.25, deadline - time.monotonic()))
+                message = self._messages.get(timeout=remaining)
+            except queue.Empty:
+                continue
+
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                error = message["error"]
+                detail = error.get("message") if isinstance(error, dict) else error
+                raise CodexAppServerError(f"{method} failed: {detail}")
+            return message.get("result")
+
+    def _notify(self, method: str, params: Any) -> None:
+        self._send({"method": method, "params": params})
+
+    def _initialize(self) -> None:
+        self._request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "tradingagents",
+                    "title": "TradingAgents",
+                    "version": "0.3.1",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        self._notify("initialized", {})
+
+    def list_models(
+        self, *, include_hidden: bool = False, limit: int = 100
+    ) -> list[CodexModelInfo]:
+        """Return all visible models advertised by app-server."""
+        models: list[CodexModelInfo] = []
+        cursor: str | None = None
+        while True:
+            result = self._request(
+                "model/list",
+                {"cursor": cursor, "includeHidden": include_hidden, "limit": limit},
+            )
+            for item in (result or {}).get("data", []):
+                if not isinstance(item, dict):
+                    continue
+                model = item.get("model") or item.get("id")
+                if not model:
+                    continue
+                models.append(
+                    CodexModelInfo(
+                        id=str(item.get("id") or model),
+                        model=str(model),
+                        display_name=str(item.get("displayName") or model),
+                        description=str(item.get("description") or ""),
+                        is_default=bool(item.get("isDefault")),
+                        hidden=bool(item.get("hidden")),
+                        default_reasoning_effort=item.get("defaultReasoningEffort"),
+                    )
+                )
+            cursor = (result or {}).get("nextCursor")
+            if not cursor:
+                return models
+
+    @staticmethod
+    def _close_pipe(pipe: Any) -> None:
+        if pipe is not None:
+            with suppress(Exception):
+                pipe.close()
+
+    def close(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        self._close_pipe(proc.stdin)
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+        self._close_pipe(proc.stdout)
+        self._close_pipe(proc.stderr)
+        self._proc = None
+
+
+def list_codex_app_server_models(
+    *, include_hidden: bool = False, timeout: float = 10.0
+) -> list[CodexModelInfo]:
+    """Fetch Codex model catalog from app-server."""
+    with CodexAppServerClient(timeout=timeout) as client:
+        return client.list_models(include_hidden=include_hidden)

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -1,0 +1,85 @@
+"""ChatGPT subscription-backed OpenAI models via LangChain's Codex client."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .base_client import BaseLLMClient, normalize_content
+from .validators import validate_model
+
+_PASSTHROUGH_KWARGS = (
+    "timeout",
+    "max_retries",
+    "reasoning_effort",
+    "temperature",
+    "callbacks",
+)
+
+
+def _missing_chatgpt_token_error() -> FileNotFoundError:
+    return FileNotFoundError(
+        "No ChatGPT OAuth token found for provider 'openai_codex'. Run "
+        "`python -c \"from langchain_openai.chatgpt_oauth import "
+        "login_chatgpt; login_chatgpt()\"` once, or use "
+        "`login_chatgpt_device()` on a headless machine. Tokens are "
+        "stored by LangChain at ~/.langchain/chatgpt-auth.json."
+    )
+
+
+class OpenAICodexClient(BaseLLMClient):
+    """Client for ChatGPT OAuth-backed Codex/OpenAI models.
+
+    This provider intentionally uses LangChain's experimental
+    ``_ChatOpenAICodex`` rather than reimplementing the ChatGPT OAuth and Codex
+    backend wire protocol here. The class is private/upstream-experimental, so
+    imports stay lazy and error messages are explicit.
+    """
+
+    provider = "openai_codex"
+
+    def get_llm(self) -> Any:
+        self.warn_if_unknown_model()
+        if self.base_url:
+            raise ValueError(
+                "Provider 'openai_codex' uses the fixed ChatGPT Codex backend and "
+                "does not accept backend_url / TRADINGAGENTS_LLM_BACKEND_URL."
+            )
+
+        try:
+            from langchain_openai.chat_models.codex import _ChatOpenAICodex
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise ImportError(
+                "Provider 'openai_codex' requires LangChain's experimental "
+                "ChatGPT OAuth Codex client. Upgrade with: "
+                "pip install -U 'langchain-openai>=1.3.3' "
+                "'langchain-core>=1.4.7' 'openai>=2.26.0'."
+            ) from exc
+
+        class NormalizedChatOpenAICodex(_ChatOpenAICodex):
+            def _get_request_payload(self, input_, *, stop=None, **kwargs):
+                try:
+                    return super()._get_request_payload(input_, stop=stop, **kwargs)
+                except FileNotFoundError as exc:
+                    raise _missing_chatgpt_token_error() from exc
+
+            def invoke(self, input, config=None, **kwargs):
+                return normalize_content(super().invoke(input, config, **kwargs))
+
+        llm_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "originator": os.environ.get("TRADINGAGENTS_CODEX_ORIGINATOR")
+            or "tradingagents",
+        }
+
+        for key in _PASSTHROUGH_KWARGS:
+            if key in self.kwargs:
+                llm_kwargs[key] = self.kwargs[key]
+
+        try:
+            return NormalizedChatOpenAICodex(**llm_kwargs)
+        except FileNotFoundError as exc:
+            raise _missing_chatgpt_token_error() from exc
+
+    def validate_model(self) -> bool:
+        return validate_model(self.provider, self.model)

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from typing import Any
 
@@ -11,6 +12,47 @@ from .base_client import BaseLLMClient, normalize_content
 from .validators import validate_model
 
 logger = logging.getLogger(__name__)
+
+# Rate-limit waits are budgeted separately from transport retries: a
+# subscription quota window can take an hour to reset, and unattended runs
+# should sleep through it rather than die.
+RATE_LIMIT_MAX_WAITS = int(os.environ.get("TRADINGAGENTS_RATE_LIMIT_MAX_WAITS", "12"))
+RATE_LIMIT_MAX_WAIT_SECONDS = float(
+    os.environ.get("TRADINGAGENTS_RATE_LIMIT_MAX_WAIT_SECONDS", "3600")
+)
+_ESCALATING_WAITS = (60, 120, 300, 600, 900)
+
+_DURATION_RE = re.compile(
+    r"(?:try again|retry|resets?)[^0-9]*"
+    r"(?:(\d+)\s*h(?:ours?)?)?\s*(?:(\d+)\s*m(?:in(?:utes?)?)?)?\s*(?:([\d.]+)\s*s(?:ec(?:onds?)?)?)?",
+    re.IGNORECASE,
+)
+
+
+def _rate_limit_exceptions() -> tuple[type[BaseException], ...]:
+    import openai
+
+    return (openai.RateLimitError,)
+
+
+def _retry_after_seconds(exc: BaseException) -> float | None:
+    """Best-effort extraction of the reset delay from a rate-limit error."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None) or {}
+    for key in ("retry-after", "x-ratelimit-reset-after", "x-ratelimit-reset-requests"):
+        value = headers.get(key)
+        if value:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                continue
+    match = _DURATION_RE.search(str(exc))
+    if match and any(match.groups()):
+        hours, minutes, seconds = match.groups()
+        return (
+            float(hours or 0) * 3600 + float(minutes or 0) * 60 + float(seconds or 0)
+        ) or None
+    return None
 
 
 def _stream_retryable_exceptions() -> tuple[type[BaseException], ...]:
@@ -85,24 +127,51 @@ class OpenAICodexClient(BaseLLMClient):
                     raise _missing_chatgpt_token_error() from exc
 
             def invoke(self, input, config=None, **kwargs):
-                # The SDK's max_retries only covers request setup; a stream
-                # that breaks mid-body raises through invoke and would kill a
-                # long multi-agent run. Retry the whole (stateless) call with
-                # the same budget.
-                retryable = _stream_retryable_exceptions()
-                attempts = max(1, int(getattr(self, "max_retries", None) or 2) + 1)
-                for attempt in range(attempts):
+                # Two failure modes are retried around the whole (stateless)
+                # call, because the SDK's max_retries only covers request
+                # setup:
+                # - transport errors mid-stream (SSE dies half-way), with the
+                #   SDK retry budget and short exponential backoff;
+                # - rate limits / usage caps, with a separate budget and long
+                #   waits (parsed reset delay when available), so unattended
+                #   runs sleep through quota windows instead of dying.
+                transport_retryable = _stream_retryable_exceptions()
+                rate_limited = _rate_limit_exceptions()
+                transport_attempts = max(1, int(getattr(self, "max_retries", None) or 2) + 1)
+                transport_failures = 0
+                rate_limit_waits = 0
+                while True:
                     try:
                         return normalize_content(super().invoke(input, config, **kwargs))
-                    except retryable as exc:
-                        if attempt == attempts - 1:
+                    except rate_limited as exc:
+                        rate_limit_waits += 1
+                        if rate_limit_waits > RATE_LIMIT_MAX_WAITS:
                             raise
-                        delay = min(2 ** attempt, 30)
+                        wait = _retry_after_seconds(exc)
+                        if wait is None:
+                            wait = _ESCALATING_WAITS[
+                                min(rate_limit_waits - 1, len(_ESCALATING_WAITS) - 1)
+                            ]
+                        wait = min(wait + 5, RATE_LIMIT_MAX_WAIT_SECONDS)  # +5s buffer
+                        logger.warning(
+                            "openai_codex rate limited (%s); sleeping %.0fs until reset "
+                            "(wait %d/%d)",
+                            exc,
+                            wait,
+                            rate_limit_waits,
+                            RATE_LIMIT_MAX_WAITS,
+                        )
+                        time.sleep(wait)
+                    except transport_retryable as exc:
+                        transport_failures += 1
+                        if transport_failures >= transport_attempts:
+                            raise
+                        delay = min(2 ** (transport_failures - 1), 30)
                         logger.warning(
                             "openai_codex stream failed mid-call (%s); retry %d/%d in %ds",
                             exc,
-                            attempt + 1,
-                            attempts - 1,
+                            transport_failures,
+                            transport_attempts - 1,
                             delay,
                         )
                         time.sleep(delay)

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import time
 from typing import Any
 
 from .base_client import BaseLLMClient, normalize_content
 from .validators import validate_model
+
+logger = logging.getLogger(__name__)
+
+
+def _stream_retryable_exceptions() -> tuple[type[BaseException], ...]:
+    """Transport failures that can hit mid-stream, after the SDK's own
+    ``max_retries`` no longer applies (the request succeeded; the SSE stream
+    died halfway). Chat completions are stateless, so re-invoking is safe.
+    """
+    import httpx
+
+    exceptions: list[type[BaseException]] = [httpx.TransportError]
+    try:
+        import openai
+
+        exceptions += [openai.APIConnectionError, openai.APITimeoutError]
+    except ImportError:
+        pass
+    return tuple(exceptions)
 
 _PASSTHROUGH_KWARGS = (
     "timeout",
@@ -64,7 +85,27 @@ class OpenAICodexClient(BaseLLMClient):
                     raise _missing_chatgpt_token_error() from exc
 
             def invoke(self, input, config=None, **kwargs):
-                return normalize_content(super().invoke(input, config, **kwargs))
+                # The SDK's max_retries only covers request setup; a stream
+                # that breaks mid-body raises through invoke and would kill a
+                # long multi-agent run. Retry the whole (stateless) call with
+                # the same budget.
+                retryable = _stream_retryable_exceptions()
+                attempts = max(1, int(getattr(self, "max_retries", None) or 2) + 1)
+                for attempt in range(attempts):
+                    try:
+                        return normalize_content(super().invoke(input, config, **kwargs))
+                    except retryable as exc:
+                        if attempt == attempts - 1:
+                            raise
+                        delay = min(2 ** attempt, 30)
+                        logger.warning(
+                            "openai_codex stream failed mid-call (%s); retry %d/%d in %ds",
+                            exc,
+                            attempt + 1,
+                            attempts - 1,
+                            delay,
+                        )
+                        time.sleep(delay)
 
         llm_kwargs: dict[str, Any] = {
             "model": self.model,

--- a/tradingagents/llm_clients/codex_oauth.py
+++ b/tradingagents/llm_clients/codex_oauth.py
@@ -1,0 +1,59 @@
+"""Helpers for ChatGPT OAuth used by the OpenAI Codex provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class CodexOAuthUnavailableError(RuntimeError):
+    """Raised when LangChain's ChatGPT OAuth helpers are unavailable."""
+
+
+class CodexOAuthMissingTokenError(RuntimeError):
+    """Raised when no ChatGPT OAuth token is available."""
+
+
+@dataclass(frozen=True)
+class ChatGPTOAuthStatus:
+    account_id: str | None
+    plan_type: str | None
+    user_id: str | None
+
+
+def get_chatgpt_oauth_status() -> ChatGPTOAuthStatus:
+    """Return current ChatGPT OAuth status, refreshing the token if needed."""
+    try:
+        from langchain_openai.chatgpt_oauth import _FileChatGPTOAuthTokenProvider
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise CodexOAuthUnavailableError(
+            "ChatGPT sign-in requires langchain-openai>=1.3.3."
+        ) from exc
+
+    try:
+        token = _FileChatGPTOAuthTokenProvider.from_default_store().get_token()
+    except FileNotFoundError as exc:
+        raise CodexOAuthMissingTokenError(
+            "No ChatGPT OAuth token found at ~/.langchain/chatgpt-auth.json."
+        ) from exc
+
+    return ChatGPTOAuthStatus(
+        account_id=token.account_id,
+        plan_type=token.plan_type,
+        user_id=token.user_id,
+    )
+
+
+def login_chatgpt_oauth(*, device_code: bool = False):
+    """Run LangChain's ChatGPT OAuth flow and return a fresh status."""
+    try:
+        from langchain_openai.chatgpt_oauth import login_chatgpt, login_chatgpt_device
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise CodexOAuthUnavailableError(
+            "ChatGPT sign-in requires langchain-openai>=1.3.3."
+        ) from exc
+
+    if device_code:
+        login_chatgpt_device()
+    else:
+        login_chatgpt()
+    return get_chatgpt_oauth_status()

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -47,6 +47,10 @@ def create_llm_client(
         from .bedrock_client import BedrockClient
         return BedrockClient(model, base_url, **kwargs)
 
+    if provider_lower in ("openai_codex", "chatgpt_codex"):
+        from .codex_client import OpenAICodexClient
+        return OpenAICodexClient(model, base_url, **kwargs)
+
     from .openai_client import OpenAIClient, is_openai_compatible
     if is_openai_compatible(provider_lower):
         return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -92,6 +92,22 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("GPT-5.5 Pro - Most capable, expensive ($30/$180 per 1M tokens)", "gpt-5.5-pro"),
         ],
     },
+    "openai_codex": {
+        "quick": [
+            ("GPT-5.3 Codex Spark - Fast ChatGPT/Codex subscription model", "gpt-5.3-codex-spark"),
+            ("GPT-5.1 Codex mini - Lightweight ChatGPT/Codex model", "gpt-5.1-codex-mini"),
+            ("GPT-5.4 Mini - General GPT model via ChatGPT/Codex auth", "gpt-5.4-mini"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("GPT-5.3 Codex - Strong ChatGPT/Codex subscription model", "gpt-5.3-codex"),
+            ("GPT-5.2 Codex - Previous Codex reasoning model", "gpt-5.2-codex"),
+            ("GPT-5.1 Codex Max - Higher-capacity Codex model", "gpt-5.1-codex-max"),
+            ("GPT-5.5 - General GPT model via ChatGPT/Codex auth", "gpt-5.5"),
+            ("Custom model ID", "custom"),
+        ],
+    },
+    "chatgpt_codex": _CUSTOM_ONLY,
     "anthropic": {
         "quick": [
             ("Claude Sonnet 5 - Best speed and intelligence balance", "claude-sonnet-5"),

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -8,6 +8,7 @@ from .model_catalog import get_known_models
 _ANY_MODEL_PROVIDERS = (
     "ollama", "openrouter", "openai_compatible",
     "mistral", "kimi", "groq", "nvidia", "bedrock",
+    "openai_codex", "chatgpt_codex",
 )
 
 VALID_MODELS = {


### PR DESCRIPTION
## Summary

- Add an experimental `openai_codex` / `chatgpt_codex` provider backed by LangChain's ChatGPT OAuth Codex client.
- Add CLI sign-in UX for ChatGPT OAuth, live Codex model discovery via `codex app-server`, and `xhigh` reasoning-effort selection.
- Document subscription-backed setup and add focused unit coverage for provider wiring, model discovery, auth prompting, and env behavior.

## Validation

- `/private/tmp/tradingagents-codex-test-venv/bin/python -m ruff check cli/main.py cli/utils.py tradingagents/llm_clients/codex_app_server.py tradingagents/llm_clients/codex_client.py tradingagents/llm_clients/codex_oauth.py tradingagents/llm_clients/api_key_env.py tradingagents/llm_clients/factory.py tradingagents/llm_clients/model_catalog.py tradingagents/llm_clients/validators.py tests/test_openai_codex_provider.py tests/test_api_key_env.py tests/test_cli_env_skip.py tests/test_env_overrides.py`
- `PYTHONPATH=. /private/tmp/tradingagents-codex-test-venv/bin/python -m py_compile cli/main.py cli/utils.py tradingagents/llm_clients/codex_app_server.py tradingagents/llm_clients/codex_client.py tradingagents/llm_clients/codex_oauth.py tradingagents/graph/trading_graph.py`
- `PYTHONPATH=. /private/tmp/tradingagents-codex-test-venv/bin/python -m pytest tests/test_openai_codex_provider.py tests/test_api_key_env.py tests/test_cli_env_skip.py::TestProviderDefaultUrl tests/test_env_overrides.py -q`

## Notes

This integration depends on LangChain's experimental private `_ChatOpenAICodex` class, so the provider is labeled experimental and fails with an explicit upgrade/sign-in message when the required OAuth helper is unavailable.
