### PR TITLE
feat: add MiMo (Xiaomi) as LLM provider

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -359,6 +359,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
         ("Kimi (Moonshot)", "kimi", "https://api.moonshot.ai/v1"),
         ("Groq", "groq", "https://api.groq.com/openai/v1"),
         ("NVIDIA NIM", "nvidia", "https://integrate.api.nvidia.com/v1"),
+        ("MiMo (Xiaomi)", "mimo", "https://token-plan-cn.xiaomimimo.com/v1"),
         ("Azure OpenAI", "azure", None),
         ("Amazon Bedrock", "bedrock", None),
         ("Ollama", "ollama", ollama_url),

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -35,6 +35,7 @@ PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "kimi":       "MOONSHOT_API_KEY",
     "groq":       "GROQ_API_KEY",
     "nvidia":     "NVIDIA_API_KEY",
+    "mimo":       "MIMO_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
     # Generic OpenAI-compatible endpoint: the client reads this when set (keyed

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -178,6 +178,17 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # Generic OpenAI-compatible endpoint: the model is whatever the user's
     # server serves, so only "Custom model ID" is offered.
     "openai_compatible": _CUSTOM_ONLY,
+    # MiMo (Xiaomi): OpenAI-compatible endpoint with a small curated model list.
+    "mimo": {
+        "quick": [
+            ("MiMo v2.5 - Latest, fast and capable", "mimo-v2.5"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("MiMo v2.5 - Latest, fast and capable", "mimo-v2.5"),
+            ("Custom model ID", "custom"),
+        ],
+    },
     # Hosted OpenAI-compatible providers that serve many (and frequently
     # changing) models — offer "Custom model ID" rather than a list that goes
     # stale. The endpoint + key are wired by the provider; the user picks the


### PR DESCRIPTION
## What
Add MiMo (Xiaomi) as a supported LLM provider, following the same pattern as existing providers (Qwen, GLM, MiniMax,
etc.).

## Changes
- `cli/utils.py` — Add MiMo to the interactive provider selection table
- `tradingagents/llm_clients/openai_client.py` — Register MiMo in `OPENAI_COMPATIBLE_PROVIDERS`
- `tradingagents/llm_clients/model_catalog.py` — Add MiMo model list (`mimo-v2.5` + Custom model ID)
- `tradingagents/llm_clients/api_key_env.py` — Map MiMo to `MIMO_API_KEY` env var

## Notes
- MiMo uses an OpenAI-compatible API endpoint (`https://token-plan-cn.xiaomimimo.com/v1`)
- Supports custom model IDs for future model releases