### PR TITLE
fix(dataflows): tolerate malformed StockTwits messages

### DIFF
--- a/tests/test_stocktwits_resilience.py
+++ b/tests/test_stocktwits_resilience.py
@@ -8,6 +8,7 @@ transport error must degrade to a placeholder rather than raise.
 from __future__ import annotations
 
 import http.client
+import json
 from unittest.mock import patch
 from urllib.error import HTTPError
 
@@ -38,12 +39,32 @@ class TestStockTwitsResilience:
             HTTPError("url", 503, "down", {}, None),
             TimeoutError("slow"),
         ],
+        ids=["incomplete-read", "http-error", "timeout"],
     )
     def test_transport_errors_return_placeholder(self, exc):
         with patch.object(stocktwits, "urlopen", return_value=_raise(exc)):
             out = stocktwits.fetch_stocktwits_messages("NVDA")
         assert "unavailable" in out.lower()
         assert out.startswith("<stocktwits unavailable")
+
+    def test_unexpected_message_shape_returns_placeholder(self):
+        class _Resp:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return json.dumps(self_inner.payload).encode("utf-8")
+
+        for payload in ({"messages": {"body": "not-a-list"}}, {"messages": ["bad"]}):
+            with patch.object(stocktwits, "urlopen", return_value=_Resp(payload)):
+                out = stocktwits.fetch_stocktwits_messages("NVDA")
+            assert out == "<no StockTwits messages found for $NVDA>"
 
 
 @pytest.mark.unit

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -58,6 +58,11 @@ def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.
         return f"<stocktwits unavailable: {type(exc).__name__}>"
 
     messages = data.get("messages", []) if isinstance(data, dict) else []
+    messages = (
+        [m for m in messages if isinstance(m, dict)]
+        if isinstance(messages, list)
+        else []
+    )
     if not messages:
         return f"<no StockTwits messages found for ${ticker.upper()}>"
 


### PR DESCRIPTION
## Problem
`fetch_stocktwits_messages()` promises to degrade gracefully when the public StockTwits endpoint is unavailable or returns unexpected data. It already handled transport errors, but it still assumed that `messages` was always a list of dictionaries.

If the API returned a malformed-but-valid JSON payload such as `{"messages": { ... }}` or a list containing non-dict values, the formatter could raise while trying to slice/format the entries instead of returning the placeholder response.

## Before / after
Before: unexpected `messages` shapes could escape the graceful-degradation path and raise during formatting.

After: `messages` is normalized to a list of dictionaries before formatting. Invalid or empty shapes now return the existing `<no StockTwits messages found ...>` placeholder.

## Verification
- `pytest tests/test_stocktwits_resilience.py -q`