### PR TITLE
fix(dataflows): make Yahoo news windows UTC and end-exclusiveFix/yahoo news utc window

### DIFF
--- a/tests/test_news_lookahead.py
+++ b/tests/test_news_lookahead.py
@@ -5,7 +5,7 @@ Regressions for #992 (flat articles bypassed the date filter), #1007 (global
 news injected future articles), #993 (empty-after-filter returned a blank body).
 """
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -38,6 +38,30 @@ def test_window_excludes_future_and_undated_in_backtest():
 
 
 @pytest.mark.unit
+def test_window_is_end_exclusive_and_accepts_the_full_end_date():
+    start = datetime(2025, 5, 1)
+    end = datetime(2025, 5, 9)
+
+    assert ynews._in_news_window(datetime(2025, 5, 1), start, end) is True
+    assert (
+        ynews._in_news_window(
+            datetime(2025, 5, 9, 23, 59, 59, 999999), start, end
+        )
+        is True
+    )
+    assert ynews._in_news_window(datetime(2025, 5, 10), start, end) is False
+
+
+@pytest.mark.unit
+def test_window_compares_equivalent_aware_instants_in_utc():
+    start = datetime(2025, 5, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 5, 9, tzinfo=timezone.utc)
+    same_instant = datetime.fromisoformat("2025-05-09T19:30:00-04:00")
+
+    assert ynews._in_news_window(same_instant, start, end) is True
+
+
+@pytest.mark.unit
 def test_window_keeps_undated_in_live_window():
     # Live window (reaches today): undated articles can't be "future", so keep them.
     start = datetime.now()
@@ -61,6 +85,36 @@ def test_global_news_future_flat_article_excluded(monkeypatch):
     out = ynews.get_global_news_yfinance("2025-05-09", look_back_days=7, limit=10)
     assert "PAST EVENT" in out
     assert "FUTURE EVENT" not in out  # #1007
+
+
+@pytest.mark.unit
+def test_global_news_excludes_midnight_after_curr_date(monkeypatch):
+    inside = {
+        "content": {
+            "title": "INSIDE WINDOW",
+            "provider": {"displayName": "P"},
+            "pubDate": "2025-05-09T23:59:59Z",
+        }
+    }
+    next_midnight = {
+        "content": {
+            "title": "NEXT MIDNIGHT",
+            "provider": {"displayName": "P"},
+            "pubDate": "2025-05-10T00:00:00Z",
+        }
+    }
+
+    class FakeSearch:
+        def __init__(self, *args, **kwargs):
+            self.news = [inside, next_midnight]
+
+    monkeypatch.setattr(ynews.yf, "Search", FakeSearch)
+    out = ynews.get_global_news_yfinance(
+        "2025-05-09", look_back_days=7, limit=10
+    )
+
+    assert "INSIDE WINDOW" in out
+    assert "NEXT MIDNIGHT" not in out
 
 
 @pytest.mark.unit

--- a/tests/test_news_lookahead.py
+++ b/tests/test_news_lookahead.py
@@ -4,7 +4,6 @@ into a historical window.
 Regressions for #992 (flat articles bypassed the date filter), #1007 (global
 news injected future articles), #993 (empty-after-filter returned a blank body).
 """
-import time
 from datetime import datetime, timezone
 
 import pytest
@@ -13,17 +12,58 @@ import tradingagents.dataflows.yfinance_news as ynews
 
 
 def _epoch(date_str):
-    return int(time.mktime(datetime.strptime(date_str, "%Y-%m-%d").timetuple()))
+    parsed = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
 
 
 @pytest.mark.unit
-def test_flat_article_publish_time_is_parsed():
-    # #992: flat articles now carry a pub_date (was always None -> unfilterable).
+def test_flat_article_publish_time_is_parsed_as_utc():
     data = ynews._extract_article_data(
-        {"title": "X", "publisher": "P", "link": "l", "providerPublishTime": _epoch("2025-05-09")}
+        {
+            "title": "X",
+            "publisher": "P",
+            "link": "l",
+            "providerPublishTime": _epoch("2025-05-09"),
+        }
     )
-    assert data["pub_date"] is not None
-    assert data["pub_date"].strftime("%Y-%m-%d") == "2025-05-09"
+
+    assert data["pub_date"] == datetime(2025, 5, 9, tzinfo=timezone.utc)
+    assert data["pub_date"].tzinfo is timezone.utc
+
+
+@pytest.mark.unit
+def test_nested_offset_publish_time_is_normalized_to_utc():
+    data = ynews._extract_article_data(
+        {"content": {"pubDate": "2025-05-09T20:00:00-04:00"}}
+    )
+
+    assert data["pub_date"] == datetime(2025, 5, 10, tzinfo=timezone.utc)
+    assert data["pub_date"].tzinfo is timezone.utc
+
+
+@pytest.mark.unit
+def test_nested_naive_publish_time_is_interpreted_as_utc():
+    data = ynews._extract_article_data(
+        {"content": {"pubDate": "2025-05-09T12:30:00"}}
+    )
+
+    assert data["pub_date"] == datetime(
+        2025, 5, 9, 12, 30, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "article",
+    [
+        {"content": {"pubDate": "not-a-date"}},
+        {"providerPublishTime": "not-an-epoch"},
+        {"content": {}},
+        {},
+    ],
+)
+def test_missing_or_malformed_publish_time_remains_undated(article):
+    assert ynews._extract_article_data(article)["pub_date"] is None
 
 
 @pytest.mark.unit

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -1,7 +1,7 @@
 """yfinance-based news data fetching functions."""
 
 import contextlib
-from datetime import datetime
+from datetime import datetime, timezone
 
 import yfinance as yf
 from dateutil.relativedelta import relativedelta
@@ -57,18 +57,27 @@ def _extract_article_data(article: dict) -> dict:
         }
 
 
-def _in_news_window(pub_date, start_dt, end_dt) -> bool:
-    """Whether an article belongs in the [start_dt, end_dt] window.
+def _as_utc(value: datetime) -> datetime:
+    """Return a UTC-aware datetime, treating naive internal values as UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
-    Dated articles are kept only if they fall in the window. An undated article
-    is kept only when the window reaches the present (live run) — in a
-    historical/backtest window it's excluded, since we can't prove it isn't
-    future news (look-ahead safety, #992/#1007).
+
+def _in_news_window(pub_date, start_dt, end_dt) -> bool:
+    """Whether an article belongs in the UTC [start, end + 1 day) window.
+
+    Dated articles are kept only if they fall in the half-open interval. An
+    undated article is kept only when the window reaches the present (live run)
+    because a historical run cannot prove that an undated article is safe.
     """
     if pub_date is not None:
-        naive = pub_date.replace(tzinfo=None) if hasattr(pub_date, "replace") else pub_date
-        return start_dt <= naive <= end_dt + relativedelta(days=1)
-    return end_dt >= datetime.now() - relativedelta(days=1)
+        published_at = _as_utc(pub_date)
+        window_start = _as_utc(start_dt)
+        window_end_exclusive = _as_utc(end_dt) + relativedelta(days=1)
+        return window_start <= published_at < window_end_exclusive
+
+    return _as_utc(end_dt) >= datetime.now(timezone.utc) - relativedelta(days=1)
 
 
 def get_news_yfinance(

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -25,12 +25,7 @@ def _extract_article_data(article: dict) -> dict:
         url_obj = content.get("canonicalUrl") or content.get("clickThroughUrl") or {}
         link = url_obj.get("url", "")
 
-        # Get publish date
-        pub_date_str = content.get("pubDate", "")
-        pub_date = None
-        if pub_date_str:
-            with contextlib.suppress(ValueError, AttributeError):
-                pub_date = datetime.fromisoformat(pub_date_str.replace("Z", "+00:00"))
+        pub_date = _parse_iso_publish_time(content.get("pubDate"))
 
         return {
             "title": title,
@@ -40,14 +35,11 @@ def _extract_article_data(article: dict) -> dict:
             "pub_date": pub_date,
         }
     else:
-        # Fallback for flat structure. Parse the epoch publish time so flat
-        # articles are date-filterable too (otherwise they bypass the
-        # historical window and leak future news, #992/#1007).
         pub_date = None
         ts = article.get("providerPublishTime")
-        if ts:
-            with contextlib.suppress(ValueError, OSError, TypeError):
-                pub_date = datetime.fromtimestamp(ts)
+        if ts is not None:
+            with contextlib.suppress(ValueError, OSError, OverflowError, TypeError):
+                pub_date = datetime.fromtimestamp(ts, tz=timezone.utc)
         return {
             "title": article.get("title", "No title"),
             "summary": article.get("summary", ""),
@@ -62,6 +54,18 @@ def _as_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _parse_iso_publish_time(value: object) -> datetime | None:
+    """Parse a Yahoo ISO publication time and normalize it to UTC."""
+    if not isinstance(value, str) or not value:
+        return None
+
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        return _as_utc(datetime.fromisoformat(normalized))
+    except (ValueError, OverflowError):
+        return None
 
 
 def _in_news_window(pub_date, start_dt, end_dt) -> bool:


### PR DESCRIPTION
## Summary

- treat Yahoo Finance news windows as UTC half-open intervals
- exclude articles published at midnight immediately following the requested end date
- normalize nested ISO and flat Unix timestamps to UTC-aware datetimes
- preserve the existing policy for undated articles

## Root cause

The previous date-window comparison used an inclusive upper bound. For an
analysis ending on `2025-05-09`, an article published exactly at
`2025-05-10T00:00:00Z` could therefore enter the historical run.

Flat Yahoo articles were also parsed using the host machine's local timezone,
which could produce different filtering results across environments.

## Changes

- normalize naive and timezone-aware datetimes to UTC
- use a half-open `[start, end + 1 day)` news window
- parse Unix timestamps directly as UTC-aware datetimes
- normalize ISO timestamps with timezone offsets to UTC
- keep malformed or missing timestamps non-fatal
- add regression tests for boundary and timezone behavior

## Test plan

- `python -m pytest tests/test_news_lookahead.py -q` — 14 passed
- `python -m pytest -q` — 568 passed, 2 skipped
- `python -m ruff check .` — passed

No live API calls or credentials are required.