### PR TITLE
fix(agents): prevent web_search tool hallucination and add fallback search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",
     "yfinance>=1.4.1",
+    "duckduckgo-search>=7.0",
 ]
 
 [project.optional-dependencies]

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -41,6 +41,7 @@ from tradingagents.agents.utils.structured import (
 )
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
+from tradingagents.dataflows.web_search import web_search_financial
 
 
 def _seven_days_back(trade_date: str) -> str:
@@ -77,16 +78,22 @@ def create_sentiment_analyst(llm):
             news_block=news_block,
             stocktwits_block=stocktwits_block,
             reddit_block=reddit_block,
+            web_block=web_block,
         )
+
+        # Step 1: If primary social sources are unavailable, supplement with web search
+        _unavailable_marker = "<unavailable>"
+        if _unavailable_marker in stocktwits_block or _unavailable_marker in reddit_block:
+            web_block = web_search_financial(ticker, limit=5)
+        else:
+            web_block = ""
 
         prompt = ChatPromptTemplate.from_messages(
             [
                 (
                     "system",
-                    "You are a helpful AI assistant, collaborating with other assistants."
-                    " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
-                    " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}"
+                    "You are a sentiment analyst. Today's date is {current_date}. {instrument_context}"
+                    " All data you need is provided below — do not attempt to call external tools or search the web."
                     "\n{system_message}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
@@ -126,6 +133,7 @@ def _build_system_message(
     news_block: str,
     stocktwits_block: str,
     reddit_block: str,
+    web_block: str = "",
 ) -> str:
     """Assemble the sentiment-analyst system message with structured data blocks."""
     return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on three complementary data sources that have already been collected for you.
@@ -152,6 +160,13 @@ Community discussion. Engagement signal via upvote score and comment count. Subr
 <start_of_reddit>
 {reddit_block}
 <end_of_reddit>
+
+### Web search results — supplementary context (only present when primary social sources were unavailable)
+Additional web results fetched to compensate for missing StockTwits/Reddit data.
+
+<start_of_web_search>
+{web_block if web_block else "N/A — primary social sources were available; no supplementary search performed."}
+<end_of_web_search>
 
 ## How to analyze this data (best practices)
 

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -39,7 +39,7 @@ def create_portfolio_manager(llm):
             else ""
         )
 
-        prompt = f"""As the Portfolio Manager, synthesize the risk analysts' debate and deliver the final trading decision.
+        prompt = f"""As the Portfolio Manager, synthesize the risk analysts' debate and deliver the final trading decision. Do not call any external tools or search the web — all necessary information is already provided below.
 
 {instrument_context}
 

--- a/tradingagents/agents/managers/research_manager.py
+++ b/tradingagents/agents/managers/research_manager.py
@@ -22,7 +22,7 @@ def create_research_manager(llm):
 
         investment_debate_state = state["investment_debate_state"]
 
-        prompt = f"""As the Research Manager and debate facilitator, your role is to critically evaluate this round of debate and deliver a clear, actionable investment plan for the trader.
+        prompt = f"""As the Research Manager and debate facilitator, your role is to critically evaluate this round of debate and deliver a clear, actionable investment plan for the trader. Do not call any external tools or search the web — all necessary information is already provided below.
 
 {instrument_context}
 

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -31,7 +31,8 @@ def create_trader(llm):
                 "content": (
                     "You are a trading agent analyzing market data to make investment decisions. "
                     "Based on your analysis, provide a specific recommendation to buy, sell, or hold. "
-                    "Anchor your reasoning in the analysts' reports and the research plan."
+                    "Anchor your reasoning in the analysts' reports and the research plan. "
+                    "Do not call any external tools or search the web — all necessary information is already provided."
                     + get_language_instruction()
                 ),
             },

--- a/tradingagents/dataflows/web_search.py
+++ b/tradingagents/dataflows/web_search.py
@@ -1,0 +1,57 @@
+"""Web search fetcher for supplementary financial context.
+
+Uses DuckDuckGo (no API key required) to fetch recent web results when
+primary data sources (StockTwits, Reddit) are unavailable. Returns
+formatted plaintext blocks ready for prompt injection and degrades
+gracefully — returns a placeholder string rather than raising.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_UNAVAILABLE = "<web_search_unavailable>"
+
+
+def web_search_financial(ticker: str, limit: int = 5) -> str:
+    """Search the web for recent financial news/sentiment about *ticker*.
+
+    Returns a formatted multi-result string, or a placeholder on failure.
+    """
+    try:
+        from duckduckgo_search import DDGS
+    except ImportError:
+        logger.warning("duckduckgo-search not installed; web search unavailable")
+        return _UNAVAILABLE
+
+    query = f"{ticker} stock news sentiment"
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.news(query, max_results=limit))
+            if not results:
+                results = list(ddgs.text(query, max_results=limit))
+    except Exception as exc:
+        logger.warning("Web search failed for %s: %s", ticker, exc)
+        return _UNAVAILABLE
+
+    if not results:
+        return _UNAVAILABLE
+
+    lines: list[str] = []
+    for i, r in enumerate(results, 1):
+        title = r.get("title", "")
+        body = r.get("body", r.get("snippet", ""))
+        source = r.get("source", r.get("href", ""))
+        date = r.get("date", "")
+        lines.append(f"[{i}] {title}")
+        if date:
+            lines.append(f"    Date: {date}")
+        if source:
+            lines.append(f"    Source: {source}")
+        if body:
+            lines.append(f"    {body}")
+        lines.append("")
+
+    return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- LLM 에이전트들이 존재하지 않는 `web_search` tool을 환각하여 structured-output 실패 → free-text 폴백으로 떨어지는 문제 수정
- StockTwits/Reddit unavailable 시 DuckDuckGo 웹 검색으로 보충하는 two-step 패턴 구현
- Research Manager, Trader, Portfolio Manager 프롬프트에 외부 tool 호출 금지 명시

Closes #1130

## Changes
- `tradingagents/dataflows/web_search.py` — DuckDuckGo 기반 웹 검색 모듈 (API 키 불필요)
- `tradingagents/agents/analysts/sentiment_analyst.py` — two-step 패턴, tool-priming 프롬프트 제거
- `tradingagents/agents/managers/research_manager.py` — no-tools 명시
- `tradingagents/agents/trader/trader.py` — no-tools 명시
- `tradingagents/agents/managers/portfolio_manager.py` — no-tools 명시
- `pyproject.toml` — `duckduckgo-search>=7.0` 의존성 추가

## Test plan
- [x] `web_search_financial("COF")` 정상 반환 확인
- [x] 전체 에이전트 모듈 import 정상
- [ ] COF 티커로 full pipeline 실행 시 "Unknown tool type: 'web_search'" 에러 소멸 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)