### PR TITLE
feat: add Anthropic prompt caching and token buffer for Claude 5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ]
+}

--- a/tests/test_anthropic_effort.py
+++ b/tests/test_anthropic_effort.py
@@ -96,3 +96,41 @@ class TestEffortGate:
         assert captured["kwargs"]["max_tokens"] == 1024
         assert captured["kwargs"]["timeout"] == 30
         assert "effort" not in captured["kwargs"]
+
+
+@pytest.mark.unit
+class TestPromptCachingAndTokenScaling:
+    def test_prompt_caching_marks_system_and_tools(self):
+        payload = {
+            "model": "claude-sonnet-5",
+            "system": "Static trading instructions",
+            "tools": [
+                {"name": "alpha", "description": "First tool"},
+                {"name": "beta", "description": "Second tool"},
+            ],
+        }
+
+        cached = mod._apply_prompt_caching(payload)
+
+        assert payload["system"] == "Static trading instructions"
+        assert "cache_control" not in payload
+        assert cached["cache_control"] == {"type": "ephemeral"}
+        assert cached["system"][0]["cache_control"] == {"type": "ephemeral"}
+        assert cached["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.parametrize(
+        "model,effort,expected",
+        [
+            ("claude-sonnet-5", "low", 8192),
+            ("claude-sonnet-5", "medium", 12288),
+            ("claude-sonnet-5", "high", 16384),
+            ("claude-fable-5", "high", 24576),
+        ],
+    )
+    def test_effort_allocates_dynamic_token_floor(self, model, effort, expected):
+        assert mod._resolve_anthropic_max_tokens(model, effort, None) == expected
+
+    def test_explicit_max_tokens_are_respected(self):
+        assert mod._resolve_anthropic_max_tokens(
+            "claude-sonnet-5", "high", 1024
+        ) == 1024

--- a/tests/test_anthropic_effort.py
+++ b/tests/test_anthropic_effort.py
@@ -125,6 +125,8 @@ class TestPromptCachingAndTokenScaling:
             ("claude-sonnet-5", "medium", 12288),
             ("claude-sonnet-5", "high", 16384),
             ("claude-fable-5", "high", 24576),
+            ("claude-mythos-5", "high", 24576),
+            ("claude-mythos-preview", "high", 24576),
         ],
     )
     def test_effort_allocates_dynamic_token_floor(self, model, effort, expected):

--- a/tests/test_temperature_config.py
+++ b/tests/test_temperature_config.py
@@ -21,6 +21,7 @@ class TestTemperatureForwarding:
             # test_openai_reasoning_effort), so forwarding is tested on gpt-4.1.
             ("openai", "gpt-4.1"),
             ("anthropic", "claude-sonnet-5"),
+            ("anthropic", "claude-fable-5"),
             ("google", "gemini-3.5-flash"),
             ("deepseek", "deepseek-chat"),
         ],

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -100,23 +100,19 @@ def _apply_prompt_caching(payload: dict[str, Any]) -> dict[str, Any]:
             }
         ]
     elif isinstance(system, list) and system:
-        cached_system = copy.deepcopy(system)
-        for index in range(len(cached_system) - 1, -1, -1):
-            block = cached_system[index]
+        for index in range(len(system) - 1, -1, -1):
+            block = system[index]
             if isinstance(block, dict):
-                cached_system[index] = _add_cache_control(block)
+                system[index] = _add_cache_control(block)
                 break
-        cached_payload["system"] = cached_system
 
     tools = cached_payload.get("tools")
     if isinstance(tools, list) and tools:
-        cached_tools = copy.deepcopy(tools)
-        for index in range(len(cached_tools) - 1, -1, -1):
-            tool = cached_tools[index]
+        for index in range(len(tools) - 1, -1, -1):
+            tool = tools[index]
             if isinstance(tool, dict):
-                cached_tools[index] = _add_cache_control(tool)
+                tools[index] = _add_cache_control(tool)
                 break
-        cached_payload["tools"] = cached_tools
 
     return cached_payload
 

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -1,3 +1,4 @@
+import copy
 import re
 from typing import Any
 
@@ -10,6 +11,16 @@ _PASSTHROUGH_KWARGS = (
     "timeout", "max_retries", "api_key", "max_tokens", "temperature",
     "callbacks", "http_client", "http_async_client", "effort",
 )
+
+_CACHE_CONTROL_EPHEMERAL = {"type": "ephemeral"}
+
+# Conservative output-token floors for supported Claude 5 models when effort is
+# enabled but the caller did not provide an explicit max_tokens cap.
+_EFFORT_MAX_TOKENS = {
+    "opus": {"low": 8192, "medium": 12288, "high": 16384},
+    "sonnet": {"low": 8192, "medium": 12288, "high": 16384},
+    "fable": {"low": 12288, "medium": 16384, "high": 24576},
+}
 
 # Anthropic's extended-thinking ``effort`` parameter is accepted by Opus 4.5+,
 # Sonnet 4.6+, and the Claude 5 family (Sonnet 5, Fable 5). Sonnet 4.5 and any
@@ -38,6 +49,75 @@ def _supports_effort(model: str) -> bool:
     return (major, minor) >= _EFFORT_MIN_VERSION[family]
 
 
+def _resolve_anthropic_max_tokens(
+    model: str,
+    effort: str | None,
+    max_tokens: int | None,
+) -> int | None:
+    """Pick a safer max_tokens floor when effort is enabled.
+
+    Anthropic's reasoning-heavy Claude 5 calls can spend a meaningful part of
+    the completion budget on internal thinking. If the caller did not set an
+    explicit cap, allocate a family-aware floor instead of relying on the
+    SDK's default.
+    """
+    if max_tokens is not None:
+        return max_tokens
+
+    if not effort or not _supports_effort(model):
+        return None
+
+    match = _EFFORT_MODEL.match(model.lower())
+    if not match:
+        return None
+
+    family = match.group(1)
+    effort_lc = effort.lower()
+    return _EFFORT_MAX_TOKENS.get(family, {}).get(effort_lc)
+
+
+def _add_cache_control(block: dict[str, Any]) -> dict[str, Any]:
+    cached_block = copy.deepcopy(block)
+    cached_block.setdefault("cache_control", _CACHE_CONTROL_EPHEMERAL)
+    return cached_block
+
+
+def _apply_prompt_caching(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mark static Anthropic prompt segments as cacheable."""
+    cached_payload = copy.deepcopy(payload)
+    cached_payload.setdefault("cache_control", _CACHE_CONTROL_EPHEMERAL)
+
+    system = cached_payload.get("system")
+    if isinstance(system, str):
+        cached_payload["system"] = [
+            {
+                "type": "text",
+                "text": system,
+                "cache_control": _CACHE_CONTROL_EPHEMERAL,
+            }
+        ]
+    elif isinstance(system, list) and system:
+        cached_system = copy.deepcopy(system)
+        for index in range(len(cached_system) - 1, -1, -1):
+            block = cached_system[index]
+            if isinstance(block, dict):
+                cached_system[index] = _add_cache_control(block)
+                break
+        cached_payload["system"] = cached_system
+
+    tools = cached_payload.get("tools")
+    if isinstance(tools, list) and tools:
+        cached_tools = copy.deepcopy(tools)
+        for index in range(len(cached_tools) - 1, -1, -1):
+            tool = cached_tools[index]
+            if isinstance(tool, dict):
+                cached_tools[index] = _add_cache_control(tool)
+                break
+        cached_payload["tools"] = cached_tools
+
+    return cached_payload
+
+
 class NormalizedChatAnthropic(ChatAnthropic):
     """ChatAnthropic with normalized content output.
 
@@ -48,6 +128,10 @@ class NormalizedChatAnthropic(ChatAnthropic):
 
     def invoke(self, input, config=None, **kwargs):
         return normalize_content(super().invoke(input, config, **kwargs))
+
+    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        return _apply_prompt_caching(payload)
 
 
 class AnthropicClient(BaseLLMClient):
@@ -70,6 +154,14 @@ class AnthropicClient(BaseLLMClient):
             if key == "effort" and not _supports_effort(self.model):
                 continue
             llm_kwargs[key] = self.kwargs[key]
+
+        resolved_max_tokens = _resolve_anthropic_max_tokens(
+            self.model,
+            llm_kwargs.get("effort"),
+            llm_kwargs.get("max_tokens"),
+        )
+        if resolved_max_tokens is not None:
+            llm_kwargs["max_tokens"] = resolved_max_tokens
 
         return NormalizedChatAnthropic(**llm_kwargs)
 

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -85,7 +85,6 @@ def _add_cache_control(block: dict[str, Any]) -> dict[str, Any]:
 def _apply_prompt_caching(payload: dict[str, Any]) -> dict[str, Any]:
     """Mark static Anthropic prompt segments as cacheable."""
     cached_payload = copy.deepcopy(payload)
-    cached_payload.setdefault("cache_control", _CACHE_CONTROL_EPHEMERAL)
 
     system = cached_payload.get("system")
     if isinstance(system, str):

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -67,11 +67,15 @@ def _resolve_anthropic_max_tokens(
     if not effort or not _supports_effort(model):
         return None
 
-    match = _EFFORT_MODEL.match(model.lower())
-    if not match:
-        return None
+    model_lc = model.lower()
+    if "mythos" in model_lc:
+        family = "fable"
+    else:
+        match = _EFFORT_MODEL.match(model_lc)
+        if not match:
+            return None
+        family = match.group(1)
 
-    family = match.group(1)
     effort_lc = effort.lower()
     return _EFFORT_MAX_TOKENS.get(family, {}).get(effort_lc)
 

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -81,9 +81,8 @@ def _resolve_anthropic_max_tokens(
 
 
 def _add_cache_control(block: dict[str, Any]) -> dict[str, Any]:
-    cached_block = copy.deepcopy(block)
-    cached_block.setdefault("cache_control", _CACHE_CONTROL_EPHEMERAL)
-    return cached_block
+    block.setdefault("cache_control", _CACHE_CONTROL_EPHEMERAL)
+    return block
 
 
 def _apply_prompt_caching(payload: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
This PR improves Anthropic Claude 5 handling in two ways:

- Adds automatic prompt caching to reduce repeated prompt processing in long trading loops.
- Adds effort-aware token budgeting so Claude 5 calls are less likely to truncate reasoning output.

## Details
- Injects Anthropic `cache_control: { type: "ephemeral" }` into reusable prompt sections.
- Caches static request prefixes such as system instructions and tool definitions.
- Applies a model-aware `max_tokens` floor when `effort` is enabled and no explicit cap is set.
- Keeps explicit caller-provided `max_tokens` values unchanged.

## Tests
- Added unit coverage for prompt caching behavior.
- Added unit coverage for dynamic token floor resolution.
- Verified touched Python files compile successfully with `py_compile`.

## Notes
- The changes are scoped to Anthropic Claude 5 behavior.
- Existing behavior is preserved when `max_tokens` is explicitly provided.