### PR TITLE
Added Codex connection support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ NVIDIA_API_KEY=
 #AWS_DEFAULT_REGION=us-west-2
 #AWS_PROFILE=
 
-# Codex local provider (experimental): uses your local Codex login/session
+# Codex local provider: uses your local Codex login/session
 # instead of OpenAI Platform API credits. Install with `pip install ".[codex]"`.
 # If the `codex` command is available, run `codex login` and sign in with ChatGPT.
 # If `codex login` is not recognized, check SDK auth with:

--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,13 @@ NVIDIA_API_KEY=
 #AWS_PROFILE=
 
 # Codex local provider (experimental): uses your local Codex login/session
-# instead of OpenAI Platform API credits. Install with `pip install ".[codex]"`,
-# then run `codex login` and sign in with ChatGPT.
+# instead of OpenAI Platform API credits. Install with `pip install ".[codex]"`.
+# If the `codex` command is available, run `codex login` and sign in with ChatGPT.
+# If `codex login` is not recognized, check SDK auth with:
+# python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
+# Common Codex model IDs: gpt-5.5, gpt-5.4, gpt-5.4-mini.
 #TRADINGAGENTS_LLM_PROVIDER=codex
-#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
+#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 #TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 
 # Optional: point at a remote Ollama server. When unset, defaults to

--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,13 @@ NVIDIA_API_KEY=
 # If the `codex` command is available, run `codex login` and sign in with ChatGPT.
 # If `codex login` is not recognized, check SDK auth with:
 # python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
-# Common Codex model IDs: gpt-5.5, gpt-5.4, gpt-5.4-mini.
+# Current public Codex model IDs:
+# gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5,
+# gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark.
+# Availability can depend on your Codex SDK/app version and ChatGPT entitlement.
 #TRADINGAGENTS_LLM_PROVIDER=codex
-#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
-#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.6-sol
+#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.6-luna
 
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows

--- a/.env.example
+++ b/.env.example
@@ -34,18 +34,14 @@ NVIDIA_API_KEY=
 
 # Codex local provider: uses your local Codex login/session
 # instead of OpenAI Platform API credits. Install with `pip install ".[codex]"`.
-# If the `codex` command is available, run `codex login` and sign in with ChatGPT.
-# If `codex login` is not recognized, check SDK auth with:
-# python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
+# For current GPT-5.6 models, install and update the standalone Codex CLI:
+# If `codex` is not recognized: npm install -g @openai/codex
+# Then run: codex update, codex --version, and codex login
 # Current public Codex model IDs:
 # gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5,
 # gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark.
-# Availability can depend on your Codex SDK/app version and ChatGPT entitlement.
-# List models available to your installed SDK/runtime with:
-# python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.models().data]); c.close()"
-# If a selected model says it requires a newer Codex version, update with:
-# python -m pip install -U --pre openai-codex
-# If the Codex CLI is available, you can also try: codex update
+# Availability depends on your current Codex CLI and ChatGPT entitlement.
+# TradingAgents prints the models it can use when the app starts.
 #TRADINGAGENTS_LLM_PROVIDER=codex
 #TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 #TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ NVIDIA_API_KEY=
 # Availability can depend on your Codex SDK/app version and ChatGPT entitlement.
 # List models available to your installed SDK/runtime with:
 # python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.models().data]); c.close()"
+# If a selected model says it requires a newer Codex version, update with:
+# python -m pip install -U --pre openai-codex
+# If the Codex CLI is available, you can also try: codex update
 #TRADINGAGENTS_LLM_PROVIDER=codex
 #TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 #TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,13 @@ NVIDIA_API_KEY=
 #AWS_DEFAULT_REGION=us-west-2
 #AWS_PROFILE=
 
+# Codex local provider (experimental): uses your local Codex login/session
+# instead of OpenAI Platform API credits. Install with `pip install ".[codex]"`,
+# then run `codex login` and sign in with ChatGPT.
+#TRADINGAGENTS_LLM_PROVIDER=codex
+#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
+#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows
 # the broader Ollama ecosystem; both the CLI dropdown and programmatic

--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,11 @@ NVIDIA_API_KEY=
 # gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5,
 # gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark.
 # Availability can depend on your Codex SDK/app version and ChatGPT entitlement.
+# List models available to your installed SDK/runtime with:
+# python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.models().data]); c.close()"
 #TRADINGAGENTS_LLM_PROVIDER=codex
-#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.6-sol
-#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.6-luna
+#TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
+#TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 
 # Optional: point at a remote Ollama server. When unset, defaults to
 # the local instance at http://localhost:11434/v1. Convention follows

--- a/README.md
+++ b/README.md
@@ -167,11 +167,15 @@ If the `codex` command is available, run `codex login` and sign in with ChatGPT.
 ```bash
 python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
 ```
-If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Current public Codex model IDs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`; exact availability can depend on your Codex SDK/app version and ChatGPT entitlement. The CLI also offers a custom model ID option for future rollout or workspace-specific models.
+If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Current public Codex model IDs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`; exact availability can depend on your Codex SDK/app version and ChatGPT entitlement. To list the models your installed SDK/runtime can actually run:
+```bash
+python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.models().data]); c.close()"
+```
+If a GPT-5.6 model returns "requires a newer version of Codex", choose one of the listed models for now or update Codex when a newer SDK/runtime is published. The CLI also offers a custom model ID option for future rollout or workspace-specific models.
 ```bash
 TRADINGAGENTS_LLM_PROVIDER=codex
-TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.6-sol
-TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.6-luna
+TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
+TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 ```
 This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access and is best treated as experimental because Codex is an agent surface, not a drop-in chat-completions API.
 

--- a/README.md
+++ b/README.md
@@ -162,11 +162,15 @@ For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_pro
 For Codex subscription access without OpenAI Platform API credits, use the experimental local Codex provider. Install the extra, authenticate Codex, then select `codex` in the CLI or set it in `.env`:
 ```bash
 pip install ".[codex]"
-codex login
 ```
+If the `codex` command is available, run `codex login` and sign in with ChatGPT. If PowerShell says `codex` is not recognized, check whether the Python SDK can see your local Codex/ChatGPT session:
+```bash
+python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
+```
+If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Common Codex model IDs are `gpt-5.5`, `gpt-5.4`, and `gpt-5.4-mini`; the CLI also offers a custom model ID option for future rollout or workspace-specific models.
 ```bash
 TRADINGAGENTS_LLM_PROVIDER=codex
-TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
+TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 ```
 This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access and is best treated as experimental because Codex is an agent surface, not a drop-in chat-completions API.

--- a/README.md
+++ b/README.md
@@ -163,25 +163,20 @@ For Codex subscription access without OpenAI Platform API credits, use the local
 ```bash
 pip install ".[codex]"
 ```
-If the `codex` command is available, run `codex login` and sign in with ChatGPT. If PowerShell says `codex` is not recognized, check whether the Python SDK can see your local Codex/ChatGPT session:
+For current Codex models such as GPT-5.6, TradingAgents uses the standalone Codex CLI when it is installed. Complete these steps in order:
 ```bash
-python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
+npm install -g @openai/codex  # only when `codex` is not recognized
+codex update                  # update an existing CLI
+codex --version
+codex login
 ```
-If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Current public Codex model IDs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`; exact availability can depend on your Codex SDK/app version and ChatGPT entitlement. To list the models your installed SDK/runtime can actually run:
-```bash
-python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.models().data]); c.close()"
-```
-If a GPT-5.6 model returns "requires a newer version of Codex", choose one of the listed models for now or update Codex when a newer SDK/runtime is published. The CLI also offers a custom model ID option for future rollout or workspace-specific models.
-```bash
-python -m pip install -U --pre openai-codex
-codex update  # when the Codex CLI is available
-```
+If `codex` is still not recognized after installation, open a new terminal so its install directory is on `PATH`, then repeat `codex --version`. If the CLI is installed and logged in but TradingAgents still says a model is unavailable, the account does not currently offer that model; select one of the runtime models printed when the app starts. Current public Codex model IDs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`.
 ```bash
 TRADINGAGENTS_LLM_PROVIDER=codex
 TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 ```
-This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access; Codex is an agent surface rather than a drop-in chat-completions API, so TradingAgents includes provider-specific setup checks and a prompt-level structured-output adapter.
+This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access; Codex is an agent surface rather than a drop-in chat-completions API, so TradingAgents includes provider-specific setup checks and a structured-output adapter.
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill i
 
 For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_provider: "bedrock"`, configure AWS credentials (environment variables, `~/.aws/credentials`, or an IAM role) and `AWS_DEFAULT_REGION`, and use a Bedrock model ID, e.g. `us.anthropic.claude-opus-4-8-v1:0`.
 
+For Codex subscription access without OpenAI Platform API credits, use the experimental local Codex provider. Install the extra, authenticate Codex, then select `codex` in the CLI or set it in `.env`:
+```bash
+pip install ".[codex]"
+codex login
+```
+```bash
+TRADINGAGENTS_LLM_PROVIDER=codex
+TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.4
+TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+```
+This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access and is best treated as experimental because Codex is an agent surface, not a drop-in chat-completions API.
+
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 
 For any other OpenAI-compatible server (vLLM, LM Studio, llama.cpp, or a custom relay), use `llm_provider: "openai_compatible"` and set the endpoint via `backend_url` (or `TRADINGAGENTS_LLM_BACKEND_URL`), e.g. `http://localhost:8000/v1` for vLLM or `http://localhost:1234/v1` for LM Studio. The model is whatever your server serves. No key is needed for local servers; set `OPENAI_COMPATIBLE_API_KEY` when the endpoint requires one.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill i
 
 For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_provider: "bedrock"`, configure AWS credentials (environment variables, `~/.aws/credentials`, or an IAM role) and `AWS_DEFAULT_REGION`, and use a Bedrock model ID, e.g. `us.anthropic.claude-opus-4-8-v1:0`.
 
-For Codex subscription access without OpenAI Platform API credits, use the experimental local Codex provider. Install the extra, authenticate Codex, then select `codex` in the CLI or set it in `.env`:
+For Codex subscription access without OpenAI Platform API credits, use the local Codex provider. Install the extra, authenticate Codex, then select `codex` in the CLI or set it in `.env`:
 ```bash
 pip install ".[codex]"
 ```
@@ -181,7 +181,7 @@ TRADINGAGENTS_LLM_PROVIDER=codex
 TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
 ```
-This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access and is best treated as experimental because Codex is an agent surface, not a drop-in chat-completions API.
+This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access; Codex is an agent surface rather than a drop-in chat-completions API, so TradingAgents includes provider-specific setup checks and a prompt-level structured-output adapter.
 
 For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ If the `codex` command is available, run `codex login` and sign in with ChatGPT.
 ```bash
 python -c "from openai_codex import Codex; c=Codex(); print(c.account()); c.close()"
 ```
-If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Common Codex model IDs are `gpt-5.5`, `gpt-5.4`, and `gpt-5.4-mini`; the CLI also offers a custom model ID option for future rollout or workspace-specific models.
+If that prints your ChatGPT account, you are authenticated and can run TradingAgents. Current public Codex model IDs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`; exact availability can depend on your Codex SDK/app version and ChatGPT entitlement. The CLI also offers a custom model ID option for future rollout or workspace-specific models.
 ```bash
 TRADINGAGENTS_LLM_PROVIDER=codex
-TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
-TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini
+TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.6-sol
+TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.6-luna
 ```
 This routes model calls through the local Codex SDK/CLI session and uses your ChatGPT/Codex entitlement. It is not the same as OpenAI Platform API access and is best treated as experimental because Codex is an agent surface, not a drop-in chat-completions API.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ python -c "from openai_codex import Codex; c=Codex(); print([m.id for m in c.mod
 ```
 If a GPT-5.6 model returns "requires a newer version of Codex", choose one of the listed models for now or update Codex when a newer SDK/runtime is published. The CLI also offers a custom model ID option for future rollout or workspace-specific models.
 ```bash
+python -m pip install -U --pre openai-codex
+codex update  # when the Codex CLI is available
+```
+```bash
 TRADINGAGENTS_LLM_PROVIDER=codex
 TRADINGAGENTS_DEEP_THINK_LLM=gpt-5.5
 TRADINGAGENTS_QUICK_THINK_LLM=gpt-5.4-mini

--- a/cli/main.py
+++ b/cli/main.py
@@ -464,6 +464,17 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
             tokens_str = "Tokens: --"
         stats_parts.append(tokens_str)
 
+        if stats["codex_requests"]:
+            average = stats["codex_request_seconds"] / stats["codex_requests"]
+            stats_parts.append(
+                "Codex: "
+                f"{stats['codex_requests']} req | "
+                f"JSON {stats['codex_structured_outputs']} | "
+                f"fallback {stats['codex_structured_fallbacks']} | "
+                f"errors {stats['codex_request_errors']} | "
+                f"avg {average:.1f}s"
+            )
+
     stats_parts.append(f"Reports: {reports_completed}/{reports_total}")
 
     # Elapsed time

--- a/cli/main.py
+++ b/cli/main.py
@@ -988,11 +988,43 @@ def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     return config
 
 
+def _preflight_llm_provider(config: dict) -> None:
+    """Run provider-specific setup checks before the live analysis UI starts."""
+    if config.get("llm_provider", "").lower() != "codex":
+        return
+
+    from tradingagents.llm_clients.codex_client import (
+        CodexSetupError,
+        preflight_codex_runtime,
+    )
+
+    models = {
+        config.get("quick_think_llm", ""),
+        config.get("deep_think_llm", ""),
+    }
+    try:
+        available = preflight_codex_runtime(model for model in models if model)
+    except CodexSetupError as exc:
+        console.print(
+            Panel(
+                str(exc),
+                title="Codex Setup Required",
+                border_style="red",
+                padding=(1, 2),
+            )
+        )
+        raise typer.Exit(1) from None
+
+    if available:
+        console.print(f"[green]✓ Codex runtime models:[/green] {', '.join(available)}")
+
+
 def run_analysis(checkpoint: bool | None = None):
     # First get all user selections
     selections = get_user_selections()
 
     config = _build_run_config(selections, checkpoint)
+    _preflight_llm_provider(config)
 
     # Create stats callback handler for tracking LLM/tool calls
     stats_handler = StatsCallbackHandler()

--- a/cli/stats_handler.py
+++ b/cli/stats_handler.py
@@ -16,6 +16,11 @@ class StatsCallbackHandler(BaseCallbackHandler):
         self.tool_calls = 0
         self.tokens_in = 0
         self.tokens_out = 0
+        self.codex_requests = 0
+        self.codex_request_seconds = 0.0
+        self.codex_request_errors = 0
+        self.codex_structured_outputs = 0
+        self.codex_structured_fallbacks = 0
 
     def on_llm_start(
         self,
@@ -65,6 +70,29 @@ class StatsCallbackHandler(BaseCallbackHandler):
         with self._lock:
             self.tool_calls += 1
 
+    def on_codex_request_end(
+        self,
+        *,
+        duration_seconds: float,
+        error: str | None = None,
+    ) -> None:
+        """Record a completed local Codex SDK request."""
+        with self._lock:
+            self.codex_requests += 1
+            self.codex_request_seconds += duration_seconds
+            if error:
+                self.codex_request_errors += 1
+
+    def on_codex_structured_output(self) -> None:
+        """Record a response accepted through Codex native JSON schema output."""
+        with self._lock:
+            self.codex_structured_outputs += 1
+
+    def on_codex_structured_fallback(self, *, agent_name: str, error: str) -> None:
+        """Record a structured call that had to retry as free text."""
+        with self._lock:
+            self.codex_structured_fallbacks += 1
+
     def get_stats(self) -> dict[str, Any]:
         """Return current statistics."""
         with self._lock:
@@ -73,4 +101,9 @@ class StatsCallbackHandler(BaseCallbackHandler):
                 "tool_calls": self.tool_calls,
                 "tokens_in": self.tokens_in,
                 "tokens_out": self.tokens_out,
+                "codex_requests": self.codex_requests,
+                "codex_request_seconds": self.codex_request_seconds,
+                "codex_request_errors": self.codex_request_errors,
+                "codex_structured_outputs": self.codex_structured_outputs,
+                "codex_structured_fallbacks": self.codex_structured_fallbacks,
             }

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -612,13 +612,6 @@ def ensure_api_key(provider: str) -> str | None:
     Returns None for providers that do not require a key (e.g. ollama)
     and for providers not found in the canonical mapping.
     """
-    if provider.lower() == "codex":
-        console.print(
-            "[yellow]Codex provider is experimental. Install openai-codex and run "
-            "`codex login` with your ChatGPT account before starting analysis.[/yellow]"
-        )
-        return None
-
     env_var = get_api_key_env(provider)
     if env_var is None:
         return None  # ollama / unknown — no key check possible

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -361,6 +361,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
         ("NVIDIA NIM", "nvidia", "https://integrate.api.nvidia.com/v1"),
         ("Azure OpenAI", "azure", None),
         ("Amazon Bedrock", "bedrock", None),
+        ("Codex local (ChatGPT/Codex subscription via `codex login`)", "codex", None),
         ("Ollama", "ollama", ollama_url),
         ("OpenAI-compatible (vLLM, LM Studio, llama.cpp, custom relay)", "openai_compatible", None),
     ]
@@ -611,6 +612,13 @@ def ensure_api_key(provider: str) -> str | None:
     Returns None for providers that do not require a key (e.g. ollama)
     and for providers not found in the canonical mapping.
     """
+    if provider.lower() == "codex":
+        console.print(
+            "[yellow]Codex provider is experimental. Install openai-codex and run "
+            "`codex login` with your ChatGPT account before starting analysis.[/yellow]"
+        )
+        return None
+
     env_var = get_api_key_env(provider)
     if env_var is None:
         return None  # ollama / unknown — no key check possible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
 bedrock = [
     "langchain-aws>=1.5.0",
 ]
+codex = [
+    "openai-codex",
+]
 
 [project.scripts]
 tradingagents = "cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ bedrock = [
     "langchain-aws>=1.5.0",
 ]
 codex = [
-    "openai-codex",
+    "openai-codex>=0.1.0b3",
 ]
 
 [project.scripts]

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -9,6 +9,7 @@ from tradingagents.llm_clients.codex_client import (
     CodexSetupError,
     _available_model_ids,
     _codex_setup_message,
+    _looks_like_schema_error,
 )
 from tradingagents.llm_clients.factory import create_llm_client
 
@@ -16,6 +17,11 @@ from tradingagents.llm_clients.factory import create_llm_client
 class SampleStructuredOutput(BaseModel):
     recommendation: str
     confidence: float
+
+
+class OptionalStructuredOutput(BaseModel):
+    required_value: str
+    optional_value: str | None = None
 
 
 @pytest.mark.unit
@@ -87,7 +93,34 @@ def test_codex_structured_output_parses_pydantic_model(monkeypatch):
     result = llm.with_structured_output(SampleStructuredOutput).invoke("Decide")
 
     assert result == SampleStructuredOutput(recommendation="Hold", confidence=0.75)
-    assert received_schema == SampleStructuredOutput.model_json_schema()
+    assert received_schema["additionalProperties"] is False
+    assert received_schema["required"] == ["recommendation", "confidence"]
+
+
+@pytest.mark.unit
+def test_codex_strict_schema_forbids_extra_properties_and_requires_optional_fields():
+    schema = codex_client._strict_json_schema(OptionalStructuredOutput.model_json_schema())
+
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["required_value", "optional_value"]
+
+
+@pytest.mark.unit
+def test_codex_detects_structured_output_schema_errors():
+    assert _looks_like_schema_error("invalid_json_schema: additionalProperties is required")
+
+
+@pytest.mark.unit
+def test_codex_accepts_openai_style_message_dicts(monkeypatch):
+    llm = CodexChatModel(model_name="gpt-5.4")
+    monkeypatch.setattr(llm, "_run_codex", lambda prompt: "Trader response")
+
+    result = llm.invoke([
+        {"role": "system", "content": "Follow the trading plan."},
+        {"role": "user", "content": "Make a recommendation."},
+    ])
+
+    assert result.content == "Trader response"
 
 
 @pytest.mark.unit

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -71,15 +71,71 @@ def test_codex_json_tool_response(monkeypatch):
 @pytest.mark.unit
 def test_codex_structured_output_parses_pydantic_model(monkeypatch):
     llm = CodexChatModel(model_name="gpt-5.4")
+    received_schema = None
+
+    def run_codex(prompt, *, output_schema=None):
+        nonlocal received_schema
+        received_schema = output_schema
+        return '{"recommendation":"Hold","confidence":0.75}'
+
     monkeypatch.setattr(
         llm,
         "_run_codex",
-        lambda prompt: '{"recommendation":"Hold","confidence":0.75}',
+        run_codex,
     )
 
     result = llm.with_structured_output(SampleStructuredOutput).invoke("Decide")
 
     assert result == SampleStructuredOutput(recommendation="Hold", confidence=0.75)
+    assert received_schema == SampleStructuredOutput.model_json_schema()
+
+
+@pytest.mark.unit
+def test_codex_invocations_reuse_runtime_but_isolate_threads(monkeypatch):
+    class FakeSandbox:
+        read_only = object()
+
+    class FakeThread:
+        def __init__(self, response):
+            self.response = response
+            self.calls = []
+
+        def run(self, prompt, **kwargs):
+            self.calls.append((prompt, kwargs))
+            return SimpleNamespace(final_response=self.response)
+
+    class FakeCodex:
+        def __init__(self):
+            self.threads = []
+
+        def models(self):
+            return SimpleNamespace(data=[SimpleNamespace(id="gpt-5.4")])
+
+        def thread_start(self, **kwargs):
+            thread = FakeThread(f"response-{len(self.threads) + 1}")
+            self.threads.append((kwargs, thread))
+            return thread
+
+    class FakeRuntime:
+        def __init__(self):
+            self.codex = FakeCodex()
+            self.get_calls = 0
+
+        def get(self):
+            self.get_calls += 1
+            return self.codex
+
+    runtime = FakeRuntime()
+    monkeypatch.setitem(__import__("sys").modules, "openai_codex", SimpleNamespace(Sandbox=FakeSandbox))
+    monkeypatch.setattr(codex_client, "_CODEX_RUNTIME", runtime)
+    llm = CodexChatModel(model_name="gpt-5.4")
+
+    assert llm._run_codex("first") == "response-1"
+    assert llm._run_codex("second") == "response-2"
+
+    assert runtime.get_calls == 2
+    assert len(runtime.codex.threads) == 2
+    assert all(kwargs["ephemeral"] is True for kwargs, _ in runtime.codex.threads)
 
 
 @pytest.mark.unit

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -237,13 +237,23 @@ def test_codex_model_error_shows_model_recovery_without_login_instruction():
         "This Codex model requires a newer Codex app/CLI/SDK.",
         original_error="gpt-5.6-luna requires a newer version of Codex",
         available_models=["gpt-5.5", "gpt-5.4-mini"],
-        recovery_steps=_model_recovery_steps(),
+        recovery_steps=_model_recovery_steps(cli_available=True),
     )
 
-    assert "python -m pip install -U --pre openai-codex" in message
-    assert "c.models()" in message
+    assert "codex update" in message
+    assert "codex --version" in message
     assert "codex login" not in message
     assert "gpt-5.5, gpt-5.4-mini" in message
+
+
+@pytest.mark.unit
+def test_codex_model_error_without_cli_shows_install_login_and_restart_steps():
+    steps = _model_recovery_steps(cli_available=False)
+
+    assert "npm install -g @openai/codex" in steps[0]
+    assert "codex --version" in steps[1]
+    assert "codex login" in steps[2]
+    assert "Restart TradingAgents" in steps[3]
 
 
 @pytest.mark.unit
@@ -266,9 +276,10 @@ def test_preflight_rejects_unavailable_runtime_model(monkeypatch):
 
     monkeypatch.setitem(__import__("sys").modules, "openai_codex", SimpleNamespace(Codex=FakeCodex))
     monkeypatch.setattr(codex_client, "_new_codex_client", FakeCodex)
+    monkeypatch.setattr(codex_client, "_codex_cli_path", lambda: None)
 
     with pytest.raises(CodexSetupError) as exc:
         codex_client.preflight_codex_runtime("gpt-5.6-luna")
 
-    assert "not available" in str(exc.value)
-    assert "python -m pip install -U --pre openai-codex" in str(exc.value)
+    assert "requires the standalone Codex CLI" in str(exc.value)
+    assert "npm install -g @openai/codex" in str(exc.value)

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -216,6 +216,22 @@ def test_available_model_ids_extracts_codex_sdk_models():
 
 
 @pytest.mark.unit
+def test_available_model_ids_supports_newer_cli_protocol_values():
+    codex = SimpleNamespace(
+        _client=SimpleNamespace(
+            _request_raw=lambda method, params: {
+                "data": [
+                    {"id": "gpt-5.6-luna", "supportedReasoningEfforts": [{"reasoningEffort": "ultra"}]},
+                    {"id": "gpt-5.6-sol", "supportedReasoningEfforts": [{"reasoningEffort": "max"}]},
+                ]
+            }
+        )
+    )
+
+    assert _available_model_ids(codex) == ["gpt-5.6-luna", "gpt-5.6-sol"]
+
+
+@pytest.mark.unit
 def test_codex_model_error_shows_model_recovery_without_login_instruction():
     message = _codex_setup_message(
         "This Codex model requires a newer Codex app/CLI/SDK.",
@@ -233,6 +249,9 @@ def test_codex_model_error_shows_model_recovery_without_login_instruction():
 @pytest.mark.unit
 def test_preflight_rejects_unavailable_runtime_model(monkeypatch):
     class FakeCodex:
+        def __init__(self, *args, **kwargs):
+            pass
+
         def __enter__(self):
             return self
 
@@ -246,6 +265,7 @@ def test_preflight_rejects_unavailable_runtime_model(monkeypatch):
             return SimpleNamespace(data=[SimpleNamespace(id="gpt-5.5")])
 
     monkeypatch.setitem(__import__("sys").modules, "openai_codex", SimpleNamespace(Codex=FakeCodex))
+    monkeypatch.setattr(codex_client, "_new_codex_client", FakeCodex)
 
     with pytest.raises(CodexSetupError) as exc:
         codex_client.preflight_codex_runtime("gpt-5.6-luna")

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from tradingagents.llm_clients.codex_client import CodexChatModel
+from tradingagents.llm_clients.codex_client import CodexChatModel, _available_model_ids
 from tradingagents.llm_clients.factory import create_llm_client
 
 
@@ -52,3 +52,17 @@ def test_codex_json_tool_response(monkeypatch):
             "type": "tool_call",
         }
     ]
+
+
+@pytest.mark.unit
+def test_available_model_ids_extracts_codex_sdk_models():
+    codex = SimpleNamespace(
+        models=lambda: SimpleNamespace(
+            data=[
+                SimpleNamespace(id="gpt-5.5"),
+                SimpleNamespace(model="gpt-5.4-mini"),
+            ]
+        )
+    )
+
+    assert _available_model_ids(codex) == ["gpt-5.5", "gpt-5.4-mini"]

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from pydantic import BaseModel
 
 from tradingagents.llm_clients import codex_client
 from tradingagents.llm_clients.codex_client import (
@@ -10,6 +11,11 @@ from tradingagents.llm_clients.codex_client import (
     _codex_setup_message,
 )
 from tradingagents.llm_clients.factory import create_llm_client
+
+
+class SampleStructuredOutput(BaseModel):
+    recommendation: str
+    confidence: float
 
 
 @pytest.mark.unit
@@ -60,6 +66,20 @@ def test_codex_json_tool_response(monkeypatch):
             "type": "tool_call",
         }
     ]
+
+
+@pytest.mark.unit
+def test_codex_structured_output_parses_pydantic_model(monkeypatch):
+    llm = CodexChatModel(model_name="gpt-5.4")
+    monkeypatch.setattr(
+        llm,
+        "_run_codex",
+        lambda prompt: '{"recommendation":"Hold","confidence":0.75}',
+    )
+
+    result = llm.with_structured_output(SampleStructuredOutput).invoke("Decide")
+
+    assert result == SampleStructuredOutput(recommendation="Hold", confidence=0.75)
 
 
 @pytest.mark.unit

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+
+from tradingagents.llm_clients.codex_client import CodexChatModel
+from tradingagents.llm_clients.factory import create_llm_client
+
+
+@pytest.mark.unit
+def test_codex_factory_returns_chat_model():
+    client = create_llm_client("codex", "gpt-5.4")
+    llm = client.get_llm()
+
+    assert isinstance(llm, CodexChatModel)
+    assert llm.model_name == "gpt-5.4"
+
+
+@pytest.mark.unit
+def test_codex_plain_response(monkeypatch):
+    llm = CodexChatModel(model_name="gpt-5.4")
+    monkeypatch.setattr(llm, "_run_codex", lambda prompt: "Final analysis")
+
+    result = llm.invoke("Analyze SPY")
+
+    assert result.content == "Final analysis"
+    assert result.tool_calls == []
+
+
+@pytest.mark.unit
+def test_codex_json_tool_response(monkeypatch):
+    llm = CodexChatModel(model_name="gpt-5.4").bind_tools([
+        SimpleNamespace(
+            name="get_stock_data",
+            description="Fetch stock data",
+            args={"ticker": {"type": "string"}},
+        )
+    ])
+    monkeypatch.setattr(
+        llm,
+        "_run_codex",
+        lambda prompt: '{"tool_calls":[{"name":"get_stock_data","args":{"ticker":"SPY"}}]}',
+    )
+
+    result = llm.invoke("Analyze SPY")
+
+    assert result.content == ""
+    assert result.tool_calls == [
+        {
+            "name": "get_stock_data",
+            "args": {"ticker": "SPY"},
+            "id": "codex_tool_0",
+            "type": "tool_call",
+        }
+    ]

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from langchain_core.callbacks import BaseCallbackHandler
 from pydantic import BaseModel
 
 from tradingagents.llm_clients import codex_client
@@ -121,6 +122,34 @@ def test_codex_accepts_openai_style_message_dicts(monkeypatch):
     ])
 
     assert result.content == "Trader response"
+
+
+@pytest.mark.unit
+def test_codex_reports_native_structured_output_and_fallback_to_callbacks(monkeypatch):
+    class StatusHandler(BaseCallbackHandler):
+        def __init__(self):
+            self.structured_outputs = 0
+            self.fallbacks = []
+
+        def on_codex_structured_output(self):
+            self.structured_outputs += 1
+
+        def on_codex_structured_fallback(self, *, agent_name, error):
+            self.fallbacks.append((agent_name, error))
+
+    handler = StatusHandler()
+    llm = CodexChatModel(model_name="gpt-5.4", callbacks=[handler])
+    monkeypatch.setattr(
+        llm,
+        "_run_codex",
+        lambda prompt, *, output_schema=None: '{"recommendation":"Hold","confidence":0.75}',
+    )
+
+    llm.with_structured_output(SampleStructuredOutput).invoke("Decide")
+    llm.record_structured_fallback("Trader", ValueError("invalid output"))
+
+    assert handler.structured_outputs == 1
+    assert handler.fallbacks == [("Trader", "invalid output")]
 
 
 @pytest.mark.unit

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -2,12 +2,20 @@ from types import SimpleNamespace
 
 import pytest
 
-from tradingagents.llm_clients.codex_client import CodexChatModel, _available_model_ids
+from tradingagents.llm_clients import codex_client
+from tradingagents.llm_clients.codex_client import (
+    CodexChatModel,
+    CodexSetupError,
+    _available_model_ids,
+    _codex_setup_message,
+)
 from tradingagents.llm_clients.factory import create_llm_client
 
 
 @pytest.mark.unit
-def test_codex_factory_returns_chat_model():
+def test_codex_factory_returns_chat_model(monkeypatch):
+    monkeypatch.setattr(codex_client, "preflight_codex_runtime", lambda model: ["gpt-5.4"])
+
     client = create_llm_client("codex", "gpt-5.4")
     llm = client.get_llm()
 
@@ -66,3 +74,42 @@ def test_available_model_ids_extracts_codex_sdk_models():
     )
 
     assert _available_model_ids(codex) == ["gpt-5.5", "gpt-5.4-mini"]
+
+
+@pytest.mark.unit
+def test_codex_setup_message_includes_recovery_commands():
+    message = _codex_setup_message(
+        "This Codex model requires a newer Codex app/CLI/SDK.",
+        original_error="gpt-5.6-luna requires a newer version of Codex",
+        available_models=["gpt-5.5", "gpt-5.4-mini"],
+    )
+
+    assert "python -m pip install -U --pre openai-codex" in message
+    assert "codex update" in message
+    assert "codex login" in message
+    assert "c.account()" in message
+    assert "gpt-5.5, gpt-5.4-mini" in message
+
+
+@pytest.mark.unit
+def test_preflight_rejects_unavailable_runtime_model(monkeypatch):
+    class FakeCodex:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def account(self):
+            return object()
+
+        def models(self):
+            return SimpleNamespace(data=[SimpleNamespace(id="gpt-5.5")])
+
+    monkeypatch.setitem(__import__("sys").modules, "openai_codex", SimpleNamespace(Codex=FakeCodex))
+
+    with pytest.raises(CodexSetupError) as exc:
+        codex_client.preflight_codex_runtime("gpt-5.6-luna")
+
+    assert "not available" in str(exc.value)
+    assert "python -m pip install -U --pre openai-codex" in str(exc.value)

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -11,6 +11,7 @@ from tradingagents.llm_clients.codex_client import (
     _available_model_ids,
     _codex_setup_message,
     _looks_like_schema_error,
+    _model_recovery_steps,
 )
 from tradingagents.llm_clients.factory import create_llm_client
 
@@ -215,17 +216,17 @@ def test_available_model_ids_extracts_codex_sdk_models():
 
 
 @pytest.mark.unit
-def test_codex_setup_message_includes_recovery_commands():
+def test_codex_model_error_shows_model_recovery_without_login_instruction():
     message = _codex_setup_message(
         "This Codex model requires a newer Codex app/CLI/SDK.",
         original_error="gpt-5.6-luna requires a newer version of Codex",
         available_models=["gpt-5.5", "gpt-5.4-mini"],
+        recovery_steps=_model_recovery_steps(),
     )
 
     assert "python -m pip install -U --pre openai-codex" in message
-    assert "codex update" in message
-    assert "codex login" in message
-    assert "c.account()" in message
+    assert "c.models()" in message
+    assert "codex login" not in message
     assert "gpt-5.5, gpt-5.4-mini" in message
 
 

--- a/tests/test_codex_model_catalog.py
+++ b/tests/test_codex_model_catalog.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tradingagents.llm_clients.model_catalog import get_model_options
+from tradingagents.llm_clients.validators import validate_model
+
+
+@pytest.mark.unit
+def test_codex_model_catalog_lists_common_codex_models():
+    quick_models = [model for _, model in get_model_options("codex", "quick")]
+    deep_models = [model for _, model in get_model_options("codex", "deep")]
+
+    for model in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"):
+        assert model in quick_models
+        assert model in deep_models
+        assert validate_model("codex", model)
+
+    assert "custom" in quick_models
+    assert "custom" in deep_models

--- a/tests/test_codex_model_catalog.py
+++ b/tests/test_codex_model_catalog.py
@@ -9,7 +9,15 @@ def test_codex_model_catalog_lists_common_codex_models():
     quick_models = [model for _, model in get_model_options("codex", "quick")]
     deep_models = [model for _, model in get_model_options("codex", "deep")]
 
-    for model in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"):
+    for model in (
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex-spark",
+    ):
         assert model in quick_models
         assert model in deep_models
         assert validate_model("codex", model)

--- a/tradingagents/agents/utils/structured.py
+++ b/tradingagents/agents/utils/structured.py
@@ -70,6 +70,9 @@ def invoke_structured_or_freetext(
                 raise ValueError("structured output returned no parsed result")
             return render(result)
         except Exception as exc:
+            record_fallback = getattr(plain_llm, "record_structured_fallback", None)
+            if callable(record_fallback):
+                record_fallback(agent_name, exc)
             logger.warning(
                 "%s: structured-output invocation failed (%s); retrying once as free text",
                 agent_name, exc,

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -18,6 +18,8 @@ PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "azure":      "AZURE_OPENAI_API_KEY",
     # Bedrock authenticates via the AWS credential chain, not a single key env.
     "bedrock":    None,
+    # Codex authenticates through the local Codex login/session.
+    "codex":      None,
     "xai":        "XAI_API_KEY",
     "deepseek":   "DEEPSEEK_API_KEY",
     # Dual-region providers each carry their own account; keys are not

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -203,17 +203,13 @@ def _codex_setup_message(
     *,
     original_error: str | None = None,
     available_models: Iterable[str] | None = None,
+    recovery_steps: Iterable[str] = (),
 ) -> str:
-    lines = [
-        problem,
-        "",
-        "To fix Codex setup:",
-        f"1. Install or update the Codex Python SDK: {CODEX_UPDATE_COMMAND}",
-        f"2. If the Codex CLI is available, update it too: {CODEX_CLI_UPDATE_COMMAND}",
-        f"3. If you are not signed in, run: {CODEX_LOGIN_COMMAND}",
-        f"4. If `codex` is not recognized, verify local SDK auth with: {CODEX_ACCOUNT_CHECK_COMMAND}",
-        f"5. List models your installed runtime can run with: {CODEX_MODEL_LIST_COMMAND}",
-    ]
+    lines = [problem]
+    steps = list(recovery_steps)
+    if steps:
+        lines.extend(["", "Next steps:"])
+        lines.extend(f"{index}. {step}" for index, step in enumerate(steps, start=1))
     if available_models:
         lines.extend(["", "Models currently reported by your installed runtime:"])
         lines.append(", ".join(available_models))
@@ -247,6 +243,20 @@ def _looks_like_schema_error(message: str) -> bool:
     return "invalid_json_schema" in lowered or "response_format" in lowered
 
 
+def _auth_recovery_steps() -> list[str]:
+    return [
+        f"Sign in with ChatGPT: {CODEX_LOGIN_COMMAND}",
+        f"Confirm the saved login: {CODEX_ACCOUNT_CHECK_COMMAND}",
+    ]
+
+
+def _model_recovery_steps() -> list[str]:
+    return [
+        f"Update the Codex Python SDK: {CODEX_UPDATE_COMMAND}",
+        f"List models available to this runtime: {CODEX_MODEL_LIST_COMMAND}",
+    ]
+
+
 def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
     """Validate Codex SDK/auth/model availability before the graph starts."""
     try:
@@ -256,6 +266,7 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
             _codex_setup_message(
                 "Codex provider is selected, but the `openai-codex` SDK is not installed.",
                 original_error=str(exc),
+                recovery_steps=[f"Install the optional provider dependency: {CODEX_INSTALL_COMMAND}"],
             )
         ) from exc
 
@@ -270,6 +281,7 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
                         "Codex provider is selected, but TradingAgents could not verify "
                         "a local Codex/ChatGPT login.",
                         original_error=str(exc),
+                        recovery_steps=_auth_recovery_steps(),
                     )
                 ) from exc
 
@@ -277,7 +289,8 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
                 raise CodexSetupError(
                     _codex_setup_message(
                         "Codex provider is selected, but no local Codex/ChatGPT "
-                        "account was found."
+                        "account was found.",
+                        recovery_steps=_auth_recovery_steps(),
                     )
                 )
 
@@ -293,7 +306,10 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
             )
         else:
             problem = "Codex provider is selected, but the Codex SDK/runtime is not ready."
-        raise CodexSetupError(_codex_setup_message(problem, original_error=message)) from exc
+        steps = _auth_recovery_steps() if _looks_like_auth_error(message) else _model_recovery_steps()
+        raise CodexSetupError(
+            _codex_setup_message(problem, original_error=message, recovery_steps=steps)
+        ) from exc
 
     missing = [model for model in requested_models if available and model not in available]
     if missing:
@@ -308,6 +324,7 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
                 problem,
                 available_models=available,
                 original_error=f"Unavailable model(s): {', '.join(missing)}",
+                recovery_steps=_model_recovery_steps(),
             )
         )
     return available
@@ -439,6 +456,7 @@ class CodexChatModel(BaseChatModel):
                         "installed Codex SDK/runtime.",
                         available_models=available,
                         original_error=f"Unavailable model: {self.model_name}",
+                        recovery_steps=_model_recovery_steps(),
                     )
                 )
             thread = codex.thread_start(
@@ -476,8 +494,25 @@ class CodexChatModel(BaseChatModel):
                 duration_seconds=perf_counter() - started,
                 error=problem,
             )
+            if _looks_like_newer_codex_required(message):
+                steps = _model_recovery_steps() + [
+                    f"If available, update the Codex CLI too: {CODEX_CLI_UPDATE_COMMAND}"
+                ]
+            elif _looks_like_auth_error(message):
+                steps = _auth_recovery_steps()
+            elif _looks_like_schema_error(message):
+                steps = [
+                    "Restart TradingAgents after applying the current Codex provider update.",
+                    "No Codex re-login is required for this error.",
+                ]
+            else:
+                steps = [f"Confirm the saved login: {CODEX_ACCOUNT_CHECK_COMMAND}"]
             raise RuntimeError(
-                _codex_setup_message(problem, original_error=message)
+                _codex_setup_message(
+                    problem,
+                    original_error=message,
+                    recovery_steps=steps,
+                )
             ) from exc
 
         self._notify_codex_status(

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -87,6 +87,23 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
         return None
 
 
+def _available_model_ids(codex: Any) -> list[str]:
+    """Return model IDs advertised by the installed Codex SDK/runtime."""
+    try:
+        models = codex.models()
+    except Exception as exc:  # noqa: BLE001 - availability check is best-effort
+        logger.warning("Could not list Codex models before invocation: %s", exc)
+        return []
+
+    data = getattr(models, "data", models)
+    ids = []
+    for model in data or []:
+        model_id = getattr(model, "id", None) or getattr(model, "model", None)
+        if model_id:
+            ids.append(str(model_id))
+    return ids
+
+
 class CodexChatModel(BaseChatModel):
     """LangChain chat wrapper around the local Codex SDK."""
 
@@ -146,6 +163,16 @@ class CodexChatModel(BaseChatModel):
 
         try:
             with Codex() as codex:
+                available = _available_model_ids(codex)
+                if available and self.model_name not in available:
+                    raise ValueError(
+                        f"Codex model {self.model_name!r} is not available in the "
+                        "installed Codex SDK/runtime. Available models: "
+                        f"{', '.join(available)}. Update the Codex SDK/app when "
+                        "newer models are available, or set "
+                        "TRADINGAGENTS_DEEP_THINK_LLM / "
+                        "TRADINGAGENTS_QUICK_THINK_LLM to one of the listed models."
+                    )
                 thread = codex.thread_start(
                     model=self.model_name,
                     sandbox=Sandbox.read_only,
@@ -153,8 +180,10 @@ class CodexChatModel(BaseChatModel):
                 result = thread.run(prompt)
         except Exception as exc:
             raise RuntimeError(
-                "Codex local invocation failed. Make sure the Codex CLI/SDK is "
-                "installed and authenticated with `codex login`."
+                "Codex local invocation failed. Make sure the Codex SDK is "
+                'installed with `pip install ".[codex]"`, your local Codex/ChatGPT '
+                "session is authenticated, and the configured model is available "
+                f"in your installed Codex runtime. Original error: {exc}"
             ) from exc
 
         return str(getattr(result, "final_response", "") or "")

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -1,4 +1,4 @@
-"""Experimental Codex local client.
+"""Codex local client.
 
 This provider lets users who have Codex through a ChatGPT plan run the
 TradingAgents workflow through their local Codex authentication instead of an
@@ -21,7 +21,7 @@ from typing import Any
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from .base_client import BaseLLMClient
 from .validators import validate_model
@@ -43,7 +43,7 @@ CODEX_MODEL_LIST_COMMAND = (
 
 
 class CodexSetupError(RuntimeError):
-    """Actionable setup error for the experimental Codex provider."""
+    """Actionable setup error for the Codex provider."""
 
 
 def _message_to_text(message: BaseMessage) -> str:
@@ -69,6 +69,17 @@ def _messages_to_prompt(messages: list[BaseMessage]) -> str:
         if text:
             chunks.append(f"{role.upper()}:\n{text}")
     return "\n\n".join(chunks)
+
+
+def _input_to_text(input_: Any) -> str:
+    """Normalize LangChain prompt inputs into plain text for Codex."""
+    if isinstance(input_, str):
+        return input_
+    if isinstance(input_, list):
+        return _messages_to_prompt(input_)
+    if hasattr(input_, "to_messages"):
+        return _messages_to_prompt(input_.to_messages())
+    return str(input_)
 
 
 def _tool_schema(tool: Any) -> dict[str, Any]:
@@ -232,6 +243,37 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
     return available
 
 
+class CodexStructuredOutput:
+    """Prompt-level structured-output adapter for Codex.
+
+    Codex does not currently expose a LangChain-native structured-output API,
+    but the agents only require that ``with_structured_output`` returns an
+    object with ``invoke`` that yields a Pydantic instance. We satisfy that
+    contract by asking Codex for schema-conforming JSON, parsing it, and letting
+    Pydantic perform the final validation.
+    """
+
+    def __init__(self, llm: CodexChatModel, schema: type[BaseModel]):
+        self.llm = llm
+        self.schema = schema
+
+    def invoke(self, input_: Any, config=None, **kwargs) -> BaseModel:
+        prompt = _input_to_text(input_)
+        schema_json = json.dumps(self.schema.model_json_schema(), indent=2)
+        structured_prompt = (
+            f"{prompt}\n\n"
+            "Return ONLY valid JSON that conforms to this JSON schema. "
+            "Do not wrap the JSON in markdown fences. Do not include commentary "
+            "outside the JSON object.\n\n"
+            f"{schema_json}"
+        )
+        raw = self.llm._run_codex(structured_prompt)
+        parsed = _extract_json_object(raw)
+        if parsed is None:
+            raise ValueError(f"Codex returned non-JSON structured output: {raw!r}")
+        return self.schema.model_validate(parsed)
+
+
 class CodexChatModel(BaseChatModel):
     """LangChain chat wrapper around the local Codex SDK."""
 
@@ -247,10 +289,7 @@ class CodexChatModel(BaseChatModel):
         return self.model_copy(update={"tools": list(tools)})
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
-        raise NotImplementedError(
-            "Codex local provider does not expose native structured output; "
-            "TradingAgents will fall back to free-text generation."
-        )
+        return CodexStructuredOutput(self, schema)
 
     def _generate(
         self,

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -18,6 +18,7 @@ import logging
 import re
 from collections.abc import Iterable
 from threading import Lock
+from time import perf_counter
 from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -344,7 +345,9 @@ class CodexStructuredOutput:
         parsed = _extract_json_object(raw)
         if parsed is None:
             raise ValueError(f"Codex returned non-JSON structured output: {raw!r}")
-        return self.schema.model_validate(parsed)
+        result = self.schema.model_validate(parsed)
+        self.llm._notify_codex_status("on_codex_structured_output")
+        return result
 
 
 class CodexChatModel(BaseChatModel):
@@ -363,6 +366,25 @@ class CodexChatModel(BaseChatModel):
 
     def with_structured_output(self, schema, *, method=None, **kwargs):
         return CodexStructuredOutput(self, schema)
+
+    def _notify_codex_status(self, method_name: str, **kwargs: Any) -> None:
+        """Send optional Codex telemetry to LangChain callback handlers."""
+        callbacks = getattr(self, "callbacks", None)
+        handlers = getattr(callbacks, "handlers", callbacks)
+        if not isinstance(handlers, Iterable) or isinstance(handlers, (str, bytes)):
+            return
+        for handler in handlers:
+            callback = getattr(handler, method_name, None)
+            if callable(callback):
+                callback(**kwargs)
+
+    def record_structured_fallback(self, agent_name: str, error: Exception) -> None:
+        """Record a visible fallback when the shared structured helper retries."""
+        self._notify_codex_status(
+            "on_codex_structured_fallback",
+            agent_name=agent_name,
+            error=str(error),
+        )
 
     def _generate(
         self,
@@ -397,6 +419,7 @@ class CodexChatModel(BaseChatModel):
         *,
         output_schema: dict[str, Any] | None = None,
     ) -> str:
+        started = perf_counter()
         try:
             from openai_codex import Sandbox
         except ImportError as exc:
@@ -425,6 +448,11 @@ class CodexChatModel(BaseChatModel):
             )
             result = thread.run(prompt, output_schema=output_schema)
         except CodexSetupError:
+            self._notify_codex_status(
+                "on_codex_request_end",
+                duration_seconds=perf_counter() - started,
+                error="Codex setup error",
+            )
             raise
         except Exception as exc:
             message = str(exc)
@@ -443,10 +471,19 @@ class CodexChatModel(BaseChatModel):
                 )
             else:
                 problem = "Codex local invocation failed."
+            self._notify_codex_status(
+                "on_codex_request_end",
+                duration_seconds=perf_counter() - started,
+                error=problem,
+            )
             raise RuntimeError(
                 _codex_setup_message(problem, original_error=message)
             ) from exc
 
+        self._notify_codex_status(
+            "on_codex_request_end",
+            duration_seconds=perf_counter() - started,
+        )
         return str(getattr(result, "final_response", "") or "")
 
     def _to_ai_message(self, raw: str) -> AIMessage:
@@ -477,7 +514,10 @@ class CodexClient(BaseLLMClient):
     def get_llm(self) -> Any:
         self.warn_if_unknown_model()
         preflight_codex_runtime(self.model)
-        return CodexChatModel(model_name=self.model)
+        return CodexChatModel(
+            model_name=self.model,
+            callbacks=self.kwargs.get("callbacks"),
+        )
 
     def validate_model(self) -> bool:
         return validate_model("codex", self.model)

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import atexit
 import json
 import logging
+import os
 import re
+import shutil
 from collections.abc import Iterable
 from threading import Lock
 from time import perf_counter
@@ -66,9 +68,7 @@ class _CodexRuntime:
     def get(self) -> Any:
         with self._lock:
             if self._codex is None:
-                from openai_codex import Codex
-
-                self._codex = Codex()
+                self._codex = _new_codex_client()
             return self._codex
 
     def close(self) -> None:
@@ -80,6 +80,33 @@ class _CodexRuntime:
 
 _CODEX_RUNTIME = _CodexRuntime()
 atexit.register(_CODEX_RUNTIME.close)
+
+
+def _codex_cli_path() -> str | None:
+    """Prefer the user's installed CLI over the SDK's pinned bundled runtime."""
+    configured = os.environ.get("TRADINGAGENTS_CODEX_CLI_PATH")
+    if configured:
+        return configured
+    return shutil.which("codex")
+
+
+def _new_codex_client() -> Any:
+    """Create Codex against the newest available local CLI when possible.
+
+    The Python SDK bundles a CLI release, but that release can lag behind the
+    separately installed Codex CLI and therefore omit newer subscription
+    models. The SDK supports supplying a CLI binary explicitly; this keeps
+    authentication local while matching the runtime users invoke in a terminal.
+    """
+    from openai_codex import Codex
+
+    cli_path = _codex_cli_path()
+    if not cli_path:
+        return Codex()
+
+    from openai_codex.client import CodexConfig
+
+    return Codex(CodexConfig(codex_bin=cli_path))
 
 
 def _content_to_text(content: Any) -> str:
@@ -183,6 +210,18 @@ def _strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 def _available_model_ids(codex: Any) -> list[str]:
     """Return model IDs advertised by the installed Codex SDK/runtime."""
+    client = getattr(codex, "_client", None)
+    raw_request = getattr(client, "_request_raw", None)
+    if callable(raw_request):
+        try:
+            # Newer Codex CLIs can add protocol enum values before the Python
+            # SDK understands them. Read the raw model-list response so model
+            # availability remains forward-compatible.
+            raw = raw_request("model/list", {"includeHidden": False})
+            data = raw.get("data", []) if isinstance(raw, dict) else []
+            return [str(model["id"]) for model in data if isinstance(model, dict) and model.get("id")]
+        except Exception as exc:  # noqa: BLE001 - fall back to the SDK parser
+            logger.warning("Could not read the raw Codex model list: %s", exc)
     try:
         models = codex.models()
     except Exception as exc:  # noqa: BLE001 - availability check is best-effort
@@ -260,7 +299,7 @@ def _model_recovery_steps() -> list[str]:
 def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
     """Validate Codex SDK/auth/model availability before the graph starts."""
     try:
-        from openai_codex import Codex
+        __import__("openai_codex")
     except ImportError as exc:
         raise CodexSetupError(
             _codex_setup_message(
@@ -272,7 +311,7 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
 
     requested_models = [models] if isinstance(models, str) else list(models)
     try:
-        with Codex() as codex:
+        with _new_codex_client() as codex:
             try:
                 account = codex.account()
             except Exception as exc:  # noqa: BLE001 - convert SDK detail to user steps

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -12,10 +12,12 @@ needs, including a JSON-mediated bridge for tool calls.
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
 import re
 from collections.abc import Iterable
+from threading import Lock
 from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -44,6 +46,39 @@ CODEX_MODEL_LIST_COMMAND = (
 
 class CodexSetupError(RuntimeError):
     """Actionable setup error for the Codex provider."""
+
+
+class _CodexRuntime:
+    """One long-lived Codex app-server process shared by local model instances.
+
+    The Codex SDK starts its app-server during ``Codex()`` construction. Starting
+    a process for each LangChain invocation dominated short TradingAgents runs,
+    particularly when analysts make several tool and report calls. Threads stay
+    per invocation so agents still get isolated conversations; only the local
+    authenticated runtime is shared.
+    """
+
+    def __init__(self) -> None:
+        self._codex: Any | None = None
+        self._lock = Lock()
+
+    def get(self) -> Any:
+        with self._lock:
+            if self._codex is None:
+                from openai_codex import Codex
+
+                self._codex = Codex()
+            return self._codex
+
+    def close(self) -> None:
+        with self._lock:
+            if self._codex is not None:
+                self._codex.close()
+                self._codex = None
+
+
+_CODEX_RUNTIME = _CodexRuntime()
+atexit.register(_CODEX_RUNTIME.close)
 
 
 def _message_to_text(message: BaseMessage) -> str:
@@ -267,7 +302,10 @@ class CodexStructuredOutput:
             "outside the JSON object.\n\n"
             f"{schema_json}"
         )
-        raw = self.llm._run_codex(structured_prompt)
+        raw = self.llm._run_codex(
+            structured_prompt,
+            output_schema=self.schema.model_json_schema(),
+        )
         parsed = _extract_json_object(raw)
         if parsed is None:
             raise ValueError(f"Codex returned non-JSON structured output: {raw!r}")
@@ -318,9 +356,14 @@ class CodexChatModel(BaseChatModel):
             f"Available tools:\n{json.dumps(tool_specs, indent=2)}"
         )
 
-    def _run_codex(self, prompt: str) -> str:
+    def _run_codex(
+        self,
+        prompt: str,
+        *,
+        output_schema: dict[str, Any] | None = None,
+    ) -> str:
         try:
-            from openai_codex import Codex, Sandbox
+            from openai_codex import Sandbox
         except ImportError as exc:
             raise ImportError(
                 "The Codex provider requires the optional SDK. Install it with "
@@ -329,22 +372,23 @@ class CodexChatModel(BaseChatModel):
             ) from exc
 
         try:
-            with Codex() as codex:
-                available = _available_model_ids(codex)
-                if available and self.model_name not in available:
-                    raise CodexSetupError(
-                        _codex_setup_message(
-                            "The configured Codex model is not available in your "
-                            "installed Codex SDK/runtime.",
-                            available_models=available,
-                            original_error=f"Unavailable model: {self.model_name}",
-                        )
+            codex = _CODEX_RUNTIME.get()
+            available = _available_model_ids(codex)
+            if available and self.model_name not in available:
+                raise CodexSetupError(
+                    _codex_setup_message(
+                        "The configured Codex model is not available in your "
+                        "installed Codex SDK/runtime.",
+                        available_models=available,
+                        original_error=f"Unavailable model: {self.model_name}",
                     )
-                thread = codex.thread_start(
-                    model=self.model_name,
-                    sandbox=Sandbox.read_only,
                 )
-                result = thread.run(prompt)
+            thread = codex.thread_start(
+                model=self.model_name,
+                sandbox=Sandbox.read_only,
+                ephemeral=True,
+            )
+            result = thread.run(prompt, output_schema=output_schema)
         except CodexSetupError:
             raise
         except Exception as exc:

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -81,8 +81,8 @@ _CODEX_RUNTIME = _CodexRuntime()
 atexit.register(_CODEX_RUNTIME.close)
 
 
-def _message_to_text(message: BaseMessage) -> str:
-    content = message.content
+def _content_to_text(content: Any) -> str:
+    """Normalize LangChain or OpenAI-style message content into plain text."""
     if isinstance(content, str):
         return content
     if isinstance(content, list):
@@ -96,10 +96,20 @@ def _message_to_text(message: BaseMessage) -> str:
     return str(content)
 
 
-def _messages_to_prompt(messages: list[BaseMessage]) -> str:
+def _message_to_text(message: BaseMessage | dict[str, Any]) -> str:
+    if isinstance(message, dict):
+        return _content_to_text(message.get("content", ""))
+    return _content_to_text(message.content)
+
+
+def _messages_to_prompt(messages: list[BaseMessage | dict[str, Any]]) -> str:
     chunks = []
     for message in messages:
-        role = getattr(message, "type", message.__class__.__name__)
+        role = (
+            message.get("role", "user")
+            if isinstance(message, dict)
+            else getattr(message, "type", message.__class__.__name__)
+        )
         text = _message_to_text(message).strip()
         if text:
             chunks.append(f"{role.upper()}:\n{text}")
@@ -149,6 +159,25 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
         return value if isinstance(value, dict) else None
     except json.JSONDecodeError:
         return None
+
+
+def _strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Make Pydantic's schema compatible with Codex structured output.
+
+    Codex requires every object to explicitly reject undeclared properties.
+    It also requires all declared object keys to be listed as required; nullable
+    values remain nullable through their ``anyOf`` schema rather than omission.
+    """
+    if isinstance(schema, dict):
+        strict = {key: _strict_json_schema(value) for key, value in schema.items()}
+        properties = strict.get("properties")
+        if isinstance(properties, dict):
+            strict["additionalProperties"] = False
+            strict["required"] = list(properties)
+        return strict
+    if isinstance(schema, list):
+        return [_strict_json_schema(item) for item in schema]
+    return schema
 
 
 def _available_model_ids(codex: Any) -> list[str]:
@@ -210,6 +239,11 @@ def _looks_like_auth_error(message: str) -> bool:
             "requires_openai_auth",
         )
     )
+
+
+def _looks_like_schema_error(message: str) -> bool:
+    lowered = message.lower()
+    return "invalid_json_schema" in lowered or "response_format" in lowered
 
 
 def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
@@ -294,7 +328,8 @@ class CodexStructuredOutput:
 
     def invoke(self, input_: Any, config=None, **kwargs) -> BaseModel:
         prompt = _input_to_text(input_)
-        schema_json = json.dumps(self.schema.model_json_schema(), indent=2)
+        output_schema = _strict_json_schema(self.schema.model_json_schema())
+        schema_json = json.dumps(output_schema, indent=2)
         structured_prompt = (
             f"{prompt}\n\n"
             "Return ONLY valid JSON that conforms to this JSON schema. "
@@ -304,7 +339,7 @@ class CodexStructuredOutput:
         )
         raw = self.llm._run_codex(
             structured_prompt,
-            output_schema=self.schema.model_json_schema(),
+            output_schema=output_schema,
         )
         parsed = _extract_json_object(raw)
         if parsed is None:
@@ -399,6 +434,12 @@ class CodexChatModel(BaseChatModel):
                 problem = (
                     "TradingAgents could not use your local Codex/ChatGPT login "
                     "for this request."
+                )
+            elif _looks_like_schema_error(message):
+                problem = (
+                    "TradingAgents sent a Codex structured-output schema that the "
+                    "installed runtime rejected. This is an integration error, not "
+                    "a Codex login problem."
                 )
             else:
                 problem = "Codex local invocation failed."

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -1,0 +1,192 @@
+"""Experimental Codex local client.
+
+This provider lets users who have Codex through a ChatGPT plan run the
+TradingAgents workflow through their local Codex authentication instead of an
+OpenAI Platform API key. It intentionally uses the published ``openai-codex``
+SDK rather than reading Codex credential files directly.
+
+Codex is an agent surface, not a Chat Completions-compatible model API. The
+adapter below provides the small LangChain chat-model surface this project
+needs, including a JSON-mediated bridge for tool calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import Field
+
+from .base_client import BaseLLMClient
+from .validators import validate_model
+
+logger = logging.getLogger(__name__)
+
+
+def _message_to_text(message: BaseMessage) -> str:
+    content = message.content
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                parts.append(str(item.get("text") or item.get("content") or ""))
+        return "\n".join(part for part in parts if part)
+    return str(content)
+
+
+def _messages_to_prompt(messages: list[BaseMessage]) -> str:
+    chunks = []
+    for message in messages:
+        role = getattr(message, "type", message.__class__.__name__)
+        text = _message_to_text(message).strip()
+        if text:
+            chunks.append(f"{role.upper()}:\n{text}")
+    return "\n\n".join(chunks)
+
+
+def _tool_schema(tool: Any) -> dict[str, Any]:
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is not None and hasattr(args_schema, "model_json_schema"):
+        parameters = args_schema.model_json_schema()
+    else:
+        parameters = getattr(tool, "args", {}) or {}
+    return {
+        "name": getattr(tool, "name", tool.__class__.__name__),
+        "description": getattr(tool, "description", "") or "",
+        "parameters": parameters,
+    }
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+    try:
+        value = json.loads(cleaned)
+        return value if isinstance(value, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    match = re.search(r"\{.*\}", cleaned, flags=re.DOTALL)
+    if not match:
+        return None
+    try:
+        value = json.loads(match.group(0))
+        return value if isinstance(value, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+class CodexChatModel(BaseChatModel):
+    """LangChain chat wrapper around the local Codex SDK."""
+
+    model_name: str = "gpt-5.4"
+    tools: list[Any] = Field(default_factory=list)
+
+    @property
+    def _llm_type(self) -> str:
+        return "codex-local"
+
+    def bind_tools(self, tools, **kwargs):  # noqa: D401 - LangChain signature
+        """Return a copy of this model configured with LangChain tools."""
+        return self.model_copy(update={"tools": list(tools)})
+
+    def with_structured_output(self, schema, *, method=None, **kwargs):
+        raise NotImplementedError(
+            "Codex local provider does not expose native structured output; "
+            "TradingAgents will fall back to free-text generation."
+        )
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager=None,
+        **kwargs,
+    ) -> ChatResult:
+        prompt = _messages_to_prompt(messages)
+        if self.tools:
+            prompt = self._add_tool_protocol(prompt)
+
+        raw = self._run_codex(prompt)
+        message = self._to_ai_message(raw)
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _add_tool_protocol(self, prompt: str) -> str:
+        tool_specs = [_tool_schema(tool) for tool in self.tools]
+        return (
+            f"{prompt}\n\n"
+            "You may either answer directly or request tool calls. If you need tools, "
+            "return ONLY valid JSON in this exact shape:\n"
+            '{"tool_calls":[{"name":"tool_name","args":{}}]}\n'
+            "If you have enough information for a final answer, return normal prose "
+            "and do not wrap it in JSON.\n\n"
+            f"Available tools:\n{json.dumps(tool_specs, indent=2)}"
+        )
+
+    def _run_codex(self, prompt: str) -> str:
+        try:
+            from openai_codex import Codex, Sandbox
+        except ImportError as exc:
+            raise ImportError(
+                "The Codex provider requires the optional SDK. Install it with "
+                '`pip install ".[codex]"` or `pip install openai-codex`, then run '
+                "`codex login` and sign in with ChatGPT."
+            ) from exc
+
+        try:
+            with Codex() as codex:
+                thread = codex.thread_start(
+                    model=self.model_name,
+                    sandbox=Sandbox.read_only,
+                )
+                result = thread.run(prompt)
+        except Exception as exc:
+            raise RuntimeError(
+                "Codex local invocation failed. Make sure the Codex CLI/SDK is "
+                "installed and authenticated with `codex login`."
+            ) from exc
+
+        return str(getattr(result, "final_response", "") or "")
+
+    def _to_ai_message(self, raw: str) -> AIMessage:
+        parsed = _extract_json_object(raw) if self.tools else None
+        tool_calls = parsed.get("tool_calls") if isinstance(parsed, dict) else None
+        if isinstance(tool_calls, list) and tool_calls:
+            normalized = []
+            for idx, call in enumerate(tool_calls):
+                if not isinstance(call, dict) or not call.get("name"):
+                    continue
+                args = call.get("args") or {}
+                if not isinstance(args, dict):
+                    logger.warning("Ignoring Codex tool call with non-object args: %s", call)
+                    continue
+                normalized.append({
+                    "name": str(call["name"]),
+                    "args": args,
+                    "id": str(call.get("id") or f"codex_tool_{idx}"),
+                })
+            if normalized:
+                return AIMessage(content="", tool_calls=normalized)
+        return AIMessage(content=raw)
+
+
+class CodexClient(BaseLLMClient):
+    """Client for Codex local/ChatGPT-authenticated runs."""
+
+    def get_llm(self) -> Any:
+        self.warn_if_unknown_model()
+        return CodexChatModel(model_name=self.model)
+
+    def validate_model(self) -> bool:
+        return validate_model("codex", self.model)

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Iterable
 from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -26,6 +27,23 @@ from .base_client import BaseLLMClient
 from .validators import validate_model
 
 logger = logging.getLogger(__name__)
+
+CODEX_INSTALL_COMMAND = 'python -m pip install -e ".[codex]"'
+CODEX_UPDATE_COMMAND = "python -m pip install -U --pre openai-codex"
+CODEX_LOGIN_COMMAND = "codex login"
+CODEX_CLI_UPDATE_COMMAND = "codex update"
+CODEX_ACCOUNT_CHECK_COMMAND = (
+    'python -c "from openai_codex import Codex; '
+    'c=Codex(); print(c.account()); c.close()"'
+)
+CODEX_MODEL_LIST_COMMAND = (
+    'python -c "from openai_codex import Codex; '
+    'c=Codex(); print([m.id for m in c.models().data]); c.close()"'
+)
+
+
+class CodexSetupError(RuntimeError):
+    """Actionable setup error for the experimental Codex provider."""
 
 
 def _message_to_text(message: BaseMessage) -> str:
@@ -104,6 +122,116 @@ def _available_model_ids(codex: Any) -> list[str]:
     return ids
 
 
+def _codex_setup_message(
+    problem: str,
+    *,
+    original_error: str | None = None,
+    available_models: Iterable[str] | None = None,
+) -> str:
+    lines = [
+        problem,
+        "",
+        "To fix Codex setup:",
+        f"1. Install or update the Codex Python SDK: {CODEX_UPDATE_COMMAND}",
+        f"2. If the Codex CLI is available, update it too: {CODEX_CLI_UPDATE_COMMAND}",
+        f"3. If you are not signed in, run: {CODEX_LOGIN_COMMAND}",
+        f"4. If `codex` is not recognized, verify local SDK auth with: {CODEX_ACCOUNT_CHECK_COMMAND}",
+        f"5. List models your installed runtime can run with: {CODEX_MODEL_LIST_COMMAND}",
+    ]
+    if available_models:
+        lines.extend(["", "Models currently reported by your installed runtime:"])
+        lines.append(", ".join(available_models))
+    if original_error:
+        lines.extend(["", f"Original Codex error: {original_error}"])
+    return "\n".join(lines)
+
+
+def _looks_like_newer_codex_required(message: str) -> bool:
+    lowered = message.lower()
+    return "requires a newer version of codex" in lowered or "update codex" in lowered
+
+
+def _looks_like_auth_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "not authenticated",
+            "authentication",
+            "unauthorized",
+            "login",
+            "sign in",
+            "requires_openai_auth",
+        )
+    )
+
+
+def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
+    """Validate Codex SDK/auth/model availability before the graph starts."""
+    try:
+        from openai_codex import Codex
+    except ImportError as exc:
+        raise CodexSetupError(
+            _codex_setup_message(
+                "Codex provider is selected, but the `openai-codex` SDK is not installed.",
+                original_error=str(exc),
+            )
+        ) from exc
+
+    requested_models = [models] if isinstance(models, str) else list(models)
+    try:
+        with Codex() as codex:
+            try:
+                account = codex.account()
+            except Exception as exc:  # noqa: BLE001 - convert SDK detail to user steps
+                raise CodexSetupError(
+                    _codex_setup_message(
+                        "Codex provider is selected, but TradingAgents could not verify "
+                        "a local Codex/ChatGPT login.",
+                        original_error=str(exc),
+                    )
+                ) from exc
+
+            if not account:
+                raise CodexSetupError(
+                    _codex_setup_message(
+                        "Codex provider is selected, but no local Codex/ChatGPT "
+                        "account was found."
+                    )
+                )
+
+            available = _available_model_ids(codex)
+    except CodexSetupError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - SDK startup/runtime failure
+        message = str(exc)
+        if _looks_like_auth_error(message):
+            problem = (
+                "Codex provider is selected, but the local Codex/ChatGPT "
+                "session is not ready."
+            )
+        else:
+            problem = "Codex provider is selected, but the Codex SDK/runtime is not ready."
+        raise CodexSetupError(_codex_setup_message(problem, original_error=message)) from exc
+
+    missing = [model for model in requested_models if available and model not in available]
+    if missing:
+        problem = (
+            "Codex provider is selected, but the configured model is not available "
+            "in your installed Codex SDK/runtime."
+        )
+        if any(model.startswith("gpt-5.6") for model in missing):
+            problem += " GPT-5.6 models may require a newer Codex app/CLI/SDK."
+        raise CodexSetupError(
+            _codex_setup_message(
+                problem,
+                available_models=available,
+                original_error=f"Unavailable model(s): {', '.join(missing)}",
+            )
+        )
+    return available
+
+
 class CodexChatModel(BaseChatModel):
     """LangChain chat wrapper around the local Codex SDK."""
 
@@ -165,25 +293,34 @@ class CodexChatModel(BaseChatModel):
             with Codex() as codex:
                 available = _available_model_ids(codex)
                 if available and self.model_name not in available:
-                    raise ValueError(
-                        f"Codex model {self.model_name!r} is not available in the "
-                        "installed Codex SDK/runtime. Available models: "
-                        f"{', '.join(available)}. Update the Codex SDK/app when "
-                        "newer models are available, or set "
-                        "TRADINGAGENTS_DEEP_THINK_LLM / "
-                        "TRADINGAGENTS_QUICK_THINK_LLM to one of the listed models."
+                    raise CodexSetupError(
+                        _codex_setup_message(
+                            "The configured Codex model is not available in your "
+                            "installed Codex SDK/runtime.",
+                            available_models=available,
+                            original_error=f"Unavailable model: {self.model_name}",
+                        )
                     )
                 thread = codex.thread_start(
                     model=self.model_name,
                     sandbox=Sandbox.read_only,
                 )
                 result = thread.run(prompt)
+        except CodexSetupError:
+            raise
         except Exception as exc:
+            message = str(exc)
+            if _looks_like_newer_codex_required(message):
+                problem = "This Codex model requires a newer Codex app/CLI/SDK."
+            elif _looks_like_auth_error(message):
+                problem = (
+                    "TradingAgents could not use your local Codex/ChatGPT login "
+                    "for this request."
+                )
+            else:
+                problem = "Codex local invocation failed."
             raise RuntimeError(
-                "Codex local invocation failed. Make sure the Codex SDK is "
-                'installed with `pip install ".[codex]"`, your local Codex/ChatGPT '
-                "session is authenticated, and the configured model is available "
-                f"in your installed Codex runtime. Original error: {exc}"
+                _codex_setup_message(problem, original_error=message)
             ) from exc
 
         return str(getattr(result, "final_response", "") or "")
@@ -215,6 +352,7 @@ class CodexClient(BaseLLMClient):
 
     def get_llm(self) -> Any:
         self.warn_if_unknown_model()
+        preflight_codex_runtime(self.model)
         return CodexChatModel(model_name=self.model)
 
     def validate_model(self) -> bool:

--- a/tradingagents/llm_clients/codex_client.py
+++ b/tradingagents/llm_clients/codex_client.py
@@ -37,6 +37,8 @@ CODEX_INSTALL_COMMAND = 'python -m pip install -e ".[codex]"'
 CODEX_UPDATE_COMMAND = "python -m pip install -U --pre openai-codex"
 CODEX_LOGIN_COMMAND = "codex login"
 CODEX_CLI_UPDATE_COMMAND = "codex update"
+CODEX_CLI_INSTALL_COMMAND = "npm install -g @openai/codex"
+CODEX_CLI_VERIFY_COMMAND = "codex --version"
 CODEX_ACCOUNT_CHECK_COMMAND = (
     'python -c "from openai_codex import Codex; '
     'c=Codex(); print(c.account()); c.close()"'
@@ -289,10 +291,24 @@ def _auth_recovery_steps() -> list[str]:
     ]
 
 
-def _model_recovery_steps() -> list[str]:
+def _model_recovery_steps(cli_available: bool | None = None) -> list[str]:
+    """Return every recovery step needed for a model-unavailable error."""
+    if cli_available is None:
+        cli_available = _codex_cli_path() is not None
+    if not cli_available:
+        return [
+            "Install the standalone Codex CLI (requires Node.js): "
+            f"{CODEX_CLI_INSTALL_COMMAND}",
+            f"Open a new terminal and confirm installation: {CODEX_CLI_VERIFY_COMMAND}",
+            f"Sign in with ChatGPT: {CODEX_LOGIN_COMMAND}",
+            "Restart TradingAgents; it will then use the standalone CLI for current models.",
+        ]
     return [
-        f"Update the Codex Python SDK: {CODEX_UPDATE_COMMAND}",
-        f"List models available to this runtime: {CODEX_MODEL_LIST_COMMAND}",
+        f"Update the standalone Codex CLI: {CODEX_CLI_UPDATE_COMMAND}",
+        f"Confirm the installed version: {CODEX_CLI_VERIFY_COMMAND}",
+        f"Confirm the saved login: {CODEX_ACCOUNT_CHECK_COMMAND}",
+        "Restart TradingAgents. If the model is still unavailable, choose one of "
+        "the models reported by this runtime because your current account may not offer it.",
     ]
 
 
@@ -352,10 +368,16 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
 
     missing = [model for model in requested_models if available and model not in available]
     if missing:
+        standalone_cli_available = _codex_cli_path() is not None
         problem = (
             "Codex provider is selected, but the configured model is not available "
             "in your installed Codex SDK/runtime."
         )
+        if not standalone_cli_available:
+            problem = (
+                "Codex provider is selected, but the configured model requires the "
+                "standalone Codex CLI and no `codex` command was found."
+            )
         if any(model.startswith("gpt-5.6") for model in missing):
             problem += " GPT-5.6 models may require a newer Codex app/CLI/SDK."
         raise CodexSetupError(
@@ -363,7 +385,7 @@ def preflight_codex_runtime(models: str | Iterable[str]) -> list[str]:
                 problem,
                 available_models=available,
                 original_error=f"Unavailable model(s): {', '.join(missing)}",
-                recovery_steps=_model_recovery_steps(),
+                recovery_steps=_model_recovery_steps(standalone_cli_available),
             )
         )
     return available

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -47,6 +47,10 @@ def create_llm_client(
         from .bedrock_client import BedrockClient
         return BedrockClient(model, base_url, **kwargs)
 
+    if provider_lower == "codex":
+        from .codex_client import CodexClient
+        return CodexClient(model, base_url, **kwargs)
+
     from .openai_client import OpenAIClient, is_openai_compatible
     if is_openai_compatible(provider_lower):
         return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -188,6 +188,9 @@ MODEL_OPTIONS: ProviderModeOptions = {
     "nvidia": _CUSTOM_ONLY,
     # Bedrock model IDs / cross-region inference profile IDs are user-specified.
     "bedrock": _CUSTOM_ONLY,
+    # Codex runs through the local Codex SDK/CLI session. Keep this custom-only
+    # because available models are governed by the user's ChatGPT/Codex plan.
+    "codex": _CUSTOM_ONLY,
 }
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -78,6 +78,22 @@ _MINIMAX_MODELS: dict[str, list[ModelOption]] = {
 }
 
 
+_CODEX_MODELS: dict[str, list[ModelOption]] = {
+    "quick": [
+        ("GPT-5.4-Mini - Small, fast Codex model", "gpt-5.4-mini"),
+        ("GPT-5.4 - Strong everyday Codex model", "gpt-5.4"),
+        ("GPT-5.5 - Frontier Codex model", "gpt-5.5"),
+        ("Custom model ID", "custom"),
+    ],
+    "deep": [
+        ("GPT-5.5 - Frontier Codex model", "gpt-5.5"),
+        ("GPT-5.4 - Strong everyday Codex model", "gpt-5.4"),
+        ("GPT-5.4-Mini - Small, fast Codex model", "gpt-5.4-mini"),
+        ("Custom model ID", "custom"),
+    ],
+}
+
+
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
         "quick": [
@@ -188,9 +204,10 @@ MODEL_OPTIONS: ProviderModeOptions = {
     "nvidia": _CUSTOM_ONLY,
     # Bedrock model IDs / cross-region inference profile IDs are user-specified.
     "bedrock": _CUSTOM_ONLY,
-    # Codex runs through the local Codex SDK/CLI session. Keep this custom-only
-    # because available models are governed by the user's ChatGPT/Codex plan.
-    "codex": _CUSTOM_ONLY,
+    # Codex runs through the local Codex SDK/CLI session. These are the common
+    # model IDs exposed by the current Codex SDK/account model list; Custom
+    # model ID remains available for future rollout or workspace-specific models.
+    "codex": _CODEX_MODELS,
 }
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -80,15 +80,23 @@ _MINIMAX_MODELS: dict[str, list[ModelOption]] = {
 
 _CODEX_MODELS: dict[str, list[ModelOption]] = {
     "quick": [
-        ("GPT-5.4-Mini - Small, fast Codex model", "gpt-5.4-mini"),
-        ("GPT-5.4 - Strong everyday Codex model", "gpt-5.4"),
-        ("GPT-5.5 - Frontier Codex model", "gpt-5.5"),
+        ("GPT-5.6 Luna - Fast, lowest-cost Codex model", "gpt-5.6-luna"),
+        ("GPT-5.6 Terra - Balanced everyday Codex model", "gpt-5.6-terra"),
+        ("GPT-5.4 Mini - Fast legacy Codex model", "gpt-5.4-mini"),
+        ("GPT-5.6 Sol - Flagship Codex model", "gpt-5.6-sol"),
+        ("GPT-5.5 - Previous-generation frontier Codex model", "gpt-5.5"),
+        ("GPT-5.4 - Legacy professional Codex model", "gpt-5.4"),
+        ("GPT-5.3 Codex Spark - Near-instant preview model", "gpt-5.3-codex-spark"),
         ("Custom model ID", "custom"),
     ],
     "deep": [
-        ("GPT-5.5 - Frontier Codex model", "gpt-5.5"),
-        ("GPT-5.4 - Strong everyday Codex model", "gpt-5.4"),
-        ("GPT-5.4-Mini - Small, fast Codex model", "gpt-5.4-mini"),
+        ("GPT-5.6 Sol - Flagship Codex model", "gpt-5.6-sol"),
+        ("GPT-5.6 Terra - Balanced everyday Codex model", "gpt-5.6-terra"),
+        ("GPT-5.5 - Previous-generation frontier Codex model", "gpt-5.5"),
+        ("GPT-5.6 Luna - Fast, lowest-cost Codex model", "gpt-5.6-luna"),
+        ("GPT-5.4 - Legacy professional Codex model", "gpt-5.4"),
+        ("GPT-5.4 Mini - Fast legacy Codex model", "gpt-5.4-mini"),
+        ("GPT-5.3 Codex Spark - Near-instant preview model", "gpt-5.3-codex-spark"),
         ("Custom model ID", "custom"),
     ],
 }
@@ -204,9 +212,9 @@ MODEL_OPTIONS: ProviderModeOptions = {
     "nvidia": _CUSTOM_ONLY,
     # Bedrock model IDs / cross-region inference profile IDs are user-specified.
     "bedrock": _CUSTOM_ONLY,
-    # Codex runs through the local Codex SDK/CLI session. These are the common
-    # model IDs exposed by the current Codex SDK/account model list; Custom
-    # model ID remains available for future rollout or workspace-specific models.
+    # Codex runs through the local Codex SDK/CLI session. These are the current
+    # public Codex model IDs from the Codex models docs; exact availability can
+    # still depend on the user's Codex SDK/app version and ChatGPT entitlement.
     "codex": _CODEX_MODELS,
 }
 

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -7,7 +7,7 @@ from .model_catalog import get_known_models
 # accepted without warning.
 _ANY_MODEL_PROVIDERS = (
     "ollama", "openrouter", "openai_compatible",
-    "mistral", "kimi", "groq", "nvidia", "bedrock",
+    "mistral", "kimi", "groq", "nvidia", "bedrock", "codex",
 )
 
 VALID_MODELS = {


### PR DESCRIPTION
## Add Local Codex Subscription Provider

This PR adds first-class support for running TradingAgents through a local Codex/ChatGPT subscription, without requiring OpenAI Platform API credits.

### What’s included

- Adds `codex` as an LLM provider, using the user’s local Codex authentication session.
- Supports current Codex CLI models, including GPT-5.6 Luna, Terra, and Sol, along with GPT-5.5, GPT-5.4, and GPT-5.4 Mini.
- Uses the installed Codex CLI when available, avoiding the older runtime bundled with the Python SDK.
- Adds model and authentication preflight checks before analysis starts.
- Adds clear, targeted setup guidance for common cases:
  - Codex CLI is missing: install command, terminal restart, version check, and login steps.
  - Codex CLI is outdated: update and verification commands.
  - User is not logged in: Codex login and account-check steps.
  - Selected model is unavailable: explains whether the CLI needs updating or the account may not have access.
- Prevents misleading login prompts for unrelated runtime or schema errors.
- Reuses the Codex local runtime across requests to reduce repeated startup overhead.
- Adds native JSON-schema structured output for Codex decision agents, instead of silently degrading to free-text generation.
- Handles both LangChain messages and OpenAI-style message dictionaries used by the workflow.
- Adds live CLI telemetry for Codex requests, native structured-output successes, free-text fallbacks, errors, and average request duration.
- Updates the README and `.env.example` with setup instructions and model guidance.
- Adds regression coverage for runtime selection, current-model discovery, structured output, fallback telemetry, and recovery guidance.

### Validation

- Ran the Codex provider, provider registry, model validation, environment, and structured-agent test suites.
- Verified current Codex CLI model discovery locally.
- Verified a minimal GPT-5.6 Luna request through the installed Codex CLI.

This makes Codex support easier to configure, easier to diagnose, and more suitable for users who have a Codex/ChatGPT subscription but do not have OpenAI API credits.