### PR TITLE
Handle missing Windows console in CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -50,6 +50,12 @@ from tradingagents.graph.analyst_execution import (
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.reporting import write_report_tree
 
+try:
+    from prompt_toolkit.output.win32 import NoConsoleScreenBufferError
+except (ImportError, AttributeError):
+    class NoConsoleScreenBufferError(Exception):  # type: ignore[no-redef]
+        pass
+
 console = Console()
 
 app = typer.Typer(
@@ -1285,7 +1291,15 @@ def analyze(
         from tradingagents.graph.checkpointer import clear_all_checkpoints
         n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
         console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
-    run_analysis(checkpoint=checkpoint)
+    try:
+        run_analysis(checkpoint=checkpoint)
+    except NoConsoleScreenBufferError as exc:
+        console.print(f"[red]{exc}[/red]")
+        console.print(
+            "[yellow]Run TradingAgents from an interactive terminal such as "
+            "Windows Terminal, PowerShell, or cmd.exe.[/yellow]"
+        )
+        raise typer.Exit(code=1) from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_console_errors.py
+++ b/tests/test_cli_console_errors.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+import cli.main as m
+
+
+@pytest.mark.unit
+def test_analyze_reports_missing_windows_console_without_traceback():
+    runner = CliRunner()
+
+    with mock.patch.object(m, "run_analysis", side_effect=m.NoConsoleScreenBufferError):
+        result = runner.invoke(m.app, [])
+
+    assert result.exit_code != 0
+    assert "No Windows console found" in result.output
+    assert "Run TradingAgents from an interactive terminal" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.unit
+def test_analyze_preserves_other_exceptions():
+    runner = CliRunner()
+
+    with mock.patch.object(m, "run_analysis", side_effect=RuntimeError("boom")):
+        result = runner.invoke(m.app, [], catch_exceptions=True)
+
+    assert isinstance(result.exception, RuntimeError)
+    assert str(result.exception) == "boom"


### PR DESCRIPTION
## Summary
- catch `NoConsoleScreenBufferError` at the CLI entry point
- print a concise actionable message instead of a full traceback when prompt_toolkit cannot find a Windows console screen buffer
- add regression coverage for the handled terminal error while preserving normal exception behavior

Fixes #1138.

## Tests
- `uv run pytest -q tests\test_cli_console_errors.py tests\test_cli_env_skip.py tests\test_cli_config_precedence.py tests\test_cli_symbol_handling.py`
- `uv run tradingagents` in this non-interactive Windows environment now prints the short console guidance instead of a traceback
