### PR TITLE
docs: document ALPHA_VANTAGE_API_KEY in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,18 @@ MOONSHOT_API_KEY=
 GROQ_API_KEY=
 NVIDIA_API_KEY=
 
+# Alpha Vantage (optional enrichment: stock OHLCV, technical indicators, company
+# fundamentals, balance sheet, cashflow, income statement, and ticker news).
+# When set, it acts as a fallback for every data category where "data_vendors"
+# lists "alpha_vantage" — yfinance is tried first; Alpha Vantage is called only
+# when yfinance fails or is rate-limited. Without this key the framework still
+# runs fully on yfinance (free, no key required).
+# Free tier: 25 API requests/day. Get a key at https://www.alphavantage.co/support/#api-key
+# To enable fallback routing, set data_vendors in default_config.py to:
+#   "yfinance,alpha_vantage"  (yfinance first, Alpha Vantage on failure)
+#   "alpha_vantage"           (Alpha Vantage exclusively — key required)
+ALPHA_VANTAGE_API_KEY=
+
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=
 

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -131,10 +131,10 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # routed to vendors you didn't choose. For ordered fallback, list several,
     # e.g. "yfinance,alpha_vantage". "default" uses all available vendors.
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "core_stock_apis": "yfinance,alpha_vantage",       # yfinance first, Alpha Vantage as fallback
+        "technical_indicators": "yfinance,alpha_vantage",  # yfinance first, Alpha Vantage as fallback
+        "fundamental_data": "yfinance,alpha_vantage",      # yfinance first, Alpha Vantage as fallback
+        "news_data": "yfinance,alpha_vantage",             # yfinance first, Alpha Vantage as fallback
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },


### PR DESCRIPTION
## What

Add the missing `ALPHA_VANTAGE_API_KEY` variable to `.env.example` with a detailed comment explaining when and why it is used.

Also update `tradingagents/default_config.py` to enable `yfinance,alpha_vantage` as the default fallback chain for all data categories - yfinance is tried first and Alpha Vantage is used only when yfinance fails or is rate-limited.

## Why

The `ALPHA_VANTAGE_API_KEY` key was referenced in the codebase (`alpha_vantage_common.py`) but completely absent from `.env.example`, leaving contributors and new users unaware it exists or how to configure it.

## Changes

- `.env.example`: Add `ALPHA_VANTAGE_API_KEY=` with a comment covering:
-   - What data it enriches (OHLCV, indicators, fundamentals, balance sheet, cashflow, income statement, ticker news)
-   - When it activates (only when `data_vendors` includes `"alpha_vantage"`)
-   - That yfinance remains the free, keyless default
-   - Both routing modes: `"yfinance,alpha_vantage"` (fallback) and `"alpha_vantage"` (exclusive)
-   - Free tier: 25 req/day with link to key signup
- - `tradingagents/default_config.py`: Set `data_vendors` to `"yfinance,alpha_vantage"` for `core_stock_apis`, `technical_indicators`, `fundamental_data`, and `news_data`