### PR TITLE
feat(llm): add xAI Grok 4.5 to the model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **xAI Grok 4.5 in the model catalog.** The CLI and known-model list now
+  expose `grok-4.5` as the default xAI quick/deep option (previous flagship
+  Grok 4.3 remains available). Structured-output smoke defaults to Grok 4.5.
+
 ## [0.3.1] — 2026-07-05
 
 Correctness and stability patch: data look-ahead, graph-router crash-safety,

--- a/scripts/smoke_structured_output.py
+++ b/scripts/smoke_structured_output.py
@@ -36,7 +36,7 @@ PROVIDER_DEFAULTS = {
     "deepseek": ("deepseek-v4-flash", None),
     "qwen": ("qwen3.7-plus", None),
     "glm": ("glm-5", None),
-    "xai": ("grok-4.3", None),
+    "xai": ("grok-4.5", None),
 }
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -116,12 +116,17 @@ MODEL_OPTIONS: ProviderModeOptions = {
     },
     "xai": {
         "quick": [
-            ("Grok 4.3 - Latest flagship, fast with built-in reasoning", "grok-4.3"),
+            # Source: docs.x.ai/developers/models/grok-4.5 — API ID grok-4.5
+            # (aliases: grok-4.5-latest, grok-build-latest). 500K ctx; function
+            # calling, structured outputs, and configurable reasoning.
+            ("Grok 4.5 - Latest flagship, coding/agentic, 500K ctx", "grok-4.5"),
+            ("Grok 4.3 - Previous-gen flagship, built-in reasoning", "grok-4.3"),
             ("Grok 4.20 (Non-Reasoning) - Speed-optimized", "grok-4.20-0309-non-reasoning"),
             ("Grok Build 0.1 - Coding-specialized, 256K ctx", "grok-build-0.1"),
         ],
         "deep": [
-            ("Grok 4.3 - Latest flagship, built-in reasoning, 1M ctx", "grok-4.3"),
+            ("Grok 4.5 - Latest flagship, coding/agentic, 500K ctx", "grok-4.5"),
+            ("Grok 4.3 - Previous-gen flagship, built-in reasoning, 1M ctx", "grok-4.3"),
             ("Grok 4.20 (Reasoning) - Previous-gen reasoning", "grok-4.20-0309-reasoning"),
             ("Grok 4.20 Multi-Agent - Multi-agent reasoning", "grok-4.20-multi-agent-0309"),
         ],


### PR DESCRIPTION
## Summary

- Add `grok-4.5` as the default xAI quick/deep catalog entry (current flagship per [xAI docs](https://docs.x.ai/developers/models/grok-4.5)).
- Keep Grok 4.3 and the 4.20 variants selectable for comparison / cost control.
- Point the structured-output smoke script's xAI default at `grok-4.5`.
- Document the change under `CHANGELOG.md` `[Unreleased]`.

Grok 4.5 supports function calling, structured outputs, and reasoning — the same surfaces TradingAgents already uses for xAI via the OpenAI-compatible client (`https://api.x.ai/v1`). No client code changes were required.

## Test plan

- [x] Catalog unit checks: `get_model_options("xai", "quick"|"deep")[0] == grok-4.5`, `validate_model("xai", "grok-4.5")`
- [x] `pytest tests/test_model_validation.py tests/test_provider_registry.py tests/test_api_key_env.py` (43 passed)
- [x] Live xAI API smoke with `XAI_API_KEY`:
  - Chat completion on `grok-4.5` returned expected content
  - Research Manager structured path produced a valid investment plan (recommendation + rationale)

Manual CLI check after merge:

```bash
export XAI_API_KEY=...
tradingagents
# Provider: xAI → Quick/Deep: Grok 4.5
```

Or non-interactive:

```bash
export TRADINGAGENTS_LLM_PROVIDER=xai
export TRADINGAGENTS_DEEP_THINK_LLM=grok-4.5
export TRADINGAGENTS_QUICK_THINK_LLM=grok-4.5
```