### PR TITLE
feat: add futures asset type

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ You will see a screen where you can select your desired tickers, analysis date, 
 
 ### Markets and tickers
 
-TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Company identity and the alpha benchmark resolve automatically per market.
+TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Instrument identity and the alpha benchmark resolve automatically per market.
 
 - US: `AAPL`, `SPY`
 - Hong Kong: `0700.HK` · Tokyo: `7203.T` · London: `AZN.L`
 - India: `RELIANCE.NS`, `.BO` · Canada: `.TO` · Australia: `.AX`
 - China A-shares: Shanghai `.SS`, Shenzhen `.SZ` (e.g. `600519.SS` for Kweichow Moutai)
 - Crypto: `BTC-USD`, `ETH-USD`
+- Futures: `GC=F`, `CL=F`, `ES=F`, or broker aliases such as `GOLD` and `USOIL` (detected automatically; company fundamentals are omitted)
 
 <p align="center">
   <img src="assets/cli/cli_init.png" width="100%" style="display: inline-block; margin: 0 2%;">

--- a/cli/main.py
+++ b/cli/main.py
@@ -41,6 +41,7 @@ from cli.utils import (
     select_research_depth,
     select_shallow_thinking_agent,
 )
+from tradingagents.agents.utils.agent_utils import resolve_instrument_identity
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.graph.analyst_execution import (
     AnalystWallTimeTracker,
@@ -554,7 +555,8 @@ def get_user_selections():
         )
     )
     selected_ticker = get_ticker()
-    asset_type = detect_asset_type(selected_ticker)
+    identity = resolve_instrument_identity(selected_ticker)
+    asset_type = detect_asset_type(selected_ticker, identity)
     # Only announce when it's not the default stock path, to avoid printing
     # "stock" on every run.
     if asset_type.value != "stock":

--- a/cli/models.py
+++ b/cli/models.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from tradingagents.asset_types import AssetType as AssetType
+
 
 class AnalystType(str, Enum):
     MARKET = "market"
@@ -8,8 +10,3 @@ class AnalystType(str, Enum):
     SOCIAL = "social"
     NEWS = "news"
     FUNDAMENTALS = "fundamentals"
-
-
-class AssetType(str, Enum):
-    STOCK = "stock"
-    CRYPTO = "crypto"

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Mapping
 from pathlib import Path
 
 import questionary
@@ -6,12 +7,13 @@ from dotenv import find_dotenv, set_key
 from rich.console import Console
 
 from cli.models import AnalystType, AssetType
+from tradingagents.asset_types import resolve_asset_type
 from tradingagents.llm_clients.api_key_env import get_api_key_env
 from tradingagents.llm_clients.model_catalog import get_model_options
 
 console = Console()
 
-TICKER_INPUT_EXAMPLES = "SPY, 0700.HK, BTC-USD"
+TICKER_INPUT_EXAMPLES = "SPY, 0700.HK, BTC-USD, GC=F"
 
 ANALYST_ORDER = [
     ("Market Analyst", AnalystType.MARKET),
@@ -78,19 +80,24 @@ def normalize_ticker_symbol(ticker: str) -> str:
         return ticker.strip().upper()
 
 
-def detect_asset_type(ticker: str) -> AssetType:
-    """Classify on the canonical symbol so e.g. BTCUSD and BTC-USDT both read as
-    crypto (#981/#982), matching what the data path will actually fetch."""
+def detect_asset_type(
+    ticker: str,
+    identity: Mapping[str, str] | None = None,
+) -> AssetType:
+    """Classify the canonical symbol and optional resolved Yahoo identity."""
     canonical = normalize_ticker_symbol(ticker)
-    if canonical.endswith(CRYPTO_SUFFIXES):
-        return AssetType.CRYPTO
-    return AssetType.STOCK
+    requested_type = (
+        AssetType.CRYPTO
+        if canonical.endswith(CRYPTO_SUFFIXES)
+        else AssetType.STOCK
+    )
+    return AssetType(resolve_asset_type(canonical, requested_type, identity))
 
 
 def filter_analysts_for_asset_type(
     analysts: list[AnalystType], asset_type: AssetType
 ) -> list[AnalystType]:
-    if asset_type != AssetType.CRYPTO:
+    if asset_type not in {AssetType.CRYPTO, AssetType.FUTURES}:
         return analysts
     return [
         analyst

--- a/tests/test_analyst_execution.py
+++ b/tests/test_analyst_execution.py
@@ -40,6 +40,21 @@ class AnalystExecutionPlanTests(unittest.TestCase):
         self.assertEqual(spec.agent_node, "Sentiment Analyst")
         self.assertEqual(spec.report_key, "sentiment_report")
 
+    def test_futures_plan_skips_fundamentals(self):
+        plan = build_analyst_execution_plan(
+            ["market", "fundamentals", "news"],
+            asset_type="futures",
+        )
+
+        self.assertEqual([spec.key for spec in plan.specs], ["market", "news"])
+
+    def test_fundamentals_only_futures_plan_has_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "futures-compatible analyst"):
+            build_analyst_execution_plan(
+                ["fundamentals"],
+                asset_type="futures",
+            )
+
 
 class AnalystWallTimeTrackerTests(unittest.TestCase):
     def test_records_wall_time_when_analyst_completes(self):

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -11,6 +11,8 @@ from unittest import mock
 
 import pytest
 
+from cli.models import AssetType
+
 
 @pytest.mark.unit
 class TestProviderDefaultUrl(unittest.TestCase):
@@ -55,9 +57,14 @@ class TestCliSkipsPromptsFromEnv(unittest.TestCase):
              mock.patch.object(m, "DEFAULT_CONFIG", fake_cfg), \
              mock.patch.object(m, "fetch_announcements", return_value=None), \
              mock.patch.object(m, "display_announcements"), \
-             mock.patch.object(m, "get_ticker", return_value="AAPL"), \
+             mock.patch.object(m, "get_ticker", return_value="YGZ26"), \
+             mock.patch.object(
+                 m,
+                 "resolve_instrument_identity",
+                 return_value={"quote_type": "FUTURE"},
+             ) as resolve_identity, \
              mock.patch.object(m, "get_analysis_date", return_value="2026-05-29"), \
-             mock.patch.object(m, "select_analysts", return_value=[]), \
+             mock.patch.object(m, "select_analysts", return_value=[]) as select_analysts, \
              mock.patch.object(m, "select_research_depth", return_value=1), \
              mock.patch.object(m, "ensure_api_key") as ensure_key, \
              mock.patch.object(m, "select_llm_provider") as prompt_provider, \
@@ -73,6 +80,8 @@ class TestCliSkipsPromptsFromEnv(unittest.TestCase):
         prompt_deep.assert_not_called()
         # API key is still verified for the env-configured provider.
         ensure_key.assert_called_once()
+        resolve_identity.assert_called_once_with("YGZ26")
+        select_analysts.assert_called_once_with(AssetType.FUTURES)
 
         # The env values flow into the returned selections.
         self.assertEqual(sel["llm_provider"], "openai")
@@ -80,6 +89,7 @@ class TestCliSkipsPromptsFromEnv(unittest.TestCase):
         self.assertEqual(sel["shallow_thinker"], "deepseek-v4-pro")
         self.assertEqual(sel["deep_thinker"], "kimi-k2.5")
         self.assertEqual(sel["output_language"], "Japanese")
+        self.assertEqual(sel["asset_type"], AssetType.FUTURES.value)
 
 
 @pytest.mark.unit
@@ -99,6 +109,7 @@ class TestResearchDepthSkippedFromEnv(unittest.TestCase):
              mock.patch.object(m, "fetch_announcements", return_value=None), \
              mock.patch.object(m, "display_announcements"), \
              mock.patch.object(m, "get_ticker", return_value="AAPL"), \
+             mock.patch.object(m, "resolve_instrument_identity", return_value={}), \
              mock.patch.object(m, "get_analysis_date", return_value="2026-05-29"), \
              mock.patch.object(m, "select_analysts", return_value=[]), \
              mock.patch.object(m, "select_research_depth") as prompt_depth, \
@@ -129,6 +140,7 @@ class TestReasoningEffortSkippedFromEnv(unittest.TestCase):
              mock.patch.object(m, "fetch_announcements", return_value=None), \
              mock.patch.object(m, "display_announcements"), \
              mock.patch.object(m, "get_ticker", return_value="AAPL"), \
+             mock.patch.object(m, "resolve_instrument_identity", return_value={}), \
              mock.patch.object(m, "get_analysis_date", return_value="2026-05-29"), \
              mock.patch.object(m, "select_analysts", return_value=[]), \
              mock.patch.object(m, "select_research_depth", return_value=1), \

--- a/tests/test_cli_symbol_handling.py
+++ b/tests/test_cli_symbol_handling.py
@@ -42,18 +42,26 @@ def test_ticker_input_validation(value, ok):
     assert is_valid_ticker_input(value) is ok
 
 
-# --- #981/#982: asset-type classified on the canonical symbol ---
+# --- #981/#982 + futures: asset type classified on the canonical symbol ---
 @pytest.mark.parametrize("raw,expected", [
     ("BTCUSD", AssetType.CRYPTO),
     ("BTC-USDT", AssetType.CRYPTO),
     ("BTC-USD", AssetType.CRYPTO),
     ("ETHUSD", AssetType.CRYPTO),
     ("AAPL", AssetType.STOCK),
-    ("GC=F", AssetType.STOCK),
+    ("GC=F", AssetType.FUTURES),
+    ("GOLD", AssetType.FUTURES),
     ("600519.SS", AssetType.STOCK),
 ])
 def test_detect_asset_type(raw, expected):
     assert detect_asset_type(raw) == expected
+
+
+def test_detect_asset_type_uses_resolved_quote_type():
+    assert detect_asset_type(
+        "YGZ26",
+        {"quote_type": "FUTURE"},
+    ) == AssetType.FUTURES
 
 
 def test_cli_normalize_delegates_to_data_layer():

--- a/tests/test_crypto_asset_mode.py
+++ b/tests/test_crypto_asset_mode.py
@@ -31,6 +31,23 @@ class CryptoAssetModeTests(unittest.TestCase):
             ],
         )
 
+    def test_filters_out_fundamentals_analyst_for_futures(self):
+        analysts = [
+            AnalystType.MARKET,
+            AnalystType.SOCIAL,
+            AnalystType.NEWS,
+            AnalystType.FUNDAMENTALS,
+        ]
+
+        self.assertEqual(
+            filter_analysts_for_asset_type(analysts, AssetType.FUTURES),
+            [
+                AnalystType.MARKET,
+                AnalystType.SOCIAL,
+                AnalystType.NEWS,
+            ],
+        )
+
     def test_keeps_all_analysts_for_stock(self):
         analysts = [
             AnalystType.MARKET,

--- a/tests/test_futures_asset_mode.py
+++ b/tests/test_futures_asset_mode.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+
+@pytest.mark.unit
+def test_programmatic_run_promotes_resolved_future_before_execution():
+    graph = MagicMock(spec=TradingAgentsGraph)
+    graph.config = {"checkpoint_enabled": False}
+    graph._checkpointer_ctx = None
+    graph._run_graph.return_value = ("final-state", "signal")
+
+    with patch(
+        "tradingagents.graph.trading_graph.resolve_instrument_identity",
+        return_value={"quote_type": "FUTURE"},
+    ):
+        result = TradingAgentsGraph.propagate(graph, "YGZ26", "2026-07-20")
+
+    assert result == ("final-state", "signal")
+    graph._configure_workflow.assert_called_once_with("futures")
+    graph._run_graph.assert_called_once_with(
+        "YGZ26",
+        "2026-07-20",
+        asset_type="futures",
+    )
+
+
+@pytest.mark.unit
+def test_programmatic_graph_reconfigures_across_asset_types():
+    graph = object.__new__(TradingAgentsGraph)
+    graph.selected_analysts = ("market", "fundamentals")
+    graph._active_analysts = ("market", "fundamentals")
+    graph.graph_setup = MagicMock()
+
+    futures_workflow = MagicMock(name="futures_workflow")
+    futures_graph = MagicMock(name="futures_graph")
+    futures_workflow.compile.return_value = futures_graph
+    stock_workflow = MagicMock(name="stock_workflow")
+    stock_graph = MagicMock(name="stock_graph")
+    stock_workflow.compile.return_value = stock_graph
+    graph.graph_setup.setup_graph.side_effect = [futures_workflow, stock_workflow]
+
+    graph._configure_workflow("futures")
+    assert graph._active_analysts == ("market",)
+    assert graph.workflow is futures_workflow
+    assert graph.graph is futures_graph
+
+    graph._configure_workflow("stock")
+    assert graph._active_analysts == ("market", "fundamentals")
+    assert graph.workflow is stock_workflow
+    assert graph.graph is stock_graph
+    assert graph.graph_setup.setup_graph.call_args_list == [
+        call(("market", "fundamentals"), asset_type="futures"),
+        call(("market", "fundamentals"), asset_type="stock"),
+    ]
+
+
+@pytest.mark.unit
+def test_futures_checkpoint_signature_uses_effective_analysts():
+    graph = object.__new__(TradingAgentsGraph)
+    graph.selected_analysts = ("market", "news", "fundamentals")
+    graph.config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+
+    signature = graph._run_signature("futures")
+
+    assert signature == "analysts=market,news|debate=1|risk=1|asset=futures"

--- a/tests/test_instrument_identity.py
+++ b/tests/test_instrument_identity.py
@@ -11,8 +11,10 @@ from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     create_msg_delete,
     get_instrument_context_from_state,
+    resolve_asset_type,
     resolve_instrument_identity,
 )
+from tradingagents.graph.trading_graph import TradingAgentsGraph
 
 
 @pytest.mark.unit
@@ -36,6 +38,7 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
         self.assertEqual(identity["sector"], "Industrials")
         self.assertEqual(identity["industry"], "Building Products & Equipment")
         self.assertEqual(identity["exchange"], "PNK")
+        self.assertEqual(identity["quote_type"], "EQUITY")
 
     def test_falls_back_to_short_name(self):
         with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
@@ -63,6 +66,36 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
             second = resolve_instrument_identity("TOTDY")
         mock.assert_called_once()  # second call served from cache
         self.assertEqual(first, second)
+
+
+@pytest.mark.unit
+class ResolveAssetTypeTests(unittest.TestCase):
+    def test_native_symbol_and_broker_alias_identify_futures(self):
+        self.assertEqual(resolve_asset_type("GC=F"), "futures")
+        self.assertEqual(resolve_asset_type("GOLD"), "futures")
+
+    def test_quote_type_identifies_futures_without_symbol_suffix(self):
+        self.assertEqual(
+            resolve_asset_type("YGZ26", "stock", {"quote_type": "FUTURE"}),
+            "futures",
+        )
+
+    def test_non_futures_preserve_existing_modes(self):
+        self.assertEqual(resolve_asset_type("AAPL", "stock"), "stock")
+        self.assertEqual(resolve_asset_type("BTC-USD", "crypto"), "crypto")
+
+    def test_rejects_unknown_asset_type(self):
+        with self.assertRaisesRegex(ValueError, "asset_type must be one of"):
+            resolve_asset_type("AAPL", "bond")
+
+    @patch(
+        "tradingagents.graph.trading_graph.resolve_instrument_identity",
+        return_value={"quote_type": "FUTURE"},
+    )
+    def test_graph_context_uses_resolved_futures_type(self, _resolve_identity):
+        context = TradingAgentsGraph.resolve_instrument_context(None, "YGZ26")
+
+        self.assertIn("commodity or index derivative", context)
 
 
 @pytest.mark.unit
@@ -94,6 +127,21 @@ class BuildInstrumentContextTests(unittest.TestCase):
         )
         self.assertIn("Name: Bitcoin USD", context)
         self.assertIn("crypto asset rather than a company", context)
+
+    def test_futures_describes_derivative_data_constraints(self):
+        context = build_instrument_context(
+            "GC=F", "futures", {"company_name": "Gold Dec 26", "exchange": "CMX"}
+        )
+
+        self.assertIn("Contract: Gold Dec 26", context)
+        self.assertIn("commodity or index derivative", context)
+        self.assertIn("company fundamentals", context)
+        self.assertIn("equity-style sentiment coverage", context)
+
+    def test_futures_suffix_example_does_not_change_other_asset_prompts(self):
+        self.assertNotIn("`=F`", build_instrument_context("AAPL", "stock"))
+        self.assertNotIn("`=F`", build_instrument_context("BTC-USD", "crypto"))
+        self.assertIn("`=F`", build_instrument_context("GC=F", "futures"))
 
 
 @pytest.mark.unit

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -864,7 +864,11 @@ class TestLegacyRemoval:
         mock_graph._run_graph = functools.partial(
             TradingAgentsGraph._run_graph, mock_graph
         )
-        TradingAgentsGraph.propagate(mock_graph, "NVDA", "2026-01-10")
+        with patch(
+            "tradingagents.graph.trading_graph.resolve_instrument_identity",
+            return_value={},
+        ):
+            TradingAgentsGraph.propagate(mock_graph, "NVDA", "2026-01-10")
         entries = mock_graph.memory_log.load_entries()
         assert len(entries) == 1
         assert entries[0]["ticker"] == "NVDA"

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -46,7 +46,7 @@ class RiskDebateState(TypedDict):
 
 class AgentState(MessagesState):
     company_of_interest: Annotated[str, "Company that we are interested in trading"]
-    asset_type: Annotated[str, "Asset type under analysis such as stock or crypto"]
+    asset_type: Annotated[str, "Asset type under analysis: stock, crypto, or futures"]
     instrument_context: Annotated[str, "Deterministic ticker identity resolved at run start"]
     trade_date: Annotated[str, "What date we are trading at"]
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -23,6 +23,7 @@ from tradingagents.agents.utils.news_data_tools import (
 )
 from tradingagents.agents.utils.prediction_markets_tools import get_prediction_markets
 from tradingagents.agents.utils.technical_indicators_tools import get_indicators
+from tradingagents.asset_types import coerce_asset_type, resolve_asset_type
 
 # Public surface: the data tools are imported here so agents and the graph
 # import them from one place, plus the instrument/language helpers defined below.
@@ -40,6 +41,7 @@ __all__ = [
     "get_prediction_markets",
     "get_verified_market_snapshot",
     "build_instrument_context",
+    "resolve_asset_type",
     "resolve_instrument_identity",
     "get_instrument_context_from_state",
     "get_language_instruction",
@@ -131,19 +133,30 @@ def build_instrument_context(
     classification are injected so agents anchor to the real company rather
     than pattern-matching the price chart to a wrong one (#814).
     """
+    asset_type = coerce_asset_type(asset_type)
     is_crypto = asset_type == "crypto"
+    is_futures = asset_type == "futures"
     instrument_label = "asset" if is_crypto else "instrument"
+    suffix_examples = "`.TO`, `.L`, `.HK`, `.T`, `-USD`"
+    if is_futures:
+        suffix_examples += ", `=F`"
     context = (
         f"The {instrument_label} to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
-        "preserving any exchange suffix (e.g. `.TO`, `.L`, `.HK`, `.T`, `-USD`)."
+        f"preserving any exchange suffix (e.g. {suffix_examples})."
     )
 
     details = []
     if identity:
         name = identity.get("company_name") or identity.get("name")
         if name:
-            details.append(f"{'Name' if is_crypto else 'Company'}: {name}")
+            if is_crypto:
+                name_label = "Name"
+            elif is_futures:
+                name_label = "Contract"
+            else:
+                name_label = "Company"
+            details.append(f"{name_label}: {name}")
         sector, industry = identity.get("sector"), identity.get("industry")
         if sector and industry:
             details.append(f"Business classification: {sector} / {industry}")
@@ -155,9 +168,10 @@ def build_instrument_context(
             details.append(f"Exchange: {identity['exchange']}")
 
     if details:
+        identity_target = "instrument" if is_futures else "company"
         context += (
             f" Resolved identity: {'; '.join(details)}. "
-            "Do not substitute a different company or ticker unless a tool "
+            f"Do not substitute a different {identity_target} or ticker unless a tool "
             "result explicitly disproves this resolved identity."
         )
 
@@ -165,6 +179,12 @@ def build_instrument_context(
         context += (
             " Treat it as a crypto asset rather than a company, and do not "
             "assume company fundamentals are available."
+        )
+    elif is_futures:
+        context += (
+            " Treat it as a commodity or index derivative rather than a company. "
+            "Do not assume company fundamentals or equity-style sentiment coverage "
+            "are available."
         )
     return context
 

--- a/tradingagents/asset_types.py
+++ b/tradingagents/asset_types.py
@@ -1,0 +1,42 @@
+"""Shared asset-type definitions and deterministic instrument classification."""
+
+from collections.abc import Mapping
+from enum import Enum
+
+
+class AssetType(str, Enum):
+    STOCK = "stock"
+    CRYPTO = "crypto"
+    FUTURES = "futures"
+
+
+def coerce_asset_type(asset_type: str | AssetType) -> str:
+    """Return a supported wire value or reject an unknown asset mode."""
+    try:
+        return AssetType(asset_type).value
+    except (TypeError, ValueError) as exc:
+        choices = ", ".join(asset.value for asset in AssetType)
+        raise ValueError(f"asset_type must be one of: {choices}") from exc
+
+
+def resolve_asset_type(
+    ticker: str,
+    asset_type: str | AssetType = AssetType.STOCK,
+    identity: Mapping[str, str] | None = None,
+) -> str:
+    """Promote a run to futures when deterministic instrument data proves it.
+
+    The validated caller-provided mode remains authoritative for non-futures
+    instruments. Broker aliases are normalized before checking Yahoo's native
+    ``=F`` suffix.
+    """
+    from tradingagents.dataflows.symbol_utils import normalize_symbol
+
+    requested_asset_type = coerce_asset_type(asset_type)
+    canonical_ticker = normalize_symbol(ticker)
+    quote_type = identity.get("quote_type") if identity else None
+    if (isinstance(canonical_ticker, str) and canonical_ticker.upper().endswith("=F")) or (
+        isinstance(quote_type, str) and quote_type.strip().upper() == "FUTURE"
+    ):
+        return AssetType.FUTURES.value
+    return requested_asset_type

--- a/tradingagents/graph/analyst_execution.py
+++ b/tradingagents/graph/analyst_execution.py
@@ -2,6 +2,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from time import monotonic
 
+from tradingagents.asset_types import coerce_asset_type
+
 
 @dataclass(frozen=True)
 class AnalystNodeSpec:
@@ -55,15 +57,23 @@ ANALYST_NODE_SPECS: dict[str, AnalystNodeSpec] = {
 
 def build_analyst_execution_plan(
     selected_analysts: Iterable[str],
+    asset_type: str = "stock",
 ) -> AnalystExecutionPlan:
+    asset_type = coerce_asset_type(asset_type)
     specs: list[AnalystNodeSpec] = []
+    skipped_fundamentals = False
     for analyst_key in selected_analysts:
         spec = ANALYST_NODE_SPECS.get(analyst_key)
         if spec is None:
             raise ValueError(f"unknown analyst key: {analyst_key}")
+        if asset_type == "futures" and analyst_key == "fundamentals":
+            skipped_fundamentals = True
+            continue
         specs.append(spec)
 
     if not specs:
+        if skipped_fundamentals:
+            raise ValueError("at least one futures-compatible analyst must be selected")
         raise ValueError("at least one analyst must be selected")
 
     return AnalystExecutionPlan(specs=specs)

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -6,6 +6,7 @@ from tradingagents.agents.utils.agent_states import (
     InvestDebateState,
     RiskDebateState,
 )
+from tradingagents.asset_types import coerce_asset_type
 
 
 class Propagator:
@@ -31,6 +32,7 @@ class Propagator:
         fall back to ticker-only context via
         ``get_instrument_context_from_state``.
         """
+        asset_type = coerce_asset_type(asset_type)
         return {
             "messages": [("human", company_name)],
             "company_of_interest": company_name,

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -59,7 +59,9 @@ class GraphSetup:
         self.conditional_logic = conditional_logic
 
     def setup_graph(
-        self, selected_analysts=("market", "social", "news", "fundamentals")
+        self,
+        selected_analysts=("market", "social", "news", "fundamentals"),
+        asset_type: str = "stock",
     ):
         """Set up and compile the agent workflow graph.
 
@@ -69,8 +71,9 @@ class GraphSetup:
                 - "social": Social media analyst
                 - "news": News analyst
                 - "fundamentals": Fundamentals analyst
+            asset_type: Instrument mode used to omit unsupported analyst stages.
         """
-        plan = build_analyst_execution_plan(selected_analysts)
+        plan = build_analyst_execution_plan(selected_analysts, asset_type=asset_type)
 
         analyst_factories = {
             "market": lambda: create_market_analyst(self.quick_thinking_llm),

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -25,6 +25,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_prediction_markets,
     get_stock_data,
     get_verified_market_snapshot,
+    resolve_asset_type,
     resolve_instrument_identity,
 )
 from tradingagents.agents.utils.memory import TradingMemoryLog
@@ -34,6 +35,7 @@ from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.llm_clients import create_llm_client
 from tradingagents.reporting import write_report_tree
 
+from .analyst_execution import build_analyst_execution_plan
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
 from .conditional_logic import ConditionalLogic
 from .propagation import Propagator
@@ -148,6 +150,7 @@ class TradingAgentsGraph:
         # Set up the graph: keep the workflow for recompilation with a checkpointer.
         self.workflow = self.graph_setup.setup_graph(selected_analysts)
         self.graph = self.workflow.compile()
+        self._active_analysts = self._analysts_for_asset_type("stock")
         self._checkpointer_ctx = None
 
     def _get_provider_kwargs(self) -> dict[str, Any]:
@@ -343,7 +346,31 @@ class TradingAgentsGraph:
         graph regardless of entry point.
         """
         identity = resolve_instrument_identity(ticker)
-        return build_instrument_context(ticker, asset_type, identity)
+        resolved_asset_type = resolve_asset_type(ticker, asset_type, identity)
+        return build_instrument_context(ticker, resolved_asset_type, identity)
+
+    def _analysts_for_asset_type(self, asset_type: str) -> tuple[str, ...]:
+        """Return the effective analyst keys for a run's asset type."""
+        plan = build_analyst_execution_plan(
+            self.selected_analysts,
+            asset_type=asset_type,
+        )
+        return tuple(spec.key for spec in plan.specs)
+
+    def _configure_workflow(self, asset_type: str) -> None:
+        """Compile the graph shape required by ``asset_type`` when it changes."""
+        effective_analysts = self._analysts_for_asset_type(asset_type)
+        if effective_analysts == self._active_analysts:
+            return
+
+        workflow = self.graph_setup.setup_graph(
+            self.selected_analysts,
+            asset_type=asset_type,
+        )
+        graph = workflow.compile()
+        self.workflow = workflow
+        self.graph = graph
+        self._active_analysts = effective_analysts
 
     def _run_signature(self, asset_type: str) -> str:
         """Graph-shape inputs that must invalidate a checkpoint if changed.
@@ -352,8 +379,9 @@ class TradingAgentsGraph:
         selection, debate/risk depth, or asset mode starts fresh instead of
         silently continuing the previous graph (#1089).
         """
+        effective_analysts = self._analysts_for_asset_type(asset_type)
         return "|".join([
-            "analysts=" + ",".join(self.selected_analysts),
+            "analysts=" + ",".join(effective_analysts),
             f"debate={self.config['max_debate_rounds']}",
             f"risk={self.config['max_risk_discuss_rounds']}",
             f"asset={asset_type}",
@@ -362,14 +390,18 @@ class TradingAgentsGraph:
     def propagate(self, company_name, trade_date, asset_type: str = "stock"):
         """Run the trading agents graph for a company on a specific date.
 
-        ``asset_type`` selects between the stock pipeline (default) and the
-        crypto pipeline (``"crypto"``) shipped in #567 — the CLI auto-detects
-        from the ticker; programmatic callers pass it explicitly. When
-        ``checkpoint_enabled`` is set in config, the graph is recompiled with
+        ``asset_type`` selects the stock (default), crypto, or futures pipeline.
+        Futures are promoted deterministically from a canonical ``=F`` symbol
+        or resolved Yahoo ``quoteType`` even when the caller leaves the default.
+        When ``checkpoint_enabled`` is set in config, the graph is recompiled with
         a per-ticker SqliteSaver so a crashed run can resume from the last
         successful node on a subsequent invocation with the same ticker+date.
         """
         self.ticker = company_name
+
+        identity = resolve_instrument_identity(company_name)
+        asset_type = resolve_asset_type(company_name, asset_type, identity)
+        self._configure_workflow(asset_type)
 
         # Resolve any pending memory-log entries for this ticker before the pipeline runs.
         self._resolve_pending_entries(company_name)


### PR DESCRIPTION
### Purpose

Add futures as a first-class asset type so futures contracts are not analyzed as companies. The previous stock fallback allowed company-fundamentals prompts and equity-style sentiment assumptions for Yahoo futures symbols and broker aliases.

### Summary of Changes

- Add a shared, validated `AssetType` model and deterministic futures resolution from canonical `=F` symbols or Yahoo `quoteType=FUTURE` metadata.
- Detect futures consistently in the CLI and programmatic graph paths, including aliases such as `GOLD` that normalize to `GC=F`.
- Add futures-specific instrument context covering derivative framing, unavailable company fundamentals, and limited equity-style sentiment coverage.
- Remove the fundamentals analyst and tools from futures workflows while preserving stock and crypto behavior.
- Include the effective futures analyst set in checkpoint signatures and support graph reconfiguration across asset types.
- Document supported futures tickers and add regression, workflow-lifecycle, and invalid-input tests.

### Security Review

- Authentication changes: None.
- Authorization changes: None.
- Input validation changes: Unsupported asset-type values are now rejected at the shared core boundary; futures promotion requires an exact normalized `=F` suffix or exact case-insensitive `FUTURE` quote type.
- Data access changes: Reuses the existing cached, fail-open yfinance identity lookup. Futures workflows no longer invoke company-financial data tools.
- API security considerations: Existing `stock` and `crypto` wire values remain compatible; `futures` is additive. No client-side trust decision is used for access control.
- Secret handling changes: None. No secrets or private identity payloads are logged or persisted by this change.
- Known risks: Yahoo identity metadata may be unavailable, but canonical futures symbols and aliases still classify syntactically.

### Files and Components Affected

- `tradingagents/asset_types.py`
- `tradingagents/agents/utils/agent_utils.py` and `agent_states.py`
- `tradingagents/graph/analyst_execution.py`, `setup.py`, `propagation.py`, and `trading_graph.py`
- `cli/models.py`, `cli/utils.py`, and `cli/main.py`
- Futures, CLI, identity, checkpoint, and memory-log tests
- `README.md`

### Testing Completed

- Unit and regression suite: 591 passed, 2 skipped because optional Bedrock/live DeepSeek prerequisites were unavailable, plus 69 subtests.
- Integration coverage: CLI quote-type classification, programmatic futures promotion, stock/futures graph transitions, and checkpoint signatures.
- Authorization tests: Not applicable; no authorization behavior changed.
- Manual testing: Confirmed the compiled futures graph omits the Fundamentals Analyst and fundamentals tool node.
- Linting: `python -m ruff check .`
- Type/syntax checks: `python -m compileall -q cli tradingagents tests`; the repository has no configured static type checker.

### Screenshots

Not applicable; no visual UI layout changed.

### Migration or Deployment Notes

No database migration, dependency, environment-variable, secret, or deployment change is required. Rollback is a normal commit revert.

### Risks and Follow-Up Items

- The CLI performs the existing best-effort Yahoo identity lookup earlier, immediately after ticker selection; it is cached and fails open.
- Commodity-specific benchmark selection remains out of scope, so futures continue to use the existing benchmark fallback (typically SPY).
- Analyst-capability policy could be centralized further in a future refactor while preserving current crypto behavior.
