### PR TITLE
Add Taiwan (TWSE/TPEx) data vendor via the twmd client

### DIFF
--- a/tests/test_twmd_vendor.py
+++ b/tests/test_twmd_vendor.py
@@ -1,0 +1,278 @@
+"""TW Market Data vendor.
+
+Covers the router contract every vendor must honour — typed errors, no-data
+signalling — and the two things specific to this vendor: Taiwan symbol handling
+and publication-date look-ahead filtering on statements and monthly revenue.
+
+No network. The twmd client is faked at the module boundary, so these run in the
+same keyless CI as the rest of the suite.
+"""
+import types
+
+import pandas as pd
+import pytest
+
+import tradingagents.dataflows.twmd as twmd
+from tradingagents.dataflows.errors import (
+    NoMarketDataError,
+    VendorNotConfiguredError,
+    VendorRateLimitError,
+)
+
+
+# --- fakes matching the twmd client surface the vendor actually uses ----------
+
+class _FakeAuthError(Exception):
+    error_code = "missing_api_key"
+
+
+class _FakePaymentError(Exception):
+    error_code = "payment_required"
+
+
+class _FakeRateLimit(Exception):
+    pass
+
+
+def _install_fake_twmd(monkeypatch, *, frames=None, raises=None, record=None):
+    """Install a fake ``twmd`` module so ``from twmd import ...`` resolves.
+
+    ``frames`` maps dataset name -> DataFrame to return; ``raises`` maps dataset
+    name -> exception instance to raise. ``record`` (a dict) captures the kwargs
+    the client was constructed with, so a test can assert the source marker.
+    """
+    frames = frames or {}
+    raises = raises or {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            if record is not None:
+                record.update(kwargs)
+
+        def get_dataset(self, dataset, **kwargs):
+            if dataset in raises:
+                raise raises[dataset]
+            return frames.get(dataset, pd.DataFrame())
+
+    fake = types.ModuleType("twmd")
+    fake.Client = FakeClient
+    fake.TwmdAuthError = _FakeAuthError
+    fake.TwmdPaymentRequired = _FakePaymentError
+    fake.TwmdRateLimitError = _FakeRateLimit
+    monkeypatch.setitem(__import__("sys").modules, "twmd", fake)
+    return fake
+
+
+def _price_frame():
+    df = pd.DataFrame(
+        [
+            {"symbol": "2330", "date": "2026-07-16", "open": 100.0, "close": 101.0},
+            {"symbol": "2330", "date": "2026-07-17", "open": 101.0, "close": 100.0},
+        ]
+    )
+    df.attrs["data_as_of"] = "2026-07-17"
+    df.attrs["lineage"] = {"provider": "TWSE", "not_investment_advice": True}
+    return df
+
+
+def _revenue_frame():
+    return pd.DataFrame(
+        [
+            {"symbol": "2330", "month": "2026-04", "revenue": 410.0,
+             "mom": -1.08, "yoy": 17.5, "announcement_date": "2026-05-17"},
+            {"symbol": "2330", "month": "2026-05", "revenue": 420.0,
+             "mom": 2.4, "yoy": 20.0, "announcement_date": "2026-06-17"},
+        ]
+    )
+
+
+# --- symbol handling ----------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("given,expected", [
+    ("2330", "2330"),
+    ("2330.TW", "2330"),
+    ("2330.tw", "2330"),
+    ("6488.TWO", "6488"),
+    (" 2330 ", "2330"),
+])
+def test_canonical_strips_yahoo_suffix(given, expected):
+    assert twmd._canonical(given) == expected
+
+
+# --- core prices --------------------------------------------------------------
+
+@pytest.mark.unit
+def test_get_stock_returns_csv_with_lineage(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"twse-daily-price": _price_frame()})
+    out = twmd.get_stock("2330.TW", "2026-07-16", "2026-07-17")
+
+    assert "Taiwan daily prices" in out
+    assert "2330 (from 2330.TW)" in out
+    assert "provider: TWSE" in out
+    assert "data_as_of: 2026-07-17" in out
+    assert "2026-07-16" in out and "2026-07-17" in out
+
+
+@pytest.mark.unit
+def test_get_stock_filters_to_requested_range(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"twse-daily-price": _price_frame()})
+    out = twmd.get_stock("2330", "2026-07-17", "2026-07-17")
+    assert "2026-07-17" in out
+    assert "2026-07-16" not in out.split("\n\n", 1)[1]  # not in the CSV body
+
+
+@pytest.mark.unit
+def test_get_stock_empty_raises_no_market_data(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"twse-daily-price": pd.DataFrame()})
+    with pytest.raises(NoMarketDataError):
+        twmd.get_stock("9999", "2026-07-16", "2026-07-17")
+
+
+@pytest.mark.unit
+def test_client_built_with_ecosystem_source_marker(monkeypatch):
+    # §6 unified attribution: the vendor must tag its traffic as tradingagents.
+    record = {}
+    _install_fake_twmd(monkeypatch, frames={"twse-daily-price": _price_frame()}, record=record)
+    twmd.get_stock("2330", "2026-07-16", "2026-07-17")
+    assert record.get("source") == "ecosys/tradingagents"
+
+
+# --- error mapping onto the router taxonomy -----------------------------------
+
+@pytest.mark.unit
+def test_auth_error_maps_to_not_configured(monkeypatch):
+    _install_fake_twmd(monkeypatch, raises={"twse-daily-price": _FakeAuthError()})
+    with pytest.raises(VendorNotConfiguredError) as info:
+        twmd.get_stock("1101", "2026-07-16", "2026-07-17")
+    # Message must point at free registration, not just fail.
+    assert "twmarketdata.com" in str(info.value)
+    assert "sample tickers" in str(info.value)
+
+
+@pytest.mark.unit
+def test_payment_required_maps_to_not_configured(monkeypatch):
+    _install_fake_twmd(monkeypatch, raises={"income-statement": _FakePaymentError()})
+    with pytest.raises(VendorNotConfiguredError):
+        twmd.get_income_statement("2330", curr_date="2026-07-17")
+
+
+@pytest.mark.unit
+def test_rate_limit_maps_to_rate_limit(monkeypatch):
+    _install_fake_twmd(monkeypatch, raises={"twse-daily-price": _FakeRateLimit()})
+    with pytest.raises(VendorRateLimitError):
+        twmd.get_stock("2330", "2026-07-16", "2026-07-17")
+
+
+@pytest.mark.unit
+def test_missing_twmd_install_is_not_configured(monkeypatch):
+    # Simulate twmd not installed: importing it raises ImportError.
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "twmd":
+            raise ImportError("No module named 'twmd'")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(VendorNotConfiguredError) as info:
+        twmd.get_stock("2330", "2026-07-16", "2026-07-17")
+    assert "pip install twmarketdata" in str(info.value)
+
+
+# --- look-ahead filtering (the correctness contribution) ----------------------
+
+@pytest.mark.unit
+def test_monthly_revenue_excludes_unannounced_rows(monkeypatch):
+    # At 2026-05-20 the May revenue (announced 2026-06-17) was not yet public.
+    _install_fake_twmd(monkeypatch, frames={"monthly-revenue": _revenue_frame()})
+    out = twmd.get_fundamentals("2330", curr_date="2026-05-20")
+
+    body = out.split("\n\n", 1)[1]
+    data_rows = [r for r in body.strip().splitlines()[1:] if r]  # drop CSV header
+    assert len(data_rows) == 1                      # only the visible month
+    assert "410.0" in data_rows[0]                  # April revenue, announced 2026-05-17
+    assert "420.0" not in body                      # May revenue, announced 2026-06-17, hidden
+    assert "by announcement_date" in out
+
+
+@pytest.mark.unit
+def test_look_ahead_note_reports_publication_basis(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"monthly-revenue": _revenue_frame()})
+    out = twmd.get_fundamentals("2330", curr_date="2026-12-31")
+    assert "published on/before 2026-12-31" in out
+
+
+@pytest.mark.unit
+def test_period_fallback_when_no_publication_date(monkeypatch):
+    # A frame with only a period column must fall back and say so, not silently
+    # present a period cut as a true point-in-time filter.
+    df = pd.DataFrame([
+        {"report_date": "2026-03-31", "revenue": 1},
+        {"report_date": "2026-06-30", "revenue": 2},
+    ])
+    _install_fake_twmd(monkeypatch, frames={"income-statement": df})
+    out = twmd.get_income_statement("2330", curr_date="2026-05-01")
+
+    body = out.split("\n\n", 1)[1]
+    assert "2026-03-31" in body
+    assert "2026-06-30" not in body
+    assert "not a per-row" in out
+
+
+@pytest.mark.unit
+def test_degenerate_publication_column_falls_back_to_period(monkeypatch):
+    # All rows share one announcement_date (a bulk-load timestamp, seen on live
+    # monthly-revenue). It cannot discriminate rows, so the cut must fall back to
+    # the period column and NOT hide older months behind that single load date.
+    df = pd.DataFrame([
+        {"month": "2023-06", "revenue": 1, "announcement_date": "2026-05-17"},
+        {"month": "2026-04", "revenue": 2, "announcement_date": "2026-05-17"},
+    ])
+    _install_fake_twmd(monkeypatch, frames={"monthly-revenue": df})
+    # A 2024 backtest date: with the buggy publication cut this returns nothing;
+    # with the period fallback it correctly shows the 2023-06 row.
+    out = twmd.get_fundamentals("2330", curr_date="2024-01-01")
+
+    body = out.split("\n\n", 1)[1]
+    assert "2023-06" in body
+    assert "2026-04" not in body
+    assert "period on/before 2024-01-01" in out
+    assert "by month" in out
+
+
+@pytest.mark.unit
+def test_no_curr_date_returns_all_rows(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"monthly-revenue": _revenue_frame()})
+    out = twmd.get_fundamentals("2330", curr_date=None)
+    body = out.split("\n\n", 1)[1]
+    assert "2026-04" in body and "2026-05" in body
+
+
+@pytest.mark.unit
+def test_statement_all_filtered_out_raises_no_data(monkeypatch):
+    _install_fake_twmd(monkeypatch, frames={"monthly-revenue": _revenue_frame()})
+    # Before any row was announced.
+    with pytest.raises(NoMarketDataError):
+        twmd.get_fundamentals("2330", curr_date="2020-01-01")
+
+
+# --- registration wiring ------------------------------------------------------
+
+@pytest.mark.unit
+def test_registered_in_vendor_methods():
+    from tradingagents.dataflows import interface
+
+    assert "twmd" in interface.VENDOR_LIST
+    for method in ("get_stock_data", "get_income_statement",
+                   "get_balance_sheet", "get_cashflow", "get_fundamentals"):
+        assert "twmd" in interface.VENDOR_METHODS[method], method
+
+
+@pytest.mark.unit
+def test_benchmark_map_has_taiwan():
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["benchmark_map"][".TW"] == "^TWII"
+    assert DEFAULT_CONFIG["benchmark_map"][".TWO"] == "^TWOII"

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -19,6 +19,13 @@ from .errors import (
 )
 from .fred import get_macro_data as get_fred_macro_data
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
+from .twmd import (
+    get_balance_sheet as get_twmd_balance_sheet,
+    get_cashflow as get_twmd_cashflow,
+    get_fundamentals as get_twmd_fundamentals,
+    get_income_statement as get_twmd_income_statement,
+    get_stock as get_twmd_stock,
+)
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
     get_cashflow as get_yfinance_cashflow,
@@ -82,6 +89,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "twmd",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -97,6 +105,7 @@ VENDOR_METHODS = {
     "get_stock_data": {
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
+        "twmd": get_twmd_stock,
     },
     # technical_indicators
     "get_indicators": {
@@ -107,18 +116,22 @@ VENDOR_METHODS = {
     "get_fundamentals": {
         "alpha_vantage": get_alpha_vantage_fundamentals,
         "yfinance": get_yfinance_fundamentals,
+        "twmd": get_twmd_fundamentals,
     },
     "get_balance_sheet": {
         "alpha_vantage": get_alpha_vantage_balance_sheet,
         "yfinance": get_yfinance_balance_sheet,
+        "twmd": get_twmd_balance_sheet,
     },
     "get_cashflow": {
         "alpha_vantage": get_alpha_vantage_cashflow,
         "yfinance": get_yfinance_cashflow,
+        "twmd": get_twmd_cashflow,
     },
     "get_income_statement": {
         "alpha_vantage": get_alpha_vantage_income_statement,
         "yfinance": get_yfinance_income_statement,
+        "twmd": get_twmd_income_statement,
     },
     # news_data
     "get_news": {

--- a/tradingagents/dataflows/twmd.py
+++ b/tradingagents/dataflows/twmd.py
@@ -1,0 +1,264 @@
+"""TW Market Data vendor for Taiwan-listed equities (TWSE / TPEx).
+
+This vendor adds coverage the US-focused defaults do not carry: Taiwan daily
+prices, the Taiwan-specific monthly revenue disclosure, and the official
+financial statements — sourced from the TW Market Data API via the ``twmd``
+client (pure-Python: httpx + pandas, no compiled dependencies).
+
+It is a *data* vendor. It returns records as the source published them and adds
+no analysis, scoring, ranking, or opinion. What the data means is the calling
+agent's job, not this module's.
+
+Look-ahead safety
+-----------------
+Statement and revenue readers filter to rows dated on or before ``curr_date``,
+so a backtest at ``curr_date`` never sees a row it could not have seen then. This
+is the same discipline as
+``alpha_vantage_fundamentals._filter_reports_by_date``: a period-based cut.
+
+The reader prefers a genuine publication-date column
+(``announcement_date`` / ``source_publish_date``) when one is present *and
+usable*, and otherwise falls back to the period column (``month`` / ``report_date``),
+naming the basis it used in the header so the cut is never silently
+misrepresented. "Usable" matters: some current datasets carry a publication-date
+column whose values are all identical — a bulk-load timestamp, not a per-row
+disclosure date — which cannot discriminate rows and would wrongly hide
+everything before it. Such a column is detected and skipped in favour of the
+period cut.
+
+A stronger, true point-in-time filter — one that reflects exactly what was known
+on ``curr_date``, including restatements — is deliberately **not** claimed here.
+It depends on per-row disclosure dates being verified reliable across the
+datasets, which is tracked separately. Until then this vendor makes the same
+period-based assurance the existing vendors make, no more.
+
+Free tier
+---------
+Five sample tickers — 2330, 2317, 2454, 0050, 2603 — return live prices and
+monthly revenue with no API key, so the vendor is demonstrable out of the box.
+Everything else needs ``TWMD_API_KEY``; without it those calls raise
+``VendorNotConfiguredError`` and the router moves on, surfacing a message that
+points to free registration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+from .errors import (
+    NoMarketDataError,
+    VendorNotConfiguredError,
+    VendorRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+# Integration marker sent on every request so the publisher can attribute
+# TradingAgents traffic (shared measurement across the ecosystem plugins).
+_SOURCE = "ecosys/tradingagents"
+
+# Yahoo-style suffixes a user may append to a Taiwan code. twmd wants the bare
+# code (``2330``), so these are stripped before the request.
+_TW_SUFFIXES = (".TW", ".TWO")
+
+# Publication-date columns, most-specific first. A row is visible at curr_date
+# only if the earliest present one of these is <= curr_date.
+_PUBLICATION_COLUMNS = ("announcement_date", "source_publish_date", "publish_date")
+
+# Period columns, used only for labelling and as the last-resort look-ahead key.
+_PERIOD_COLUMNS = ("report_date", "period", "month", "date")
+
+
+def _client():
+    """Build a twmd client, or raise the router's not-configured error.
+
+    ``twmd`` is an optional dependency; a missing install is a configuration
+    problem the router should route around, not a crash.
+    """
+    try:
+        from twmd import Client
+    except ImportError as exc:  # pragma: no cover - exercised via router only
+        raise VendorNotConfiguredError(
+            "The twmd client is required for the Taiwan (twmd) vendor. "
+            "Install it with: pip install twmarketdata"
+        ) from exc
+    return Client(source=_SOURCE)
+
+
+def _canonical(symbol: str) -> str:
+    """Return the bare Taiwan code twmd expects (strip a Yahoo ``.TW`` suffix)."""
+    s = (symbol or "").strip().upper()
+    for suffix in _TW_SUFFIXES:
+        if s.endswith(suffix):
+            return s[: -len(suffix)]
+    return s
+
+
+def _call(func, canonical: str, *args, **kwargs):
+    """Invoke a twmd client method, mapping its errors onto the router taxonomy.
+
+    ``canonical`` is used only for the rate-limit message; ``args``/``kwargs`` pass
+    straight through to ``func`` (so a ``symbol=`` kwarg does not collide with this
+    wrapper's own parameters).
+    """
+    from twmd import TwmdAuthError, TwmdPaymentRequired, TwmdRateLimitError
+
+    try:
+        return func(*args, **kwargs)
+    except (TwmdAuthError, TwmdPaymentRequired) as exc:
+        # No key, invalid key, or an unentitled key. All mean "this vendor
+        # cannot serve the call as configured" — route around it, and let the
+        # message guide the user to a (free) key.
+        raise VendorNotConfiguredError(
+            f"TW Market Data needs an API key for this request "
+            f"({getattr(exc, 'error_code', None) or 'authentication required'}). "
+            f"Free registration takes about three minutes at twmarketdata.com; "
+            f"set TWMD_API_KEY once you have one. Five sample tickers "
+            f"(2330, 2317, 2454, 0050, 2603) work without a key for prices and "
+            f"monthly revenue."
+        ) from exc
+    except TwmdRateLimitError as exc:
+        raise VendorRateLimitError(f"TW Market Data rate-limited {canonical!r}") from exc
+
+
+def _is_usable_date_column(series: pd.Series) -> bool:
+    """Whether a date column can discriminate rows for a look-ahead cut.
+
+    A column whose non-null values are all identical is a bulk-load timestamp,
+    not a per-row disclosure date; cutting on it would hide every row before that
+    one date regardless of period, so it is treated as unusable.
+    """
+    non_null = series.dropna()
+    return non_null.nunique() > 1
+
+
+def _visible_at(df: pd.DataFrame, curr_date: Optional[str]) -> tuple[pd.DataFrame, str]:
+    """Drop rows dated after ``curr_date``. Returns (frame, basis-note).
+
+    Prefers a usable publication-date column; otherwise falls back to the period
+    column. The basis note names which column and which kind of cut was made, so
+    the header never overstates what was applied.
+    """
+    if not curr_date or df.empty:
+        return df, "no date filter"
+    for col in _PUBLICATION_COLUMNS:
+        if col in df.columns and _is_usable_date_column(df[col]):
+            kept = df[df[col].astype(str) <= curr_date]
+            return kept, f"published on/before {curr_date} (by {col})"
+    for col in _PERIOD_COLUMNS:
+        if col in df.columns:
+            kept = df[df[col].astype(str) <= curr_date]
+            return kept, (
+                f"period on/before {curr_date} (by {col}; period-based cut, the "
+                f"same assurance the other vendors make — not a per-row "
+                f"point-in-time filter)"
+            )
+    return df, "no usable date column found; returned unfiltered"
+
+
+def _header(title: str, canonical: str, symbol: str, rows: int, extra: str = "") -> str:
+    label = canonical if canonical == symbol.strip().upper() else f"{canonical} (from {symbol})"
+    head = f"# {title} for {label}\n# Source: TW Market Data (official Taiwan exchanges)\n"
+    head += f"# Total records: {rows}\n"
+    if extra:
+        head += f"# {extra}\n"
+    return head + "\n"
+
+
+def _frame_to_output(df: pd.DataFrame, title: str, canonical: str, symbol: str, note: str) -> str:
+    lineage = df.attrs.get("lineage") if hasattr(df, "attrs") else None
+    data_as_of = df.attrs.get("data_as_of") if hasattr(df, "attrs") else None
+    extra_bits = []
+    if data_as_of:
+        extra_bits.append(f"data_as_of: {data_as_of}")
+    if isinstance(lineage, dict) and lineage.get("provider"):
+        extra_bits.append(f"provider: {lineage['provider']}")
+    if note:
+        extra_bits.append(f"look-ahead: {note}")
+    extra = "; ".join(extra_bits)
+    return _header(title, canonical, symbol, len(df), extra) + df.to_csv(index=False)
+
+
+# ---------------------------------------------------------------------------
+# core_stock_apis
+# ---------------------------------------------------------------------------
+
+def get_stock(symbol: str, start_date: str, end_date: str) -> str:
+    """Daily OHLCV for a Taiwan-listed symbol, ``start_date``..``end_date`` inclusive.
+
+    Free for the five sample tickers; any other ticker needs ``TWMD_API_KEY``.
+    """
+    canonical = _canonical(symbol)
+    client = _client()
+    df = _call(
+        client.get_dataset, canonical,
+        "twse-daily-price", symbol=canonical, date_from=start_date, date_to=end_date,
+    )
+    if df.empty:
+        raise NoMarketDataError(symbol, canonical, f"no rows between {start_date} and {end_date}")
+    if "date" in df.columns:
+        df = df[(df["date"].astype(str) >= start_date) & (df["date"].astype(str) <= end_date)]
+    if df.empty:
+        raise NoMarketDataError(symbol, canonical, f"no rows between {start_date} and {end_date}")
+    return _frame_to_output(df, f"Taiwan daily prices {start_date} to {end_date}", canonical, symbol, "")
+
+
+# ---------------------------------------------------------------------------
+# fundamental_data
+# ---------------------------------------------------------------------------
+
+def _statement(dataset: str, title: str, ticker: str, curr_date: Optional[str]) -> str:
+    canonical = _canonical(ticker)
+    client = _client()
+    # Forward as_of when we have a curr_date. twmd's as_of support on these
+    # endpoints is unverified, so we do not rely on it — the client-side
+    # publication-date filter below is the real look-ahead guard.
+    df = _call(
+        client.get_dataset, canonical,
+        dataset, symbol=canonical, as_of=curr_date,
+    )
+    if df.empty:
+        raise NoMarketDataError(ticker, canonical, f"no {title.lower()} data")
+    df, note = _visible_at(df, curr_date)
+    if df.empty:
+        raise NoMarketDataError(ticker, canonical, f"no {title.lower()} published on/before {curr_date}")
+    return _frame_to_output(df, title, canonical, ticker, note)
+
+
+def get_income_statement(ticker: str, freq: str = "quarterly", curr_date: Optional[str] = None) -> str:
+    """Income statement, filtered to rows published on/before ``curr_date``."""
+    return _statement("income-statement", "Taiwan income statement", ticker, curr_date)
+
+
+def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: Optional[str] = None) -> str:
+    """Balance sheet, filtered to rows published on/before ``curr_date``."""
+    return _statement("balance-sheet", "Taiwan balance sheet", ticker, curr_date)
+
+
+def get_cashflow(ticker: str, freq: str = "quarterly", curr_date: Optional[str] = None) -> str:
+    """Cash flow statement, filtered to rows published on/before ``curr_date``."""
+    return _statement("cash-flow-statement", "Taiwan cash flow statement", ticker, curr_date)
+
+
+def get_fundamentals(ticker: str, curr_date: Optional[str] = None) -> str:
+    """Monthly revenue history — the Taiwan-specific monthly disclosure.
+
+    Free for the five sample tickers. Rows are filtered to those announced on or
+    before ``curr_date`` so a historical run does not see revenue that had not
+    yet been reported. The MoM and YoY figures are the publisher's own computed
+    fields, reported as given.
+    """
+    canonical = _canonical(ticker)
+    client = _client()
+    # Ask for several years so a backtest at an older curr_date has history to
+    # cut down to, rather than only the most recent months.
+    df = _call(client.get_dataset, canonical, "monthly-revenue", symbol=canonical, limit=120)
+    if df.empty:
+        raise NoMarketDataError(ticker, canonical, "no monthly revenue data")
+    df, note = _visible_at(df, curr_date)
+    if df.empty:
+        raise NoMarketDataError(ticker, canonical, f"no monthly revenue announced on/before {curr_date}")
+    return _frame_to_output(df, "Taiwan monthly revenue", canonical, ticker, note)

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -159,6 +159,8 @@ DEFAULT_CONFIG = _apply_env_overrides({
         ".AX":  "^AXJO",       # Australia (ASX 200)
         ".SS":  "000001.SS",   # Shanghai (SSE Composite)
         ".SZ":  "399001.SZ",   # Shenzhen (SZSE Component)
+        ".TW":  "^TWII",       # Taiwan (TAIEX / 加權指數)
+        ".TWO": "^TWOII",      # Taipei Exchange (TPEx / 櫃買指數)
         "":     "SPY",         # default for US-listed tickers (no suffix)
     },
 })


### PR DESCRIPTION
Follow-up to #1156.

Standalone patch-style install (no fork needed to use it today): https://github.com/Anthonychiu1205/twmd-tradingagents-provider

## Summary

Adds `twmd` as a data vendor, giving the analysts coverage of Taiwan-listed
equities the current US-focused vendors do not carry: TWSE/TPEx daily prices,
the Taiwan-specific monthly revenue disclosure, and official financial
statements. It plugs into the existing vendor router exactly like
`alpha_vantage` and `yfinance` — no core changes, no new abstractions.

Data comes from the [TW Market Data](https://twmarketdata.com) API through the
`twmd` client, which is pure Python (httpx + pandas, no compiled dependencies).
Five sample tickers (2330, 2317, 2454, 0050, 2603) return live prices and
monthly revenue **without an API key**, so the vendor is runnable and testable
out of the box.

## Why

`yfinance` can price a `.TW` symbol, but it does not carry the data classes that
make Taiwan analysis work: the statutory **monthly revenue** disclosure (a
Taiwan-specific monthly filing with no US equivalent) and the official financial
statements from the local regulator. This vendor fills that coverage gap. It is
a coverage contribution, not a new analysis capability — the vendor returns
records and nothing else; the agents do the analysis.

## What changed

| File | Change |
| --- | --- |
| `tradingagents/dataflows/twmd.py` | New vendor module (impl functions) |
| `tradingagents/dataflows/interface.py` | Register `twmd` in `VENDOR_LIST` and `VENDOR_METHODS` |
| `tradingagents/default_config.py` | `benchmark_map`: `.TW → ^TWII`, `.TWO → ^TWOII` |
| `tests/test_twmd_vendor.py` | 20 unit tests, no network |

Methods served: `get_stock_data`, `get_fundamentals` (monthly revenue),
`get_income_statement`, `get_balance_sheet`, `get_cashflow`. Technical
indicators and news can follow in a later PR — kept out here to keep the surface
small and reviewable.

## Follows existing conventions

- **Typed error taxonomy.** The vendor raises the router's own
  `NoMarketDataError` / `VendorNotConfiguredError` / `VendorRateLimitError`, so
  `route_to_vendor` needs no new `except` clause. A missing key or an unentitled
  request becomes `VendorNotConfiguredError`, so the router cleanly falls through
  to the next vendor in the chain.
- **Look-ahead safety.** Statement and revenue readers apply the same
  period-based cut as `alpha_vantage_fundamentals._filter_reports_by_date`: rows
  dated after `curr_date` are dropped so a backtest never sees a figure it could
  not have seen then. The reader prefers a genuine per-row publication date when
  one is present and *usable*, and otherwise falls back to the period column,
  **naming the basis in the header** so what was applied is never overstated. It
  deliberately does not claim a stronger point-in-time filter than the other
  vendors — see the note below.
- **No-fabrication.** Empty results raise `NoMarketDataError`, which the router
  turns into the standard `NO_DATA_AVAILABLE` sentinel rather than an empty
  string an agent could hallucinate around.
- **Optional dependency.** `twmd` is imported lazily; if it is not installed the
  vendor raises `VendorNotConfiguredError` (with `pip install twmarketdata`) rather
  than breaking import for users who do not use it.

## Usage

```python
from tradingagents.dataflows.config import set_config

# Route Taiwan tickers through the twmd vendor (with a US fallback).
set_config({"data_vendors": {
    "core_stock_apis": "twmd,yfinance",
    "fundamental_data": "twmd,yfinance",
}})
```

Set `TWMD_API_KEY` for full coverage; the five sample tickers work without one.

## Tests

`tests/test_twmd_vendor.py` — 20 unit tests, no network (the twmd client is
faked at the module boundary), matching the suite's `@pytest.mark.unit` style:
symbol handling, error mapping, look-ahead filtering (including the degenerate
publication-date fallback), no-data signalling, and router registration.

```
pytest tests/test_twmd_vendor.py -q
20 passed
```

Also verified end-to-end against the live API with no key: the five sample
tickers return real prices and monthly revenue through `route_to_vendor`, and
key-gated datasets surface the registration guidance.

## A note on point-in-time / restatements

This vendor makes the **same period-based look-ahead assurance** the existing
vendors make. A stronger, true point-in-time filter — reflecting exactly what
was known on `curr_date`, including restatements — is intentionally not claimed
here. It depends on per-row disclosure dates being verified reliable across the
datasets, which is tracked separately upstream. (Concretely: some current
datasets carry a publication-date column whose values are all one bulk-load
timestamp; the reader detects that and falls back to the period cut rather than
wrongly hiding older rows.)

## Compliance / scope

This vendor retrieves data. It emits no recommendations, ratings, price targets,
or directional views, consistent with the framework's role: the vendor supplies
records, the agents reason over them.
