### PR TITLE
fix(dataflows): stop snapshot fundamentals leaking future data into backtests

### DIFF
--- a/tests/test_fundamentals_snapshot_lookahead.py
+++ b/tests/test_fundamentals_snapshot_lookahead.py
@@ -1,0 +1,125 @@
+"""Snapshot fundamentals must not leak the present into a backtest.
+
+Statement endpoints were already date-filtered, but the vendor "overview"
+endpoints (yfinance ``.info``, Alpha Vantage OVERVIEW) return a live quote:
+market cap, TTM ratios, the 52-week range and the 50/200-day averages always
+describe today. Replaying 2024-11-01 therefore fed the fundamentals analyst a
+200-day average from the present, contradicting the ``close_200_sma`` the market
+analyst computed as of the trade date and derailing the debate.
+"""
+import json
+
+import pandas as pd
+import pytest
+
+import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+import tradingagents.dataflows.y_finance as yfin
+from tradingagents.dataflows.stockstats_utils import is_historical_date
+
+LEAKY_LABELS = ("Market Cap", "52 Week High", "50 Day Average", "200 Day Average")
+
+_INFO = {
+    "longName": "Bitcoin USD",
+    "sector": "Crypto",
+    "marketCap": 1315814113280,
+    "fiftyTwoWeekHigh": 126198.07,
+    "fiftyDayAverage": 63092.676,
+    "twoHundredDayAverage": 72809.93,
+}
+
+_OVERVIEW = json.dumps({
+    "Symbol": "AAPL",
+    "Name": "Apple Inc",
+    "Sector": "TECHNOLOGY",
+    "Description": "Apple completed its 2025 acquisition of ExampleCorp.",
+    "MarketCapitalization": "3000000000000",
+    "PERatio": "35.2",
+    "52WeekHigh": "260.1",
+    "200DayMovingAverage": "220.5",
+})
+
+
+@pytest.fixture
+def fake_info(monkeypatch):
+    class _FakeTicker:
+        def __init__(self, symbol):
+            self.info = dict(_INFO)
+
+    monkeypatch.setattr(yfin.yf, "Ticker", _FakeTicker)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("curr_date,expected", [
+    ("2024-11-01", True),
+    (None, False),
+    ("", False),
+    ("2999-01-01", False),
+    ("not-a-date", False),
+])
+def test_is_historical_date(curr_date, expected):
+    assert is_historical_date(curr_date) is expected
+
+
+@pytest.mark.unit
+def test_today_is_not_historical():
+    """The boundary the `<` comparison hinges on: today is live, not a replay."""
+    today = pd.Timestamp.today().normalize()
+
+    assert is_historical_date(today.strftime("%Y-%m-%d")) is False
+    assert is_historical_date((today - pd.Timedelta(days=1)).strftime("%Y-%m-%d")) is True
+
+
+@pytest.mark.unit
+def test_yfinance_withholds_snapshot_metrics_on_past_date(fake_info):
+    report = yfin.get_fundamentals("BTC-USD", "2024-11-01")
+
+    for label in LEAKY_LABELS:
+        assert label not in report
+    assert "72809.93" not in report
+    assert "Bitcoin USD" in report
+    assert "look-ahead bias" in report
+    assert "2024-11-01" in report
+
+
+@pytest.mark.unit
+def test_yfinance_keeps_snapshot_metrics_without_date(fake_info):
+    report = yfin.get_fundamentals("BTC-USD", None)
+
+    for label in LEAKY_LABELS:
+        assert label in report
+    assert "72809.93" in report
+
+
+@pytest.mark.unit
+def test_yfinance_reports_note_when_no_safe_fields_survive(monkeypatch):
+    """Withholding everything is not the same as an unknown symbol."""
+    class _PriceOnlyTicker:
+        def __init__(self, symbol):
+            self.info = {"marketCap": 123, "twoHundredDayAverage": 72809.93}
+
+    monkeypatch.setattr(yfin.yf, "Ticker", _PriceOnlyTicker)
+
+    report = yfin.get_fundamentals("BTC-USD", "2024-11-01")
+
+    assert "72809.93" not in report
+    assert "look-ahead bias" in report
+
+
+@pytest.mark.unit
+def test_alpha_vantage_strips_snapshot_keys_on_past_date():
+    payload = json.loads(avf._strip_snapshot_fields(_OVERVIEW, "2024-11-01"))
+
+    assert set(payload) == {"Symbol", "Name", "Sector", "Note"}
+    assert "look-ahead bias" in payload["Note"]
+    # Vendor prose gets rewritten, so it can narrate events after curr_date.
+    assert "2025 acquisition" not in avf._strip_snapshot_fields(_OVERVIEW, "2024-11-01")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body,curr_date", [
+    (_OVERVIEW, None),
+    ("Our standard API rate limit is 25 requests per day", "2024-11-01"),
+    (json.dumps(["unexpected", "shape"]), "2024-11-01"),
+])
+def test_alpha_vantage_passes_through_unchanged(body, curr_date):
+    assert avf._strip_snapshot_fields(body, curr_date) == body

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,6 +1,44 @@
 import json
 
 from .alpha_vantage_common import _make_api_request
+from .stockstats_utils import is_historical_date
+
+# OVERVIEW is a live snapshot: valuation ratios, the 52-week range and the
+# 50/200-day averages describe today, not the date being analyzed. Only these
+# descriptive keys are safe to serve while replaying the past.
+# "Description" is excluded on purpose: Alpha Vantage rewrites that prose over
+# time, so it can describe acquisitions or product lines that postdate curr_date.
+_POINT_IN_TIME_SAFE_KEYS = frozenset({
+    "Symbol", "AssetType", "Name", "CIK",
+    "Exchange", "Currency", "Country", "Sector", "Industry", "Address",
+})
+
+_STALE_SNAPSHOT_NOTE = (
+    "{curr_date} is in the past and Alpha Vantage OVERVIEW has no point-in-time "
+    "equivalent, so live-quote metrics (market cap, PE, 52-week range, "
+    "50/200-day averages) are omitted here to avoid look-ahead bias. Use "
+    "get_income_statement / get_balance_sheet / get_cashflow for as-of-date "
+    "financials, and get_indicators for as-of-date price statistics."
+)
+
+
+def _strip_snapshot_fields(result, curr_date: str):
+    """Drop live-snapshot OVERVIEW keys when curr_date is historical.
+
+    Mirrors ``_filter_reports_by_date``: a non-JSON body or a present-day
+    ``curr_date`` is returned unchanged.
+    """
+    if not is_historical_date(curr_date) or not isinstance(result, str):
+        return result
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return result
+    if not isinstance(payload, dict):
+        return result
+    filtered = {k: v for k, v in payload.items() if k in _POINT_IN_TIME_SAFE_KEYS}
+    filtered["Note"] = _STALE_SNAPSHOT_NOTE.format(curr_date=curr_date)
+    return json.dumps(filtered)
 
 
 def _filter_reports_by_date(result, curr_date: str):
@@ -33,7 +71,8 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
 
     Args:
         ticker (str): Ticker symbol of the company
-        curr_date (str): Current date you are trading at, yyyy-mm-dd (not used for Alpha Vantage)
+        curr_date (str): Current date you are trading at, yyyy-mm-dd. When it is
+            in the past, live-snapshot metrics are withheld to avoid look-ahead.
 
     Returns:
         str: Company overview data including financial ratios and key metrics
@@ -42,7 +81,7 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
         "symbol": ticker,
     }
 
-    return _make_api_request("OVERVIEW", params)
+    return _strip_snapshot_fields(_make_api_request("OVERVIEW", params), curr_date)
 
 
 def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -235,6 +235,21 @@ def filter_financials_by_date(data: pd.DataFrame, curr_date: str) -> pd.DataFram
     return data.loc[:, mask]
 
 
+def is_historical_date(curr_date: str) -> bool:
+    """True when curr_date precedes today, i.e. we are replaying the past.
+
+    Vendor "snapshot" endpoints (yfinance ``.info``, Alpha Vantage OVERVIEW)
+    always describe today and have no point-in-time equivalent, so callers use
+    this to suppress fields that would leak the present into a backtest.
+    """
+    if not curr_date:
+        return False
+    parsed = pd.to_datetime(curr_date, errors="coerce")
+    if pd.isna(parsed):
+        return False
+    return parsed.normalize() < pd.Timestamp.today().normalize()
+
+
 class StockstatsUtils:
     @staticmethod
     def get_stock_stats(

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -9,6 +9,7 @@ from .stockstats_utils import (
     StockstatsUtils,
     _assert_ohlcv_not_stale,
     filter_financials_by_date,
+    is_historical_date,
     load_ohlcv,
     yf_retry,
 )
@@ -271,11 +272,30 @@ def get_stockstats_indicator(
     return str(indicator_value)
 
 
+# `.info` is a live snapshot: market cap, TTM ratios, the 52-week range and the
+# 50/200-day averages all describe today regardless of the date being analyzed.
+# Only these descriptive fields are safe to serve while replaying the past.
+_POINT_IN_TIME_SAFE_FIELDS = frozenset({"Name", "Sector", "Industry"})
+
+_STALE_SNAPSHOT_NOTE = (
+    "# NOTE: {curr_date} is in the past and yfinance provides no point-in-time\n"
+    "# snapshot, so live-quote metrics (market cap, PE, 52-week range, 50/200-day\n"
+    "# averages) are omitted here to avoid look-ahead bias. Use\n"
+    "# get_income_statement / get_balance_sheet / get_cashflow for as-of-date\n"
+    "# financials, and get_indicators for as-of-date price statistics such as\n"
+    "# close_50_sma and close_200_sma.\n"
+)
+
+
 def get_fundamentals(
     ticker: Annotated[str, "ticker symbol of the company"],
-    curr_date: Annotated[str, "current date (not used for yfinance)"] = None
+    curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None
 ):
-    """Get company fundamentals overview from yfinance."""
+    """Get company fundamentals overview from yfinance.
+
+    For a historical ``curr_date`` the live-snapshot metrics are withheld; see
+    ``_POINT_IN_TIME_SAFE_FIELDS``.
+    """
     canonical = normalize_symbol(ticker)
     try:
         ticker_obj = yf.Ticker(canonical)
@@ -315,6 +335,10 @@ def get_fundamentals(
             ("Free Cash Flow", info.get("freeCashflow")),
         ]
 
+        is_stale_snapshot = is_historical_date(curr_date)
+        if is_stale_snapshot:
+            fields = [f for f in fields if f[0] in _POINT_IN_TIME_SAFE_FIELDS]
+
         lines = []
         for label, value in fields:
             if value is not None:
@@ -324,11 +348,16 @@ def get_fundamentals(
         # unknown symbols, so `info` is truthy but every field is empty. Treat
         # "no usable fields" as no data rather than emitting a bare header the
         # agent might fabricate around.
-        if not lines:
+        # An empty result under a historical date means we withheld the fields,
+        # not that the symbol is unknown — the note still has to reach the agent.
+        if not lines and not is_stale_snapshot:
             raise NoMarketDataError(ticker, canonical, "no fundamental fields returned")
 
         header = f"# Company Fundamentals for {canonical}\n"
-        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+        header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        if is_stale_snapshot:
+            header += _STALE_SNAPSHOT_NOTE.format(curr_date=curr_date)
+        header += "\n"
 
         return header + "\n".join(lines)
 


### PR DESCRIPTION
## Problem

`yfinance`'s `.info` and Alpha Vantage's `OVERVIEW` are **live quote snapshots**. Market cap, TTM ratios, the 52-week range and the 50/200-day averages always describe *today*, regardless of the date being analyzed.

The statement endpoints already guard against this (`filter_financials_by_date`, `_filter_reports_by_date`), but the snapshot path was missed — `y_finance.get_fundamentals` even documented its `curr_date` parameter as `"current date (not used for yfinance)"`.

So every backtest feeds the Fundamentals Analyst present-day data.

## Impact — observed, not theoretical

Running `propagate("BTC-USD", "2024-11-01")`:

| Agent | Source | 200-day average |
|---|---|---|
| Market Analyst | `get_indicators` → `close_200_sma` | **$63,385** (correct as of 2024-11-01) |
| Fundamentals Analyst | `.info` snapshot | **$72,810** (present-day value) |

The Bull argued price was 9.6% *above* its long-term trend; the Bear read the same asset as a death cross. The Research Manager then reported:

> *"200-day MA discrepancy: Bull cites $63,385; Bear cites $72,810 — this creates a fundamental disagreement on whether BTC is above or below its long-term trend line"*

...and the Portfolio Manager returned **Hold** on the grounds that the data was irreconcilable. The disagreement was entirely an artifact of the leak. The 52-week high ($126,198) and $1.31T market cap were likewise impossible values for November 2024.

This reproduced across three different models, so it is not model-specific.

## Fix

Withhold snapshot-derived fields when `curr_date` is in the past, keeping only descriptive identity fields (`Name`, `Sector`, `Industry`), and tell the agent where the as-of-date figures actually live:

```
# NOTE: 2024-11-01 is in the past and yfinance provides no point-in-time
# snapshot, so live-quote metrics (market cap, PE, 52-week range, 50/200-day
# averages) are omitted here to avoid look-ahead bias. Use
# get_income_statement / get_balance_sheet / get_cashflow for as-of-date
# financials, and get_indicators for as-of-date price statistics such as
# close_50_sma and close_200_sma.
```

- New `is_historical_date()` in `stockstats_utils.py`, alongside the existing `filter_financials_by_date`
- `y_finance.get_fundamentals` — filters fields; an empty result under a historical date no longer misreports as `NoMarketDataError`, since the data existed and was deliberately withheld
- `alpha_vantage_fundamentals` — `_strip_snapshot_fields` mirrors the shape of the existing `_filter_reports_by_date` (JSON-string in/out, non-JSON passes through). `Description` is excluded as well, since that prose is rewritten over time and can narrate events postdating `curr_date`

**Live usage is unchanged** — with `curr_date` unset or set to today, every field is returned exactly as before.

## Verification

After the fix, the same BTC-USD 2024-11-01 run contains **zero** occurrences of `72,810` / `126,198` / `$1.31T`. Both debaters reason from the single correct `close_200_sma = $63,385`, and the decision changes from the artifact-driven `Hold` to `Overweight`.

The Fundamentals Analyst handles the note gracefully — it reports that no usable statement data exists for BTC, points at `get_indicators`, and moves on.

## Test plan

- [x] `tests/test_fundamentals_snapshot_lookahead.py` — 12 cases covering both vendors: fields withheld on a historical date, fields preserved when live, the today/yesterday boundary, unparseable dates, non-JSON pass-through, `Description` exclusion, and the "everything withheld ≠ unknown symbol" case
- [x] Full suite: 587 passed. Two pre-existing failures in `test_ollama_base_url.py` are unrelated (CLI string assertions) and confirmed failing on unmodified `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
