### PR TITLE
feat(dataflows): add Newsflash deduplicated news-event vendor (keyless)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ NVIDIA_API_KEY=
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=
 
+# Newsflash (deduplicated news events with per-event corroboration/confidence:
+# https://newsflash.sh). Optional — keyless access works (~50 requests/day,
+# 24-hour lookback); a free key raises the rate limit and history depth for
+# backtests. Select it with data_vendors["news_data"] = "newsflash".
+#NEWSFLASH_API_KEY=
+
 # Optional: a custom OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp,
 # relay). Select provider "openai_compatible" and set the base URL; the key is
 # optional (local servers need none).

--- a/tests/test_newsflash.py
+++ b/tests/test_newsflash.py
@@ -1,0 +1,224 @@
+"""Newsflash deduplicated news-event vendor: confidence/corroboration
+formatting, look-ahead-safe date windows, tier-window disclosure, keyless auth,
+rate-limit typing, and router integration.
+
+All API access is mocked, so these run without a network connection.
+"""
+import os
+import unittest
+from unittest import mock
+
+import pytest
+
+from tradingagents.dataflows import interface, newsflash
+from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows.errors import VendorRateLimitError
+from tradingagents.dataflows.newsflash import NewsflashRateLimitError
+
+
+def _event(title, *, confidence, corroboration, sources, last_seen="2026-07-23T16:00:00.000Z"):
+    return {
+        "id": 1,
+        "canonical_title": title,
+        "summary": f"Summary of {title}",
+        "category": "tradfi",
+        "first_seen_at": "2026-07-23T08:00:00.000Z",
+        "last_seen_at": last_seen,
+        "sources": sources,
+        "corroboration": corroboration,
+        "confidence": confidence,
+    }
+
+
+# One corroborated event (2 outlets -> confidence 0.67) and one single-source
+# event (confidence 0.33) — the pair the confidence gate exists to distinguish.
+_PAYLOAD = {
+    "count": 2,
+    "events": [
+        _event("Fed signals rate cut", confidence=0.6667, corroboration=2,
+               sources=["reuters", "cnbc-finance"]),
+        _event("Unverified merger rumor", confidence=0.3333, corroboration=1,
+               sources=["some-blog"]),
+    ],
+}
+
+# A response whose history window was clamped by the tier gate (keyless test
+# tier: 24 hours). The note must reach the analyst so an empty backtest window
+# reads "clamped", not "no news".
+_CLAMPED_EMPTY = {
+    "count": 0,
+    "events": [],
+    "window": {
+        "from": "2026-07-22T00:00:00.000Z",
+        "note": "the test tier can query the last 24 hours",
+    },
+}
+
+
+@pytest.mark.unit
+class NewsflashFormatTests(unittest.TestCase):
+    def test_confidence_corroboration_and_sources_render(self):
+        with mock.patch.object(newsflash, "_request", return_value=_PAYLOAD):
+            out = newsflash.get_news("AAPL", "2026-07-16", "2026-07-23")
+        self.assertIn("Fed signals rate cut", out)
+        self.assertIn("confidence 0.67", out)
+        self.assertIn("2 sources: reuters, cnbc-finance", out)
+        self.assertIn("Date: 2026-07-23", out)
+
+    def test_corroborated_vs_single_source_labeling(self):
+        # The fake-news gate: >= 2 outlets reads "confirmed", 1 outlet is
+        # explicitly "unconfirmed" so the analyst can't take a rumor as fact.
+        with mock.patch.object(newsflash, "_request", return_value=_PAYLOAD):
+            out = newsflash.get_news("AAPL", "2026-07-16", "2026-07-23")
+        confirmed_line = next(ln for ln in out.splitlines() if "Fed signals" in ln)
+        rumor_line = next(ln for ln in out.splitlines() if "merger rumor" in ln)
+        self.assertIn("(confirmed", confirmed_line)
+        self.assertIn("(unconfirmed", rumor_line)
+        self.assertIn("1 source: some-blog", rumor_line)
+
+    def test_no_matches_reports_clearly(self):
+        with mock.patch.object(newsflash, "_request", return_value={"count": 0, "events": []}):
+            out = newsflash.get_news("OBSCURE", "2026-07-16", "2026-07-23")
+        self.assertIn("No news events found for OBSCURE", out)
+
+    def test_clamped_window_is_disclosed(self):
+        # Keyless tiers clamp history depth server-side; the disclosure must be
+        # surfaced (especially on empty results) so a backtest outside the tier
+        # window is reported as clamped rather than as "no news".
+        with mock.patch.object(newsflash, "_request", return_value=_CLAMPED_EMPTY):
+            out = newsflash.get_news("AAPL", "2025-01-01", "2025-01-07")
+        self.assertIn("No news events found", out)
+        self.assertIn("history window clamped", out)
+        self.assertIn("test tier can query the last 24 hours", out)
+
+
+@pytest.mark.unit
+class NewsflashWindowTests(unittest.TestCase):
+    def test_get_news_sends_lookahead_safe_bounds(self):
+        # The from/to bounds are the look-ahead guard: they must be passed
+        # through verbatim so the server never returns post-window events.
+        with mock.patch.object(newsflash, "_request", return_value=_PAYLOAD) as req:
+            newsflash.get_news("AAPL", "2026-07-16", "2026-07-23")
+        params = req.call_args.args[0]
+        self.assertEqual(params["from"], "2026-07-16")
+        # Inclusive of the whole end day (a bare date would be parsed as its
+        # midnight and drop the day, #1126), but nothing after it leaks.
+        self.assertEqual(params["to"], "2026-07-23T23:59:59.999Z")
+        self.assertEqual(params["q"], "AAPL")
+        self.assertEqual(params["semantic"], "1")  # meaning-based ticker match
+
+    def test_global_news_window_derived_from_lookback(self):
+        with mock.patch.object(newsflash, "_request", return_value=_PAYLOAD) as req:
+            newsflash.get_global_news("2026-07-23", look_back_days=7, limit=10)
+        params = req.call_args.args[0]
+        self.assertEqual(params["from"], "2026-07-16")
+        self.assertEqual(params["to"], "2026-07-23T23:59:59.999Z")
+        self.assertEqual(params["limit"], "10")
+        self.assertNotIn("q", params)  # keyword-less: latest events across categories
+
+    def test_global_news_defaults_come_from_config(self):
+        set_config({"global_news_lookback_days": 3, "global_news_article_limit": 5})
+        with mock.patch.object(newsflash, "_request", return_value=_PAYLOAD) as req:
+            newsflash.get_global_news("2026-07-23")
+        params = req.call_args.args[0]
+        self.assertEqual(params["from"], "2026-07-20")
+        self.assertEqual(params["limit"], "5")
+
+    def test_semantic_unavailable_degrades_to_keyword_match(self):
+        # Deployments without embeddings answer 503 for semantic=1; the vendor
+        # must retry as a plain keyword query instead of failing the call.
+        def fake_request(params):
+            if params.get("semantic"):
+                raise ValueError("Newsflash request failed (503): semantic search is not configured")
+            return _PAYLOAD
+
+        with mock.patch.object(newsflash, "_request", side_effect=fake_request) as req:
+            out = newsflash.get_news("AAPL", "2026-07-16", "2026-07-23")
+        self.assertIn("Fed signals rate cut", out)
+        self.assertNotIn("semantic", req.call_args.args[0])
+
+
+@pytest.mark.unit
+class NewsflashAuthTests(unittest.TestCase):
+    def _get(self, status=200, payload=None):
+        response = mock.Mock()
+        response.status_code = status
+        response.json.return_value = payload if payload is not None else _PAYLOAD
+        return response
+
+    def test_keyless_request_sends_no_auth_header(self):
+        with (
+            mock.patch.dict("os.environ"),
+            mock.patch.object(newsflash.requests, "get", return_value=self._get()) as get,
+        ):
+            os.environ.pop("NEWSFLASH_API_KEY", None)
+            newsflash._request({"q": "AAPL"})
+        self.assertEqual(get.call_args.kwargs["headers"], {})
+
+    def test_api_key_sent_as_bearer_token(self):
+        with (
+            mock.patch.dict("os.environ", {"NEWSFLASH_API_KEY": "nf_test_key"}),
+            mock.patch.object(newsflash.requests, "get", return_value=self._get()) as get,
+        ):
+            newsflash._request({"q": "AAPL"})
+        self.assertEqual(
+            get.call_args.kwargs["headers"], {"Authorization": "Bearer nf_test_key"}
+        )
+
+    def test_daily_limit_raises_typed_rate_limit_error(self):
+        # 429 must surface as a VendorRateLimitError so the router skips to the
+        # next configured vendor instead of aborting the run.
+        response = self._get(status=429, payload={"error": "daily limit reached (50 requests/day)"})
+        with (
+            mock.patch.object(newsflash.requests, "get", return_value=response),
+            self.assertRaises(NewsflashRateLimitError) as ctx,
+        ):
+            newsflash._request({"q": "AAPL"})
+        self.assertIsInstance(ctx.exception, VendorRateLimitError)
+        self.assertIn("daily limit reached", str(ctx.exception))
+
+    def test_api_error_body_is_surfaced(self):
+        response = self._get(status=400, payload={"error": "invalid category"})
+        with (
+            mock.patch.object(newsflash.requests, "get", return_value=response),
+            self.assertRaises(ValueError) as ctx,
+        ):
+            newsflash._request({"category": "bogus"})
+        self.assertIn("invalid category", str(ctx.exception))
+
+
+@pytest.mark.unit
+class NewsflashRoutingTests(unittest.TestCase):
+    def test_news_data_category_routes_to_newsflash(self):
+        set_config({"data_vendors": {"news_data": "newsflash"}})
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_news": {"newsflash": lambda *a, **k: "NEWSFLASH_OK"}},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-07-16", "2026-07-23")
+        self.assertEqual(out, "NEWSFLASH_OK")
+
+    def test_rate_limited_newsflash_falls_back_to_next_vendor(self):
+        # data_vendors="newsflash,yfinance": a 429 on the primary must roll over
+        # to the configured fallback, not abort the run.
+        def limited(*a, **k):
+            raise NewsflashRateLimitError("daily limit reached")
+
+        set_config({"data_vendors": {"news_data": "newsflash,yfinance"}})
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_news": {"newsflash": limited, "yfinance": lambda *a, **k: "YF_OK"}},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-07-16", "2026-07-23")
+        self.assertEqual(out, "YF_OK")
+
+    def test_both_news_methods_registered(self):
+        self.assertIn("newsflash", interface.VENDOR_METHODS["get_news"])
+        self.assertIn("newsflash", interface.VENDOR_METHODS["get_global_news"])
+        self.assertIn("newsflash", interface.VENDOR_LIST)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -18,6 +18,10 @@ from .errors import (
     VendorRateLimitError,
 )
 from .fred import get_macro_data as get_fred_macro_data
+from .newsflash import (
+    get_global_news as get_newsflash_global_news,
+    get_news as get_newsflash_news,
+)
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
@@ -82,6 +86,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "newsflash",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -124,10 +129,12 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "newsflash": get_newsflash_news,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "newsflash": get_newsflash_global_news,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,

--- a/tradingagents/dataflows/newsflash.py
+++ b/tradingagents/dataflows/newsflash.py
@@ -1,0 +1,244 @@
+"""Newsflash deduplicated news-event vendor.
+
+Fetches news as an *event graph* rather than raw articles: Newsflash
+(https://newsflash.sh) crawls many outlets, deduplicates coverage of one
+happening into a single event, and attaches a ``corroboration`` count (distinct
+outlets) plus a ``confidence`` score (``min(1, sources/3)``). That makes it a
+fake-news/rumor gate for the news analyst: a single-source item arrives at
+confidence 0.33 and is flagged as unconfirmed, while >= 0.67 means two or more
+independent outlets corroborate the story.
+
+Keyless access works out of the box (test tier, ~50 requests/day, 24-hour
+lookback). An optional free API key read from ``NEWSFLASH_API_KEY`` raises the
+rate limit and history depth (up to the full multi-year archive for backtests).
+History depth is tier-gated server-side; when a requested window is clamped the
+response discloses it in a ``window`` note, which is surfaced in the report so
+a backtest never silently mistakes "outside my tier's window" for "no news".
+
+Date filtering (``from``/``to``) is applied server-side, so a historical
+``end_date`` never leaks future events into a backtest window.
+"""
+import logging
+import os
+from datetime import datetime, timedelta
+
+import requests
+
+from .config import get_config
+from .errors import VendorRateLimitError
+
+logger = logging.getLogger(__name__)
+
+NEWSFLASH_BASE = "https://newsflash.sh"
+
+# Network timeout (seconds), consistent with the other vendors.
+REQUEST_TIMEOUT = 30
+
+# Categories understood by the API's ``category`` filter (informational; the
+# vendor queries across all of them and lets corroboration do the ranking).
+CATEGORIES = (
+    "crypto", "tradfi", "business", "tech", "politics",
+    "world", "science", "health", "energy", "sports",
+)
+
+# Events corroborated by at least this many outlets (confidence >= 0.67) are
+# labeled confirmed; below it they are flagged as single-source/unconfirmed.
+CONFIRMED_CONFIDENCE = 0.66
+
+
+class NewsflashRateLimitError(VendorRateLimitError):
+    """Raised when the Newsflash daily request limit is exceeded.
+
+    A VendorRateLimitError, so the routing layer skips to the next configured
+    vendor instead of aborting the run.
+    """
+
+
+def _request(params: dict) -> dict:
+    """GET /api/events, surfacing rate limits and API error bodies clearly.
+
+    No key is required (keyless test tier); when ``NEWSFLASH_API_KEY`` is set it
+    is sent as a bearer token to unlock higher limits and deeper history.
+    """
+    headers = {}
+    api_key = os.getenv("NEWSFLASH_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    response = requests.get(
+        f"{NEWSFLASH_BASE}/api/events",
+        params=params,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+    )
+
+    # The API reports problems as JSON {"error": ..., "hint": ...}; keep the
+    # body's message when we have one, it is more actionable than the status.
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("error", response.text)
+        except ValueError:
+            detail = response.text
+        if response.status_code == 429:
+            raise NewsflashRateLimitError(f"Newsflash rate limit exceeded: {detail}")
+        raise ValueError(f"Newsflash request failed ({response.status_code}): {detail}")
+
+    return response.json()
+
+
+def _search_events(params: dict) -> dict:
+    """Query events, preferring semantic (meaning-based) search for keywords.
+
+    ``semantic=1`` matches by embedding similarity, so a ticker or topic finds
+    events that never contain the literal string (e.g. "AAPL" -> Apple
+    stories). Deployments without embeddings answer 503 for semantic queries;
+    degrade to the plain keyword match rather than failing the call.
+    """
+    if not params.get("q"):
+        return _request(params)
+    try:
+        return _request({**params, "semantic": "1"})
+    except ValueError as e:
+        if "503" not in str(e):
+            raise
+        logger.warning("Newsflash semantic search unavailable; using keyword match: %s", e)
+        return _request(params)
+
+
+def _to_bound(end_date: str) -> str:
+    """Upper window bound: the whole of ``end_date``, nothing after it.
+
+    The API parses a bare ``yyyy-mm-dd`` as midnight UTC, which would silently
+    drop the end day itself. Pin the bound to the day's last instant so the
+    window is inclusive of ``end_date`` (matching the other news vendors'
+    convention, #1126) while remaining look-ahead safe for backtests.
+    """
+    return f"{end_date}T23:59:59.999Z"
+
+
+def _window_note(payload: dict) -> str:
+    """Render the API's history-clamp disclosure, if any.
+
+    Present whenever the tier window tightened the requested ``from`` bound —
+    without it a keyless backtest would read "no news" where the truth is
+    "outside the 24-hour test-tier window".
+    """
+    window = payload.get("window") or {}
+    note = window.get("note")
+    if not note:
+        return ""
+    clamped_from = (window.get("from") or "")[:10]
+    scope = f" to {clamped_from} onward" if clamped_from else ""
+    return f"\n_Note: history window clamped{scope} — {note}_\n"
+
+
+def _format_events(payload: dict, empty_message: str) -> str:
+    """Render events as markdown with per-event corroboration and confidence."""
+    events = payload.get("events") or []
+    if not events:
+        return empty_message + _window_note(payload)
+
+    lines = []
+    for event in events:
+        confidence = event.get("confidence") or 0.0
+        corroboration = event.get("corroboration") or 0
+        sources = ", ".join(event.get("sources") or [])
+        status = "confirmed" if confidence >= CONFIRMED_CONFIDENCE else "unconfirmed"
+        date = (event.get("last_seen_at") or "")[:10]
+        lines.append(
+            f"### {event.get('canonical_title')} "
+            f"({status}, confidence {confidence:.2f}, "
+            f"{corroboration} source{'s' if corroboration != 1 else ''}: {sources})"
+        )
+        if date:
+            lines.append(f"Date: {date}")
+        summary = event.get("summary")
+        if summary:
+            lines.append(summary)
+        lines.append("")
+
+    return "\n".join(lines) + _window_note(payload)
+
+
+def _report_header(title: str) -> str:
+    return (
+        f"## {title}\n"
+        f"Deduplicated news events from Newsflash: each item is one happening with a "
+        f"corroboration count and a confidence score (min(1, sources/3)). Treat events "
+        f"below confidence {CONFIRMED_CONFIDENCE} as single-source and unconfirmed — "
+        f"do not trade on them as established fact.\n\n"
+    )
+
+
+def get_news(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve deduplicated news events for a ticker/topic from Newsflash.
+
+    Args:
+        ticker: Ticker symbol or topic keyword(s); matched semantically, so a
+            symbol also finds company coverage that never spells it out.
+        start_date: Start date in yyyy-mm-dd format.
+        end_date: End date in yyyy-mm-dd format; applied server-side, so a
+            historical window never leaks future events (look-ahead safe).
+
+    Returns:
+        A markdown report of matching events, each with its corroboration
+        count, confidence score, and contributing outlets.
+    """
+    article_limit = get_config()["news_article_limit"]
+
+    payload = _search_events({
+        "q": ticker,
+        "from": start_date,
+        "to": _to_bound(end_date),
+        "limit": str(article_limit),
+    })
+
+    return _report_header(
+        f"{ticker} News (Newsflash), from {start_date} to {end_date}:"
+    ) + _format_events(
+        payload,
+        f"No news events found for {ticker} between {start_date} and {end_date}.",
+    )
+
+
+def get_global_news(
+    curr_date: str,
+    look_back_days: int | None = None,
+    limit: int | None = None,
+) -> str:
+    """Retrieve global/macro news events from Newsflash.
+
+    Args:
+        curr_date: Current date in yyyy-mm-dd format; the end of the window
+            (applied server-side, look-ahead safe).
+        look_back_days: Number of days to look back. ``None`` falls back to
+            ``global_news_lookback_days`` from the active config.
+        limit: Maximum number of events to return. ``None`` falls back to
+            ``global_news_article_limit`` from the active config.
+
+    Returns:
+        A markdown report of the latest events across all categories (crypto,
+        tradfi, business, tech, politics, world, science, health, energy,
+        sports), each with its corroboration count and confidence score.
+    """
+    config = get_config()
+    if look_back_days is None:
+        look_back_days = config["global_news_lookback_days"]
+    if limit is None:
+        limit = config["global_news_article_limit"]
+
+    curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    start_date = (curr_dt - timedelta(days=look_back_days)).strftime("%Y-%m-%d")
+
+    payload = _search_events({
+        "from": start_date,
+        "to": _to_bound(curr_date),
+        "limit": str(limit),
+    })
+
+    return _report_header(
+        f"Global News (Newsflash), from {start_date} to {curr_date}:"
+    ) + _format_events(
+        payload,
+        f"No global news events found between {start_date} and {curr_date}.",
+    )

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -134,7 +134,7 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, newsflash (keyless; deduped events with confidence scores)
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },


### PR DESCRIPTION
Adds [Newsflash](https://newsflash.sh) as a `news_data` vendor for `get_news` / `get_global_news`, alongside yfinance and Alpha Vantage.

**Why another news vendor:** existing vendors return raw articles. Newsflash serves an event graph — coverage of one happening is deduplicated into a single event carrying `corroboration` (distinct outlets) and `confidence = min(1, sources/3)`. That gives the news analyst a structural rumor gate: events at confidence ≥ 0.66 are corroborated by 2+ independent outlets; single-source items are explicitly labeled `unconfirmed` in the report so agents don't trade rumors as fact.

**Fits the v0.3 data-access contract:**
- `from`/`to` windows enforced server-side, end day inclusive per the existing half-open convention (#1126) — look-ahead safe for backtests.
- Tier-clamped history windows are disclosed in the report (the API's `window` note), so an empty backtest window reads "clamped", never a silent "no news".
- 429 raises a typed `NewsflashRateLimitError(VendorRateLimitError)` → router rolls over to the next configured vendor (e.g. `"newsflash,yfinance"`).
- No silent fallback, no new dependencies (uses `requests`), config comments and `.env.example` updated.

**Keyless testability:** no key or signup needed to review — `config["data_vendors"]["news_data"] = "newsflash"` works immediately (test tier, ~50 req/day, 24h lookback). An optional free `NEWSFLASH_API_KEY` raises limits and unlocks deeper history for backtests. Ticker queries use semantic search (`semantic=1`) so `AAPL` finds Apple coverage that never spells out the symbol, degrading to keyword match if unavailable.

**Tests:** `tests/test_newsflash.py` (15 tests, all mocked, mirrors `test_polymarket.py`) — formatting, confidence labeling, window bounds, clamp disclosure, auth headers, typed rate limit, router integration. Full suite passes (591); ruff clean.

Disclosure: I built Newsflash — happy to adjust naming, defaults, or scope to fit the project's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTSt4BDWJCsGjUyLCnbuj5