### PR TITLE
docs: add uv setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Install the package and its dependencies:
 pip install .
 ```
 
+Alternatively, use [uv](https://docs.astral.sh/uv/) to create the project
+environment and install TradingAgents in one step:
+
+```bash
+uv sync --python 3.12
+uv run tradingagents
+```
+
+`uv sync` creates `.venv` automatically. Use `uv run <command>` to run any
+project command without activating that environment, for example
+`uv run --extra dev python -m pytest` when working on the test suite.
+
 ### Docker
 
 Alternatively, run with Docker:


### PR DESCRIPTION
## Summary

- document `uv sync --python 3.12` as an alternative installation workflow
- show how to launch the installed CLI with `uv run tradingagents` without activating `.venv`
- document the `dev` extra required to run the test suite through uv

## Validation

- `uv run tradingagents --help`
- `uv run --extra dev python -m pytest` (`576 passed, 2 skipped`)
- `git diff --check upstream/main...HEAD`

Closes #970