### PR TITLE
Gap-decision bridge: decide.py entrypoint + external signal context (Refs luxeandliving/trading-workspace#37) (#1)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,12 +20,34 @@ name: Build & push image
 # entrypoint in a container (secret unset -- /decide would 403, but that's
 # not what's being checked) and hits /health for real over a published port,
 # same bar the earlier manual verification (local `uvicorn` + curl) used.
+#
+# Continuous build on push to main (unchanged) PLUS `workflow_call` (hermes#210)
+# so deploy.yml can build+push a specific release ref on demand -- same shape
+# as Hermes/options-signal-bot/news-gap-ml's own build-image.yml/deploy.yml
+# relationship. Release tag convention: TradingAgents_v{major}.{minor}.
+# {patch}.{YYYYMMDD}, matching Hermes' Hermes_v{...} shape.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: "Tag/branch to build (blank = this ref)"
+        required: false
+        type: string
+        default: ""
+    outputs:
+      image_tag:
+        description: "Resolved tag that was built & pushed to GHCR"
+        value: ${{ jobs.build-push.outputs.image_tag }}
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag/branch to build (blank = this ref)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -34,13 +56,22 @@ permissions:
 jobs:
   build-push:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Resolve tag
         id: tag
         run: |
-          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          REF="${{ inputs.ref }}"
+          if [ -n "$REF" ]; then
+            echo "sha=$REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
           # Docker/GHCR repository names must be all-lowercase --
           # github.repository preserves this repo's real casing
           # (luxeandliving/TradingAgents), which buildx rejects outright
@@ -78,7 +109,7 @@ jobs:
           exit 1
 
       - name: Login to GHCR
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -86,7 +117,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}   # packages:write — no PAT needed for the repo's own namespace
 
       - name: Push image (smoke check passed)
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,90 @@
+name: Build & push image
+
+# Builds the TradingAgents image and pushes it to GHCR
+# (ghcr.io/<owner>/TradingAgents), tagged by short commit SHA + latest --
+# same tag shape as hermes/options-signal-bot/news-gap-ml's own
+# build-image.yml, so deploy.sh can pin/roll back the same way.
+#
+# hermes#213: this image runs the decision HTTP service (scripts/service.py),
+# NOT the interactive `tradingagents` CLI the repo's existing Dockerfile
+# defaults to (ENTRYPOINT ["tradingagents"]) -- the compose deploy overrides
+# both entrypoint and command to run uvicorn instead. The Dockerfile itself
+# is untouched; it already installs the full package (including fastapi/
+# uvicorn, now core dependencies) and copies the whole source tree, so
+# scripts/service.py is present and importable either way.
+#
+# Trigger is push to main, plus pull_request so a broken Dockerfile is
+# caught before merge, not after (mirrors news-gap-ml's #201 posture).
+#
+# Smoke-tested INSIDE this workflow before push: boots the real service
+# entrypoint in a container (secret unset -- /decide would 403, but that's
+# not what's being checked) and hits /health for real over a published port,
+# same bar the earlier manual verification (local `uvicorn` + curl) used.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve tag
+        id: tag
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build image (not pushed yet)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          build-args: APP_VERSION=${{ steps.tag.outputs.sha }}
+          tags: tradingagents:smoke-${{ steps.tag.outputs.sha }}
+
+      - name: Smoke check (boot the real service, hit /health)
+        run: |
+          docker run -d --name ta-smoke -p 18100:8100 \
+            --entrypoint python \
+            tradingagents:smoke-${{ steps.tag.outputs.sha }} \
+            -m uvicorn scripts.service:app --host 0.0.0.0 --port 8100
+          for i in $(seq 1 15); do
+            if curl -sf http://127.0.0.1:18100/health >/dev/null; then
+              echo "health check passed"
+              docker logs ta-smoke
+              docker stop ta-smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error:: service never became healthy"
+          docker logs ta-smoke
+          docker stop ta-smoke
+          exit 1
+
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}   # packages:write — no PAT needed for the repo's own namespace
+
+      - name: Push image (smoke check passed)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          build-args: APP_VERSION=${{ steps.tag.outputs.sha }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.sha }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -39,7 +39,14 @@ jobs:
 
       - name: Resolve tag
         id: tag
-        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          # Docker/GHCR repository names must be all-lowercase --
+          # github.repository preserves this repo's real casing
+          # (luxeandliving/TradingAgents), which buildx rejects outright
+          # ("repository name must be lowercase") if used raw in a tag.
+          # Confirmed live: the first push attempt failed exactly this way.
+          echo "repo_lc=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Build image (not pushed yet)
         uses: docker/build-push-action@v7
@@ -86,5 +93,5 @@ jobs:
           push: true
           build-args: APP_VERSION=${{ steps.tag.outputs.sha }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.sha }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ steps.tag.outputs.repo_lc }}:${{ steps.tag.outputs.sha }}
+            ghcr.io/${{ steps.tag.outputs.repo_lc }}:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,171 @@
+name: Deploy
+
+# Release-triggered deploy (hermes#210), matching Hermes's own deploy.yml
+# pattern: resolve -> build -> deploy (pull + pin + health-check + auto-
+# rollback, rollback image verified rather than trusted on exit code alone --
+# same bug class as Hermes' incident #143).
+#
+# Unlike options-signal-bot/news-gap-ml (cron-invoked `run --rm`, hermes#210),
+# tradingagents-service is a PERSISTENT `docker compose up -d` service, same
+# deploy shape as Hermes itself -- health-checked via the container's own
+# Dockerfile HEALTHCHECK (TradingAgents#9), not an HTTP curl, since this
+# service publishes no host port (reachable only on the internal
+# hermes-internal network news-gap-ml also joins).
+#
+# scripts/deploy.sh (hermes repo) is UNCHANGED and still deploys this service
+# too as part of its own run -- same posture Hermes keeps both paths for
+# itself. Running both back-to-back is harmless (pull+up -d is idempotent);
+# just avoid overlapping runs (concurrency group below).
+#
+# No market-hours guard: a restart briefly interrupts news-gap-ml's ability
+# to call /decide (a few seconds, per the health-poll below), but a failed/
+# timed-out call there is already logged and swallowed by design (see
+# live_listener.py's own docstring) -- worst case is one missed decision
+# call, not a broken live position the way restarting Hermes' own process is.
+#
+# Release tag convention (matches Hermes' Hermes_v{major}.{minor}.{patch}.
+# {YYYYMMDD}, e.g. Hermes_v0.3.13.20260716): TradingAgents_v{major}.{minor}.
+# {patch}.{YYYYMMDD}.
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or branch to deploy (blank = the tag this runs on)"
+        required: false
+        default: ""
+
+concurrency:
+  group: production-deploy-tradingagents
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+    steps:
+      - name: Resolve deploy ref
+        id: ref
+        run: |
+          REF="${{ inputs.ref }}"
+          [ -z "$REF" ] && REF="${{ github.ref_name }}"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Deploying ref: $REF"
+
+  build:
+    needs: resolve
+    uses: ./.github/workflows/build-image.yml
+    with:
+      ref: ${{ needs.resolve.outputs.ref }}
+    secrets: inherit
+
+  deploy:
+    name: Deploy to production
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Deploy over SSH (pull + pin + health-check + verified auto-rollback)
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: root
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          command_timeout: 15m
+          script: |
+            set -euo pipefail
+            TRADINGAGENTS_DIR=/home/hermes/TradingAgents
+            APP_USER=hermes
+            REF="${{ needs.resolve.outputs.ref }}"
+            STATE_FILE="$TRADINGAGENTS_DIR/.last_good_version"
+            IMAGE="ghcr.io/luxeandliving/tradingagents"
+
+            dc() { sudo -u "$APP_USER" docker compose -f "$TRADINGAGENTS_DIR/docker-compose.yml" "$@"; }
+            set_app_version() {
+              # Same pinning pattern as Hermes's own deploy.yml (#145, incident
+              # #143's root cause) -- .env must hold an explicit immutable tag
+              # after every deploy attempt, never a transient shell var.
+              if sudo -u "$APP_USER" grep -q '^APP_VERSION=' "$TRADINGAGENTS_DIR/.env" 2>/dev/null; then
+                sudo -u "$APP_USER" sed -i "s|^APP_VERSION=.*|APP_VERSION=$1|" "$TRADINGAGENTS_DIR/.env"
+              else
+                echo "APP_VERSION=$1" | sudo -u "$APP_USER" tee -a "$TRADINGAGENTS_DIR/.env" > /dev/null
+              fi
+              echo "APP_VERSION pinned to: $1"
+            }
+            # Verify the image actually pulled for a given tag really is that
+            # tag, by reading its own baked-in APP_VERSION build-arg (hermes#210:
+            # closes the "silently redeployed :latest instead of the pinned
+            # rollback tag" gap -- same bug class as Hermes' incident #143).
+            verify_image_tag() {
+              local expect="$1"
+              local actual
+              actual=$(sudo -u "$APP_USER" docker inspect "$IMAGE:$expect" \
+                --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+                | grep '^APP_VERSION=' | cut -d= -f2 || echo "")
+              if [ "$actual" != "$expect" ]; then
+                echo "::warning::Image tag verification mismatch -- expected $expect, image reports APP_VERSION=$actual"
+                return 1
+              fi
+              echo "Image tag verified: $IMAGE:$expect (APP_VERSION=$actual)"
+            }
+            _healthy() {
+              status=$(sudo -u "$APP_USER" docker inspect --format '{{.State.Health.Status}}' \
+                "$(dc ps -q tradingagents-service)" 2>/dev/null || echo "unknown")
+              [ "$status" = "healthy" ]
+            }
+
+            cd "$TRADINGAGENTS_DIR"
+            if ! sudo -u "$APP_USER" grep -q '^TRADINGAGENTS_SERVICE_SECRET=' "$TRADINGAGENTS_DIR/.env" 2>/dev/null || \
+               [ -z "$(sudo -u "$APP_USER" grep '^TRADINGAGENTS_SERVICE_SECRET=' "$TRADINGAGENTS_DIR/.env" | cut -d= -f2-)" ]; then
+              echo "::error::TRADINGAGENTS_SERVICE_SECRET is missing/empty in $TRADINGAGENTS_DIR/.env — the service will fail closed on every request. Aborting."
+              exit 1
+            fi
+
+            PREV=$(sudo -u "$APP_USER" cat "$STATE_FILE" 2>/dev/null || echo "")
+            echo "Rollback point: ${PREV:-<none — first tracked deploy>}"
+
+            set_app_version "$REF"
+            dc pull tradingagents-service
+            verify_image_tag "$REF" || echo "::warning::Proceeding to health-check anyway -- the health check itself is the real gate."
+
+            echo "--- Starting tradingagents-service ..."
+            dc up -d tradingagents-service
+
+            echo "--- Waiting for tradingagents-service to report healthy ..."
+            HEALTHY=0
+            for i in $(seq 1 30); do
+              if _healthy; then HEALTHY=1; break; fi
+              sleep 2
+            done
+
+            if [ "$HEALTHY" = "1" ]; then
+              echo "tradingagents-service is healthy"
+              echo "$REF" | sudo -u "$APP_USER" tee "$STATE_FILE" > /dev/null
+              sudo -u "$APP_USER" bash -c "date -u +%Y%m%dT%H%M%SZ > '$TRADINGAGENTS_DIR/.last_deployed'"
+              echo "Deploy OK — $REF"
+            else
+              echo "::error::tradingagents-service never became healthy on $REF"
+              dc logs --tail=50 tradingagents-service 2>/dev/null | sed 's/^/    /' || true
+              if [ -n "$PREV" ]; then
+                echo "Rolling back to last known-good: $PREV"
+                set_app_version "$PREV"
+                dc pull tradingagents-service
+                verify_image_tag "$PREV"
+                dc up -d tradingagents-service
+                sleep 4
+                if _healthy; then
+                  echo "Rolled back — $PREV is healthy. Deploy of $REF FAILED but the service is intact."
+                else
+                  echo "::error::Restored image $PREV ALSO fails health check — TradingAgents service may be broken. Investigate immediately."
+                fi
+              else
+                echo "::error::No prior known-good tag to roll back to (first deploy?). tradingagents-service left on the failed image $REF — investigate immediately."
+              fi
+              exit 1
+            fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,16 @@ RUN pip install --no-cache-dir .
 
 FROM python:3.12-slim
 
+# hermes#213: deploy.sh's tag-pinning/rollback logic (shared with
+# scanner/news-gap-ml's own deploy blocks) resolves :latest's real version
+# by reading this baked-in env var back out via `docker inspect` -- without
+# it, NEW_TAG comes back empty and the deploy aborts right after the pull
+# (confirmed live: first deploy attempt failed exactly this way, this
+# Dockerfile never declared APP_VERSION before).
+ARG APP_VERSION=dev
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    APP_VERSION=$APP_VERSION
 
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,14 @@ WORKDIR /home/appuser/app
 
 COPY --from=builder --chown=appuser:appuser /build .
 
+# hermes#213: only meaningful for the tradingagents-service compose
+# override (entrypoint/command swapped to run uvicorn instead of the CLI
+# below) -- deploy.sh polls this status to know when the container is ready
+# to record as .last_good_version. Harmless no-op signal on the interactive
+# `tradingagents` CLI service (nothing listens on 8100 there; it just shows
+# "unhealthy", which nothing consumes).
+EXPOSE 8100
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8100/health', timeout=3)" || exit 1
+
 ENTRYPOINT ["tradingagents"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,27 @@ services:
     tty: true
     stdin_open: true
 
+  # Decision HTTP service (hermes#213) -- persistent `docker compose up -d`
+  # service, unlike the interactive `tradingagents` service above (tty/
+  # stdin_open, meant for `run -it`) or news-gap-ml/options-signal-bot's
+  # per-tick `run --rm` shape, since this must stay listening for requests.
+  # No `ports:` published to the host -- reachable only from other
+  # containers on the shared hermes-internal network (news-gap-ml joins the
+  # same network to call it by the `tradingagents-service` alias below).
+  # TRADINGAGENTS_SERVICE_SECRET is defense in depth on top of that network
+  # isolation, not a substitute for it.
+  tradingagents-service:
+    image: ghcr.io/luxeandliving/tradingagents:${APP_VERSION:-latest}
+    entrypoint: ["python"]
+    command: ["-m", "uvicorn", "scripts.service:app", "--host", "0.0.0.0", "--port", "8100"]
+    env_file:
+      - .env
+    restart: unless-stopped
+    networks:
+      hermes-internal:
+        aliases:
+          - tradingagents-service
+
   ollama:
     image: ollama/ollama:latest
     volumes:
@@ -34,3 +55,11 @@ services:
 volumes:
   tradingagents_data:
   ollama_data:
+
+networks:
+  # Created once on the droplet (deploy.sh, idempotent `docker network
+  # create`) so news-gap-ml's container can reach this service by name --
+  # not created here since docker compose would otherwise try to manage
+  # (and remove) a network another project also depends on.
+  hermes-internal:
+    external: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.3.81",
     "backtrader>=1.9.78.123",
+    "fastapi>=0.115.0",
     "langchain-anthropic>=0.3.15",
     "langchain-experimental>=0.3.4",
     "langchain-google-genai>=4.0.0",
@@ -30,6 +31,7 @@ dependencies = [
     "stockstats>=0.6.5",
     "tqdm>=4.67.1",
     "typing-extensions>=4.14.0",
+    "uvicorn>=0.30.0",
     "yfinance>=1.4.1",
 ]
 

--- a/run_scanner_retro.py
+++ b/run_scanner_retro.py
@@ -1,0 +1,68 @@
+import sys
+import os
+import truststore
+truststore.inject_into_ssl()  # patches ssl.create_default_context → used by httpx (LLM calls)
+
+from datetime import datetime
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+# yfinance 1.4.1 uses curl_cffi (its own libcurl TLS stack), not Python ssl.
+# Norton SSL inspection CA is not in libcurl's bundle → patch Session.__init__
+# so every session curl_cffi creates has verify=False baked in.
+try:
+    import curl_cffi.requests as _cffi_req
+    import urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    _orig_session_init = _cffi_req.Session.__init__
+    def _patched_session_init(self, *args, **kwargs):
+        kwargs.setdefault("verify", False)
+        _orig_session_init(self, *args, **kwargs)
+    _cffi_req.Session.__init__ = _patched_session_init
+    print("yfinance: curl_cffi Session patched with verify=False (Norton SSL workaround)")
+except Exception as e:
+    print(f"yfinance SSL patch failed: {e} — downloads may fail")
+
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+ENTRIES = [
+    ("NMDC.NS",       "2026-06-12"),
+    ("HINDUNILVR.NS", "2026-06-12"),
+    # M&M.NS skipped — TradingAgents path-safety regex blocks '&' character
+    ("COFORGE.NS",    "2026-06-12"),
+]
+
+RESULTS_FILE = "scanner_retro_results.md"
+
+config = DEFAULT_CONFIG.copy()
+config["max_debate_rounds"] = 1
+config["max_risk_discuss_rounds"] = 1
+
+results = []
+results.append(f"# Scanner Retroactive TradingAgents Run\n")
+results.append(f"**Run date:** {datetime.now().strftime('%Y-%m-%d %H:%M')}\n")
+results.append(f"**Entry date analysed:** 2026-06-12 (scanner picks)\n")
+results.append(f"**Note:** M&M.NS skipped — TradingAgents path-safety regex blocks '&' character\n\n---\n")
+
+for ticker, date in ENTRIES:
+    print(f"\n{'='*60}")
+    print(f"Running: {ticker} @ {date}")
+    print(f"{'='*60}")
+    sys.stdout.flush()
+
+    try:
+        ta = TradingAgentsGraph(debug=False, config=config)
+        _, decision = ta.propagate(ticker, date)
+        print(f"DECISION: {decision}")
+        results.append(f"\n## {ticker}\n**Decision:** {decision}\n")
+    except Exception as e:
+        err = f"ERROR: {e}"
+        print(err)
+        results.append(f"\n## {ticker}\n**Error:** {e}\n")
+
+    with open(RESULTS_FILE, "w", encoding="utf-8") as f:
+        f.write("\n".join(results))
+    print(f"Saved intermediate results to {RESULTS_FILE}")
+
+print("\nAll done.")

--- a/scanner_retro_results.md
+++ b/scanner_retro_results.md
@@ -1,0 +1,21 @@
+# Scanner Retroactive TradingAgents Run
+
+**Run date:** 2026-06-16 23:36
+
+**Entry date analysed:** 2026-06-12 (scanner picks)
+
+**Note:** M&M.NS skipped — TradingAgents path-safety regex blocks '&' character
+
+---
+
+
+## NMDC.NS
+**Error:** FRED_API_KEY environment variable is not set. Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html.
+
+
+## HINDUNILVR.NS
+**Error:** FRED_API_KEY environment variable is not set. Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html.
+
+
+## COFORGE.NS
+**Error:** FRED_API_KEY environment variable is not set. Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html.

--- a/scripts/decide.py
+++ b/scripts/decide.py
@@ -1,0 +1,185 @@
+"""Callable entrypoint for a single propagate() decision — the bridge news-gap-ml's
+live_listener.py subprocesses into once its OR-gate trigger fires (trading-workspace
+issue #18). Runs the full multi-agent graph for one ticker/date and prints exactly
+one line of JSON to stdout: the decision, nothing else. All progress/error output
+goes to stderr so a subprocess caller can parse stdout unconditionally.
+
+This makes a real, billed call to the configured LLM provider — it is not free and
+is not fast (propagate() chains several sequential LLM calls through the analyst/
+debate/risk graph). Do not call this in a tight loop.
+
+Ticker must include the exchange suffix TradingAgents expects (see README.md,
+e.g. "RELIANCE.NS" for NSE India, "WIPRO.NS", plain "NVDA" for US) — this script
+does not guess or normalize tickers.
+
+--context (trading-workspace#37, optional) carries a JSON blob of a prior
+technical signal from an external scanner (news-gap-ml's leg-3 trigger, which
+*is* options-signal-bot's own stock_decisions/decision_features row) — passed
+through to the market analyst as context to reason about, not ground truth to
+trust blindly. Only news-gap-ml's technical-trigger leg has anything to hand
+over here; news/global-shock triggers have no equivalent prior signal, so they
+call this script without --context, same as before.
+
+Usage:
+    python scripts/decide.py --ticker WIPRO.NS --date 2026-07-15
+    python scripts/decide.py --ticker NVDA --date 2026-07-15 --asset-type stock
+    python scripts/decide.py --ticker WIPRO.NS --date 2026-07-15 --context '{"side": "long", "score": 78.5, ...}'
+
+Output (stdout, single line):
+    {"ticker": "WIPRO.NS", "trade_date": "2026-07-15", "rating": "Buy",
+     "holding_recommendation": "Square Off Intraday",
+     "final_trade_decision": "...", "generated_at": "2026-07-15T09:03:11+00:00",
+     "cost_usd": 0.0412, "token_usage": {"claude-sonnet-4-6": {"input_tokens": 8000, ...}}}
+
+On failure: non-zero exit code, error detail on stderr, nothing on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+from langchain_core.callbacks import UsageMetadataCallbackHandler
+
+from tradingagents.agents.utils.rating import parse_holding_recommendation
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+# Indian tickers get much better news coverage from the indian_news vendor than
+# the yfinance-only default (see default_config.py's data_vendors comment) —
+# applied automatically so callers don't need to know this vendor detail.
+_INDIAN_SUFFIXES = (".NS", ".BO")
+
+# $ per 1M tokens (input, output) — trading-workspace issue #24. Keyed by the
+# model_name langchain reports in AIMessage.response_metadata, which can carry
+# a dated suffix (e.g. "claude-haiku-4-5-20251001") — _price_for() matches by
+# longest-prefix so both bare and dated IDs resolve. Update when the .env
+# TRADINGAGENTS_DEEP_THINK_LLM/QUICK_THINK_LLM models or their pricing change.
+_PRICING_PER_MTOK = {
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+    "claude-opus-4-8": (5.00, 25.00),
+    "claude-opus-4-7": (5.00, 25.00),
+}
+
+
+def _price_for(model_name: str) -> tuple:
+    """Longest-prefix match against _PRICING_PER_MTOK, or None if unknown."""
+    match = max(
+        (key for key in _PRICING_PER_MTOK if model_name.startswith(key)),
+        key=len, default=None,
+    )
+    return _PRICING_PER_MTOK[match] if match else None
+
+
+def _compute_cost(usage_metadata: dict) -> tuple[float, list]:
+    """Returns (total_usd, [model names with no pricing entry])."""
+    total = 0.0
+    unpriced = []
+    for model_name, usage in usage_metadata.items():
+        price = _price_for(model_name)
+        if price is None:
+            unpriced.append(model_name)
+            continue
+        price_in, price_out = price
+        total += usage.get("input_tokens", 0) / 1_000_000 * price_in
+        total += usage.get("output_tokens", 0) / 1_000_000 * price_out
+    return round(total, 4), unpriced
+
+
+def _build_config(ticker: str) -> dict:
+    config = DEFAULT_CONFIG.copy()
+    if ticker.upper().endswith(_INDIAN_SUFFIXES):
+        config["data_vendors"] = {
+            **config["data_vendors"],
+            "news_data": "indian_news,yfinance",
+        }
+    return config
+
+
+# Ordered (field, label) pairs surfaced from a --context payload, if present.
+# Field names match options-signal-bot's stock_decisions/decision_features
+# columns (trading-workspace#37) — not every field is always populated
+# (decision_features has no historical backfill), so missing ones are skipped.
+_CONTEXT_DETAIL_FIELDS = (
+    ("structure", "structure"), ("rsi14", "RSI14"), ("ema20", "EMA20"), ("ema50", "EMA50"),
+    ("atr14", "ATR14"), ("pullback_atr", "pullback (ATR)"),
+    ("entry_price", "entry"), ("stop_price", "stop"), ("target_price", "target"),
+)
+
+
+def _format_external_signal_context(raw_json: str) -> str:
+    """Turn a --context JSON blob into a natural-language passage for the
+    market analyst's prompt. Framed so the analyst reasons *about* the
+    scanner's finding rather than re-deriving it from scratch (the point of
+    #37) while still forming its own independent view (not "trust it
+    blindly" — the whole reason this graph has a debate/risk structure)."""
+    try:
+        signal = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        print(f"decide.py: --context was not valid JSON ({exc}), ignoring: {raw_json[:200]!r}", file=sys.stderr)
+        return ""
+
+    parts = [
+        f"A separate technical scanner already flagged this stock today "
+        f"({signal.get('side', 'unknown')} {signal.get('action', 'signal')}, "
+        f"score {signal.get('score', '?')}/100)."
+    ]
+    details = [f"{label}={signal[key]}" for key, label in _CONTEXT_DETAIL_FIELDS if signal.get(key) is not None]
+    if details:
+        parts.append("Scanner detail: " + ", ".join(details) + ".")
+    parts.append(
+        "Treat this as one input to weigh alongside your own independent analysis, "
+        "not as ground truth — verify or challenge it with your own tools rather than assuming it holds."
+    )
+    return " ".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--ticker", required=True, help='e.g. "WIPRO.NS", "RELIANCE.NS", "NVDA"')
+    parser.add_argument("--date", required=True, dest="trade_date", help="YYYY-MM-DD")
+    parser.add_argument("--asset-type", default="stock", choices=["stock", "crypto"])
+    parser.add_argument("--context", default=None, help="JSON blob of a prior technical signal (trading-workspace#37)")
+    args = parser.parse_args()
+
+    external_signal_context = _format_external_signal_context(args.context) if args.context else ""
+
+    usage_handler = UsageMetadataCallbackHandler()
+    try:
+        config = _build_config(args.ticker)
+        ta = TradingAgentsGraph(debug=False, config=config, callbacks=[usage_handler])
+        final_state, rating = ta.propagate(
+            args.ticker, args.trade_date, asset_type=args.asset_type,
+            external_signal_context=external_signal_context,
+        )
+        final_decision = final_state["final_trade_decision"]
+        holding_recommendation = parse_holding_recommendation(final_decision)
+    except Exception as exc:  # noqa: BLE001 — report cleanly on stderr, never on stdout
+        print(f"decide.py failed for {args.ticker} on {args.trade_date}: {exc}", file=sys.stderr)
+        return 1
+
+    cost_usd, unpriced_models = _compute_cost(usage_handler.usage_metadata)
+    if unpriced_models:
+        print(f"decide.py: no pricing entry for model(s) {unpriced_models} — cost_usd is a partial total", file=sys.stderr)
+    print(f"decide.py: ${cost_usd:.4f} for this call ({usage_handler.usage_metadata})", file=sys.stderr)
+
+    result = {
+        "ticker": args.ticker,
+        "trade_date": args.trade_date,
+        "asset_type": args.asset_type,
+        "rating": rating,
+        "holding_recommendation": holding_recommendation,
+        "final_trade_decision": final_decision,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "cost_usd": cost_usd,
+        "token_usage": usage_handler.usage_metadata,
+    }
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/decide.py
+++ b/scripts/decide.py
@@ -34,7 +34,12 @@ Output (stdout, single line):
     {"ticker": "WIPRO.NS", "trade_date": "2026-07-15", "rating": "Buy",
      "holding_recommendation": "Square Off Intraday",
      "final_trade_decision": "...", "generated_at": "2026-07-15T09:03:11+00:00",
-     "cost_usd": 0.0412, "token_usage": {"claude-sonnet-4-6": {"input_tokens": 8000, ...}}}
+     "cost_usd": 0.50, "token_usage": {"claude-sonnet-4-6": {"input_tokens": 8000, ...}}}
+    (TFR-215: cost_usd example updated to match the real observed average
+    ~$0.50/decision, not the original $0.0412 placeholder -- that number was
+    12x too low and was a real budgeting trap for anyone sizing MAX_TRIGGERS_
+    PER_POLL/day-cost ceilings off this docstring. See news-gap-ml's
+    live_listener.py (trading-workspace#86) for the measured figure.)
 
 On failure: non-zero exit code, error detail on stderr, nothing on stdout.
 """

--- a/scripts/decide.py
+++ b/scripts/decide.py
@@ -24,6 +24,11 @@ Usage:
     python scripts/decide.py --ticker WIPRO.NS --date 2026-07-15
     python scripts/decide.py --ticker NVDA --date 2026-07-15 --asset-type stock
     python scripts/decide.py --ticker WIPRO.NS --date 2026-07-15 --context '{"side": "long", "score": 78.5, ...}'
+    python scripts/decide.py --ticker CRUDEOILM --date 2026-07-15 --asset-type commodity
+        (trading-workspace#68 -- broker/MCX-style commodity names like
+        CRUDEOILM/GOLDM resolve to their global USD benchmark future, e.g.
+        CL=F/GC=F, via symbol_utils.py's alias table, same as XAUUSD/USOIL
+        already do for stock/crypto)
 
 Output (stdout, single line):
     {"ticker": "WIPRO.NS", "trade_date": "2026-07-15", "rating": "Buy",
@@ -182,7 +187,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--ticker", required=True, help='e.g. "WIPRO.NS", "RELIANCE.NS", "NVDA"')
     parser.add_argument("--date", required=True, dest="trade_date", help="YYYY-MM-DD")
-    parser.add_argument("--asset-type", default="stock", choices=["stock", "crypto"])
+    parser.add_argument("--asset-type", default="stock", choices=["stock", "crypto", "commodity"])
     parser.add_argument("--context", default=None, help="JSON blob of a prior technical signal (trading-workspace#37)")
     args = parser.parse_args()
 

--- a/scripts/decide.py
+++ b/scripts/decide.py
@@ -137,6 +137,47 @@ def _format_external_signal_context(raw_json: str) -> str:
     return " ".join(parts)
 
 
+def run_decision(ticker: str, trade_date: str, asset_type: str = "stock", context: str | None = None) -> dict:
+    """Run one propagate() decision and return the result dict (hermes#213).
+
+    Extracted from main() so both the CLI below and scripts/service.py's
+    HTTP endpoint share one implementation of the actual decision-making
+    call -- only the transport (argv/stdout vs. HTTP request/response)
+    differs between callers.
+
+    Raises on failure; callers decide how to report it (the CLI prints to
+    stderr and exits 1, the HTTP service returns a 500 with the exception
+    detail).
+    """
+    external_signal_context = _format_external_signal_context(context) if context else ""
+
+    usage_handler = UsageMetadataCallbackHandler()
+    config = _build_config(ticker)
+    ta = TradingAgentsGraph(debug=False, config=config, callbacks=[usage_handler])
+    final_state, rating = ta.propagate(
+        ticker, trade_date, asset_type=asset_type,
+        external_signal_context=external_signal_context,
+    )
+    final_decision = final_state["final_trade_decision"]
+    holding_recommendation = parse_holding_recommendation(final_decision)
+
+    cost_usd, unpriced_models = _compute_cost(usage_handler.usage_metadata)
+    if unpriced_models:
+        print(f"decide.py: no pricing entry for model(s) {unpriced_models} — cost_usd is a partial total", file=sys.stderr)
+
+    return {
+        "ticker": ticker,
+        "trade_date": trade_date,
+        "asset_type": asset_type,
+        "rating": rating,
+        "holding_recommendation": holding_recommendation,
+        "final_trade_decision": final_decision,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "cost_usd": cost_usd,
+        "token_usage": usage_handler.usage_metadata,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--ticker", required=True, help='e.g. "WIPRO.NS", "RELIANCE.NS", "NVDA"')
@@ -145,38 +186,13 @@ def main() -> int:
     parser.add_argument("--context", default=None, help="JSON blob of a prior technical signal (trading-workspace#37)")
     args = parser.parse_args()
 
-    external_signal_context = _format_external_signal_context(args.context) if args.context else ""
-
-    usage_handler = UsageMetadataCallbackHandler()
     try:
-        config = _build_config(args.ticker)
-        ta = TradingAgentsGraph(debug=False, config=config, callbacks=[usage_handler])
-        final_state, rating = ta.propagate(
-            args.ticker, args.trade_date, asset_type=args.asset_type,
-            external_signal_context=external_signal_context,
-        )
-        final_decision = final_state["final_trade_decision"]
-        holding_recommendation = parse_holding_recommendation(final_decision)
+        result = run_decision(args.ticker, args.trade_date, args.asset_type, args.context)
     except Exception as exc:  # noqa: BLE001 — report cleanly on stderr, never on stdout
         print(f"decide.py failed for {args.ticker} on {args.trade_date}: {exc}", file=sys.stderr)
         return 1
 
-    cost_usd, unpriced_models = _compute_cost(usage_handler.usage_metadata)
-    if unpriced_models:
-        print(f"decide.py: no pricing entry for model(s) {unpriced_models} — cost_usd is a partial total", file=sys.stderr)
-    print(f"decide.py: ${cost_usd:.4f} for this call ({usage_handler.usage_metadata})", file=sys.stderr)
-
-    result = {
-        "ticker": args.ticker,
-        "trade_date": args.trade_date,
-        "asset_type": args.asset_type,
-        "rating": rating,
-        "holding_recommendation": holding_recommendation,
-        "final_trade_decision": final_decision,
-        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "cost_usd": cost_usd,
-        "token_usage": usage_handler.usage_metadata,
-    }
+    print(f"decide.py: ${result['cost_usd']:.4f} for this call ({result['token_usage']})", file=sys.stderr)
     print(json.dumps(result))
     return 0
 

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -61,8 +61,9 @@ def check_auth(authorization: str | None) -> None:
 
 @app.get("/health")
 def health() -> dict:
-    """No auth -- used for the deploy smoke check, carries no sensitive data."""
-    return {"status": "ok"}
+    """No auth -- used for the deploy smoke check and hermes#218's cross-service
+    health page, carries no sensitive data."""
+    return {"status": "ok", "version": os.getenv("APP_VERSION", "dev")}
 
 
 @app.post("/decide")

--- a/scripts/service.py
+++ b/scripts/service.py
@@ -1,0 +1,77 @@
+"""HTTP service wrapper around decide.py's run_decision() (hermes#213).
+
+news-gap-ml's containerized cron can no longer subprocess into this venv
+directly -- container filesystem isolation breaks the sibling-directory
+assumption call_tradingagents_decision() relied on (TRADINGAGENTS_DIR
+resolves to a path that doesn't exist inside the container). This exposes
+the same decision-making contract over a local HTTP endpoint instead: both
+processes run on the same droplet, so this is a loopback call, not a real
+network boundary crossing.
+
+Auth: a single shared secret (TRADINGAGENTS_SERVICE_SECRET), same
+fail-closed / constant-time-compare posture as MOTILAL_WEBHOOK_SECRET
+elsewhere in this workspace -- internal-only, both sides on the same box.
+Sent as a Bearer token rather than embedded in the JSON body, since
+(unlike the TradingView-originated broker webhooks that pattern comes
+from) this isn't a third-party source whose request shape we don't
+control.
+
+Run with: uvicorn scripts.service:app --host 127.0.0.1 --port 8100
+(loopback-only -- this must never be exposed off the box, the shared
+secret is not a substitute for network isolation).
+"""
+from __future__ import annotations
+
+import hmac
+import os
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+# scripts/ has no __init__.py (it's a collection of standalone entrypoints,
+# not a package) -- add it to sys.path so `from decide import run_decision`
+# resolves the same way running decide.py directly would.
+sys.path.insert(0, str(Path(__file__).parent))
+from decide import run_decision  # noqa: E402
+
+_SERVICE_SECRET = os.getenv("TRADINGAGENTS_SERVICE_SECRET", "")
+
+app = FastAPI(title="TradingAgents decision service")
+
+
+class DecisionRequest(BaseModel):
+    ticker: str
+    trade_date: str
+    asset_type: str = "stock"
+    context: str | None = None
+
+
+def check_auth(authorization: str | None) -> None:
+    """Fail closed: an unconfigured secret rejects every request rather
+    than skipping validation entirely, same posture as hermes'
+    _validate_webhook() (#144) -- an unset secret must never mean
+    "unauthenticated," it must mean "nothing gets in."
+    """
+    token = (authorization or "").removeprefix("Bearer ").strip()
+    if not _SERVICE_SECRET or not hmac.compare_digest(token, _SERVICE_SECRET):
+        raise HTTPException(status_code=403, detail="invalid or missing service secret")
+
+
+@app.get("/health")
+def health() -> dict:
+    """No auth -- used for the deploy smoke check, carries no sensitive data."""
+    return {"status": "ok"}
+
+
+@app.post("/decide")
+def decide(req: DecisionRequest, authorization: str | None = Header(default=None)) -> dict:
+    check_auth(authorization)
+    try:
+        return run_decision(req.ticker, req.trade_date, req.asset_type, req.context)
+    except Exception as exc:  # noqa: BLE001 -- surface as a clean 500, same info decide.py puts on stderr
+        raise HTTPException(
+            status_code=500,
+            detail=f"decide.py failed for {req.ticker} on {req.trade_date}: {exc}",
+        ) from exc

--- a/scripts/smoke_structured_output.py
+++ b/scripts/smoke_structured_output.py
@@ -152,7 +152,7 @@ def main() -> int:
     checks = [
         ("Research Manager", investment_plan, ["**Recommendation**:"]),
         ("Trader",           trader_plan,     ["**Action**:", "FINAL TRANSACTION PROPOSAL:"]),
-        ("Portfolio Manager", final_decision, ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:"]),
+        ("Portfolio Manager", final_decision, ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:", "**Holding Recommendation**:", "**Holding Rationale**:"]),
     ]
     print("\n" + "=" * 70 + "\nStructure checks\n" + "=" * 70)
     failures = 0

--- a/tests/test_decide_service.py
+++ b/tests/test_decide_service.py
@@ -1,0 +1,157 @@
+"""Tests for the TradingAgents HTTP decision service (hermes#213) --
+scripts/service.py, and decide.py's run_decision() extraction that both the
+CLI and the service share.
+
+Context: news-gap-ml's containerized cron can no longer subprocess into this
+venv directly (container filesystem isolation broke the sibling-directory
+assumption -- every triggered decision silently failed from the 2026-07-15/16
+container cutover onward). This service is the fix: news-gap-ml reaches
+TradingAgents over a loopback HTTP call instead.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _load_module(name: str, filename: str):
+    """scripts/ isn't a package (no __init__.py) -- load a script module
+    directly by path, same pattern test_external_signal_context.py already
+    uses for decide.py."""
+    path = Path(__file__).parent.parent / "scripts" / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def service():
+    return _load_module("tradingagents_service_under_test", "service.py")
+
+
+@pytest.fixture
+def client(service):
+    return TestClient(service.app)
+
+
+@pytest.mark.unit
+class TestRunDecisionExtraction:
+    """run_decision() must behave identically to decide.py's old inline
+    main() body -- this is a pure extract-function refactor."""
+
+    def test_run_decision_returns_expected_shape(self):
+        decide = _load_module("tradingagents_decide_under_test", "decide.py")
+        fake_final_state = {"final_trade_decision": "FINAL TRANSACTION PROPOSAL: **BUY**"}
+        with patch.object(decide, "TradingAgentsGraph") as MockGraph:
+            MockGraph.return_value.propagate.return_value = (fake_final_state, "Buy")
+            result = decide.run_decision("WIPRO.NS", "2026-07-16")
+
+        assert result["ticker"] == "WIPRO.NS"
+        assert result["trade_date"] == "2026-07-16"
+        assert result["asset_type"] == "stock"
+        assert result["rating"] == "Buy"
+        assert result["final_trade_decision"] == fake_final_state["final_trade_decision"]
+        assert "generated_at" in result
+        assert "cost_usd" in result
+        assert "token_usage" in result
+
+    def test_run_decision_raises_on_failure(self):
+        """CLI catches this and exits 1; the service catches it and returns 500."""
+        decide = _load_module("tradingagents_decide_under_test", "decide.py")
+        with patch.object(decide, "TradingAgentsGraph") as MockGraph:
+            MockGraph.return_value.propagate.side_effect = RuntimeError("LLM provider timeout")
+            with pytest.raises(RuntimeError, match="LLM provider timeout"):
+                decide.run_decision("WIPRO.NS", "2026-07-16")
+
+
+@pytest.mark.unit
+class TestServiceAuth:
+    def test_health_requires_no_auth(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_decide_rejects_missing_auth_header(self, client, service):
+        service._SERVICE_SECRET = "real-secret"
+        resp = client.post("/decide", json={"ticker": "WIPRO.NS", "trade_date": "2026-07-16"})
+        assert resp.status_code == 403
+
+    def test_decide_rejects_wrong_secret(self, client, service):
+        service._SERVICE_SECRET = "real-secret"
+        resp = client.post(
+            "/decide", json={"ticker": "WIPRO.NS", "trade_date": "2026-07-16"},
+            headers={"Authorization": "Bearer wrong-secret"},
+        )
+        assert resp.status_code == 403
+
+    def test_decide_fails_closed_when_secret_unconfigured(self, client, service):
+        """An unset TRADINGAGENTS_SERVICE_SECRET must reject every request --
+        never silently skip auth (same posture as hermes' _validate_webhook,
+        issue #144)."""
+        service._SERVICE_SECRET = ""
+        resp = client.post(
+            "/decide", json={"ticker": "WIPRO.NS", "trade_date": "2026-07-16"},
+            headers={"Authorization": "Bearer anything"},
+        )
+        assert resp.status_code == 403
+
+    def test_decide_accepts_correct_secret(self, client, service):
+        service._SERVICE_SECRET = "real-secret"
+        with patch.object(service, "run_decision", return_value={"rating": "Hold"}):
+            resp = client.post(
+                "/decide", json={"ticker": "WIPRO.NS", "trade_date": "2026-07-16"},
+                headers={"Authorization": "Bearer real-secret"},
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"rating": "Hold"}
+
+
+@pytest.mark.unit
+class TestServiceDecideEndpoint:
+    def test_decide_passes_request_fields_through(self, client, service):
+        service._SERVICE_SECRET = "s"
+        with patch.object(service, "run_decision", return_value={"rating": "Sell"}) as mock_run:
+            client.post(
+                "/decide",
+                json={
+                    "ticker": "WIPRO.NS", "trade_date": "2026-07-16",
+                    "asset_type": "stock", "context": '{"side": "short"}',
+                },
+                headers={"Authorization": "Bearer s"},
+            )
+        mock_run.assert_called_once_with("WIPRO.NS", "2026-07-16", "stock", '{"side": "short"}')
+
+    def test_decide_defaults_asset_type_and_context(self, client, service):
+        service._SERVICE_SECRET = "s"
+        with patch.object(service, "run_decision", return_value={"rating": "Hold"}) as mock_run:
+            client.post(
+                "/decide", json={"ticker": "NVDA", "trade_date": "2026-07-16"},
+                headers={"Authorization": "Bearer s"},
+            )
+        mock_run.assert_called_once_with("NVDA", "2026-07-16", "stock", None)
+
+    def test_decide_surfaces_failure_as_500(self, client, service):
+        service._SERVICE_SECRET = "s"
+        with patch.object(service, "run_decision", side_effect=RuntimeError("LLM provider timeout")):
+            resp = client.post(
+                "/decide", json={"ticker": "WIPRO.NS", "trade_date": "2026-07-16"},
+                headers={"Authorization": "Bearer s"},
+            )
+        assert resp.status_code == 500
+        assert "LLM provider timeout" in resp.json()["detail"]
+
+    def test_decide_missing_required_field_is_422(self, client, service):
+        service._SERVICE_SECRET = "s"
+        resp = client.post(
+            "/decide", json={"ticker": "WIPRO.NS"},  # missing trade_date
+            headers={"Authorization": "Bearer s"},
+        )
+        assert resp.status_code == 422

--- a/tests/test_decide_service.py
+++ b/tests/test_decide_service.py
@@ -77,7 +77,19 @@ class TestServiceAuth:
     def test_health_requires_no_auth(self, client):
         resp = client.get("/health")
         assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
+        assert resp.json()["status"] == "ok"
+
+    def test_health_reports_deployed_version(self, client, monkeypatch):
+        """hermes#218's cross-service health page reads this -- baked in via
+        the Dockerfile's ARG/ENV APP_VERSION, defaults to 'dev' locally."""
+        monkeypatch.setenv("APP_VERSION", "d94b57c")
+        resp = client.get("/health")
+        assert resp.json()["version"] == "d94b57c"
+
+    def test_health_version_defaults_to_dev_when_unset(self, client, monkeypatch):
+        monkeypatch.delenv("APP_VERSION", raising=False)
+        resp = client.get("/health")
+        assert resp.json()["version"] == "dev"
 
     def test_decide_rejects_missing_auth_header(self, client, service):
         service._SERVICE_SECRET = "real-secret"

--- a/tests/test_external_signal_context.py
+++ b/tests/test_external_signal_context.py
@@ -1,0 +1,93 @@
+"""Tests for the external-scanner signal context (trading-workspace#37) —
+news-gap-ml's leg-3 (technical) trigger hands its own scanner's finding to
+TradingAgents' market analyst as context to reason about, not ground truth."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import pytest
+
+from tradingagents.agents.utils.agent_utils import get_external_signal_context_from_state
+from tradingagents.graph.propagation import Propagator
+
+
+def _load_decide_module():
+    """scripts/decide.py isn't a package module (no scripts/__init__.py) —
+    load it directly by path, same as running it as a script would."""
+    path = Path(__file__).parent.parent / "scripts" / "decide.py"
+    spec = importlib.util.spec_from_file_location("decide", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["decide"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+class GetExternalSignalContextFromStateTests(unittest.TestCase):
+    def test_absent_key_returns_empty(self):
+        self.assertEqual(get_external_signal_context_from_state({}), "")
+
+    def test_blank_string_returns_empty(self):
+        self.assertEqual(get_external_signal_context_from_state({"external_signal_context": "   "}), "")
+
+    def test_non_string_returns_empty(self):
+        self.assertEqual(get_external_signal_context_from_state({"external_signal_context": None}), "")
+
+    def test_present_value_is_returned(self):
+        state = {"external_signal_context": "A separate technical scanner already flagged this stock today."}
+        self.assertEqual(get_external_signal_context_from_state(state), state["external_signal_context"])
+
+
+@pytest.mark.unit
+class CreateInitialStateExternalSignalContextTests(unittest.TestCase):
+    def test_defaults_to_empty(self):
+        state = Propagator().create_initial_state("WIPRO.NS", "2026-07-15")
+        self.assertEqual(state["external_signal_context"], "")
+
+    def test_passed_value_threads_through(self):
+        state = Propagator().create_initial_state(
+            "WIPRO.NS", "2026-07-15", external_signal_context="scanner says long, score 78.5",
+        )
+        self.assertEqual(state["external_signal_context"], "scanner says long, score 78.5")
+
+
+@pytest.mark.unit
+class FormatExternalSignalContextTests(unittest.TestCase):
+    def setUp(self):
+        self.decide = _load_decide_module()
+
+    def test_full_payload_includes_all_present_fields(self):
+        raw = (
+            '{"side": "long", "action": "entry", "score": 78.5, "structure": "uptrend", '
+            '"rsi14": 62.3, "ema20": 121.5, "ema50": 118.2, "atr14": 3.1, '
+            '"entry_price": 123.4, "stop_price": 120.0, "target_price": 130.0}'
+        )
+        result = self.decide._format_external_signal_context(raw)
+        self.assertIn("long entry", result)
+        self.assertIn("score 78.5/100", result)
+        self.assertIn("structure=uptrend", result)
+        self.assertIn("RSI14=62.3", result)
+        self.assertIn("entry=123.4", result)
+        self.assertIn("stop=120.0", result)
+        self.assertIn("target=130.0", result)
+        self.assertIn("not as ground truth", result)
+
+    def test_missing_optional_fields_are_skipped_not_blank(self):
+        result = self.decide._format_external_signal_context('{"side": "short", "action": "entry", "score": 40}')
+        self.assertIn("short entry", result)
+        self.assertNotIn("RSI14=", result)
+        self.assertNotIn("Scanner detail:", result)  # no detail fields present at all
+
+    def test_invalid_json_returns_empty_string_not_raise(self):
+        result = self.decide._format_external_signal_context("not json")
+        self.assertEqual(result, "")
+
+    def test_empty_dict_still_produces_a_framing_sentence(self):
+        result = self.decide._format_external_signal_context("{}")
+        self.assertIn("A separate technical scanner already flagged this stock today", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_indian_news.py
+++ b/tests/test_indian_news.py
@@ -1,0 +1,89 @@
+"""Indian news vendor (ET Markets + Google News RSS): merge, dedup, and
+look-ahead-safe date filtering, mirroring the yfinance news vendor's contract
+(tests/test_news_lookahead.py) but for the India-scoped source.
+"""
+from datetime import datetime
+
+import pytest
+
+import tradingagents.dataflows.indian_news as inews
+
+
+def _article(title, pub_date=None, publisher="P", link="l"):
+    return {"title": title, "publisher": publisher, "link": link, "pub_date": pub_date}
+
+
+@pytest.mark.unit
+def test_strip_exchange_suffix():
+    assert inews._strip_exchange_suffix("NBCC.NS") == "NBCC"
+    assert inews._strip_exchange_suffix("NBCC.BO") == "NBCC"
+    assert inews._strip_exchange_suffix("NBCC") == "NBCC"
+
+
+@pytest.mark.unit
+def test_ticker_news_merges_et_and_google_and_dedupes(monkeypatch):
+    in_window = datetime(2026, 6, 15)
+    et_articles = [
+        _article("NBCC wins order worth Rs 800 crore", in_window, publisher="ET"),
+        _article("SHARED HEADLINE", in_window, publisher="ET"),
+    ]
+    google_articles = [
+        _article("SHARED HEADLINE", in_window, publisher="Moneycontrol"),
+        _article("NBCC share price target raised", in_window, publisher="CNBC"),
+    ]
+    monkeypatch.setattr(inews, "_fetch_et_markets", lambda limit: et_articles)
+    monkeypatch.setattr(inews, "_fetch_google_news", lambda query, limit: google_articles)
+
+    out = inews.get_news_india("NBCC.NS", "2026-06-01", "2026-06-30")
+    assert "NBCC wins order worth Rs 800 crore" in out
+    assert "NBCC share price target raised" in out
+    # deduped: the shared headline appears once, keeping the first (ET) source
+    assert out.count("SHARED HEADLINE") == 1
+    assert "(source: ET)" in out
+
+
+@pytest.mark.unit
+def test_ticker_news_no_articles_at_all(monkeypatch):
+    monkeypatch.setattr(inews, "_fetch_et_markets", lambda limit: [])
+    monkeypatch.setattr(inews, "_fetch_google_news", lambda query, limit: [])
+    out = inews.get_news_india("NBCC", "2026-06-01", "2026-06-30")
+    assert out == "No news found for NBCC"
+
+
+@pytest.mark.unit
+def test_ticker_news_all_outside_window_is_informative(monkeypatch):
+    outside = datetime(2020, 1, 1)
+    monkeypatch.setattr(inews, "_fetch_et_markets", lambda limit: [_article("NBCC OLD NEWS", outside)])
+    monkeypatch.setattr(inews, "_fetch_google_news", lambda query, limit: [])
+    out = inews.get_news_india("NBCC", "2026-06-01", "2026-06-30")
+    assert "No news found for NBCC between 2026-06-01 and 2026-06-30" in out
+    assert "###" not in out
+
+
+@pytest.mark.unit
+def test_global_news_prefers_et_then_tops_up_google(monkeypatch):
+    curr = "2026-07-10"
+    et_articles = [_article(f"ET {i}", datetime(2026, 7, 9)) for i in range(2)]
+    monkeypatch.setattr(inews, "_fetch_et_markets", lambda limit: et_articles)
+    monkeypatch.setattr(inews, "_fetch_google_news", lambda query, limit: [_article("GOOGLE TOPUP", datetime(2026, 7, 9))])
+
+    out = inews.get_global_news_india(curr, look_back_days=7, limit=3)
+    assert "ET 0" in out and "ET 1" in out
+    assert "GOOGLE TOPUP" in out
+
+
+@pytest.mark.unit
+def test_global_news_empty_is_informative(monkeypatch):
+    monkeypatch.setattr(inews, "_fetch_et_markets", lambda limit: [])
+    monkeypatch.setattr(inews, "_fetch_google_news", lambda query, limit: [])
+    out = inews.get_global_news_india("2026-07-10", look_back_days=7, limit=5)
+    assert out == "No global news found for 2026-07-10"
+
+
+@pytest.mark.unit
+def test_ticker_news_fetch_error_is_reported_not_raised(monkeypatch):
+    def boom(limit):
+        raise RuntimeError("network down")
+    monkeypatch.setattr(inews, "_fetch_et_markets", boom)
+    out = inews.get_news_india("NBCC", "2026-06-01", "2026-06-30")
+    assert "Error fetching news for NBCC" in out

--- a/tests/test_instrument_identity.py
+++ b/tests/test_instrument_identity.py
@@ -95,6 +95,22 @@ class BuildInstrumentContextTests(unittest.TestCase):
         self.assertIn("Name: Bitcoin USD", context)
         self.assertIn("crypto asset rather than a company", context)
 
+    def test_commodity_uses_commodity_label_and_keeps_hint(self):
+        """trading-workspace#68 -- CRUDEOILM/GOLDM (MCX mini-contract names)
+        resolve to a global benchmark future (CL=F/GC=F) upstream via
+        symbol_utils.py; the raw ticker passed here is whatever the caller
+        used (e.g. the MCX name), same as XAUUSD/GOLD already work for stock."""
+        context = build_instrument_context("CRUDEOILM", "commodity")
+        self.assertIn("commodity to analyze is `CRUDEOILM`", context)
+        self.assertIn("commodity futures contract rather than a company", context)
+        self.assertIn("supply/demand", context)
+
+    def test_commodity_with_resolved_identity_uses_name_label(self):
+        context = build_instrument_context(
+            "GC=F", "commodity", {"company_name": "Gold Futures"}
+        )
+        self.assertIn("Name: Gold Futures", context)
+
 
 @pytest.mark.unit
 class GetInstrumentContextFromStateTests(unittest.TestCase):
@@ -116,6 +132,12 @@ class GetInstrumentContextFromStateTests(unittest.TestCase):
             {"company_of_interest": "BTC-USD", "asset_type": "crypto"}
         )
         self.assertIn("crypto asset", context)
+
+    def test_fallback_respects_commodity_asset_type(self):
+        context = get_instrument_context_from_state(
+            {"company_of_interest": "CRUDEOILM", "asset_type": "commodity"}
+        )
+        self.assertIn("commodity futures contract", context)
 
 
 @pytest.mark.unit

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from tradingagents.agents.managers.portfolio_manager import create_portfolio_manager
-from tradingagents.agents.schemas import PortfolioDecision, PortfolioRating
+from tradingagents.agents.schemas import HoldingRecommendation, PortfolioDecision, PortfolioRating
 from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.graph.propagation import Propagator
 from tradingagents.graph.reflection import Reflector
@@ -93,6 +93,8 @@ def _structured_pm_llm(captured: dict, decision: PortfolioDecision | None = None
             rating=PortfolioRating.HOLD,
             executive_summary="Hold the position; await catalyst.",
             investment_thesis="Balanced view; neither side carried the debate.",
+            holding_recommendation=HoldingRecommendation.DATA_DEPENDENT,
+            holding_rationale="No overnight-specific catalyst either way.",
         )
     structured = MagicMock()
     structured.invoke.side_effect = lambda prompt: (
@@ -716,6 +718,8 @@ class TestPortfolioManagerInjection:
             investment_thesis="AI capex cycle remains intact; institutional flows constructive.",
             price_target=215.0,
             time_horizon="3-6 months",
+            holding_recommendation=HoldingRecommendation.HOLD_OVERNIGHT,
+            holding_rationale="Multi-week setup still developing; no reason to exit intraday.",
         )
         llm = _structured_pm_llm(captured, decision)
         pm_node = create_portfolio_manager(llm)

--- a/tests/test_news_lookahead.py
+++ b/tests/test_news_lookahead.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import pytest
 
 import tradingagents.dataflows.yfinance_news as ynews
+from tradingagents.dataflows.utils import in_news_window
 
 
 def _epoch(date_str):
@@ -32,9 +33,9 @@ def test_window_excludes_future_and_undated_in_backtest():
     end = datetime(2025, 5, 9)  # historical window (well in the past)
     inside = datetime(2025, 5, 5)
     future = datetime(2025, 6, 1)
-    assert ynews._in_news_window(inside, start, end) is True
-    assert ynews._in_news_window(future, start, end) is False     # look-ahead blocked
-    assert ynews._in_news_window(None, start, end) is False        # undated -> excluded in backtest
+    assert in_news_window(inside, start, end) is True
+    assert in_news_window(future, start, end) is False     # look-ahead blocked
+    assert in_news_window(None, start, end) is False        # undated -> excluded in backtest
 
 
 @pytest.mark.unit
@@ -42,7 +43,7 @@ def test_window_keeps_undated_in_live_window():
     # Live window (reaches today): undated articles can't be "future", so keep them.
     start = datetime.now()
     end = datetime.now()
-    assert ynews._in_news_window(None, start, end) is True
+    assert in_news_window(None, start, end) is True
 
 
 @pytest.mark.unit

--- a/tests/test_reddit_fallback.py
+++ b/tests/test_reddit_fallback.py
@@ -212,3 +212,39 @@ class TestCryptoSearchTerm:
 
     def test_equity_passes_through(self):
         assert self._captured_ticker("NVDA") == "NVDA"
+
+
+@pytest.mark.unit
+class TestIndianSubreddits:
+    """trading-workspace#66: US finance subreddits carry ~zero organic
+    discussion of NSE/BSE-only names, so .NS/.BO tickers default to real
+    Indian-trader subreddits instead, with the Yahoo exchange suffix
+    stripped from the search query (nobody types ".NS" on Reddit)."""
+
+    def _captured(self, ticker, subreddits=None):
+        seen = {"subs": [], "tickers": []}
+
+        def fake_fetch(t, sub, limit, timeout):
+            seen["subs"].append(sub)
+            seen["tickers"].append(t)
+            return []
+
+        with patch.object(reddit, "_fetch_subreddit", side_effect=fake_fetch):
+            reddit.fetch_reddit_posts(ticker, subreddits=subreddits, inter_request_delay=0)
+        return seen
+
+    def test_indian_ticker_defaults_to_indian_subreddits(self):
+        seen = self._captured("RELIANCE.NS")
+        assert tuple(seen["subs"]) == reddit.INDIAN_SUBREDDITS
+
+    def test_us_ticker_still_defaults_to_default_subreddits(self):
+        seen = self._captured("NVDA")
+        assert tuple(seen["subs"]) == reddit.DEFAULT_SUBREDDITS
+
+    def test_indian_ticker_search_strips_exchange_suffix(self):
+        seen = self._captured("NBCC.BO")
+        assert seen["tickers"] == ["NBCC"] * len(reddit.INDIAN_SUBREDDITS)
+
+    def test_explicit_subreddits_override_default(self):
+        seen = self._captured("RELIANCE.NS", subreddits=("stocks",))
+        assert tuple(seen["subs"]) == ("stocks",)

--- a/tests/test_safe_ticker_component.py
+++ b/tests/test_safe_ticker_component.py
@@ -19,6 +19,13 @@ class TestSafeTickerComponent(unittest.TestCase):
         for ticker in ("GC=F", "CL=F", "ES=F", "XAUUSD+", "EURUSD+"):
             self.assertEqual(safe_ticker_component(ticker), ticker)
 
+    def test_accepts_ampersand_in_nse_symbols(self):
+        # TFR-215: M&M.NS (Mahindra & Mahindra) previously raised ValueError
+        # on every request -- '&' is not a path-traversal character on any
+        # common filesystem, just missing from the allowed set.
+        for ticker in ("M&M.NS", "M&MFIN.NS"):
+            self.assertEqual(safe_ticker_component(ticker), ticker)
+
     def test_rejects_path_separators(self):
         for bad in (".", "..", "../etc", "a/b", "a\\b", "/abs", "..\\..\\x"):
             with self.assertRaises(ValueError):

--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -10,7 +10,12 @@ to it.
 
 import pytest
 
-from tradingagents.agents.utils.rating import RATINGS_5_TIER, parse_rating
+from tradingagents.agents.utils.rating import (
+    HOLDING_RECOMMENDATIONS,
+    RATINGS_5_TIER,
+    parse_holding_recommendation,
+    parse_rating,
+)
 from tradingagents.graph.signal_processing import SignalProcessor
 
 # ---------------------------------------------------------------------------
@@ -62,6 +67,51 @@ class TestParseRating:
 
 
 # ---------------------------------------------------------------------------
+# Heuristic parser: overnight-vs-intraday holding call (issue #27)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseHoldingRecommendation:
+    def test_explicit_label_hold_overnight(self):
+        assert parse_holding_recommendation(
+            "Holding Recommendation: Hold Overnight\nEarnings due tomorrow."
+        ) == "Hold Overnight"
+
+    def test_explicit_label_with_markdown_bold(self):
+        assert parse_holding_recommendation(
+            "**Holding Recommendation**: Square Off Intraday\n"
+            "No overnight catalyst."
+        ) == "Square Off Intraday"
+
+    def test_explicit_label_with_trailing_qualifier(self):
+        # The model may append reasoning after the label on the same line.
+        text = "Holding Recommendation: Hold Overnight — thesis depends on tomorrow's guidance."
+        assert parse_holding_recommendation(text) == "Hold Overnight"
+
+    def test_rendered_pm_markdown_shape(self):
+        # The exact shape produced by render_pm_decision must always parse.
+        text = (
+            "**Rating**: Buy\n\n"
+            "**Executive Summary**: Enter at $189-192, 6% portfolio cap.\n\n"
+            "**Investment Thesis**: AI capex cycle intact.\n\n"
+            "**Holding Recommendation**: Data-Dependent\n\n"
+            "**Holding Rationale**: Hold only if still green into the close."
+        )
+        assert parse_holding_recommendation(text) == "Data-Dependent"
+
+    def test_no_label_returns_default(self):
+        assert parse_holding_recommendation("No mention of holding duration at all.") == "Data-Dependent"
+
+    def test_no_label_custom_default(self):
+        assert parse_holding_recommendation("Plain prose.", default="Hold Overnight") == "Hold Overnight"
+
+    def test_all_three_values_recognised(self):
+        for v in HOLDING_RECOMMENDATIONS:
+            assert parse_holding_recommendation(f"Holding Recommendation: {v}") == v
+
+
+# ---------------------------------------------------------------------------
 # SignalProcessor: thin adapter over the heuristic
 # ---------------------------------------------------------------------------
 
@@ -87,3 +137,8 @@ class TestSignalProcessor:
     def test_default_when_no_rating_present(self):
         sp = SignalProcessor()
         assert sp.process_signal("Plain prose without a recommendation.") == "Hold"
+
+    def test_returns_holding_recommendation_from_pm_markdown(self):
+        sp = SignalProcessor()
+        md = "**Holding Recommendation**: Square Off Intraday\n\n**Holding Rationale**: Reasons."
+        assert sp.process_holding_recommendation(md) == "Square Off Intraday"

--- a/tests/test_stocktwits_resilience.py
+++ b/tests/test_stocktwits_resilience.py
@@ -75,3 +75,35 @@ class TestStockTwitsCryptoSymbols:
         with patch.object(stocktwits, "urlopen", side_effect=fake_urlopen):
             stocktwits.fetch_stocktwits_messages("BTC-USD")
         assert "/symbol/BTC.X.json" in seen["url"]
+
+
+@pytest.mark.unit
+class TestStockTwitsIndianSymbols:
+    """trading-workspace#66: StockTwits lists NSE/BSE names under its own
+    ``.NSE``/``.BSE`` cashtag suffix, not Yahoo's ``.NS``/``.BO`` -- verified
+    live against RELIANCE.NSE (30 real messages, 2026-07-16). Without this
+    mapping every Indian ticker silently got zero StockTwits coverage."""
+
+    @pytest.mark.parametrize(
+        ("ticker", "expected"),
+        [
+            ("RELIANCE.NS", "RELIANCE.NSE"),
+            ("nbcc.bo", "NBCC.BSE"),
+            ("WIPRO.NS", "WIPRO.NSE"),
+            ("NVDA", "NVDA"),          # US equity: untouched
+            ("BTC-USD", "BTC.X"),      # crypto rule still wins first
+        ],
+    )
+    def test_indian_symbol_mapping(self, ticker, expected):
+        assert stocktwits._stocktwits_symbol(ticker) == expected
+
+    def test_indian_ticker_requests_nse_endpoint(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            raise TimeoutError("stop after capturing the URL")
+
+        with patch.object(stocktwits, "urlopen", side_effect=fake_urlopen):
+            stocktwits.fetch_stocktwits_messages("RELIANCE.NS")
+        assert "/symbol/RELIANCE.NSE.json" in seen["url"]

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from tradingagents.agents.analysts.sentiment_analyst import create_sentiment_analyst
 from tradingagents.agents.managers.research_manager import create_research_manager
 from tradingagents.agents.schemas import (
+    HoldingRecommendation,
     PortfolioDecision,
     PortfolioRating,
     ResearchPlan,
@@ -94,6 +95,8 @@ class TestNullishFloatCoercion:
             executive_summary="s",
             investment_thesis="t",
             price_target="N/A",
+            holding_recommendation=HoldingRecommendation.DATA_DEPENDENT,
+            holding_rationale="r",
         )
         assert d.price_target is None
 

--- a/tests/test_symbol_utils.py
+++ b/tests/test_symbol_utils.py
@@ -35,6 +35,16 @@ class TestNormalizeSymbol(unittest.TestCase):
         self.assertEqual(normalize_symbol("NAS100"), "^NDX")
         self.assertEqual(normalize_symbol("US30"), "^DJI")
 
+    def test_mcx_commodity_aliases_map_to_global_benchmark(self):
+        """trading-workspace#68 -- MCX's own mini-contract names resolve to
+        the global USD benchmark future TradingAgents actually analyzes, not
+        MCX's own INR contract (which this repo has no data source for)."""
+        self.assertEqual(normalize_symbol("CRUDEOILM"), "CL=F")
+        self.assertEqual(normalize_symbol("GOLDM"), "GC=F")
+        self.assertEqual(normalize_symbol("crudeoilm"), "CL=F")
+        self.assertEqual(normalize_symbol("SILVERM"), "SI=F")
+        self.assertEqual(normalize_symbol("NATGASMINI"), "NG=F")
+
     def test_forex_pairs_get_x_suffix(self):
         self.assertEqual(normalize_symbol("EURUSD"), "EURUSD=X")
         self.assertEqual(normalize_symbol("GBPJPY"), "GBPJPY=X")

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,6 +1,7 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from tradingagents.agents.utils.agent_utils import (
+    get_external_signal_context_from_state,
     get_indicators,
     get_instrument_context_from_state,
     get_language_instruction,
@@ -14,6 +15,9 @@ def create_market_analyst(llm):
     def market_analyst_node(state):
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
+        external_signal_context = get_external_signal_context_from_state(state)
+        if external_signal_context:
+            external_signal_context = f" {external_signal_context}"
 
         tools = [
             get_stock_data,
@@ -66,7 +70,7 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
                     " You have access to the following tools: {tool_names}."
-                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
+                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}{external_signal_context}\n"
                     "{system_message}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
@@ -77,6 +81,7 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
         prompt = prompt.partial(tool_names=", ".join([tool.name for tool in tools]))
         prompt = prompt.partial(current_date=current_date)
         prompt = prompt.partial(instrument_context=instrument_context)
+        prompt = prompt.partial(external_signal_context=external_signal_context)
 
         chain = prompt | llm.bind_tools(tools)
 

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -52,6 +52,11 @@ def create_portfolio_manager(llm):
 - **Underweight**: Reduce exposure, take partial profits
 - **Sell**: Exit position or avoid entry
 
+**Holding Recommendation** (use exactly one, independent of the rating above):
+- **Hold Overnight**: only when the thesis specifically depends on something that resolves after today's close (an anticipated catalyst, a multi-day setup still developing)
+- **Square Off Intraday**: today's move is what the thesis was for; no specific reason to carry overnight gap risk (and, if held via options, overnight theta decay)
+- **Data-Dependent**: the call genuinely hinges on how the position performs into the close — state that condition explicitly
+
 **Context:**
 - Research Manager's investment plan: **{research_plan}**
 - Trader's transaction proposal: **{trader_plan}**

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -21,7 +21,7 @@ def create_bear_researcher(llm):
         fundamentals_label = (
             "Company fundamentals report"
             if asset_type == "stock"
-            else "Asset fundamentals report (may be unavailable for crypto)"
+            else "Asset fundamentals report (may be unavailable for crypto/commodities)"
         )
 
         prompt = f"""You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -21,7 +21,7 @@ def create_bull_researcher(llm):
         fundamentals_label = (
             "Company fundamentals report"
             if asset_type == "stock"
-            else "Asset fundamentals report (may be unavailable for crypto)"
+            else "Asset fundamentals report (may be unavailable for crypto/commodities)"
         )
 
         prompt = f"""You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -65,6 +65,21 @@ class TraderAction(str, Enum):
     SELL = "Sell"
 
 
+class HoldingRecommendation(str, Enum):
+    """Overnight-vs-intraday holding-duration call made by the Portfolio Manager.
+
+    Distinct from ``rating`` (direction) and ``time_horizon`` (a coarse,
+    optional multi-week/month band): this is the specific overnight decision
+    that matters most for options positions, where the position itself may
+    not even exist past today's close (theta decay), and a name-specific gap
+    can swing the position more than a full session of intraday movement.
+    """
+
+    HOLD_OVERNIGHT = "Hold Overnight"
+    SQUARE_OFF_INTRADAY = "Square Off Intraday"
+    DATA_DEPENDENT = "Data-Dependent"
+
+
 # ---------------------------------------------------------------------------
 # Research Manager
 # ---------------------------------------------------------------------------
@@ -221,6 +236,32 @@ class PortfolioDecision(BaseModel):
         default=None,
         description="Optional recommended holding period, e.g. '3-6 months'.",
     )
+    holding_recommendation: HoldingRecommendation = Field(
+        description=(
+            "Whether to hold this position overnight or square it off before "
+            "today's close — evaluated independently of the directional rating "
+            "and the multi-week time_horizon above. Weigh overnight gap risk "
+            "(a name-specific catalyst, or a broad market move while this "
+            "market is closed) and, if the position is held via options, "
+            "theta decay through the close, against whichever intraday move "
+            "has already been captured. Use Hold Overnight only when the "
+            "thesis specifically depends on something that resolves after "
+            "today's close (an anticipated catalyst, a multi-day setup still "
+            "developing). Use Square Off Intraday when the case is that "
+            "today's move is what the thesis was for and there's no specific "
+            "reason to carry overnight risk. Use Data-Dependent only when the "
+            "call genuinely hinges on how the position performs into the "
+            "close (e.g. only hold overnight if still profitable) — state "
+            "that condition explicitly in holding_rationale, not just the tier."
+        ),
+    )
+    holding_rationale: str = Field(
+        description=(
+            "One to two sentences justifying the holding_recommendation "
+            "specifically — the overnight risk being weighed, not a restatement "
+            "of the directional thesis already covered in investment_thesis."
+        ),
+    )
 
     @field_validator("price_target", mode="before")
     @classmethod
@@ -242,6 +283,10 @@ def render_pm_decision(decision: PortfolioDecision) -> str:
         f"**Executive Summary**: {decision.executive_summary}",
         "",
         f"**Investment Thesis**: {decision.investment_thesis}",
+        "",
+        f"**Holding Recommendation**: {decision.holding_recommendation.value}",
+        "",
+        f"**Holding Rationale**: {decision.holding_rationale}",
     ]
     if decision.price_target is not None:
         parts.extend(["", f"**Price Target**: {decision.price_target}"])

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -74,3 +74,4 @@ class AgentState(MessagesState):
     ]
     final_trade_decision: Annotated[str, "Final decision made by the Risk Analysts"]
     past_context: Annotated[str, "Memory log context injected at run start (same-ticker decisions + cross-ticker lessons)"]
+    external_signal_context: Annotated[str, "Prior signal from an external scanner injected at run start (trading-workspace#37) — informational, not authoritative"]

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -46,7 +46,7 @@ class RiskDebateState(TypedDict):
 
 class AgentState(MessagesState):
     company_of_interest: Annotated[str, "Company that we are interested in trading"]
-    asset_type: Annotated[str, "Asset type under analysis such as stock or crypto"]
+    asset_type: Annotated[str, "Asset type under analysis such as stock, crypto, or commodity"]
     instrument_context: Annotated[str, "Deterministic ticker identity resolved at run start"]
     trade_date: Annotated[str, "What date we are trading at"]
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -42,6 +42,7 @@ __all__ = [
     "build_instrument_context",
     "resolve_instrument_identity",
     "get_instrument_context_from_state",
+    "get_external_signal_context_from_state",
     "get_language_instruction",
     "create_msg_delete",
 ]
@@ -185,6 +186,17 @@ def get_instrument_context_from_state(state: Mapping[str, Any]) -> str:
         str(state["company_of_interest"]),
         state.get("asset_type", "stock"),
     )
+
+
+def get_external_signal_context_from_state(state: Mapping[str, Any]) -> str:
+    """Return the external-scanner signal context for the current run, or ""
+    when none was injected (trading-workspace#37 — most callers never set
+    this; only news-gap-ml's technical-trigger leg does). No fallback
+    construction here, unlike get_instrument_context_from_state — there's no
+    deterministic way to derive this lazily if it wasn't provided at run
+    start, so an absent value just means "no prior signal to consider"."""
+    context = state.get("external_signal_context")
+    return context if isinstance(context, str) and context.strip() else ""
 
 
 def create_msg_delete():

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -120,6 +120,9 @@ def resolve_instrument_identity(ticker: str) -> dict:
     return identity
 
 
+_INSTRUMENT_LABELS = {"crypto": "asset", "commodity": "commodity"}
+
+
 def build_instrument_context(
     ticker: str,
     asset_type: str = "stock",
@@ -131,9 +134,16 @@ def build_instrument_context(
     :func:`resolve_instrument_identity`), the company name and business
     classification are injected so agents anchor to the real company rather
     than pattern-matching the price chart to a wrong one (#814).
+
+    ``asset_type="commodity"`` (trading-workspace#68) covers a global futures
+    benchmark (e.g. ``CL=F``/``GC=F``, resolved from an MCX mini-contract
+    name via symbol_utils.py) -- there is no "company" to anchor to, same
+    structural gap as crypto, so it gets the same no-fundamentals framing
+    below plus its own commodity-specific driver language.
     """
     is_crypto = asset_type == "crypto"
-    instrument_label = "asset" if is_crypto else "instrument"
+    is_commodity = asset_type == "commodity"
+    instrument_label = _INSTRUMENT_LABELS.get(asset_type, "instrument")
     context = (
         f"The {instrument_label} to analyze is `{ticker}`. "
         "Use this exact ticker in every tool call, report, and recommendation, "
@@ -144,7 +154,7 @@ def build_instrument_context(
     if identity:
         name = identity.get("company_name") or identity.get("name")
         if name:
-            details.append(f"{'Name' if is_crypto else 'Company'}: {name}")
+            details.append(f"{'Name' if is_crypto or is_commodity else 'Company'}: {name}")
         sector, industry = identity.get("sector"), identity.get("industry")
         if sector and industry:
             details.append(f"Business classification: {sector} / {industry}")
@@ -166,6 +176,14 @@ def build_instrument_context(
         context += (
             " Treat it as a crypto asset rather than a company, and do not "
             "assume company fundamentals are available."
+        )
+    elif is_commodity:
+        context += (
+            " Treat it as a commodity futures contract rather than a company, "
+            "and do not assume company fundamentals (earnings, balance sheet, "
+            "insider activity) are available -- reason from supply/demand "
+            "balance, inventories, OPEC+/central-bank policy, and geopolitical "
+            "developments instead."
         )
     return context
 

--- a/tradingagents/agents/utils/rating.py
+++ b/tradingagents/agents/utils/rating.py
@@ -46,3 +46,37 @@ def parse_rating(text: str, default: str = "Hold") -> str:
                 return clean.capitalize()
 
     return default
+
+
+# Overnight-vs-intraday holding call (see HoldingRecommendation in schemas.py).
+# Values are multi-word, so this uses a "rest of line" capture rather than
+# _RATING_LABEL_RE's single-word one — matched by prefix against the three
+# canonical values rather than exact string equality, tolerant of trailing
+# punctuation/qualifiers the model appends after the label.
+_HOLDING_LABEL_RE = re.compile(r"holding\s*recommendation.*?[:\-]\s*(.+)", re.IGNORECASE)
+HOLDING_RECOMMENDATIONS: tuple[str, ...] = ("Hold Overnight", "Square Off Intraday", "Data-Dependent")
+
+
+def parse_holding_recommendation(text: str, default: str = "Data-Dependent") -> str:
+    """Heuristically extract the overnight-vs-intraday holding call from prose text.
+
+    Same two-pass strategy as parse_rating: an explicit "Holding
+    Recommendation: X" label first, then the first canonical value found
+    anywhere in the text. Defaults to "Data-Dependent" rather than either
+    extreme when nothing matches — an unparseable response should read as
+    "needs a human look," not as a confident call either way.
+    """
+    for line in text.splitlines():
+        m = _HOLDING_LABEL_RE.search(line)
+        if m:
+            candidate = m.group(1).strip(" *")
+            for value in HOLDING_RECOMMENDATIONS:
+                if candidate.lower().startswith(value.lower()):
+                    return value
+
+    lower_text = text.lower()
+    for value in HOLDING_RECOMMENDATIONS:
+        if value.lower() in lower_text:
+            return value
+
+    return default

--- a/tradingagents/dataflows/indian_news.py
+++ b/tradingagents/dataflows/indian_news.py
@@ -1,0 +1,222 @@
+"""India-scoped news vendor: ET Markets RSS (direct feed) + Google News RSS (search).
+
+yfinance's ``get_news`` mostly surfaces globally-syndicated wire stories and
+has thin coverage for NSE/BSE-listed names — the exact gap flagged in the
+KALYANKJIL/NBCC options research (individual Indian stock moves are often
+driven by discrete company/PSU/regulatory news that a US-centric vendor
+doesn't index).
+
+Two keyless sources, combined:
+  - ET Markets' own RSS feed is real Indian financial press covering
+    corporate announcements, earnings dates, order wins, block deals, etc. —
+    but it's a firehose (no per-ticker query param), so it's filtered by
+    ticker-name substring match for per-stock lookups.
+  - Google News' RSS search endpoint fills the per-ticker search gap and,
+    when scoped with ``gl=IN&ceid=IN:en``, still ranks Indian financial press
+    (Moneycontrol, CNBC TV18, Business Standard) ahead of global sources.
+
+NSE's own corporate-announcements RSS (the gold standard for discrete
+company events) was evaluated but is blocked by NSE's bot-protection WAF for
+non-browser clients — the same class of block already tracked for AngelOne's
+API (#155). Revisit if that's ever resolved.
+
+Both sources return only recent articles (no deep historical archive), so
+this vendor serves *live* analysis, not retroactive news-to-chart backtesting.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+
+import requests
+from dateutil.relativedelta import relativedelta
+
+from .config import get_config
+from .utils import in_news_window
+
+_GOOGLE_NEWS_RSS_URL = "https://news.google.com/rss/search"
+_ET_MARKETS_RSS_URL = "https://economictimes.indiatimes.com/markets/stocks/rssfeeds/2146842.cms"
+_TIMEOUT_S = 10
+_HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def _strip_exchange_suffix(ticker: str) -> str:
+    """``RELIANCE.NS`` / ``NBCC.BO`` -> ``RELIANCE`` / ``NBCC`` for matching/search."""
+    for suffix in (".NS", ".BO"):
+        if ticker.upper().endswith(suffix):
+            return ticker[: -len(suffix)]
+    return ticker
+
+
+def _parse_rss_items(content: bytes, limit: int) -> list[dict]:
+    """Parse a generic RSS ``<item>`` list into ``{title, link, publisher, pub_date}`` dicts."""
+    root = ET.fromstring(content)
+    articles = []
+    for item in list(root.iterfind(".//item"))[:limit]:
+        title_el = item.find("title")
+        link_el = item.find("link")
+        pubdate_el = item.find("pubDate")
+        source_el = item.find("source")
+
+        pub_date = None
+        if pubdate_el is not None and pubdate_el.text:
+            try:
+                pub_date = parsedate_to_datetime(pubdate_el.text).replace(tzinfo=None)
+            except (ValueError, TypeError):
+                pub_date = None
+
+        articles.append({
+            "title": title_el.text if title_el is not None else "No title",
+            "link": link_el.text if link_el is not None else "",
+            "publisher": source_el.text if source_el is not None and source_el.text else "Economic Times",
+            "pub_date": pub_date,
+        })
+    return articles
+
+
+def _fetch_google_news(query: str, limit: int) -> list[dict]:
+    """Query Google News RSS search, scoped to India."""
+    params = {"q": query, "hl": "en-IN", "gl": "IN", "ceid": "IN:en"}
+    resp = requests.get(_GOOGLE_NEWS_RSS_URL, params=params, timeout=_TIMEOUT_S, headers=_HEADERS)
+    resp.raise_for_status()
+    return _parse_rss_items(resp.content, limit)
+
+
+def _fetch_et_markets(limit: int) -> list[dict]:
+    """Fetch ET Markets' general stocks RSS feed (not per-ticker queryable)."""
+    resp = requests.get(_ET_MARKETS_RSS_URL, timeout=_TIMEOUT_S, headers=_HEADERS)
+    resp.raise_for_status()
+    return _parse_rss_items(resp.content, limit)
+
+
+def _dedupe_by_title(articles: list[dict]) -> list[dict]:
+    seen = set()
+    out = []
+    for article in articles:
+        if article["title"] not in seen:
+            seen.add(article["title"])
+            out.append(article)
+    return out
+
+
+def get_news_india(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve India-scoped news for a specific stock ticker.
+
+    Combines ET Markets' general feed (filtered by ticker-name substring
+    match in the headline) with a targeted Google News RSS search, since
+    neither source alone reliably covers a given NSE/BSE name.
+
+    Args:
+        ticker: NSE/BSE ticker, with or without ``.NS``/``.BO`` suffix (e.g. "NBCC", "NBCC.NS").
+        start_date: Start date in yyyy-mm-dd format.
+        end_date: End date in yyyy-mm-dd format.
+
+    Returns:
+        Formatted string containing news articles.
+    """
+    article_limit = get_config()["news_article_limit"]
+    query_ticker = _strip_exchange_suffix(ticker)
+    try:
+        et_articles = [
+            a for a in _fetch_et_markets(100)
+            if query_ticker.lower() in a["title"].lower()
+        ]
+        google_articles = _fetch_google_news(f"{query_ticker} stock NSE", article_limit)
+        articles = _dedupe_by_title(et_articles + google_articles)[:article_limit]
+
+        if not articles:
+            return f"No news found for {ticker}"
+
+        start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+
+        news_str = ""
+        filtered_count = 0
+        for article in articles:
+            if not in_news_window(article["pub_date"], start_dt, end_dt):
+                continue
+            news_str += f"### {article['title']} (source: {article['publisher']})\n"
+            if article["link"]:
+                news_str += f"Link: {article['link']}\n"
+            news_str += "\n"
+            filtered_count += 1
+
+        if filtered_count == 0:
+            return f"No news found for {ticker} between {start_date} and {end_date}"
+
+        return f"## {ticker} News, from {start_date} to {end_date}:\n\n{news_str}"
+
+    except Exception as e:
+        return f"Error fetching news for {ticker}: {str(e)}"
+
+
+def get_global_news_india(
+    curr_date: str,
+    look_back_days: int | None = None,
+    limit: int | None = None,
+) -> str:
+    """Retrieve India-scoped macro/market news.
+
+    ET Markets' general feed is the primary source (real Indian financial
+    press, not keyword-search-ranked); Google News topic queries top up the
+    macro angle (RBI policy, SEBI regulation, FII/DII flows) that a pure
+    stock-market feed under-covers.
+
+    Args:
+        curr_date: Current date in yyyy-mm-dd format.
+        look_back_days: Lookback window in days. ``None`` falls back to
+            ``global_news_lookback_days`` from the active config.
+        limit: Max articles to return. ``None`` falls back to
+            ``global_news_article_limit`` from the active config.
+
+    Returns:
+        Formatted string containing global news articles.
+    """
+    config = get_config()
+    if look_back_days is None:
+        look_back_days = config["global_news_lookback_days"]
+    if limit is None:
+        limit = config["global_news_article_limit"]
+
+    macro_queries = [
+        "RBI monetary policy repo rate India",
+        "SEBI regulation India markets",
+        "FII DII flows India equity",
+    ]
+
+    try:
+        all_articles = list(_fetch_et_markets(limit))
+        for query in macro_queries:
+            if len(all_articles) >= limit:
+                break
+            all_articles.extend(_fetch_google_news(query, limit))
+
+        all_articles = _dedupe_by_title(all_articles)
+
+        if not all_articles:
+            return f"No global news found for {curr_date}"
+
+        curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+        start_dt = curr_dt - relativedelta(days=look_back_days)
+        start_date = start_dt.strftime("%Y-%m-%d")
+
+        news_str = ""
+        kept = 0
+        for article in all_articles[:limit]:
+            if not in_news_window(article["pub_date"], start_dt, curr_dt):
+                continue
+            news_str += f"### {article['title']} (source: {article['publisher']})\n"
+            if article["link"]:
+                news_str += f"Link: {article['link']}\n"
+            news_str += "\n"
+            kept += 1
+
+        if kept == 0:
+            return f"No global news found between {start_date} and {curr_date}"
+
+        return f"## Global Market News (India), from {start_date} to {curr_date}:\n\n{news_str}"
+
+    except Exception as e:
+        return f"Error fetching global news: {str(e)}"

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -18,6 +18,10 @@ from .errors import (
     VendorRateLimitError,
 )
 from .fred import get_macro_data as get_fred_macro_data
+from .indian_news import (
+    get_global_news_india,
+    get_news_india,
+)
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
@@ -82,6 +86,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "indian_news",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -124,10 +129,12 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "indian_news": get_news_india,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "indian_news": get_global_news_india,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -48,6 +48,22 @@ _ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
 # investing trend more measured. Caller can override.
 DEFAULT_SUBREDDITS = ("wallstreetbets", "stocks", "investing")
 
+# US finance subreddits carry near-zero organic discussion of NSE/BSE-only
+# names (as opposed to US-listed ADRs like INFY/WIT/HDB/IBN) -- verified live,
+# these three carry real Indian retail-trader discussion instead
+# (trading-workspace#66).
+INDIAN_SUBREDDITS = ("IndianStreetBets", "DalalStreetTalks", "IndiaInvestments")
+
+_INDIAN_EXCHANGE_SUFFIXES = (".NS", ".BO")
+
+
+def _strip_indian_exchange_suffix(ticker: str) -> str:
+    upper = ticker.strip().upper()
+    for suffix in _INDIAN_EXCHANGE_SUFFIXES:
+        if upper.endswith(suffix):
+            return upper[: -len(suffix)]
+    return ticker
+
 
 def _search_qs(ticker: str, limit: int) -> str:
     return urlencode({
@@ -190,7 +206,7 @@ def _fetch_subreddit(
 
 def fetch_reddit_posts(
     ticker: str,
-    subreddits: Iterable[str] = DEFAULT_SUBREDDITS,
+    subreddits: Iterable[str] | None = None,
     limit_per_sub: int = 5,
     timeout: float = 10.0,
     inter_request_delay: float = 1.0,
@@ -198,13 +214,25 @@ def fetch_reddit_posts(
     """Fetch recent Reddit posts mentioning ``ticker`` across finance
     subreddits and return them as a formatted plaintext block.
 
+    ``subreddits`` defaults to ``INDIAN_SUBREDDITS`` for ``.NS``/``.BO``
+    tickers and ``DEFAULT_SUBREDDITS`` otherwise -- pass an explicit iterable
+    to override either way.
+
     ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests to
     stay under Reddit's public per-IP rate limit; combined with the RSS-first
     path it makes 429s rare even when several analyses run back-to-back.
     """
+    if subreddits is None:
+        subreddits = (
+            INDIAN_SUBREDDITS
+            if ticker.strip().upper().endswith(_INDIAN_EXCHANGE_SUFFIXES)
+            else DEFAULT_SUBREDDITS
+        )
     # Crypto reaches us as a Yahoo pair (BTC-USD); search Reddit for the base
     # ("BTC") so the query actually matches discussion instead of near-nothing.
-    ticker = crypto_base(ticker) or ticker
+    # NSE/BSE tickers reach us with Yahoo's exchange suffix, which nobody on
+    # Reddit types when discussing the stock -- strip it the same way.
+    ticker = crypto_base(ticker) or _strip_indian_exchange_suffix(ticker)
     blocks = []
     total_posts = 0
     for i, sub in enumerate(subreddits):

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -27,15 +27,30 @@ _API = "https://api.stocktwits.com/api/2/streams/symbol/{ticker}.json"
 _UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
 
 
+_INDIAN_EXCHANGE_SUFFIXES = {".NS": ".NSE", ".BO": ".BSE"}
+
+
 def _stocktwits_symbol(ticker: str) -> str:
-    """Map a crypto pair to StockTwits' ``<BASE>.X`` convention.
+    """Map a crypto pair or Indian NSE/BSE ticker to StockTwits' own cashtag
+    convention.
 
     StockTwits lists crypto as ``BTC.X`` (Yahoo's ``BTC-USD`` form 404s), so any
-    crypto symbol resolves to its base plus ``.X``; other symbols pass through
-    upper-cased.
+    crypto symbol resolves to its base plus ``.X``. StockTwits separately lists
+    Indian equities as ``<SYMBOL>.NSE``/``<SYMBOL>.BSE`` (Yahoo's ``.NS``/``.BO``
+    form 404s) — verified live against ``RELIANCE.NSE`` (30 real messages,
+    2026-07-16), following its 2022 India launch. Without this mapping every
+    ``.NS``/``.BO`` ticker silently got zero StockTwits coverage even though
+    real Indian retail-sentiment data exists under the platform's own symbol
+    convention (trading-workspace#66). Other symbols pass through upper-cased.
     """
     base = crypto_base(ticker)
-    return f"{base}.X" if base else ticker.strip().upper()
+    if base:
+        return f"{base}.X"
+    upper = ticker.strip().upper()
+    for yahoo_suffix, st_suffix in _INDIAN_EXCHANGE_SUFFIXES.items():
+        if upper.endswith(yahoo_suffix):
+            return upper[: -len(yahoo_suffix)] + st_suffix
+    return upper
 
 
 def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.0) -> str:

--- a/tradingagents/dataflows/symbol_utils.py
+++ b/tradingagents/dataflows/symbol_utils.py
@@ -60,6 +60,13 @@ _ALIASES = {
     "BCOUSD": "BZ=F", "UKOIL": "BZ=F", "BRENT": "BZ=F",
     "NATGAS": "NG=F", "XNGUSD": "NG=F",
     "COPPER": "HG=F", "XCUUSD": "HG=F",
+    # MCX mini-contract names (trading-workspace#68) -> the global USD
+    # benchmark future, not MCX's own INR contract. The news/macro driver
+    # (war, OPEC, Fed) is global and USD-denominated; the MCX mini contract
+    # is what's actually traded, but that mapping/execution stays entirely
+    # outside TradingAgents (tci-execution-bot's mcx_handler.py) -- this
+    # table only resolves what to *analyze*.
+    "CRUDEOILM": "CL=F", "GOLDM": "GC=F", "SILVERM": "SI=F", "NATGASMINI": "NG=F",
     # Index CFDs -> Yahoo index symbols
     "SPX500": "^GSPC", "US500": "^GSPC", "SPX": "^GSPC",
     "NAS100": "^NDX", "US100": "^NDX", "USTEC": "^NDX",

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -3,8 +3,24 @@ from datetime import date, datetime, timedelta
 from typing import Annotated
 
 import pandas as pd
+from dateutil.relativedelta import relativedelta
 
 SavePathType = Annotated[str, "File path to save data. If None, data is not saved."]
+
+
+def in_news_window(pub_date, start_dt, end_dt) -> bool:
+    """Whether an article belongs in the [start_dt, end_dt] window.
+
+    Shared by every news vendor (yfinance, Indian RSS, ...) so look-ahead
+    safety is enforced identically regardless of source: dated articles are
+    kept only if they fall in the window; an undated article is kept only
+    when the window reaches the present (live run), since a historical/backtest
+    window can't prove it isn't future news (#992/#1007).
+    """
+    if pub_date is not None:
+        naive = pub_date.replace(tzinfo=None) if hasattr(pub_date, "replace") else pub_date
+        return start_dt <= naive <= end_dt + relativedelta(days=1)
+    return end_dt >= datetime.now() - relativedelta(days=1)
 
 # Tickers can contain letters, digits, dot, dash, underscore, caret
 # (index symbols like ^GSPC), equals (futures like GC=F), and plus

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -23,11 +23,12 @@ def in_news_window(pub_date, start_dt, end_dt) -> bool:
     return end_dt >= datetime.now() - relativedelta(days=1)
 
 # Tickers can contain letters, digits, dot, dash, underscore, caret
-# (index symbols like ^GSPC), equals (futures like GC=F), and plus
-# (forex/CFD symbols like XAUUSD+). None of these enable directory
-# traversal, so the value never escapes a containing directory when
-# interpolated into a path. Anything else is rejected.
-_TICKER_PATH_RE = re.compile(r"^[A-Za-z0-9._\-\^=+]+$")
+# (index symbols like ^GSPC), equals (futures like GC=F), plus
+# (forex/CFD symbols like XAUUSD+), and ampersand (NSE symbols with '&' in
+# the company name, e.g. M&M.NS -- Mahindra & Mahindra; TFR-215). None of
+# these enable directory traversal, so the value never escapes a containing
+# directory when interpolated into a path. Anything else is rejected.
+_TICKER_PATH_RE = re.compile(r"^[A-Za-z0-9._\-\^=+&]+$")
 
 
 def safe_ticker_component(value: str, *, max_len: int = 32) -> str:

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from .config import get_config
 from .stockstats_utils import yf_retry
 from .symbol_utils import normalize_symbol
+from .utils import in_news_window
 
 
 def _extract_article_data(article: dict) -> dict:
@@ -57,20 +58,6 @@ def _extract_article_data(article: dict) -> dict:
         }
 
 
-def _in_news_window(pub_date, start_dt, end_dt) -> bool:
-    """Whether an article belongs in the [start_dt, end_dt] window.
-
-    Dated articles are kept only if they fall in the window. An undated article
-    is kept only when the window reaches the present (live run) — in a
-    historical/backtest window it's excluded, since we can't prove it isn't
-    future news (look-ahead safety, #992/#1007).
-    """
-    if pub_date is not None:
-        naive = pub_date.replace(tzinfo=None) if hasattr(pub_date, "replace") else pub_date
-        return start_dt <= naive <= end_dt + relativedelta(days=1)
-    return end_dt >= datetime.now() - relativedelta(days=1)
-
-
 def get_news_yfinance(
     ticker: str,
     start_date: str,
@@ -111,7 +98,7 @@ def get_news_yfinance(
             data = _extract_article_data(article)
 
             # Keep only articles within the requested window (look-ahead safe).
-            if not _in_news_window(data["pub_date"], start_dt, end_dt):
+            if not in_news_window(data["pub_date"], start_dt, end_dt):
                 continue
 
             news_str += f"### {data['title']} (source: {data['publisher']})\n"
@@ -198,7 +185,7 @@ def get_global_news_yfinance(
             # Extract uniformly (flat + nested) and apply the same look-ahead-safe
             # window filter, so flat articles can't leak future news (#1007).
             data = _extract_article_data(article)
-            if not _in_news_window(data["pub_date"], start_dt, curr_dt):
+            if not in_news_window(data["pub_date"], start_dt, curr_dt):
                 continue
             news_str += f"### {data['title']} (source: {data['publisher']})\n"
             if data["summary"]:

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -134,7 +134,7 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance, indian_news (NSE/BSE tickers: try "indian_news,yfinance")
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -22,6 +22,7 @@ class Propagator:
         asset_type: str = "stock",
         past_context: str = "",
         instrument_context: str = "",
+        external_signal_context: str = "",
     ) -> dict[str, Any]:
         """Create the initial state for the agent graph.
 
@@ -30,6 +31,12 @@ class Propagator:
         ``TradingAgentsGraph.resolve_instrument_context``). When empty, agents
         fall back to ticker-only context via
         ``get_instrument_context_from_state``.
+
+        ``external_signal_context`` is an optional natural-language summary of
+        a prior signal from an external scanner (trading-workspace#37, e.g.
+        news-gap-ml's technical-trigger leg) — informational context for the
+        market analyst to reason *about*, not a substitute for its own
+        independent analysis. Empty by default; most callers never set it.
         """
         return {
             "messages": [("human", company_name)],
@@ -38,6 +45,7 @@ class Propagator:
             "instrument_context": instrument_context,
             "trade_date": str(trade_date),
             "past_context": past_context,
+            "external_signal_context": external_signal_context,
             "investment_debate_state": InvestDebateState(
                 {
                     "bull_history": "",

--- a/tradingagents/graph/signal_processing.py
+++ b/tradingagents/graph/signal_processing.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tradingagents.agents.utils.rating import parse_rating
+from tradingagents.agents.utils.rating import parse_holding_recommendation, parse_rating
 
 
 class SignalProcessor:
@@ -29,3 +29,7 @@ class SignalProcessor:
     def process_signal(self, full_signal: str) -> str:
         """Return one of Buy / Overweight / Hold / Underweight / Sell."""
         return parse_rating(full_signal)
+
+    def process_holding_recommendation(self, full_signal: str) -> str:
+        """Return one of Hold Overnight / Square Off Intraday / Data-Dependent."""
+        return parse_holding_recommendation(full_signal)

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -359,7 +359,7 @@ class TradingAgentsGraph:
             f"asset={asset_type}",
         ])
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(self, company_name, trade_date, asset_type: str = "stock", external_signal_context: str = ""):
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -368,6 +368,11 @@ class TradingAgentsGraph:
         ``checkpoint_enabled`` is set in config, the graph is recompiled with
         a per-ticker SqliteSaver so a crashed run can resume from the last
         successful node on a subsequent invocation with the same ticker+date.
+
+        ``external_signal_context`` (trading-workspace#37) is an optional
+        natural-language summary of a prior signal from an external scanner
+        (e.g. news-gap-ml's technical-trigger leg) for the market analyst to
+        reason about — see Propagator.create_initial_state().
         """
         self.ticker = company_name
 
@@ -394,7 +399,10 @@ class TradingAgentsGraph:
                 logger.info("Starting fresh for %s on %s", company_name, trade_date)
 
         try:
-            return self._run_graph(company_name, trade_date, asset_type=asset_type)
+            return self._run_graph(
+                company_name, trade_date, asset_type=asset_type,
+                external_signal_context=external_signal_context,
+            )
         finally:
             if self._checkpointer_ctx is not None:
                 self._checkpointer_ctx.__exit__(None, None, None)
@@ -416,7 +424,7 @@ class TradingAgentsGraph:
             )
         return write_report_tree(final_state, ticker, save_path)
 
-    def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
+    def _run_graph(self, company_name, trade_date, asset_type: str = "stock", external_signal_context: str = ""):
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents.
@@ -428,6 +436,7 @@ class TradingAgentsGraph:
             asset_type=asset_type,
             past_context=past_context,
             instrument_context=instrument_context,
+            external_signal_context=external_signal_context,
         )
         args = self.propagator.get_graph_args()
 


### PR DESCRIPTION
Commits the untracked scanner retro-run script + results doc. Results capture a fully-failed 2026-06-16 run (FRED_API_KEY unset; M&M.NS blocked by '&' path-safety regex) — committed as a record of the blockers, not as findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)