### PR TITLE
feat: write reproducible run manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ config["temperature"] = 0.0
 
 What does not vary anymore: the analyzed company identity is resolved deterministically from the ticker before any agent runs, and the market analyst grounds exact price and indicator claims in a verified data snapshot. Earlier reports of "different companies" or fabricated price levels across runs are addressed by these two mechanisms.
 
+Saved reports include `run_manifest.json`. It records the requested as-of
+date, asset type, analyst set, model/provider IDs, configured data-vendor IDs,
+the safe subset of the effective configuration and its SHA-256, hashes of the
+instrument and memory context, and the final rating/output hash. This makes it
+possible to distinguish a changed configuration from changed model or live-data
+behavior when comparing runs. Vendor IDs describe the configured vendor chains;
+they do not prove which fallback served an individual tool call, so archive
+live inputs separately when exact replay is required.
+
 Backtest results are not guaranteed to match any published figure. Returns depend on the model, the temperature, the date range, data quality, and the sampling above. Treat the framework as a research scaffold for studying multi-agent analysis, not as a strategy with a fixed, replicable return.
 
 ## Contributing

--- a/cli/main.py
+++ b/cli/main.py
@@ -49,6 +49,7 @@ from tradingagents.graph.analyst_execution import (
 )
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.reporting import write_report_tree
+from tradingagents.run_manifest import build_run_manifest
 
 console = Console()
 
@@ -747,9 +748,20 @@ def get_analysis_date():
             )
 
 
-def save_report_to_disk(final_state, ticker: str, save_path: Path):
+def save_report_to_disk(
+    final_state,
+    ticker: str,
+    save_path: Path,
+    *,
+    run_manifest: dict | None = None,
+):
     """Save the complete analysis report to disk (shared CLI/API writer)."""
-    return write_report_tree(final_state, ticker, save_path)
+    return write_report_tree(
+        final_state,
+        ticker,
+        save_path,
+        run_manifest=run_manifest,
+    )
 
 
 def display_complete_report(final_state):
@@ -1255,7 +1267,18 @@ def run_analysis(checkpoint: bool | None = None):
         ).strip()
         save_path = Path(save_path_str)
         try:
-            report_file = save_report_to_disk(final_state, selections["ticker"], save_path)
+            run_manifest = build_run_manifest(
+                config,
+                final_state,
+                selections["ticker"],
+                selected_analyst_keys,
+            )
+            report_file = save_report_to_disk(
+                final_state,
+                selections["ticker"],
+                save_path,
+                run_manifest=run_manifest,
+            )
             console.print(f"\n[green]✓ Report saved to:[/green] {save_path.resolve()}")
             console.print(f"  [dim]Complete report:[/dim] {report_file.name}")
         except Exception as e:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,12 +1,14 @@
 """Report parity: the shared writer produces the report tree for the CLI and the
 programmatic API alike (#1037)."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.reporting import write_report_tree
+from tradingagents.run_manifest import build_run_manifest
 
 
 def _state():
@@ -34,6 +36,50 @@ def test_write_report_tree_creates_files(tmp_path):
 
 
 @pytest.mark.unit
+def test_write_report_tree_writes_supplied_manifest(tmp_path):
+    manifest = {"schema_version": "1", "run": {"ticker": "AAPL"}}
+    write_report_tree(_state(), "AAPL", tmp_path, run_manifest=manifest)
+
+    assert json.loads((tmp_path / "run_manifest.json").read_text()) == manifest
+
+
+@pytest.mark.unit
+def test_run_manifest_is_deterministic_and_excludes_runtime_paths(tmp_path):
+    config = {
+        "llm_provider": "openai",
+        "deep_think_llm": "deep-model",
+        "quick_think_llm": "quick-model",
+        "backend_url": "https://user:secret@example.test/v1?api_key=secret",
+        "temperature": 0.0,
+        "data_vendors": {"core_stock_apis": "yfinance,alpha_vantage"},
+        "tool_vendors": {"get_news": "yfinance"},
+        "results_dir": str(tmp_path),
+    }
+    state = {
+        "trade_date": "2026-01-15",
+        "asset_type": "stock",
+        "instrument_context": "Apple Inc. (AAPL)",
+        "past_context": "prior run",
+        "final_trade_decision": "**Rating**: Buy",
+    }
+
+    first = build_run_manifest(config, state, "AAPL", ["market", "news"])
+    config["results_dir"] = str(tmp_path / "somewhere-else")
+    second = build_run_manifest(config, state, "AAPL", ["market", "news"])
+
+    assert first == second
+    assert first["configuration"]["backend_url"] == "https://example.test/v1"
+    assert first["configured_data_sources"]["category_vendor_ids"] == {
+        "core_stock_apis": "yfinance,alpha_vantage",
+    }
+    assert first["run"]["requested_as_of"] == "2026-01-15"
+    assert first["output"]["final_rating"] == "Buy"
+    serialized = json.dumps(first)
+    assert "secret" not in serialized
+    assert str(tmp_path) not in serialized
+
+
+@pytest.mark.unit
 def test_save_reports_explicit_path(tmp_path):
     # Unbound: with an explicit save_path, the method doesn't touch self/config.
     out = TradingAgentsGraph.save_reports(None, _state(), "AAPL", save_path=tmp_path)
@@ -43,8 +89,17 @@ def test_save_reports_explicit_path(tmp_path):
 
 @pytest.mark.unit
 def test_save_reports_defaults_under_results_dir(tmp_path):
-    mock_self = SimpleNamespace(config={"results_dir": str(tmp_path)})
+    mock_self = SimpleNamespace(
+        config={
+            "results_dir": str(tmp_path),
+            "llm_provider": "openai",
+            "data_vendors": {"core_stock_apis": "yfinance"},
+        },
+        selected_analysts=("market",),
+    )
     out = TradingAgentsGraph.save_reports(mock_self, _state(), "AAPL")
     assert out.exists()
     assert out.parent.parent.name == "reports"  # results_dir/reports/AAPL_<stamp>/...
     assert out.parent.name.startswith("AAPL_")
+    manifest = json.loads((out.parent / "run_manifest.json").read_text())
+    assert manifest["run"]["selected_analysts"] == ["market"]

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -33,6 +33,7 @@ from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.llm_clients import create_llm_client
 from tradingagents.reporting import write_report_tree
+from tradingagents.run_manifest import build_run_manifest
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
 from .conditional_logic import ConditionalLogic
@@ -405,7 +406,9 @@ class TradingAgentsGraph:
         """Write the markdown report tree for a completed run, like the CLI does.
 
         Programmatic callers get the same on-disk reports the CLI produces. Pass
-        an explicit ``save_path`` or let it default under ``results_dir``.
+        an explicit ``save_path`` or let it default under ``results_dir``. A
+        machine-readable ``run_manifest.json`` is included when called on a
+        graph instance.
         """
         if save_path is None:
             stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -414,7 +417,20 @@ class TradingAgentsGraph:
                 / "reports"
                 / f"{safe_ticker_component(ticker)}_{stamp}"
             )
-        return write_report_tree(final_state, ticker, save_path)
+        run_manifest = None
+        if self is not None:
+            run_manifest = build_run_manifest(
+                self.config,
+                final_state,
+                ticker,
+                getattr(self, "selected_analysts", ()),
+            )
+        return write_report_tree(
+            final_state,
+            ticker,
+            save_path,
+            run_manifest=run_manifest,
+        )
 
     def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
         """Execute the graph and write the resulting state to disk and memory log."""

--- a/tradingagents/reporting.py
+++ b/tradingagents/reporting.py
@@ -1,16 +1,24 @@
 """Reusable report-tree writer shared by the CLI and the programmatic API.
 
 Writes a run's per-section markdown (analysts, research, trading, risk,
-portfolio) plus a consolidated ``complete_report.md`` under ``save_path``. The
-CLI and ``TradingAgentsGraph.save_reports`` both call this, so a headless / API
-run produces the same on-disk report tree a CLI run does.
+portfolio) plus a consolidated ``complete_report.md`` and, when supplied, a
+``run_manifest.json`` under ``save_path``. The CLI and
+``TradingAgentsGraph.save_reports`` both call this, so a headless / API run
+produces the same on-disk report tree a CLI run does.
 """
 
+import json
 from datetime import datetime
 from pathlib import Path
 
 
-def write_report_tree(final_state: dict, ticker: str, save_path) -> Path:
+def write_report_tree(
+    final_state: dict,
+    ticker: str,
+    save_path,
+    *,
+    run_manifest: dict | None = None,
+) -> Path:
     """Save a completed run's reports to ``save_path``; return the complete-report path."""
     save_path = Path(save_path)
     save_path.mkdir(parents=True, exist_ok=True)
@@ -98,4 +106,9 @@ def write_report_tree(final_state: dict, ticker: str, save_path) -> Path:
     # Write consolidated report
     header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
     (save_path / "complete_report.md").write_text(header + "\n\n".join(sections), encoding="utf-8")
+    if run_manifest is not None:
+        (save_path / "run_manifest.json").write_text(
+            json.dumps(run_manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     return save_path / "complete_report.md"

--- a/tradingagents/run_manifest.py
+++ b/tradingagents/run_manifest.py
@@ -1,0 +1,152 @@
+"""Deterministic metadata for comparing and auditing TradingAgents runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib import metadata
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from tradingagents.agents.utils.rating import parse_rating
+
+_CONFIG_KEYS = (
+    "llm_provider",
+    "deep_think_llm",
+    "quick_think_llm",
+    "backend_url",
+    "google_thinking_level",
+    "openai_reasoning_effort",
+    "anthropic_effort",
+    "temperature",
+    "llm_max_retries",
+    "output_language",
+    "max_debate_rounds",
+    "max_risk_discuss_rounds",
+    "max_recur_limit",
+    "checkpoint_enabled",
+    "news_article_limit",
+    "global_news_article_limit",
+    "global_news_lookback_days",
+    "global_news_queries",
+    "data_vendors",
+    "tool_vendors",
+    "benchmark_ticker",
+    "benchmark_map",
+)
+
+
+def _json_value(value: Any) -> Any:
+    """Convert common config values to stable, JSON-serializable values."""
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _safe_backend_url(value: Any) -> str | None:
+    """Keep endpoint identity while dropping credentials, query strings, and fragments."""
+    if value is None or value == "":
+        return None
+
+    parsed = urlsplit(str(value))
+    if not parsed.scheme or not parsed.hostname:
+        # Do not risk copying credentials from an unusual, non-URL endpoint
+        # string into a report intended for sharing.
+        return "<custom>"
+
+    host = parsed.hostname
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def _package_version() -> str | None:
+    try:
+        return metadata.version("tradingagents")
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def build_run_manifest(
+    config: dict[str, Any],
+    final_state: dict[str, Any],
+    ticker: str,
+    selected_analysts: tuple[str, ...] | list[str] = (),
+) -> dict[str, Any]:
+    """Build a shareable manifest for a completed run.
+
+    The manifest records requested inputs and configured vendor identifiers. It
+    deliberately does not claim that a configured fallback vendor served any
+    particular tool call; live-source capture/replay is a separate concern.
+    """
+    effective_config = {
+        key: _json_value(config[key])
+        for key in _CONFIG_KEYS
+        if key in config
+    }
+    if "backend_url" in effective_config:
+        effective_config["backend_url"] = _safe_backend_url(config.get("backend_url"))
+
+    canonical_config = json.dumps(
+        effective_config,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    decision = str(final_state.get("final_trade_decision") or "")
+    past_context = str(final_state.get("past_context") or "")
+    instrument_context = str(final_state.get("instrument_context") or "")
+
+    return {
+        "schema_version": "1",
+        "software": {
+            "package": "tradingagents",
+            "version": _package_version(),
+        },
+        "run": {
+            "ticker": ticker,
+            "requested_as_of": (
+                str(final_state["trade_date"])
+                if final_state.get("trade_date") is not None
+                else None
+            ),
+            "asset_type": final_state.get("asset_type"),
+            "selected_analysts": list(selected_analysts),
+        },
+        "models": {
+            "provider": config.get("llm_provider"),
+            "deep": config.get("deep_think_llm"),
+            "quick": config.get("quick_think_llm"),
+        },
+        "configured_data_sources": {
+            "category_vendor_ids": _json_value(config.get("data_vendors", {})),
+            "tool_vendor_ids": _json_value(config.get("tool_vendors", {})),
+        },
+        "configuration": effective_config,
+        "configuration_sha256": _sha256_text(canonical_config),
+        "context": {
+            "instrument_context_sha256": (
+                _sha256_text(instrument_context) if instrument_context else None
+            ),
+            "memory_context_sha256": (
+                _sha256_text(past_context) if past_context else None
+            ),
+        },
+        "output": {
+            "final_rating": parse_rating(decision) if decision else None,
+            "final_trade_decision_sha256": (
+                _sha256_text(decision) if decision else None
+            ),
+        },
+    }


### PR DESCRIPTION
## Summary

- write a machine-readable `run_manifest.json` alongside CLI and package API reports
- record the requested as-of date, asset type, selected analysts, provider/model IDs, configured vendor-chain IDs, a safe effective-config hash, context hashes, and the final rating/output hash
- sanitize backend URLs so credentials, query strings, and fragments are never copied into a shareable report

## Validation

- `pytest -m unit -q`: 360 passed, 1 skipped, 202 deselected (69 subtests passed)
- focused reporting tests: 5 passed
- `ruff check` on all touched Python files: passed
- `git diff --check`: passed

## Reproducibility boundary

This does **not** claim deterministic model output or exact replay. The vendor IDs describe configured chains, not proof of which fallback served a particular call; exact replay still requires archived live inputs.

One boundary question for maintainers: is configured vendor-chain identity the right first manifest boundary here, or would you prefer this to wait until per-tool served-vendor/input receipts can also be captured? Please correct this framing if it does not match the project's intended reproducibility contract.