### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -351,6 +351,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
         ("Anthropic", "anthropic", "https://api.anthropic.com/"),
         ("xAI", "xai", "https://api.x.ai/v1"),
         ("DeepSeek", "deepseek", "https://api.deepseek.com"),
+        ("Atlas Cloud", "atlascloud", "https://api.atlascloud.ai/v1"),
         ("Qwen", "qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
         ("GLM", "glm", "https://open.bigmodel.cn/api/paas/v4/"),
         ("MiniMax", "minimax", "https://api.minimax.io/v1"),

--- a/tests/test_atlascloud_provider.py
+++ b/tests/test_atlascloud_provider.py
@@ -1,0 +1,62 @@
+"""Atlas Cloud provider integration across the shared provider registries."""
+
+import pytest
+
+from cli.utils import provider_default_url
+from tradingagents.llm_clients.api_key_env import get_api_key_env
+from tradingagents.llm_clients.capabilities import get_capabilities
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.model_catalog import get_model_options
+from tradingagents.llm_clients.openai_client import (
+    OPENAI_COMPATIBLE_PROVIDERS,
+    DeepSeekChatOpenAI,
+    is_openai_compatible,
+)
+from tradingagents.llm_clients.validators import validate_model
+
+MODEL = "deepseek-ai/deepseek-v4-pro"
+
+
+@pytest.mark.unit
+def test_atlascloud_registry_contract():
+    spec = OPENAI_COMPATIBLE_PROVIDERS["atlascloud"]
+
+    assert is_openai_compatible("atlascloud")
+    assert spec.base_url == "https://api.atlascloud.ai/v1"
+    assert spec.chat_class is DeepSeekChatOpenAI
+    assert get_api_key_env("atlascloud") == "ATLASCLOUD_API_KEY"
+    assert provider_default_url("atlascloud") == "https://api.atlascloud.ai/v1"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("mode", ["quick", "deep"])
+def test_atlascloud_model_catalog(mode):
+    options = get_model_options("atlascloud", mode)
+
+    assert any(value == MODEL for _, value in options)
+    assert validate_model("atlascloud", MODEL)
+
+
+@pytest.mark.unit
+def test_atlascloud_uses_deepseek_tool_calling_capabilities():
+    capabilities = get_capabilities(MODEL)
+
+    assert capabilities.supports_tool_choice is False
+    assert capabilities.requires_reasoning_content_roundtrip is True
+
+
+@pytest.mark.unit
+def test_atlascloud_client_resolves_endpoint_and_key(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+
+    llm = create_llm_client(provider="atlascloud", model=MODEL).get_llm()
+
+    assert type(llm).__name__ == "DeepSeekChatOpenAI"
+    assert str(llm.openai_api_base) == "https://api.atlascloud.ai/v1"
+    key = (
+        llm.openai_api_key.get_secret_value()
+        if hasattr(llm.openai_api_key, "get_secret_value")
+        else llm.openai_api_key
+    )
+    assert key == "test-key"
+    assert getattr(llm, "use_responses_api", False) in (False, None)

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -20,6 +20,7 @@ PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "bedrock":    None,
     "xai":        "XAI_API_KEY",
     "deepseek":   "DEEPSEEK_API_KEY",
+    "atlascloud": "ATLASCLOUD_API_KEY",
     # Dual-region providers each carry their own account; keys are not
     # interchangeable between the international and China endpoints.
     "qwen":       "DASHSCOPE_API_KEY",

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -96,6 +96,7 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "deepseek-reasoner": _DEEPSEEK_THINKING,
     "deepseek-v4-flash": _DEEPSEEK_THINKING,
     "deepseek-v4-pro": _DEEPSEEK_THINKING,
+    "deepseek-ai/deepseek-v4-pro": _DEEPSEEK_THINKING,
     # MiniMax — full official model lineup per
     # platform.minimax.io/docs/api-reference/text-openai-api
     "MiniMax-M2.7": _MINIMAX_THINKING,

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -141,6 +141,22 @@ MODEL_OPTIONS: ProviderModeOptions = {
             ("Custom model ID", "custom"),
         ],
     },
+    "atlascloud": {
+        "quick": [
+            (
+                "DeepSeek V4 Pro via Atlas Cloud - OpenAI-compatible",
+                "deepseek-ai/deepseek-v4-pro",
+            ),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            (
+                "DeepSeek V4 Pro via Atlas Cloud - OpenAI-compatible",
+                "deepseek-ai/deepseek-v4-pro",
+            ),
+            ("Custom model ID", "custom"),
+        ],
+    },
     # Qwen: same model IDs across global (dashscope-intl) and China
     # (dashscope) endpoints, so the two provider keys share one model list.
     "qwen": _QWEN_MODELS,

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -213,6 +213,9 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderSpec] = {
     "openai":     ProviderSpec(use_responses_api=True),
     "xai":        ProviderSpec(base_url="https://api.x.ai/v1"),
     "deepseek":   ProviderSpec(base_url="https://api.deepseek.com", chat_class=DeepSeekChatOpenAI),
+    "atlascloud": ProviderSpec(
+        base_url="https://api.atlascloud.ai/v1", chat_class=DeepSeekChatOpenAI
+    ),
     "qwen":       ProviderSpec(base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
     "qwen-cn":    ProviderSpec(base_url="https://dashscope.aliyuncs.com/compatible-mode/v1"),
     "glm":        ProviderSpec(base_url="https://api.z.ai/api/paas/v4/"),


### PR DESCRIPTION
## Summary

- register Atlas Cloud as an OpenAI-compatible LLM provider
- add CLI selection, API-key mapping, and quick/deep model catalog entries
- reuse the existing DeepSeek client capabilities for the Atlas model ID

## Validation

- relevant test suite: 55 passed, 68 subtests passed
- Ruff lint passed; new test file format check passed
- Python 3.12 compileall passed for changed files
- Atlas Cloud model catalog: HTTP 200, default model present
- Atlas Cloud chat completions: HTTP 200, standard `choices` response

No README or documentation changes.
