### PR TITLE
Add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,18 @@ GROQ_API_KEY=
 NVIDIA_API_KEY=
 
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
-#FRED_API_KEY=
+FRED_API_KEY=
+
+# Alpha Vantage (alternative data vendor for stock, technical, fundamental, news).
+# Free key: https://www.alphavantage.co/support/#api-key
+ALPHA_VANTAGE_API_KEY=
+
+# Azure OpenAI (provider "azure", select via "azure" in CLI or
+# TRADINGAGENTS_LLM_PROVIDER=azure). Required env vars:
+#AZURE_OPENAI_API_KEY=
+#AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
+#AZURE_OPENAI_DEPLOYMENT_NAME=
+#OPENAI_API_VERSION=2025-03-01-preview
 
 # Optional: a custom OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp,
 # relay). Select provider "openai_compatible" and set the base URL; the key is
@@ -29,6 +40,9 @@ NVIDIA_API_KEY=
 # credential chain (env keys / ~/.aws/credentials / IAM role / AWS_PROFILE). Set
 # the region either way; a bearer token takes precedence when both are present.
 #AWS_BEARER_TOKEN_BEDROCK=
+# AWS_REGION / AWS_DEFAULT_REGION both specify the Bedrock region (AWS_REGION
+# takes precedence). Set at least one of them.
+#AWS_REGION=us-west-2
 #AWS_DEFAULT_REGION=us-west-2
 #AWS_PROFILE=
 
@@ -66,3 +80,9 @@ NVIDIA_API_KEY=
 #TRADINGAGENTS_OPENAI_REASONING_EFFORT=medium
 #TRADINGAGENTS_GOOGLE_THINKING_LEVEL=high
 #TRADINGAGENTS_ANTHROPIC_EFFORT=high
+# Benchmark ticker for alpha calculation (default: SPY).
+#TRADINGAGENTS_BENCHMARK_TICKER=SPY
+# Override filesystem paths (defaults are under ~/.tradingagents/).
+#TRADINGAGENTS_RESULTS_DIR=~/.tradingagents/logs
+#TRADINGAGENTS_CACHE_DIR=~/.tradingagents/cache
+#TRADINGAGENTS_MEMORY_LOG_PATH=~/.tradingagents/memory/trading_memory.md


### PR DESCRIPTION
- Added ALPHA_VANTAGE_API_KEY (used by alpha_vantage_common.py)
- Added Azure OpenAI env vars: AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT_NAME, OPENAI_API_VERSION
- Added AWS_REGION (used as Bedrock region fallback)
- Added TRADINGAGENTS_BENCHMARK_TICKER, TRADINGAGENTS_RESULTS_DIR, TRADINGAGENTS_CACHE_DIR, TRADINGAGENTS_MEMORY_LOG_PATH