### PR TITLE
refactor: add type annotations and extract shared researcher/debator base classes

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from tradingagents.agents.utils.agent_utils import (
@@ -10,8 +12,8 @@ from tradingagents.agents.utils.agent_utils import (
 )
 
 
-def create_fundamentals_analyst(llm):
-    def fundamentals_analyst_node(state):
+def create_fundamentals_analyst(llm: Any) -> Any:
+    def fundamentals_analyst_node(state: Any) -> dict[str, Any]:
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
 

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from tradingagents.agents.utils.agent_utils import (
@@ -9,9 +11,9 @@ from tradingagents.agents.utils.agent_utils import (
 )
 
 
-def create_market_analyst(llm):
+def create_market_analyst(llm: Any) -> Any:
 
-    def market_analyst_node(state):
+    def market_analyst_node(state: Any) -> dict[str, Any]:
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
 

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from tradingagents.agents.utils.agent_utils import (
@@ -10,8 +12,8 @@ from tradingagents.agents.utils.agent_utils import (
 )
 
 
-def create_news_analyst(llm):
-    def news_analyst_node(state):
+def create_news_analyst(llm: Any) -> Any:
+    def news_analyst_node(state: Any) -> dict[str, Any]:
         current_date = state["trade_date"]
         asset_type = state.get("asset_type", "stock")
         asset_label = "company" if asset_type == "stock" else "asset"

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -25,6 +25,7 @@ See: https://github.com/TauricResearch/TradingAgents/issues/796
 """
 
 from datetime import datetime, timedelta
+from typing import Any
 
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -48,7 +49,7 @@ def _seven_days_back(trade_date: str) -> str:
     return (datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
 
 
-def create_sentiment_analyst(llm):
+def create_sentiment_analyst(llm: Any) -> Any:
     """Create a sentiment analyst node for the trading graph.
 
     Pre-fetches news + StockTwits + Reddit data, injects them into the
@@ -58,7 +59,7 @@ def create_sentiment_analyst(llm):
     """
     structured_llm = bind_structured(llm, SentimentReport, "Sentiment Analyst")
 
-    def sentiment_analyst_node(state):
+    def sentiment_analyst_node(state: Any) -> dict[str, Any]:
         ticker = state["company_of_interest"]
         end_date = state["trade_date"]
         start_date = _seven_days_back(end_date)
@@ -191,7 +192,7 @@ Fill the following fields:
 # ---------------------------------------------------------------------------
 # Backwards-compatibility shim
 # ---------------------------------------------------------------------------
-def create_social_media_analyst(llm):
+def create_social_media_analyst(llm: Any) -> Any:
     """Deprecated alias for :func:`create_sentiment_analyst`.
 
     Kept so existing code that imports ``create_social_media_analyst``

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -10,6 +10,8 @@ back gracefully to free-text generation.
 
 from __future__ import annotations
 
+from typing import Any
+
 from tradingagents.agents.schemas import PortfolioDecision, render_pm_decision
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
@@ -22,10 +24,10 @@ from tradingagents.agents.utils.structured import (
 )
 
 
-def create_portfolio_manager(llm):
+def create_portfolio_manager(llm: Any) -> Any:
     structured_llm = bind_structured(llm, PortfolioDecision, "Portfolio Manager")
 
-    def portfolio_manager_node(state) -> dict:
+    def portfolio_manager_node(state: Any) -> dict:
         instrument_context = get_instrument_context_from_state(state)
 
         history = state["risk_debate_state"]["history"]

--- a/tradingagents/agents/managers/research_manager.py
+++ b/tradingagents/agents/managers/research_manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from tradingagents.agents.schemas import ResearchPlan, render_research_plan
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
@@ -14,10 +16,10 @@ from tradingagents.agents.utils.structured import (
 )
 
 
-def create_research_manager(llm):
+def create_research_manager(llm: Any) -> Any:
     structured_llm = bind_structured(llm, ResearchPlan, "Research Manager")
 
-    def research_manager_node(state) -> dict:
+    def research_manager_node(state: Any) -> dict:
         instrument_context = get_instrument_context_from_state(state)
         history = state["investment_debate_state"].get("history", "")
 

--- a/tradingagents/agents/researchers/_base.py
+++ b/tradingagents/agents/researchers/_base.py
@@ -1,0 +1,53 @@
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
+
+
+def _create_researcher(llm, role: str, prompt_template: str):
+    def node(state) -> dict:
+        investment_debate_state = state["investment_debate_state"]
+        history = investment_debate_state.get("history", "")
+
+        market_research_report = state["market_report"]
+        sentiment_report = state["sentiment_report"]
+        news_report = state["news_report"]
+        fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
+        asset_type = state.get("asset_type", "stock")
+        target_label = "stock" if asset_type == "stock" else "asset"
+        fundamentals_label = (
+            "Company fundamentals report"
+            if asset_type == "stock"
+            else "Asset fundamentals report (may be unavailable for crypto)"
+        )
+
+        prompt = prompt_template.format(
+            target_label=target_label,
+            fundamentals_label=fundamentals_label,
+            instrument_context=instrument_context,
+            market_research_report=market_research_report,
+            sentiment_report=sentiment_report,
+            news_report=news_report,
+            fundamentals_report=fundamentals_report,
+            history=history,
+            current_response=investment_debate_state.get("current_response", ""),
+        ) + get_language_instruction()
+
+        response = llm.invoke(prompt)
+        argument = f"{role.capitalize()} Analyst: {response.content}"
+
+        new_state = {
+            "history": history + "\n" + argument,
+            "bull_history": investment_debate_state.get("bull_history", ""),
+            "bear_history": investment_debate_state.get("bear_history", ""),
+            "current_response": argument,
+            "count": investment_debate_state["count"] + 1,
+        }
+        new_state[f"{role}_history"] = (
+            investment_debate_state.get(f"{role}_history", "") + "\n" + argument
+        )
+
+        return {"investment_debate_state": new_state}
+
+    return node

--- a/tradingagents/agents/researchers/_base.py
+++ b/tradingagents/agents/researchers/_base.py
@@ -1,11 +1,13 @@
+from typing import Any
+
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
 )
 
 
-def _create_researcher(llm, role: str, prompt_template: str):
-    def node(state) -> dict:
+def _create_researcher(llm: Any, role: str, prompt_template: str) -> Any:
+    def node(state: Any) -> dict:
         investment_debate_state = state["investment_debate_state"]
         history = investment_debate_state.get("history", "")
 

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -1,30 +1,6 @@
-from tradingagents.agents.utils.agent_utils import (
-    get_instrument_context_from_state,
-    get_language_instruction,
-)
+from ._base import _create_researcher
 
-
-def create_bear_researcher(llm):
-    def bear_node(state) -> dict:
-        investment_debate_state = state["investment_debate_state"]
-        history = investment_debate_state.get("history", "")
-        bear_history = investment_debate_state.get("bear_history", "")
-
-        current_response = investment_debate_state.get("current_response", "")
-        market_research_report = state["market_report"]
-        sentiment_report = state["sentiment_report"]
-        news_report = state["news_report"]
-        fundamentals_report = state["fundamentals_report"]
-        instrument_context = get_instrument_context_from_state(state)
-        asset_type = state.get("asset_type", "stock")
-        target_label = "stock" if asset_type == "stock" else "asset"
-        fundamentals_label = (
-            "Company fundamentals report"
-            if asset_type == "stock"
-            else "Asset fundamentals report (may be unavailable for crypto)"
-        )
-
-        prompt = f"""You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
+BEAR_PROMPT = """You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
 
 Key points to focus on:
 
@@ -44,20 +20,8 @@ Latest world affairs news: {news_report}
 Conversation history of the debate: {history}
 Last bull argument: {current_response}
 Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the {target_label}.
-""" + get_language_instruction()
+"""
 
-        response = llm.invoke(prompt)
 
-        argument = f"Bear Analyst: {response.content}"
-
-        new_investment_debate_state = {
-            "history": history + "\n" + argument,
-            "bear_history": bear_history + "\n" + argument,
-            "bull_history": investment_debate_state.get("bull_history", ""),
-            "current_response": argument,
-            "count": investment_debate_state["count"] + 1,
-        }
-
-        return {"investment_debate_state": new_investment_debate_state}
-
-    return bear_node
+def create_bear_researcher(llm):
+    return _create_researcher(llm, "bear", BEAR_PROMPT)

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ._base import _create_researcher
 
 BEAR_PROMPT = """You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
@@ -23,5 +25,5 @@ Use this information to deliver a compelling bear argument, refute the bull's cl
 """
 
 
-def create_bear_researcher(llm):
+def create_bear_researcher(llm: Any):
     return _create_researcher(llm, "bear", BEAR_PROMPT)

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -25,5 +25,5 @@ Use this information to deliver a compelling bear argument, refute the bull's cl
 """
 
 
-def create_bear_researcher(llm: Any):
+def create_bear_researcher(llm: Any) -> Any:
     return _create_researcher(llm, "bear", BEAR_PROMPT)

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ._base import _create_researcher
 
 BULL_PROMPT = """You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
@@ -21,5 +23,5 @@ Use this information to deliver a compelling bull argument, refute the bear's co
 """
 
 
-def create_bull_researcher(llm):
+def create_bull_researcher(llm: Any):
     return _create_researcher(llm, "bull", BULL_PROMPT)

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -23,5 +23,5 @@ Use this information to deliver a compelling bull argument, refute the bear's co
 """
 
 
-def create_bull_researcher(llm: Any):
+def create_bull_researcher(llm: Any) -> Any:
     return _create_researcher(llm, "bull", BULL_PROMPT)

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -1,30 +1,6 @@
-from tradingagents.agents.utils.agent_utils import (
-    get_instrument_context_from_state,
-    get_language_instruction,
-)
+from ._base import _create_researcher
 
-
-def create_bull_researcher(llm):
-    def bull_node(state) -> dict:
-        investment_debate_state = state["investment_debate_state"]
-        history = investment_debate_state.get("history", "")
-        bull_history = investment_debate_state.get("bull_history", "")
-
-        current_response = investment_debate_state.get("current_response", "")
-        market_research_report = state["market_report"]
-        sentiment_report = state["sentiment_report"]
-        news_report = state["news_report"]
-        fundamentals_report = state["fundamentals_report"]
-        instrument_context = get_instrument_context_from_state(state)
-        asset_type = state.get("asset_type", "stock")
-        target_label = "stock" if asset_type == "stock" else "asset"
-        fundamentals_label = (
-            "Company fundamentals report"
-            if asset_type == "stock"
-            else "Asset fundamentals report (may be unavailable for crypto)"
-        )
-
-        prompt = f"""You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
+BULL_PROMPT = """You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
 
 Key points to focus on:
 - Growth Potential: Highlight the company's market opportunities, revenue projections, and scalability.
@@ -42,20 +18,8 @@ Latest world affairs news: {news_report}
 Conversation history of the debate: {history}
 Last bear argument: {current_response}
 Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.
-""" + get_language_instruction()
+"""
 
-        response = llm.invoke(prompt)
 
-        argument = f"Bull Analyst: {response.content}"
-
-        new_investment_debate_state = {
-            "history": history + "\n" + argument,
-            "bull_history": bull_history + "\n" + argument,
-            "bear_history": investment_debate_state.get("bear_history", ""),
-            "current_response": argument,
-            "count": investment_debate_state["count"] + 1,
-        }
-
-        return {"investment_debate_state": new_investment_debate_state}
-
-    return bull_node
+def create_bull_researcher(llm):
+    return _create_researcher(llm, "bull", BULL_PROMPT)

--- a/tradingagents/agents/risk_mgmt/_base.py
+++ b/tradingagents/agents/risk_mgmt/_base.py
@@ -1,0 +1,66 @@
+from tradingagents.agents.utils.agent_utils import (
+    get_instrument_context_from_state,
+    get_language_instruction,
+)
+
+
+def _create_debator(llm, role: str, prompt_template: str):
+    def node(state) -> dict:
+        risk_debate_state = state["risk_debate_state"]
+        history = risk_debate_state.get("history", "")
+
+        market_research_report = state["market_report"]
+        sentiment_report = state["sentiment_report"]
+        news_report = state["news_report"]
+        fundamentals_report = state["fundamentals_report"]
+        instrument_context = get_instrument_context_from_state(state)
+        trader_decision = state["trader_investment_plan"]
+
+        prompt = prompt_template.format(
+            trader_decision=trader_decision,
+            instrument_context=instrument_context,
+            market_research_report=market_research_report,
+            sentiment_report=sentiment_report,
+            news_report=news_report,
+            fundamentals_report=fundamentals_report,
+            history=history,
+            current_aggressive_response=risk_debate_state.get(
+                "current_aggressive_response", ""
+            ),
+            current_conservative_response=risk_debate_state.get(
+                "current_conservative_response", ""
+            ),
+            current_neutral_response=risk_debate_state.get(
+                "current_neutral_response", ""
+            ),
+        ) + get_language_instruction()
+
+        response = llm.invoke(prompt)
+        speaker = role.capitalize()
+        argument = f"{speaker} Analyst: {response.content}"
+
+        new_state = {
+            "history": history + "\n" + argument,
+            "aggressive_history": risk_debate_state.get("aggressive_history", ""),
+            "conservative_history": risk_debate_state.get("conservative_history", ""),
+            "neutral_history": risk_debate_state.get("neutral_history", ""),
+            "latest_speaker": speaker,
+            "current_aggressive_response": risk_debate_state.get(
+                "current_aggressive_response", ""
+            ),
+            "current_conservative_response": risk_debate_state.get(
+                "current_conservative_response", ""
+            ),
+            "current_neutral_response": risk_debate_state.get(
+                "current_neutral_response", ""
+            ),
+            "count": risk_debate_state["count"] + 1,
+        }
+        new_state[f"{role}_history"] = (
+            risk_debate_state.get(f"{role}_history", "") + "\n" + argument
+        )
+        new_state[f"current_{role}_response"] = argument
+
+        return {"risk_debate_state": new_state}
+
+    return node

--- a/tradingagents/agents/risk_mgmt/_base.py
+++ b/tradingagents/agents/risk_mgmt/_base.py
@@ -1,11 +1,13 @@
+from typing import Any
+
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
 )
 
 
-def _create_debator(llm, role: str, prompt_template: str):
-    def node(state) -> dict:
+def _create_debator(llm: Any, role: str, prompt_template: str) -> Any:
+    def node(state: Any) -> dict:
         risk_debate_state = state["risk_debate_state"]
         history = risk_debate_state.get("history", "")
 

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ._base import _create_debator
 
 AGGRESSIVE_PROMPT = """As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits—even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative. Here is the trader's decision:
@@ -16,5 +18,5 @@ Here is the current conversation history: {history} Here are the last arguments 
 Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_aggressive_debator(llm):
+def create_aggressive_debator(llm: Any):
     return _create_debator(llm, "aggressive", AGGRESSIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -1,27 +1,6 @@
-from tradingagents.agents.utils.agent_utils import (
-    get_instrument_context_from_state,
-    get_language_instruction,
-)
+from ._base import _create_debator
 
-
-def create_aggressive_debator(llm):
-    def aggressive_node(state) -> dict:
-        risk_debate_state = state["risk_debate_state"]
-        history = risk_debate_state.get("history", "")
-        aggressive_history = risk_debate_state.get("aggressive_history", "")
-
-        current_conservative_response = risk_debate_state.get("current_conservative_response", "")
-        current_neutral_response = risk_debate_state.get("current_neutral_response", "")
-
-        market_research_report = state["market_report"]
-        sentiment_report = state["sentiment_report"]
-        news_report = state["news_report"]
-        fundamentals_report = state["fundamentals_report"]
-        instrument_context = get_instrument_context_from_state(state)
-
-        trader_decision = state["trader_investment_plan"]
-
-        prompt = f"""As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits—even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative. Here is the trader's decision:
+AGGRESSIVE_PROMPT = """As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits—even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative. Here is the trader's decision:
 
 {trader_decision}
 
@@ -34,26 +13,8 @@ Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
 Here is the current conversation history: {history} Here are the last arguments from the conservative analyst: {current_conservative_response} Here are the last arguments from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
-Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
+Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting."""
 
-        response = llm.invoke(prompt)
 
-        argument = f"Aggressive Analyst: {response.content}"
-
-        new_risk_debate_state = {
-            "history": history + "\n" + argument,
-            "aggressive_history": aggressive_history + "\n" + argument,
-            "conservative_history": risk_debate_state.get("conservative_history", ""),
-            "neutral_history": risk_debate_state.get("neutral_history", ""),
-            "latest_speaker": "Aggressive",
-            "current_aggressive_response": argument,
-            "current_conservative_response": risk_debate_state.get("current_conservative_response", ""),
-            "current_neutral_response": risk_debate_state.get(
-                "current_neutral_response", ""
-            ),
-            "count": risk_debate_state["count"] + 1,
-        }
-
-        return {"risk_debate_state": new_risk_debate_state}
-
-    return aggressive_node
+def create_aggressive_debator(llm):
+    return _create_debator(llm, "aggressive", AGGRESSIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -18,5 +18,5 @@ Here is the current conversation history: {history} Here are the last arguments 
 Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_aggressive_debator(llm: Any):
+def create_aggressive_debator(llm: Any) -> Any:
     return _create_debator(llm, "aggressive", AGGRESSIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ._base import _create_debator
 
 CONSERVATIVE_PROMPT = """As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains. Here is the trader's decision:
@@ -16,5 +18,5 @@ Here is the current conversation history: {history} Here is the last response fr
 Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_conservative_debator(llm):
+def create_conservative_debator(llm: Any):
     return _create_debator(llm, "conservative", CONSERVATIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -18,5 +18,5 @@ Here is the current conversation history: {history} Here is the last response fr
 Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_conservative_debator(llm: Any):
+def create_conservative_debator(llm: Any) -> Any:
     return _create_debator(llm, "conservative", CONSERVATIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -1,27 +1,6 @@
-from tradingagents.agents.utils.agent_utils import (
-    get_instrument_context_from_state,
-    get_language_instruction,
-)
+from ._base import _create_debator
 
-
-def create_conservative_debator(llm):
-    def conservative_node(state) -> dict:
-        risk_debate_state = state["risk_debate_state"]
-        history = risk_debate_state.get("history", "")
-        conservative_history = risk_debate_state.get("conservative_history", "")
-
-        current_aggressive_response = risk_debate_state.get("current_aggressive_response", "")
-        current_neutral_response = risk_debate_state.get("current_neutral_response", "")
-
-        market_research_report = state["market_report"]
-        sentiment_report = state["sentiment_report"]
-        news_report = state["news_report"]
-        fundamentals_report = state["fundamentals_report"]
-        instrument_context = get_instrument_context_from_state(state)
-
-        trader_decision = state["trader_investment_plan"]
-
-        prompt = f"""As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains. Here is the trader's decision:
+CONSERVATIVE_PROMPT = """As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains. Here is the trader's decision:
 
 {trader_decision}
 
@@ -34,28 +13,8 @@ Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
-Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
+Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting."""
 
-        response = llm.invoke(prompt)
 
-        argument = f"Conservative Analyst: {response.content}"
-
-        new_risk_debate_state = {
-            "history": history + "\n" + argument,
-            "aggressive_history": risk_debate_state.get("aggressive_history", ""),
-            "conservative_history": conservative_history + "\n" + argument,
-            "neutral_history": risk_debate_state.get("neutral_history", ""),
-            "latest_speaker": "Conservative",
-            "current_aggressive_response": risk_debate_state.get(
-                "current_aggressive_response", ""
-            ),
-            "current_conservative_response": argument,
-            "current_neutral_response": risk_debate_state.get(
-                "current_neutral_response", ""
-            ),
-            "count": risk_debate_state["count"] + 1,
-        }
-
-        return {"risk_debate_state": new_risk_debate_state}
-
-    return conservative_node
+def create_conservative_debator(llm):
+    return _create_debator(llm, "conservative", CONSERVATIVE_PROMPT)

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -18,5 +18,5 @@ Here is the current conversation history: {history} Here is the last response fr
 Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_neutral_debator(llm: Any):
+def create_neutral_debator(llm: Any) -> Any:
     return _create_debator(llm, "neutral", NEUTRAL_PROMPT)

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -1,27 +1,6 @@
-from tradingagents.agents.utils.agent_utils import (
-    get_instrument_context_from_state,
-    get_language_instruction,
-)
+from ._base import _create_debator
 
-
-def create_neutral_debator(llm):
-    def neutral_node(state) -> dict:
-        risk_debate_state = state["risk_debate_state"]
-        history = risk_debate_state.get("history", "")
-        neutral_history = risk_debate_state.get("neutral_history", "")
-
-        current_aggressive_response = risk_debate_state.get("current_aggressive_response", "")
-        current_conservative_response = risk_debate_state.get("current_conservative_response", "")
-
-        market_research_report = state["market_report"]
-        sentiment_report = state["sentiment_report"]
-        news_report = state["news_report"]
-        fundamentals_report = state["fundamentals_report"]
-        instrument_context = get_instrument_context_from_state(state)
-
-        trader_decision = state["trader_investment_plan"]
-
-        prompt = f"""As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.Here is the trader's decision:
+NEUTRAL_PROMPT = """As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.Here is the trader's decision:
 
 {trader_decision}
 
@@ -34,26 +13,8 @@ Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
 Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the conservative analyst: {current_conservative_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
-Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
+Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting."""
 
-        response = llm.invoke(prompt)
 
-        argument = f"Neutral Analyst: {response.content}"
-
-        new_risk_debate_state = {
-            "history": history + "\n" + argument,
-            "aggressive_history": risk_debate_state.get("aggressive_history", ""),
-            "conservative_history": risk_debate_state.get("conservative_history", ""),
-            "neutral_history": neutral_history + "\n" + argument,
-            "latest_speaker": "Neutral",
-            "current_aggressive_response": risk_debate_state.get(
-                "current_aggressive_response", ""
-            ),
-            "current_conservative_response": risk_debate_state.get("current_conservative_response", ""),
-            "current_neutral_response": argument,
-            "count": risk_debate_state["count"] + 1,
-        }
-
-        return {"risk_debate_state": new_risk_debate_state}
-
-    return neutral_node
+def create_neutral_debator(llm):
+    return _create_debator(llm, "neutral", NEUTRAL_PROMPT)

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ._base import _create_debator
 
 NEUTRAL_PROMPT = """As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.Here is the trader's decision:
@@ -16,5 +18,5 @@ Here is the current conversation history: {history} Here is the last response fr
 Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting."""
 
 
-def create_neutral_debator(llm):
+def create_neutral_debator(llm: Any):
     return _create_debator(llm, "neutral", NEUTRAL_PROMPT)

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -19,7 +19,7 @@ so that:
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -30,7 +30,7 @@ from pydantic import BaseModel, Field, field_validator
 _NULLISH_FLOAT = {"", "none", "n/a", "na", "null", "nil", "-", "tbd", "unknown"}
 
 
-def _coerce_optional_float(value):
+def _coerce_optional_float(value: Any) -> Any:
     if isinstance(value, str) and value.strip().lower() in _NULLISH_FLOAT:
         return None
     return value
@@ -151,7 +151,7 @@ class TraderProposal(BaseModel):
 
     @field_validator("entry_price", "stop_loss", mode="before")
     @classmethod
-    def _nullish_float_to_none(cls, v):
+    def _nullish_float_to_none(cls, v: Any) -> Any:
         return _coerce_optional_float(v)
 
 
@@ -224,7 +224,7 @@ class PortfolioDecision(BaseModel):
 
     @field_validator("price_target", mode="before")
     @classmethod
-    def _nullish_float_to_none(cls, v):
+    def _nullish_float_to_none(cls, v: Any) -> Any:
         return _coerce_optional_float(v)
 
 

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+from typing import Any
 
 from langchain_core.messages import AIMessage
 
@@ -18,10 +19,10 @@ from tradingagents.agents.utils.structured import (
 )
 
 
-def create_trader(llm):
+def create_trader(llm: Any) -> Any:
     structured_llm = bind_structured(llm, TraderProposal, "Trader")
 
-    def trader_node(state, name):
+    def trader_node(state: Any, name: str) -> dict[str, Any]:
         company_name = state["company_of_interest"]
         instrument_context = get_instrument_context_from_state(state)
         investment_plan = state["investment_plan"]

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -188,7 +188,7 @@ def get_instrument_context_from_state(state: Mapping[str, Any]) -> str:
 
 
 def create_msg_delete() -> callable:
-    def delete_messages(state):
+    def delete_messages(state: Any) -> dict[str, Any]:
         """Clear messages and add a context-anchored placeholder.
 
         The placeholder must not be a bare ``"Continue"``: some

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -76,7 +76,7 @@ def _clean_identity_value(value: Any) -> str | None:
 
 
 @functools.lru_cache(maxsize=256)
-def resolve_instrument_identity(ticker: str) -> dict:
+def resolve_instrument_identity(ticker: str) -> dict[str, str]:
     """Resolve deterministic identity metadata (company name, sector, …) for a ticker.
 
     This exists to stop the pipeline from hallucinating a *different* company
@@ -187,7 +187,7 @@ def get_instrument_context_from_state(state: Mapping[str, Any]) -> str:
     )
 
 
-def create_msg_delete():
+def create_msg_delete() -> callable:
     def delete_messages(state):
         """Clear messages and add a context-anchored placeholder.
 

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -73,7 +73,8 @@ class TradingMemoryLog:
         if not entries:
             return ""
 
-        same, cross = [], []
+        same: list[dict[str, Any]] = []
+        cross: list[dict[str, Any]] = []
         for e in reversed(entries):
             if len(same) >= n_same and len(cross) >= n_cross:
                 break

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime
 from io import StringIO
+from typing import Any
 
 import pandas as pd
 import requests
@@ -34,7 +35,7 @@ def get_api_key() -> str:
         )
     return api_key
 
-def format_datetime_for_api(date_input) -> str:
+def format_datetime_for_api(date_input: str | datetime) -> str:
     """Convert various date formats to YYYYMMDDTHHMM format required by Alpha Vantage API."""
     if isinstance(date_input, str):
         # If already in correct format, return as-is

--- a/tradingagents/dataflows/alpha_vantage_fundamentals.py
+++ b/tradingagents/dataflows/alpha_vantage_fundamentals.py
@@ -1,9 +1,10 @@
 import json
+from typing import Any
 
 from .alpha_vantage_common import _make_api_request
 
 
-def _filter_reports_by_date(result, curr_date: str):
+def _filter_reports_by_date(result: Any, curr_date: str) -> str:
     """Drop annual/quarterly reports dated after curr_date to prevent look-ahead.
 
     ``_make_api_request`` returns the fundamentals payload as a JSON string, so
@@ -45,19 +46,19 @@ def get_fundamentals(ticker: str, curr_date: str = None) -> str:
     return _make_api_request("OVERVIEW", params)
 
 
-def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None):
+def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str = None) -> str:
     """Retrieve balance sheet data for a given ticker symbol using Alpha Vantage."""
     result = _make_api_request("BALANCE_SHEET", {"symbol": ticker})
     return _filter_reports_by_date(result, curr_date)
 
 
-def get_cashflow(ticker: str, freq: str = "quarterly", curr_date: str = None):
+def get_cashflow(ticker: str, freq: str = "quarterly", curr_date: str = None) -> str:
     """Retrieve cash flow statement data for a given ticker symbol using Alpha Vantage."""
     result = _make_api_request("CASH_FLOW", {"symbol": ticker})
     return _filter_reports_by_date(result, curr_date)
 
 
-def get_income_statement(ticker: str, freq: str = "quarterly", curr_date: str = None):
+def get_income_statement(ticker: str, freq: str = "quarterly", curr_date: str = None) -> str:
     """Retrieve income statement data for a given ticker symbol using Alpha Vantage."""
     result = _make_api_request("INCOME_STATEMENT", {"symbol": ticker})
     return _filter_reports_by_date(result, curr_date)

--- a/tradingagents/dataflows/alpha_vantage_news.py
+++ b/tradingagents/dataflows/alpha_vantage_news.py
@@ -1,7 +1,7 @@
 from .alpha_vantage_common import _make_api_request, format_datetime_for_api
 
 
-def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
+def get_news(ticker: str, start_date: str, end_date: str) -> dict[str, str] | str:
     """Returns live and historical market news & sentiment data from premier news outlets worldwide.
 
     Covers stocks, cryptocurrencies, forex, and topics like fiscal policy, mergers & acquisitions, IPOs.
@@ -23,7 +23,7 @@ def get_news(ticker, start_date, end_date) -> dict[str, str] | str:
 
     return _make_api_request("NEWS_SENTIMENT", params)
 
-def get_global_news(curr_date, look_back_days: int = 7, limit: int = 50) -> dict[str, str] | str:
+def get_global_news(curr_date: str, look_back_days: int = 7, limit: int = 50) -> dict[str, str] | str:
     """Returns global market news & sentiment data without ticker-specific filtering.
 
     Covers broad market topics like financial markets, economy, and more.

--- a/tradingagents/dataflows/config.py
+++ b/tradingagents/dataflows/config.py
@@ -1,19 +1,21 @@
+from collections.abc import Mapping
 from copy import deepcopy
+from typing import Any
 
 import tradingagents.default_config as default_config
 
 # Use default config but allow it to be overridden
-_config: dict | None = None
+_config: dict[str, Any] | None = None
 
 
-def initialize_config():
+def initialize_config() -> None:
     """Initialize the configuration with default values."""
     global _config
     if _config is None:
         _config = deepcopy(default_config.DEFAULT_CONFIG)
 
 
-def set_config(config: dict):
+def set_config(config: Mapping[str, Any]) -> None:
     """Update the configuration with custom values.
 
     Dict-valued keys (e.g. ``data_vendors``) are merged one level deep so a
@@ -30,7 +32,7 @@ def set_config(config: dict):
             _config[key] = value
 
 
-def get_config() -> dict:
+def get_config() -> dict[str, Any]:
     """Get the current configuration."""
     if _config is None:
         initialize_config()

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from .alpha_vantage import (
     get_balance_sheet as get_alpha_vantage_balance_sheet,
@@ -165,7 +166,7 @@ def get_vendor(category: str, method: str = None) -> str:
     # Fall back to category-level configuration
     return config.get("data_vendors", {}).get(category, "default")
 
-def route_to_vendor(method: str, *args, **kwargs):
+def route_to_vendor(method: str, *args: Any, **kwargs: Any) -> Any:
     """Route method calls to appropriate vendor implementation with fallback support."""
     category = get_category_for_method(method)
     vendor_config = get_vendor(category, method)

--- a/tradingagents/dataflows/market_data_validator.py
+++ b/tradingagents/dataflows/market_data_validator.py
@@ -45,7 +45,7 @@ def _verified_rows(symbol: str, curr_date: str) -> pd.DataFrame:
     return df
 
 
-def _fmt(value) -> str:
+def _fmt(value: Any) -> str:
     if value is None or pd.isna(value):
         return "N/A"
     if isinstance(value, pd.Timestamp):

--- a/tradingagents/dataflows/polymarket.py
+++ b/tradingagents/dataflows/polymarket.py
@@ -12,6 +12,7 @@ outcomes (a "Yes" at 0.76 means the market prices a 76% chance).
 import json
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 import requests
 
@@ -34,7 +35,7 @@ def _request(path: str, params: dict) -> dict:
     return response.json()
 
 
-def _parse_json_list(value) -> list:
+def _parse_json_list(value: Any) -> list:
     """Gamma encodes ``outcomes``/``outcomePrices`` as JSON-string arrays."""
     if isinstance(value, list):
         return value

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import time
-from typing import Annotated
+from datetime import datetime
+from typing import Annotated, Any
 
 import pandas as pd
 import yfinance as yf
@@ -26,7 +27,7 @@ MAX_OHLCV_STALE_DAYS = 10
 OHLCV_CACHE_TTL_SECONDS = 900
 
 
-def yf_retry(func, max_retries=3, base_delay=2.0):
+def yf_retry(func: Any, max_retries: int = 3, base_delay: float = 2.0) -> Any:
     """Execute a yfinance call with exponential backoff on rate limits.
 
     yfinance raises YFRateLimitError on HTTP 429 responses but does not
@@ -128,7 +129,7 @@ def _assert_ohlcv_not_stale(
         )
 
 
-def _needs_same_day_refresh(data_file, curr_date_dt, today_date) -> bool:
+def _needs_same_day_refresh(data_file: str, curr_date_dt: datetime, today_date: datetime) -> bool:
     """Whether a cached frame must be refetched to reflect the requested day.
 
     The cache file is keyed per day, so without this a run started before the
@@ -245,7 +246,7 @@ class StockstatsUtils:
         curr_date: Annotated[
             str, "curr date for retrieving stock price data, YYYY-mm-dd"
         ],
-    ):
+    ) -> str:
         data = load_ohlcv(symbol, curr_date)
         df = wrap(data)
         df["Date"] = df["Date"].dt.strftime("%Y-%m-%d")

--- a/tradingagents/dataflows/utils.py
+++ b/tradingagents/dataflows/utils.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime, timedelta
-from typing import Annotated
+from typing import Annotated, Any
 
 import pandas as pd
 
@@ -48,12 +48,12 @@ def save_output(data: pd.DataFrame, tag: str, save_path: SavePathType = None) ->
         print(f"{tag} saved to {save_path}")
 
 
-def get_current_date():
+def get_current_date() -> str:
     return date.today().strftime("%Y-%m-%d")
 
 
-def decorate_all_methods(decorator):
-    def class_decorator(cls):
+def decorate_all_methods(decorator: Any) -> Any:
+    def class_decorator(cls: type) -> type:
         for attr_name, attr_value in cls.__dict__.items():
             if callable(attr_value):
                 setattr(cls, attr_name, decorator(attr_value))
@@ -62,7 +62,7 @@ def decorate_all_methods(decorator):
     return class_decorator
 
 
-def get_next_weekday(date):
+def get_next_weekday(date: datetime | str) -> datetime:
 
     if not isinstance(date, datetime):
         date = datetime.strptime(date, "%Y-%m-%d")

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -19,7 +19,7 @@ def get_YFin_data_online(
     symbol: Annotated[str, "ticker symbol of the company"],
     start_date: Annotated[str, "Start date in yyyy-mm-dd format"],
     end_date: Annotated[str, "End date in yyyy-mm-dd format"],
-):
+) -> str:
 
     datetime.strptime(start_date, "%Y-%m-%d")
     end_dt = datetime.strptime(end_date, "%Y-%m-%d")
@@ -274,7 +274,7 @@ def get_stockstats_indicator(
 def get_fundamentals(
     ticker: Annotated[str, "ticker symbol of the company"],
     curr_date: Annotated[str, "current date (not used for yfinance)"] = None
-):
+) -> str:
     """Get company fundamentals overview from yfinance."""
     canonical = normalize_symbol(ticker)
     try:
@@ -342,7 +342,7 @@ def get_balance_sheet(
     ticker: Annotated[str, "ticker symbol of the company"],
     freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
     curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None
-):
+) -> str:
     """Get balance sheet data from yfinance."""
     canonical = normalize_symbol(ticker)
     try:
@@ -377,7 +377,7 @@ def get_cashflow(
     ticker: Annotated[str, "ticker symbol of the company"],
     freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
     curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None
-):
+) -> str:
     """Get cash flow data from yfinance."""
     canonical = normalize_symbol(ticker)
     try:
@@ -412,7 +412,7 @@ def get_income_statement(
     ticker: Annotated[str, "ticker symbol of the company"],
     freq: Annotated[str, "frequency of data: 'annual' or 'quarterly'"] = "quarterly",
     curr_date: Annotated[str, "current date in YYYY-MM-DD format"] = None
-):
+) -> str:
     """Get income statement data from yfinance."""
     canonical = normalize_symbol(ticker)
     try:
@@ -445,7 +445,7 @@ def get_income_statement(
 
 def get_insider_transactions(
     ticker: Annotated[str, "ticker symbol of the company"]
-):
+) -> str:
     """Get insider transactions data from yfinance."""
     canonical = normalize_symbol(ticker)
     try:

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -69,7 +69,7 @@ def _extract_article_data(article: dict) -> dict:
         }
 
 
-def _in_news_window(pub_date, start_dt, end_dt) -> bool:
+def _in_news_window(pub_date: str | None, start_dt: datetime, end_dt: datetime) -> bool:
     """Whether an article belongs in the half-open window ``[start, end + 1 day)``.
 
     Every operand is normalized to UTC, and the upper bound is exclusive so an

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 _TRADINGAGENTS_HOME = os.path.join(os.path.expanduser("~"), ".tradingagents")
 
@@ -32,7 +33,7 @@ _BOOL_TRUE = ("true", "1", "yes", "on")
 _BOOL_FALSE = ("false", "0", "no", "off")
 
 
-def _coerce(value: str, reference):
+def _coerce(value: str, reference: Any) -> Any:
     """Coerce env-var string to the type of the existing default value.
 
     Invalid values raise ``ValueError`` rather than silently falling back to a
@@ -55,7 +56,7 @@ def _coerce(value: str, reference):
     return value
 
 
-def _apply_env_overrides(config: dict) -> dict:
+def _apply_env_overrides(config: dict[str, Any]) -> dict[str, Any]:
     """Apply TRADINGAGENTS_* env vars to the config dict in-place."""
     for env_var, key in _ENV_OVERRIDES.items():
         raw = os.environ.get(env_var)

--- a/tradingagents/graph/conditional_logic.py
+++ b/tradingagents/graph/conditional_logic.py
@@ -6,12 +6,12 @@ from tradingagents.agents.utils.agent_states import AgentState
 class ConditionalLogic:
     """Handles conditional logic for determining graph flow."""
 
-    def __init__(self, max_debate_rounds=1, max_risk_discuss_rounds=1):
+    def __init__(self, max_debate_rounds: int = 1, max_risk_discuss_rounds: int = 1):
         """Initialize with configuration parameters."""
         self.max_debate_rounds = max_debate_rounds
         self.max_risk_discuss_rounds = max_risk_discuss_rounds
 
-    def should_continue_market(self, state: AgentState):
+    def should_continue_market(self, state: AgentState) -> str:
         """Determine if market analysis should continue."""
         messages = state["messages"]
         last_message = messages[-1]
@@ -19,7 +19,7 @@ class ConditionalLogic:
             return "tools_market"
         return "Msg Clear Market"
 
-    def should_continue_social(self, state: AgentState):
+    def should_continue_social(self, state: AgentState) -> str:
         """Determine if sentiment-analyst tool round should continue.
 
         Method name keeps the legacy ``social`` suffix to match the
@@ -33,7 +33,7 @@ class ConditionalLogic:
             return "tools_social"
         return "Msg Clear Sentiment"
 
-    def should_continue_news(self, state: AgentState):
+    def should_continue_news(self, state: AgentState) -> str:
         """Determine if news analysis should continue."""
         messages = state["messages"]
         last_message = messages[-1]
@@ -41,7 +41,7 @@ class ConditionalLogic:
             return "tools_news"
         return "Msg Clear News"
 
-    def should_continue_fundamentals(self, state: AgentState):
+    def should_continue_fundamentals(self, state: AgentState) -> str:
         """Determine if fundamentals analysis should continue."""
         messages = state["messages"]
         last_message = messages[-1]

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -11,7 +11,7 @@ from tradingagents.agents.utils.agent_states import (
 class Propagator:
     """Handles state initialization and propagation through the graph."""
 
-    def __init__(self, max_recur_limit=100):
+    def __init__(self, max_recur_limit: int = 100):
         """Initialize with configuration parameters."""
         self.max_recur_limit = max_recur_limit
 

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -59,8 +59,8 @@ class GraphSetup:
         self.conditional_logic = conditional_logic
 
     def setup_graph(
-        self, selected_analysts=("market", "social", "news", "fundamentals")
-    ):
+        self, selected_analysts: Any = ("market", "social", "news", "fundamentals")
+    ) -> Any:
         """Set up and compile the agent workflow graph.
 
         Args:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -44,7 +44,7 @@ from .signal_processing import SignalProcessor
 logger = logging.getLogger(__name__)
 
 
-def _coerce_max_retries(value):
+def _coerce_max_retries(value: Any) -> int:
     """Validate an ``llm_max_retries`` value to a non-negative int.
 
     Accepts an int or a numeric string (env vars arrive as strings). Rejects
@@ -67,11 +67,11 @@ class TradingAgentsGraph:
 
     def __init__(
         self,
-        selected_analysts=("market", "social", "news", "fundamentals"),
-        debug=False,
-        config: dict[str, Any] = None,
-        callbacks: list | None = None,
-    ):
+        selected_analysts: tuple[str, ...] = ("market", "social", "news", "fundamentals"),
+        debug: bool = False,
+        config: dict[str, Any] | None = None,
+        callbacks: list[Any] | None = None,
+    ) -> None:
         """Initialize the trading agents graph and components.
 
         Args:
@@ -138,9 +138,9 @@ class TradingAgentsGraph:
         self.signal_processor = SignalProcessor(self.quick_thinking_llm)
 
         # State tracking
-        self.curr_state = None
-        self.ticker = None
-        self.log_states_dict = {}  # date to full state dict
+        self.curr_state: dict | None = None
+        self.ticker: str | None = None
+        self.log_states_dict: dict[str, Any] = {}  # date to full state dict
 
         # Graph-shape-affecting run choices, kept for the checkpoint signature.
         self.selected_analysts = tuple(selected_analysts)
@@ -359,7 +359,7 @@ class TradingAgentsGraph:
             f"asset={asset_type}",
         ])
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(self, company_name: str, trade_date: str, asset_type: str = "stock") -> tuple[dict, Any]:
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -401,7 +401,7 @@ class TradingAgentsGraph:
                 self._checkpointer_ctx = None
                 self.graph = self.workflow.compile()
 
-    def save_reports(self, final_state, ticker, save_path=None) -> Path:
+    def save_reports(self, final_state: dict, ticker: str, save_path: str | Path | None = None) -> Path:
         """Write the markdown report tree for a completed run, like the CLI does.
 
         Programmatic callers get the same on-disk reports the CLI produces. Pass
@@ -416,7 +416,7 @@ class TradingAgentsGraph:
             )
         return write_report_tree(final_state, ticker, save_path)
 
-    def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
+    def _run_graph(self, company_name: str, trade_date: str, asset_type: str = "stock") -> tuple[dict, Any]:
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents.
@@ -481,7 +481,7 @@ class TradingAgentsGraph:
 
         return final_state, self.process_signal(final_state["final_trade_decision"])
 
-    def _log_state(self, trade_date, final_state):
+    def _log_state(self, trade_date: str, final_state: dict) -> None:
         """Log the final state to a JSON file."""
         self.log_states_dict[str(trade_date)] = {
             "company_of_interest": final_state["company_of_interest"],
@@ -523,6 +523,6 @@ class TradingAgentsGraph:
         with open(log_path, "w", encoding="utf-8") as f:
             json.dump(self.log_states_dict[str(trade_date)], f, indent=4)
 
-    def process_signal(self, full_signal):
+    def process_signal(self, full_signal: str) -> Any:
         """Process a signal to extract the core decision."""
         return self.signal_processor.process_signal(full_signal)

--- a/tradingagents/llm_clients/anthropic_client.py
+++ b/tradingagents/llm_clients/anthropic_client.py
@@ -46,14 +46,14 @@ class NormalizedChatAnthropic(ChatAnthropic):
     downstream handling.
     """
 
-    def invoke(self, input, config=None, **kwargs):
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         return normalize_content(super().invoke(input, config, **kwargs))
 
 
 class AnthropicClient(BaseLLMClient):
     """Client for Anthropic Claude models."""
 
-    def __init__(self, model: str, base_url: str | None = None, **kwargs):
+    def __init__(self, model: str, base_url: str | None = None, **kwargs: Any):
         super().__init__(model, base_url, **kwargs)
 
     def get_llm(self) -> Any:

--- a/tradingagents/llm_clients/azure_client.py
+++ b/tradingagents/llm_clients/azure_client.py
@@ -14,7 +14,7 @@ _PASSTHROUGH_KWARGS = (
 class NormalizedAzureChatOpenAI(AzureChatOpenAI):
     """AzureChatOpenAI with normalized content output."""
 
-    def invoke(self, input, config=None, **kwargs):
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         return normalize_content(super().invoke(input, config, **kwargs))
 
 
@@ -28,7 +28,7 @@ class AzureOpenAIClient(BaseLLMClient):
         OPENAI_API_VERSION: API version (e.g. 2025-03-01-preview)
     """
 
-    def __init__(self, model: str, base_url: str | None = None, **kwargs):
+    def __init__(self, model: str, base_url: str | None = None, **kwargs: Any):
         super().__init__(model, base_url, **kwargs)
 
     def get_llm(self) -> Any:

--- a/tradingagents/llm_clients/base_client.py
+++ b/tradingagents/llm_clients/base_client.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 
-def normalize_content(response):
+def normalize_content(response: Any) -> Any:
     """Normalize LLM response content to a plain string.
 
     Multiple providers (OpenAI Responses API, Google Gemini 3) return content
@@ -25,7 +25,7 @@ def normalize_content(response):
 class BaseLLMClient(ABC):
     """Abstract base class for LLM clients."""
 
-    def __init__(self, model: str, base_url: str | None = None, **kwargs):
+    def __init__(self, model: str, base_url: str | None = None, **kwargs: Any):
         self.model = model
         self.base_url = base_url
         self.kwargs = kwargs

--- a/tradingagents/llm_clients/bedrock_client.py
+++ b/tradingagents/llm_clients/bedrock_client.py
@@ -9,7 +9,7 @@ _DEFAULT_REGION = "us-west-2"
 _BEDROCK_CLASS = None
 
 
-def _bedrock_class():
+def _bedrock_class() -> type:
     """Lazily import langchain-aws (the optional ``[bedrock]`` extra) and return a
     ChatBedrockConverse subclass with normalized content output.
 
@@ -31,7 +31,7 @@ def _bedrock_class():
     class NormalizedChatBedrockConverse(ChatBedrockConverse):
         """ChatBedrockConverse with normalized (string) content output."""
 
-        def invoke(self, input, config=None, **kwargs):
+        def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
             return normalize_content(super().invoke(input, config, **kwargs))
 
     _BEDROCK_CLASS = NormalizedChatBedrockConverse

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -1,4 +1,6 @@
 
+from typing import Any
+
 from .base_client import BaseLLMClient
 
 
@@ -6,7 +8,7 @@ def create_llm_client(
     provider: str,
     model: str,
     base_url: str | None = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> BaseLLMClient:
     """Create an LLM client for the specified provider.
 

--- a/tradingagents/llm_clients/google_client.py
+++ b/tradingagents/llm_clients/google_client.py
@@ -13,14 +13,14 @@ class NormalizedChatGoogleGenerativeAI(ChatGoogleGenerativeAI):
     This normalizes to string for consistent downstream handling.
     """
 
-    def invoke(self, input, config=None, **kwargs):
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         return normalize_content(super().invoke(input, config, **kwargs))
 
 
 class GoogleClient(BaseLLMClient):
     """Client for Google Gemini models."""
 
-    def __init__(self, model: str, base_url: str | None = None, **kwargs):
+    def __init__(self, model: str, base_url: str | None = None, **kwargs: Any):
         super().__init__(model, base_url, **kwargs)
 
     def get_llm(self) -> Any:

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -32,10 +32,10 @@ class NormalizedChatOpenAI(ChatOpenAI):
     stays small.
     """
 
-    def invoke(self, input, config=None, **kwargs):
+    def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
         return normalize_content(super().invoke(input, config, **kwargs))
 
-    def with_structured_output(self, schema, *, method=None, **kwargs):
+    def with_structured_output(self, schema: Any, *, method: str | None = None, **kwargs: Any) -> Any:
         caps = get_capabilities(self.model_name)
         if caps.preferred_structured_method == "none":
             raise NotImplementedError(
@@ -61,7 +61,7 @@ class LocalCompatibleChatOpenAI(NormalizedChatOpenAI):
     across local servers regardless of the model ID's capabilities (#1057).
     """
 
-    def with_structured_output(self, schema, *, method=None, **kwargs):
+    def with_structured_output(self, schema: Any, *, method: str | None = None, **kwargs: Any) -> Any:
         resolved = method or get_capabilities(self.model_name).preferred_structured_method
         if resolved == "function_calling":
             kwargs.setdefault("tool_choice", None)
@@ -100,7 +100,7 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
     ``NormalizedChatOpenAI.with_structured_output``, not here.
     """
 
-    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+    def _get_request_payload(self, input_: Any, *, stop: Any = None, **kwargs: Any) -> Any:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         outgoing = payload.get("messages", [])
         for message_dict, message in zip(outgoing, _input_to_messages(input_), strict=False):
@@ -111,7 +111,7 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
                 message_dict["reasoning_content"] = reasoning
         return payload
 
-    def _create_chat_result(self, response, generation_info=None):
+    def _create_chat_result(self, response: Any, generation_info: Any = None) -> Any:
         chat_result = super()._create_chat_result(response, generation_info)
         response_dict = (
             response
@@ -150,7 +150,7 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     ``NormalizedChatOpenAI.with_structured_output``, not here.
     """
 
-    def _get_request_payload(self, input_, *, stop=None, **kwargs):
+    def _get_request_payload(self, input_: Any, *, stop: Any = None, **kwargs: Any) -> Any:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
         if get_capabilities(self.model_name).requires_reasoning_split:
             # Pass via extra_body, not as a top-level kwarg: the openai SDK
@@ -268,7 +268,7 @@ class OpenAIClient(BaseLLMClient):
         model: str,
         base_url: str | None = None,
         provider: str = "openai",
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(model, base_url, **kwargs)
         self.provider = provider.lower()

--- a/tradingagents/reporting.py
+++ b/tradingagents/reporting.py
@@ -8,9 +8,10 @@ run produces the same on-disk report tree a CLI run does.
 
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 
-def write_report_tree(final_state: dict, ticker: str, save_path) -> Path:
+def write_report_tree(final_state: dict[str, Any], ticker: str, save_path: str | Path) -> Path:
     """Save a completed run's reports to ``save_path``; return the complete-report path."""
     save_path = Path(save_path)
     save_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Add missing `Any` type annotations across the entire codebase (agents, dataflows,
graph, llm_clients) and DRY up duplicated node-creation logic in researchers and
risk debators into shared `_base.py` factories.

## Changes

- **Type annotations** — ~41 files: add `typing.Any` imports and annotate
  `create_*` factory functions and their inner `node(state)` closures with
  `Any` / `dict[str, Any]` return types. Covers analysts, managers, researchers,
  traders, dataflows, graph setup, LLM clients, and config.

- **DRY researchers** — Extract the shared node-construction logic from
  `bull_researcher.py` / `bear_researcher.py` into `researchers/_base.py`
  exposing `_create_researcher(llm, role, prompt_template)`. Each role file now
  only contains its prompt constant and a one-liner delegating to the factory.

- **DRY risk debators** — Extract the shared node-construction logic from
  `aggressive_debator.py` / `conservative_debator.py` / `neutral_debator.py`
  into `risk_mgmt/_base.py` exposing `_create_debator(llm, role, prompt_template)`.
  Same pattern: each file keeps only its prompt and a one-liner factory call.