### PR TITLE
Fix NSE/BSE news and social search behavior

### DIFF
--- a/tests/test_india_sentiment_sources.py
+++ b/tests/test_india_sentiment_sources.py
@@ -1,0 +1,56 @@
+"""India-specific news/social routing regression tests for issue #1178."""
+
+import pytest
+
+import tradingagents.dataflows.reddit as reddit
+from tradingagents.dataflows.stocktwits import _stocktwits_symbol
+from tradingagents.dataflows.symbol_utils import build_india_search_terms
+
+pytestmark = pytest.mark.unit
+
+
+def test_stocktwits_maps_yahoo_india_suffixes():
+    assert _stocktwits_symbol("SBIN.NS") == "SBIN.NSE"
+    assert _stocktwits_symbol("500325.BO") == "500325.BSE"
+
+
+def test_reddit_routes_nse_to_india_communities():
+    assert reddit._subreddits_for_ticker("SBIN.NS") == reddit.INDIA_SUBREDDITS
+    assert reddit._subreddits_for_ticker("500325.BO") == reddit.INDIA_SUBREDDITS
+    assert reddit._subreddits_for_ticker("AAPL") == reddit.DEFAULT_SUBREDDITS
+
+
+def test_reddit_combines_market_terms_into_one_query():
+    terms = build_india_search_terms(
+        "SBIN.NS",
+        {"company_name": "State Bank of India"},
+    )
+    assert reddit._build_search_query(terms) == (
+        'SBIN OR SBI OR "State Bank of India" OR "SBIN NSE"'
+    )
+
+
+def test_fetch_reddit_posts_uses_one_query_across_india_sources(monkeypatch):
+    calls = []
+
+    def fake_fetch(query, sub, limit, timeout):
+        calls.append((query, sub, limit, timeout))
+        return []
+
+    monkeypatch.setattr(reddit, "_fetch_subreddit", fake_fetch)
+    monkeypatch.setattr(reddit.time, "sleep", lambda _seconds: None)
+
+    terms = build_india_search_terms(
+        "SBIN.NS",
+        {"company_name": "State Bank of India"},
+    )
+    result = reddit.fetch_reddit_posts(
+        "SBIN.NS",
+        search_terms=terms,
+        inter_request_delay=0,
+    )
+
+    expected_query = 'SBIN OR SBI OR "State Bank of India" OR "SBIN NSE"'
+    assert [sub for _query, sub, _limit, _timeout in calls] == list(reddit.INDIA_SUBREDDITS)
+    assert all(query == expected_query for query, _sub, _limit, _timeout in calls)
+    assert "State Bank of India" in result

--- a/tests/test_instrument_identity.py
+++ b/tests/test_instrument_identity.py
@@ -13,6 +13,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     resolve_instrument_identity,
 )
+from tradingagents.dataflows.symbol_utils import build_india_search_terms
 
 
 @pytest.mark.unit
@@ -36,6 +37,7 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
         self.assertEqual(identity["sector"], "Industrials")
         self.assertEqual(identity["industry"], "Building Products & Equipment")
         self.assertEqual(identity["exchange"], "PNK")
+        self.assertEqual(identity["short_name"], "TOTO")
 
     def test_falls_back_to_short_name(self):
         with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
@@ -63,6 +65,31 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
             second = resolve_instrument_identity("TOTDY")
         mock.assert_called_once()  # second call served from cache
         self.assertEqual(first, second)
+
+
+@pytest.mark.unit
+class IndiaSearchTermTests(unittest.TestCase):
+    def test_sbin_terms_include_alias_name_and_exchange(self):
+        terms = build_india_search_terms(
+            "SBIN.NS",
+            {"company_name": "State Bank of India"},
+        )
+        self.assertEqual(
+            terms,
+            ("SBIN", "SBI", "State Bank of India", "SBIN NSE"),
+        )
+
+    def test_reliance_terms_recover_ril_acronym(self):
+        terms = build_india_search_terms(
+            "RELIANCE.NS",
+            {"company_name": "Reliance Industries Limited"},
+        )
+        self.assertEqual(terms[0], "RELIANCE")
+        self.assertIn("RIL", terms)
+        self.assertIn("RELIANCE NSE", terms)
+
+    def test_non_indian_symbol_returns_no_override(self):
+        self.assertEqual(build_india_search_terms("AAPL", {"company_name": "Apple Inc."}), ())
 
 
 @pytest.mark.unit

--- a/tests/test_symbol_normalization_paths.py
+++ b/tests/test_symbol_normalization_paths.py
@@ -73,3 +73,22 @@ def test_news_lookup_normalizes_symbol(monkeypatch):
     assert seen["symbol"] == "GC=F"   # news queried with the canonical symbol
     assert "XAUUSD" in out            # the user's ticker stays in the report
     assert "GC=F" in out              # provenance noted
+
+
+def test_news_lookup_preserves_nse_suffix(monkeypatch):
+    seen = {}
+
+    class FakeTicker:
+        def __init__(self, symbol):
+            seen["symbol"] = symbol
+
+        def get_news(self, count):
+            return []
+
+    monkeypatch.setattr(ynews.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr(ynews, "yf_retry", lambda fn: fn())
+
+    out = ynews.get_news_yfinance("SBIN.NS", "2026-07-01", "2026-07-10")
+
+    assert seen["symbol"] == "SBIN.NS"
+    assert "SBIN.NS" in out

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -34,6 +34,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
     get_news,
+    resolve_instrument_identity,
 )
 from tradingagents.agents.utils.structured import (
     NO_EXTERNAL_TOOLS,
@@ -42,6 +43,7 @@ from tradingagents.agents.utils.structured import (
 )
 from tradingagents.dataflows.reddit import fetch_reddit_posts
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
+from tradingagents.dataflows.symbol_utils import build_india_search_terms, india_equity_parts
 
 
 def _seven_days_back(trade_date: str) -> str:
@@ -64,12 +66,22 @@ def create_sentiment_analyst(llm):
         start_date = _seven_days_back(end_date)
         instrument_context = get_instrument_context_from_state(state)
 
+        # The graph resolves identity before agents run, so this lookup is served
+        # from the resolver cache in normal execution.  Only NSE/BSE instruments
+        # need the extra aliases; all other markets retain existing behavior.
+        india_search_terms: tuple[str, ...] = ()
+        if india_equity_parts(ticker):
+            india_search_terms = build_india_search_terms(
+                ticker,
+                resolve_instrument_identity(ticker),
+            )
+
         # Pre-fetch all three sources. Each fetcher degrades gracefully and
         # returns a string (no exceptions surface from here), so the LLM
         # always sees something — either real data or a clear placeholder.
         news_block = get_news.func(ticker, start_date, end_date)
         stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+        reddit_block = fetch_reddit_posts(ticker, search_terms=india_search_terms or None)
 
         system_message = _build_system_message(
             ticker=ticker,

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -102,11 +102,16 @@ def resolve_instrument_identity(ticker: str) -> dict:
         return {}
 
     identity: dict[str, str] = {}
-    company_name = _clean_identity_value(info.get("longName")) or _clean_identity_value(
-        info.get("shortName")
-    )
+    long_name = _clean_identity_value(info.get("longName"))
+    short_name = _clean_identity_value(info.get("shortName"))
+    company_name = long_name or short_name
     if company_name:
         identity["company_name"] = company_name
+    # Keep a distinct Yahoo short name as an additional search alias.  The
+    # canonical display name remains ``company_name`` so existing prompts and
+    # reports do not change.
+    if short_name and (not company_name or short_name.casefold() != company_name.casefold()):
+        identity["short_name"] = short_name
     for source_key, target_key in (
         ("sector", "sector"),
         ("industry", "industry"),

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -30,7 +30,7 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from .symbol_utils import crypto_base
+from .symbol_utils import crypto_base, india_equity_parts
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +47,41 @@ _ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
 # discussion. wallstreetbets has the most volume but most noise; stocks /
 # investing trend more measured. Caller can override.
 DEFAULT_SUBREDDITS = ("wallstreetbets", "stocks", "investing")
+# NSE/BSE discussion is concentrated in India-specific communities.  Do not
+# mix these with the US defaults: a base ticker can collide with a US symbol.
+INDIA_SUBREDDITS = ("IndianStockMarket", "IndiaStocks", "StockMarketIndia")
 
 
-def _search_qs(ticker: str, limit: int) -> str:
+def _subreddits_for_ticker(ticker: str) -> tuple[str, ...]:
+    """Select market-aware default communities for ``ticker``."""
+    return INDIA_SUBREDDITS if india_equity_parts(ticker) else DEFAULT_SUBREDDITS
+
+
+def _clean_search_terms(
+    ticker: str,
+    search_terms: Iterable[str] | None,
+) -> tuple[str, ...]:
+    """Return safe, ordered search terms, preserving legacy ticker behavior."""
+    candidates = search_terms or (crypto_base(ticker) or ticker,)
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for term in candidates:
+        value = " ".join(str(term).replace('"', "").split())
+        key = value.casefold()
+        if value and key not in seen:
+            seen.add(key)
+            cleaned.append(value)
+    return tuple(cleaned)
+
+
+def _build_search_query(terms: Iterable[str]) -> str:
+    """Combine aliases into one Reddit query without multiplying requests."""
+    return " OR ".join(f'"{term}"' if " " in term else term for term in terms)
+
+
+def _search_qs(search_query: str, limit: int) -> str:
     return urlencode({
-        "q": ticker,
+        "q": search_query,
         "restrict_sr": "on",
         "sort": "new",
         "t": "week",  # last 7 days
@@ -190,10 +220,11 @@ def _fetch_subreddit(
 
 def fetch_reddit_posts(
     ticker: str,
-    subreddits: Iterable[str] = DEFAULT_SUBREDDITS,
+    subreddits: Iterable[str] | None = None,
     limit_per_sub: int = 5,
     timeout: float = 10.0,
     inter_request_delay: float = 1.0,
+    search_terms: Iterable[str] | None = None,
 ) -> str:
     """Fetch recent Reddit posts mentioning ``ticker`` across finance
     subreddits and return them as a formatted plaintext block.
@@ -201,23 +232,29 @@ def fetch_reddit_posts(
     ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests to
     stay under Reddit's public per-IP rate limit; combined with the RSS-first
     path it makes 429s rare even when several analyses run back-to-back.
+
+    For NSE/BSE tickers, callers may provide market-aware aliases while the
+    default subreddit set automatically switches to India-focused communities.
+    Aliases are joined into a single ``OR`` query, so request volume is unchanged.
     """
-    # Crypto reaches us as a Yahoo pair (BTC-USD); search Reddit for the base
-    # ("BTC") so the query actually matches discussion instead of near-nothing.
-    ticker = crypto_base(ticker) or ticker
+    terms = _clean_search_terms(ticker, search_terms)
+    search_query = _build_search_query(terms)
+    search_label = ", ".join(terms)
+    selected_subreddits = tuple(subreddits) if subreddits is not None else _subreddits_for_ticker(ticker)
+
     blocks = []
     total_posts = 0
-    for i, sub in enumerate(subreddits):
+    for i, sub in enumerate(selected_subreddits):
         if i > 0:
             time.sleep(inter_request_delay)
-        posts = _fetch_subreddit(ticker, sub, limit_per_sub, timeout)
+        posts = _fetch_subreddit(search_query, sub, limit_per_sub, timeout)
         total_posts += len(posts)
         if not posts:
-            blocks.append(f"r/{sub}: <no posts found mentioning {ticker.upper()} in the past 7 days>")
+            blocks.append(f"r/{sub}: <no posts found matching {search_label} in the past 7 days>")
             continue
 
         via_rss = any(p.get("source") == "rss" for p in posts)
-        header = f"r/{sub} — {len(posts)} recent posts mentioning {ticker.upper()}"
+        header = f"r/{sub} — {len(posts)} recent posts matching {search_label}"
         header += " (via RSS feed; scores/comments unavailable):" if via_rss else ":"
         lines = [header]
         for p in posts:
@@ -244,7 +281,7 @@ def fetch_reddit_posts(
 
     if total_posts == 0:
         return (
-            f"<no Reddit posts found mentioning {ticker.upper()} across "
-            f"{', '.join(f'r/{s}' for s in subreddits)} in the past 7 days>"
+            f"<no Reddit posts found matching {search_label} across "
+            f"{', '.join(f'r/{s}' for s in selected_subreddits)} in the past 7 days>"
         )
     return "\n\n".join(blocks)

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -28,14 +28,24 @@ _UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
 
 
 def _stocktwits_symbol(ticker: str) -> str:
-    """Map a crypto pair to StockTwits' ``<BASE>.X`` convention.
+    """Map Yahoo symbols to StockTwits' symbol conventions.
 
     StockTwits lists crypto as ``BTC.X`` (Yahoo's ``BTC-USD`` form 404s), so any
-    crypto symbol resolves to its base plus ``.X``; other symbols pass through
-    upper-cased.
+    crypto symbol resolves to its base plus ``.X``.  Indian equities use the
+    exchange names ``.NSE`` / ``.BSE`` on StockTwits rather than Yahoo's
+    abbreviated ``.NS`` / ``.BO`` suffixes.  Other symbols pass through
+    upper-cased unchanged.
     """
     base = crypto_base(ticker)
-    return f"{base}.X" if base else ticker.strip().upper()
+    if base:
+        return f"{base}.X"
+
+    symbol = ticker.strip().upper()
+    if symbol.endswith(".NS"):
+        return symbol[:-3] + ".NSE"
+    if symbol.endswith(".BO"):
+        return symbol[:-3] + ".BSE"
+    return symbol
 
 
 def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.0) -> str:

--- a/tradingagents/dataflows/symbol_utils.py
+++ b/tradingagents/dataflows/symbol_utils.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
 
 # NoMarketDataError lives in the vendor-error taxonomy (errors.py); re-exported
 # here for the many call sites that import it alongside normalize_symbol.
@@ -78,6 +79,12 @@ _YAHOO_SAFE = re.compile(r"^[A-Za-z0-9._\-\^=]+$")
 # in any of these resolves to ``-USD`` (#982). Longest first so ``USDT``/``USDC``
 # match before the ``USD`` substring.
 _CRYPTO_QUOTES = ("USDT", "USDC", "USD")
+
+# Yahoo's exchange suffixes for Indian equities.  These are deliberately kept
+# separate from symbol normalization: market-data calls must retain the suffix,
+# while text-search sources need human-friendly aliases.
+_INDIA_EXCHANGE_SUFFIXES = {".NS": "NSE", ".BO": "BSE"}
+_ACRONYM_STOPWORDS = frozenset({"AND", "OF", "THE"})
 
 
 def crypto_base(raw: str) -> str | None:
@@ -136,6 +143,89 @@ def normalize_symbol(raw: str) -> str:
     if canonical != raw.strip().upper():
         logger.info("Resolved symbol %r to Yahoo symbol %r", raw, canonical)
     return canonical
+
+
+def india_equity_parts(raw: str) -> tuple[str, str] | None:
+    """Return ``(base_symbol, exchange)`` for Yahoo NSE/BSE equities.
+
+    Examples:
+        ``SBIN.NS`` -> ``("SBIN", "NSE")``
+        ``500325.BO`` -> ``("500325", "BSE")``
+
+    The full exchange-qualified ticker remains the canonical market-data
+    symbol; this helper is only for selecting text-search terms and sources.
+    """
+    canonical = normalize_symbol(raw)
+    if not isinstance(canonical, str):
+        return None
+    upper = canonical.strip().upper()
+    for suffix, exchange in _INDIA_EXCHANGE_SUFFIXES.items():
+        if upper.endswith(suffix) and len(upper) > len(suffix):
+            return upper[: -len(suffix)], exchange
+    return None
+
+
+def _company_acronym(name: str) -> str | None:
+    """Build a conservative company-name acronym for social search.
+
+    This recovers common India-market aliases without a hard-coded company
+    table, for example ``State Bank of India`` -> ``SBI`` and
+    ``Reliance Industries Limited`` -> ``RIL``.  Two-letter initials are
+    omitted because they are usually too noisy for social search.
+    """
+    words = re.findall(r"[A-Za-z0-9]+", name.upper())
+    initials = "".join(word[0] for word in words if word not in _ACRONYM_STOPWORDS)
+    return initials if 3 <= len(initials) <= 6 else None
+
+
+def build_india_search_terms(
+    ticker: str,
+    identity: Mapping[str, object] | None = None,
+) -> tuple[str, ...]:
+    """Build ordered, de-duplicated text-search aliases for NSE/BSE stocks.
+
+    Market-data callers continue to use the full Yahoo symbol.  Text-search
+    sources instead receive terms such as:
+
+    ``SBIN.NS`` -> ``SBIN``, ``SBI``, ``State Bank of India``, ``SBIN NSE``
+
+    Returns an empty tuple for non-Indian symbols so existing US, crypto, and
+    other international behavior remains unchanged.
+    """
+    parts = india_equity_parts(ticker)
+    if parts is None:
+        return ()
+
+    base_symbol, exchange = parts
+    terms: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        if not isinstance(value, str):
+            return
+        cleaned = " ".join(value.split())
+        key = cleaned.casefold()
+        if cleaned and key not in seen:
+            seen.add(key)
+            terms.append(cleaned)
+
+    add(base_symbol)
+    if identity:
+        company_name = identity.get("company_name") or identity.get("name")
+        if isinstance(company_name, str):
+            add(_company_acronym(company_name))
+            add(company_name)
+        add(identity.get("short_name"))
+
+        aliases = identity.get("aliases")
+        if isinstance(aliases, str):
+            add(aliases)
+        elif isinstance(aliases, (list, tuple, set, frozenset)):
+            for alias in aliases:
+                add(alias)
+
+    add(f"{base_symbol} {exchange}")
+    return tuple(terms)
 
 
 def is_yahoo_safe(symbol: str) -> bool:


### PR DESCRIPTION
## Summary

This PR improves India-specific news and social-data behavior for NSE and BSE instruments while preserving exchange-qualified Yahoo Finance symbols for market-data retrieval.

### Changes

* Preserve full `.NS` and `.BO` ticker symbols for Yahoo Finance news retrieval.
* Map Yahoo Finance exchange suffixes to StockTwits-compatible symbols:

  * `.NS` → `.NSE`
  * `.BO` → `.BSE`
* Generate market-aware social-search aliases using:

  * the base ticker
  * the resolved company name
  * common India-specific ticker aliases
  * exchange-qualified search terms such as `SBIN NSE`
* Route NSE/BSE Reddit searches to India-focused investing communities.
* Combine multiple aliases into a single Reddit OR query to avoid increasing request volume.
* Add regression tests for NSE/BSE symbol handling, social queries, and Yahoo ticker preservation.

## Example

```text
SBIN.NS
├── Yahoo Finance: SBIN.NS
├── StockTwits: SBIN.NSE
└── Reddit search: SBIN OR SBI OR "State Bank of India" OR "SBIN NSE"
```

## Testing

```text
26 passed in 4.09s
```

```text
Ruff: All checks passed
```

Closes #1178.
