### PR TITLE
fix(llm): map OpenRouter DeepSeek models to DeepSeek capabilities

### DIFF
--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -109,7 +109,15 @@ _BY_ID: dict[str, ModelCapabilities] = {
 
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
 # or ``MiniMax-M3*`` variants inherit the thinking-mode quirks automatically.
+#
+# OpenRouter hosts DeepSeek models under a ``deepseek/`` prefix (e.g.
+# ``deepseek/deepseek-v4-flash``). Without this pattern they fell through to
+# the generic caps, which force a ``tool_choice`` function dict — something
+# DeepSeek's thinking models answer with a very slow response (~49s vs ~4s
+# for the same call with tool_choice suppressed). Matching the prefix gives
+# them the same DeepSeek handling as native ``deepseek``-provider models.
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
+    (re.compile(r"^deepseek/"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
     (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),


### PR DESCRIPTION
## Problem

OpenRouter hosts DeepSeek models under a `deepseek/` prefix (e.g. `deepseek/deepseek-v4-flash`), but the per-model capability table only matches native IDs (`deepseek-v4-flash`, `^deepseek-v\d`). Prefixed models therefore fall through to the generic default capabilities, which set `supports_tool_choice=True`.

For DeepSeek's thinking models this forces a `tool_choice` function dict on every structured-output call. DeepSeek answers that with a very slow response: the same trivial structured call took **~49s** with `tool_choice` forced vs **~4s** with it suppressed. On the large prompts TradingAgents sends (news/sentiment/fundamentals context), this made the structured-output agents (Sentiment Analyst, Research Manager, Trader, Portfolio Manager) appear to hang for many minutes.

## Root cause

`get_capabilities("deepseek/deepseek-v4-flash")` returned `_DEFAULT` because:
- exact-ID match: no entry for the prefixed ID
- pattern match: `^deepseek-v\d` does not match a string starting with `deepseek/`

The client then sent `tool_choice` as a function spec, triggering DeepSeek's slow thinking path.

## Fix

Add a `^deepseek/` pattern so OpenRouter-hosted DeepSeek models get the same `_DEEPSEEK_THINKING` capabilities as native `deepseek`-provider models (`supports_tool_choice=False`, `tool_choice` suppressed, schema still shipped as a tool).

## Verification

Measured in-container with `deepseek/deepseek-v4-flash` via OpenRouter:

| Call | Before | After |
|------|--------|-------|
| structured-output (trivial prompt) | ~49s | ~4-8s |

- `get_capabilities("deepseek/deepseek-v4-flash")` now returns `supports_tool_choice=False`
- Sentiment Analyst structured output renders correctly (band + score + confidence) and completes in seconds
- Full NVDA and AAPL runs (all 4 analysts + debate + trader + risk + PM) complete end-to-end

## Test plan

- [x] Unit: capability lookup for `deepseek/deepseek-v4-flash` returns DeepSeek caps
- [x] Integration: structured-output call on OpenRouter is fast (<15s) and parses
- [x] E2E: full `TradingAgentsGraph.propagate()` run completes for US ticker
- [ ] Confirm no regression for native `deepseek` provider models (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)