### PR TITLE
fix: prevent fabricated claims in opening debate turns

### DIFF
--- a/tests/test_debate_opening_prompt.py
+++ b/tests/test_debate_opening_prompt.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+from tradingagents.agents.researchers.bear_researcher import create_bear_researcher
+from tradingagents.agents.researchers.bull_researcher import create_bull_researcher
+
+
+def _state():
+    return {
+        "investment_debate_state": {
+            "history": "",
+            "bull_history": "",
+            "bear_history": "",
+            "current_response": "",
+            "count": 0,
+        },
+        "market_report": "market",
+        "sentiment_report": "sentiment",
+        "news_report": "news",
+        "fundamentals_report": "fundamentals",
+    }
+
+
+def test_bull_opening_does_not_attribute_missing_bear_argument():
+    llm = MagicMock()
+    llm.invoke.return_value.content = "opening case"
+
+    create_bull_researcher(llm)(_state())
+
+    prompt = llm.invoke.call_args.args[0]
+    assert "No bear argument has been presented yet" in prompt
+
+
+def test_bear_opening_does_not_attribute_missing_bull_argument():
+    llm = MagicMock()
+    llm.invoke.return_value.content = "opening case"
+
+    create_bear_researcher(llm)(_state())
+
+    prompt = llm.invoke.call_args.args[0]
+    assert "No bull argument has been presented yet" in prompt

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -11,6 +11,7 @@ def create_bear_researcher(llm):
         bear_history = investment_debate_state.get("bear_history", "")
 
         current_response = investment_debate_state.get("current_response", "")
+        last_bull_argument = current_response or "No bull argument has been presented yet. Build the opening bear case from the available evidence without attributing claims to the bull side."
         market_research_report = state["market_report"]
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
@@ -42,7 +43,7 @@ Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 {fundamentals_label}: {fundamentals_report}
 Conversation history of the debate: {history}
-Last bull argument: {current_response}
+Last bull argument: {last_bull_argument}
 Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the {target_label}.
 """ + get_language_instruction()
 

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -10,8 +10,12 @@ def create_bear_researcher(llm):
         history = investment_debate_state.get("history", "")
         bear_history = investment_debate_state.get("bear_history", "")
 
-        current_response = investment_debate_state.get("current_response", "")
-        last_bull_argument = current_response or "No bull argument has been presented yet. Build the opening bear case from the available evidence without attributing claims to the bull side."
+        initial_bull_arg = (
+            "No bull argument has been presented yet. Build the opening bear case from the "
+            "available evidence without attributing claims to the bull side."
+        )
+        current_response = investment_debate_state.get("current_response", initial_bull_arg)
+        last_bull_argument = current_response
         market_research_report = state["market_report"]
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -11,6 +11,7 @@ def create_bull_researcher(llm):
         bull_history = investment_debate_state.get("bull_history", "")
 
         current_response = investment_debate_state.get("current_response", "")
+        last_bear_argument = current_response or "No bear argument has been presented yet. Build the opening bull case from the available evidence without attributing claims to the bear side."
         market_research_report = state["market_report"]
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
@@ -40,7 +41,7 @@ Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 {fundamentals_label}: {fundamentals_report}
 Conversation history of the debate: {history}
-Last bear argument: {current_response}
+Last bear argument: {last_bear_argument}
 Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.
 """ + get_language_instruction()
 


### PR DESCRIPTION
## Summary
- avoid presenting an empty debate state as a concrete opposing argument
- make opening bull and bear turns explicitly evidence-led
- add regression coverage for both opening prompts

## Problem
The first researcher receives an empty `current_response`, but the prompt labels it as the other side's last argument. Models can therefore rebut claims that were never made, which makes the debate history less trustworthy.

## Solution
Use a role-specific opening-context sentence when `current_response` is empty. Later turns continue to receive the actual previous argument unchanged.

## Tests
- `python -m pytest tests/test_debate_opening_prompt.py -q` (not run: pytest is not installed in the local runtime)
- `python -m compileall` (source syntax checked)

## Scope and risk
Prompt construction and two focused tests only. No graph ordering, state schema, or trading logic changes.

Closes #1176