### PR TITLE
fix(llm): cap max_tokens and enable streaming to prevent hangs with post-7/31 deepseek-v4-flash (#1204)

### DIFF
--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -19,6 +19,7 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_BENCHMARK_TICKER":     "benchmark_ticker",
     "TRADINGAGENTS_TEMPERATURE":          "temperature",
     "TRADINGAGENTS_LLM_MAX_RETRIES":      "llm_max_retries",
+    "TRADINGAGENTS_MAX_TOKENS":           "max_tokens",
     # Provider-specific reasoning/thinking knobs (None = each provider's own
     # default). Settable here for non-interactive runs; the CLI also offers an
     # interactive choice, which is skipped when the matching var is set.
@@ -100,6 +101,12 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # provider/SDK at its own default (usually 2). Raise it to ride out bursty
     # 429 throttling on rate-limited deployments instead of aborting a run (#1091).
     "llm_max_retries": None,
+    # Max output tokens per LLM call. DeepSeek V4 thinking models emit long
+    # reasoning chains; without an explicit cap the backend can stream the
+    # chain indefinitely (gateway idle timeout) or truncate content to empty
+    # (#1204). Default 8192 leaves room for reasoning + content; override via
+    # TRADINGAGENTS_MAX_TOKENS.
+    "max_tokens": 8192,
     # Checkpoint/resume: when True, LangGraph saves state after each node
     # so a crashed run can resume from the last successful step.
     "checkpoint_enabled": False,

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -183,6 +183,13 @@ class TradingAgentsGraph:
         if max_retries is not None and max_retries != "":
             kwargs["max_retries"] = _coerce_max_retries(max_retries)
 
+        # Max output tokens per LLM call. DeepSeek V4 thinking models emit long
+        # reasoning chains; an explicit cap keeps content from being truncated to
+        # empty or the gateway from idling out on an unbounded chain (#1204).
+        max_tokens = self.config.get("max_tokens")
+        if max_tokens is not None and max_tokens != "":
+            kwargs["max_tokens"] = int(max_tokens)
+
         return kwargs
 
     def _create_tool_nodes(self) -> dict[str, ToolNode]:

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -166,6 +166,7 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
 _PASSTHROUGH_KWARGS = (
     "timeout", "max_retries", "reasoning_effort", "temperature",
     "api_key", "callbacks", "http_client", "http_async_client",
+    "max_tokens",
 )
 
 # OpenAI's ``reasoning_effort`` is only accepted by reasoning models — the GPT-5

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -92,8 +92,9 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
     stays here. When DeepSeek's thinking models return a response with
     ``reasoning_content``, that field must be echoed back as part of the
     assistant message on the next turn or the API fails with HTTP 400.
-    ``_create_chat_result`` captures it on receive and
-    ``_get_request_payload`` re-attaches it on send.
+    ``_create_chat_result`` captures it on the non-streaming path and
+    ``_convert_chunk_to_generation_chunk`` captures it on the streaming
+    path; ``_get_request_payload`` re-attaches it on send.
 
     Tool-choice handling for V4 and reasoner — those models reject the
     ``tool_choice`` parameter — is handled by the capability dispatch in
@@ -110,6 +111,24 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
             if reasoning is not None:
                 message_dict["reasoning_content"] = reasoning
         return payload
+
+    def _convert_chunk_to_generation_chunk(self, chunk, default_chunk_class, base_generation_info):
+        # langchain-openai's stream path drops ``reasoning_content`` from
+        # deltas. Rescue it into ``additional_kwargs`` so the round-trip on
+        # the next turn — see ``_get_request_payload`` — has it. Chunk
+        # aggregation in langchain-core concatenates string additional_kwargs,
+        # yielding a complete reasoning_content on the final AIMessage.
+        gen_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk, default_chunk_class, base_generation_info
+        )
+        if gen_chunk is None:
+            return None
+        choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
+        if choices:
+            reasoning = (choices[0].get("delta") or {}).get("reasoning_content")
+            if reasoning:
+                gen_chunk.message.additional_kwargs["reasoning_content"] = reasoning
+        return gen_chunk
 
     def _create_chat_result(self, response, generation_info=None):
         chat_result = super()._create_chat_result(response, generation_info)
@@ -329,6 +348,23 @@ class OpenAIClient(BaseLLMClient):
             if key == "reasoning_effort" and not _supports_reasoning_effort(self.model):
                 continue
             llm_kwargs[key] = self.kwargs[key]
+
+        # The OpenCode Go gateway (opencode.ai) drops the connection on long
+        # non-streamed responses (~3 min idle timeout). Streaming keeps the
+        # socket active; aggregation back to a single AIMessage is transparent.
+        base_url_for_check = llm_kwargs.get("base_url", "") or ""
+        is_opencode_go = "opencode.ai" in base_url_for_check
+        if is_opencode_go:
+            llm_kwargs.setdefault("streaming", True)
+
+        # DeepSeek thinking models — and OpenCode Go's DeepSeek backends —
+        # need the reasoning_content round-trip subclass (captures the field
+        # on both streaming and non-streaming paths).
+        is_deepseek_model = "deepseek" in self.model.lower()
+        if self.provider in ("deepseek", "opencode-go") or (
+            is_opencode_go and is_deepseek_model
+        ):
+            chat_cls = DeepSeekChatOpenAI
 
         # The subclass (provider quirks) comes from the registry spec.
         return chat_cls(**llm_kwargs)


### PR DESCRIPTION
## Summary

Fixes #1204. TradingAgents hangs indefinitely with the post-7/31 stable `deepseek-v4-flash` (long reasoning chains). Root cause is two-fold:

1. **No `max_tokens` sent.** `_PASSTHROUGH_KWARGS` in `llm_clients/openai_client.py` does not forward `max_tokens`. With the new long-reasoning v4-flash, an unbounded generation exceeds the gateway's ~3 min idle timeout and the connection is dropped — the process sits in `wait_woken` forever. When a bounded default does apply, the reasoning chain can consume the entire budget and `content` comes back empty.
2. **No streaming for OpenAI-compatible backends.** The OpenCode Go gateway (and similar proxies) closes connections on long non-streamed responses; streaming keeps the socket active.

Verified against `opencode.ai/zen/go/v1` with `deepseek-v4-flash`:

| Prompt | max_tokens | Result |
|--------|-----------|--------|
| trivial | 100 | OK (reasoning 26 tokens) |
| complex | 500 | **empty content** (reasoning ate all 500) |
| complex | 2048 | OK (reasoning 529 + content 55) |
| complex | unset | **no response in 90s** (HTTP 000 timeout) |

## Changes

- **`tradingagents/default_config.py`**: add `TRADINGAGENTS_MAX_TOKENS` env override + `max_tokens: 8192` default.
- **`tradingagents/graph/trading_graph.py`**: forward `max_tokens` from config into LLM client kwargs.
- **`tradingagents/llm_clients/openai_client.py`**:
  - add `max_tokens` to `_PASSTHROUGH_KWARGS`;
  - enable `streaming` when `base_url` points at `opencode.ai` (keeps the socket alive; langchain aggregates chunks back to a single AIMessage);
  - use `DeepSeekChatOpenAI` for opencode.ai + deepseek models so `reasoning_content` is captured on the streaming path via `_convert_chunk_to_generation_chunk` and round-tripped on the next turn.

## Verification

- Unit tests: 94 passed (incl. `test_deepseek_reasoning`, `test_capabilities`, `test_env_overrides`, `test_openai_compatible_provider`, `test_llm_max_retries`, `test_temperature_config`).
- End-to-end: full 159566.SZ run (all 4 analysts + research + trader + risk debate) completes; previously hung 3/3 times at the analyst phase.
- `max_tokens` default (8192) and env override (`TRADINGAGENTS_MAX_TOKENS=16384`) both verified.

## Related

- #782 (opencode-go provider: streaming required, gateway 3-min idle timeout, reasoning_content delta capture)
- #1199 (DeepSeek thinking models + tool_choice → very slow responses)