### PR TITLE
harden: disable external XML entity processing in reddit.py...

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pytz>=2025.2",
     "questionary>=2.1.0",
     "redis>=6.2.0",
+    "defusedxml>=0.7.1",
     "requests>=2.32.4",
     "rich>=14.0.0",
     "typer>=0.21.0",

--- a/tests/test_reddit_fallback.py
+++ b/tests/test_reddit_fallback.py
@@ -192,6 +192,31 @@ class TestFormatterHandlesRssPosts:
         assert "via RSS" not in out
 
 
+_XXE_ATOM = """\
+<?xml version="1.0"?>
+<!DOCTYPE feed [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry><title>&xxe;</title></entry>
+</feed>
+"""
+
+
+@pytest.mark.unit
+class TestXxeSecurity:
+    """defusedxml must block XXE payloads without crashing the pipeline."""
+
+    def test_xxe_payload_rejected_gracefully(self):
+        with patch.object(reddit, "urlopen", return_value=_resp(lambda: _XXE_ATOM.encode())):
+            result = reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        assert result == []
+
+    def test_dtd_payload_rejected_gracefully(self):
+        dtd_xml = b"<?xml version='1.0'?><!DOCTYPE feed []><feed/>"
+        with patch.object(reddit, "urlopen", return_value=_resp(lambda: dtd_xml)):
+            result = reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        assert result == []
+
+
 @pytest.mark.unit
 class TestCryptoSearchTerm:
     """A crypto pair (BTC-USD) barely matches Reddit text; search the base (#1113)."""

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -23,7 +23,8 @@ import json
 import logging
 import re
 import time
-import xml.etree.ElementTree as ET
+import defusedxml
+import defusedxml.ElementTree as ET
 from collections.abc import Iterable
 from datetime import datetime
 from urllib.error import HTTPError
@@ -120,9 +121,11 @@ def _fetch_subreddit_rss(
             return _fetch_subreddit_rss(ticker, sub, limit, timeout, _retry=False)
         logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
         return []
-    except (OSError, http.client.HTTPException, ET.ParseError) as exc:
+    except (OSError, http.client.HTTPException, ET.ParseError,
+            defusedxml.DefusedXmlException) as exc:
         # OSError covers URLError/TimeoutError/connection resets; HTTPException
         # covers chunked-transfer errors (IncompleteRead/BadStatusLine, #1024).
+        # DefusedXmlException covers XXE/DTD/billion-laughs attacks blocked by defusedxml.
         logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
         return []
 


### PR DESCRIPTION
## Summary
Harden input handling in `tradingagents/dataflows/reddit.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410` |
| **File** | `tradingagents/dataflows/reddit.py:26` |
| **Assessment** | Defensive hardening |

**Description**: Found use of the native Python XML libraries, which is vulnerable to XML external entity (XXE)
attacks. The Python documentation recommends the 'defusedxml' library instead. Use 'defusedxml'.
See https://github.com/tiran/defusedxml for more information.


## Threat Model Context

This is a CLI tool - exploitation requires the attacker to control arguments or input files passed to the tool.

## Changes
- `tradingagents/dataflows/reddit.py`
- `pyproject.toml`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
