### PR TITLE
Add crypto derivatives/on-chain signals and crypto-native subreddits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Crypto derivatives/on-chain signals for the market analyst.** New
+  `crypto_signals` vendor category (keyless, no auth) surfacing perpetual
+  funding rate and open interest (Binance), the market-wide Fear & Greed
+  Index (alternative.me), and Bitcoin network hashrate (mempool.space) —
+  data the framework had no equivalent for. Bound to the Market Analyst
+  only when `asset_type == "crypto"`.
+- **Crypto-native subreddits for the sentiment analyst.** The equities
+  default (`wallstreetbets`/`stocks`/`investing`) returns near-zero signal
+  for a crypto ticker; a crypto asset now searches `CryptoCurrency`,
+  `Bitcoin`, and `CryptoMarkets` instead.
+
 ## [0.3.1] — 2026-07-05
 
 Correctness and stability patch: data look-ahead, graph-router crash-safety,

--- a/tests/test_crypto_signals.py
+++ b/tests/test_crypto_signals.py
@@ -1,0 +1,237 @@
+"""Crypto derivatives/on-chain vendors (binance, feargreed, mempool): symbol
+normalization, output formatting, graceful degradation on network errors, and
+router integration — plus the crypto-native subreddit selection in the
+sentiment analyst.
+
+All HTTP access is mocked, so these run without a network connection.
+"""
+import copy
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+import tradingagents.dataflows.config as config_module
+import tradingagents.default_config as default_config
+from tradingagents.dataflows import binance, feargreed, interface, mempool
+from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows.reddit import CRYPTO_SUBREDDITS, DEFAULT_SUBREDDITS
+
+
+@pytest.mark.unit
+class BinanceSymbolTests(unittest.TestCase):
+    def test_dash_usd_pair_maps_to_usdt_perp(self):
+        self.assertEqual(binance._binance_symbol("BTC-USD"), "BTCUSDT")
+        self.assertEqual(binance._binance_symbol("ETH-USD"), "ETHUSDT")
+
+    def test_lowercase_and_bare_usd_forms(self):
+        self.assertEqual(binance._binance_symbol("btc-usd"), "BTCUSDT")
+        self.assertEqual(binance._binance_symbol("BTCUSD"), "BTCUSDT")
+
+
+@pytest.mark.unit
+class BinanceFundingRateTests(unittest.TestCase):
+    _ROWS = [
+        {"symbol": "BTCUSDT", "fundingTime": 1786003200000, "fundingRate": "0.00002632", "markPrice": "64789.40"},
+        {"symbol": "BTCUSDT", "fundingTime": 1786032000000, "fundingRate": "0.00005939", "markPrice": "64604.20"},
+    ]
+
+    def test_report_has_table_and_neutral_read(self):
+        with mock.patch.object(binance, "_request", return_value=self._ROWS):
+            out = binance.get_funding_rate("BTC-USD")
+        self.assertIn("### Perpetual Funding Rate (BTCUSDT, Binance)", out)
+        self.assertIn("| 64,789.40 |", out)
+        self.assertIn("neutral", out)
+
+    def test_elevated_positive_funding_flags_crowded_longs(self):
+        rows = [{"symbol": "BTCUSDT", "fundingTime": 1786003200000, "fundingRate": "0.0005", "markPrice": "64789.40"}]
+        with mock.patch.object(binance, "_request", return_value=rows):
+            out = binance.get_funding_rate("BTC-USD")
+        self.assertIn("crowded", out)
+        self.assertIn("long", out)
+
+    def test_negative_funding_flags_crowded_shorts(self):
+        rows = [{"symbol": "BTCUSDT", "fundingTime": 1786003200000, "fundingRate": "-0.0005", "markPrice": "64789.40"}]
+        with mock.patch.object(binance, "_request", return_value=rows):
+            out = binance.get_funding_rate("BTC-USD")
+        self.assertIn("squeeze", out)
+
+    def test_empty_response_reports_no_data(self):
+        with mock.patch.object(binance, "_request", return_value=[]):
+            out = binance.get_funding_rate("BTC-USD")
+        self.assertIn("No funding rate data", out)
+
+    def test_network_error_degrades_gracefully(self):
+        import requests
+        with mock.patch.object(binance, "_request", side_effect=requests.RequestException("boom")):
+            out = binance.get_funding_rate("BTC-USD")
+        self.assertIn("currently unavailable", out)
+        self.assertIn("BTCUSDT", out)
+
+
+@pytest.mark.unit
+class BinanceOpenInterestTests(unittest.TestCase):
+    def test_report_shows_current_oi(self):
+        with mock.patch.object(binance, "_request", return_value={"symbol": "BTCUSDT", "openInterest": "105581.817"}):
+            out = binance.get_open_interest("BTC-USD")
+        self.assertIn("### Open Interest (BTCUSDT, Binance perpetual)", out)
+        self.assertIn("105,581.82 BTC contracts", out)
+
+    def test_network_error_degrades_gracefully(self):
+        import requests
+        with mock.patch.object(binance, "_request", side_effect=requests.RequestException("boom")):
+            out = binance.get_open_interest("BTC-USD")
+        self.assertIn("currently unavailable", out)
+
+
+@pytest.mark.unit
+class FearGreedIndexTests(unittest.TestCase):
+    def _mock_response(self, rows):
+        resp = MagicMock()
+        resp.json.return_value = {"data": rows}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_report_has_table(self):
+        rows = [{"value": "29", "value_classification": "Fear", "timestamp": "1786060800"}]
+        with mock.patch.object(feargreed.requests, "get", return_value=self._mock_response(rows)):
+            out = feargreed.get_fear_greed_index()
+        self.assertIn("Crypto Fear & Greed Index", out)
+        self.assertIn("| 2026-08-07 | 29 | Fear |", out)
+
+    def test_empty_response_reports_no_data(self):
+        with mock.patch.object(feargreed.requests, "get", return_value=self._mock_response([])):
+            out = feargreed.get_fear_greed_index()
+        self.assertIn("No Fear & Greed Index data", out)
+
+    def test_network_error_degrades_gracefully(self):
+        import requests
+        with mock.patch.object(feargreed.requests, "get", side_effect=requests.RequestException("boom")):
+            out = feargreed.get_fear_greed_index()
+        self.assertIn("currently unavailable", out)
+
+
+@pytest.mark.unit
+class MempoolHashrateTests(unittest.TestCase):
+    def _mock_response(self):
+        resp = MagicMock()
+        resp.json.return_value = {
+            "currentHashrate": 928265012830267900000,
+            "currentDifficulty": 126231507121868.2,
+            "hashrates": [
+                {"timestamp": 1785974400, "avgHashrate": 899192029875902200000},
+                {"timestamp": 1786060800, "avgHashrate": 794167855200950800000},
+            ],
+        }
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_report_has_current_and_trend(self):
+        with mock.patch.object(mempool.requests, "get", return_value=self._mock_response()):
+            out = mempool.get_network_hashrate()
+        self.assertIn("### Bitcoin Network Hashrate (mempool.space)", out)
+        self.assertIn("928.3 EH/s", out)
+        self.assertIn("| 2026-08-07 | 794.2 |", out)
+
+    def test_network_error_degrades_gracefully(self):
+        import requests
+        with mock.patch.object(mempool.requests, "get", side_effect=requests.RequestException("boom")):
+            out = mempool.get_network_hashrate()
+        self.assertIn("currently unavailable", out)
+
+
+@pytest.mark.unit
+class CryptoSignalsRoutingTests(unittest.TestCase):
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def test_all_four_methods_route_to_crypto_signals_category(self):
+        for method in (
+            "get_crypto_funding_rate",
+            "get_crypto_open_interest",
+            "get_crypto_fear_greed_index",
+            "get_bitcoin_network_hashrate",
+        ):
+            self.assertEqual(interface.get_category_for_method(method), "crypto_signals")
+
+    def test_default_vendor_resolves_per_method(self):
+        set_config({"data_vendors": {"crypto_signals": "default"}})
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_bitcoin_network_hashrate": {"mempool": lambda: "HASHRATE_OK"}},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_bitcoin_network_hashrate")
+        self.assertEqual(out, "HASHRATE_OK")
+
+    def test_unexpected_vendor_error_degrades_gracefully(self):
+        # crypto_signals is an optional category: an unhandled vendor exception
+        # (beyond the internal requests.RequestException catch each vendor
+        # already does) must not abort the run.
+        set_config({"data_vendors": {"crypto_signals": "default"}})
+
+        def _boom():
+            raise RuntimeError("unexpected")
+
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_bitcoin_network_hashrate": {"mempool": _boom}},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_bitcoin_network_hashrate")
+        self.assertIn("DATA_UNAVAILABLE", out)
+
+
+@pytest.mark.unit
+class SentimentAnalystCryptoSubredditsTests(unittest.TestCase):
+    """The sentiment analyst must search crypto-native subreddits for a crypto
+    asset — the equities default (wallstreetbets/stocks/investing) returns
+    near-zero signal for a ticker like BTC-USD."""
+
+    def _run(self, asset_type):
+        from tradingagents.agents.analysts.sentiment_analyst import create_sentiment_analyst
+        from tradingagents.agents.schemas import SentimentBand, SentimentReport
+
+        captured = {}
+        report = SentimentReport(
+            overall_band=SentimentBand.BULLISH, overall_score=7.0,
+            confidence="high", narrative="n/a",
+        )
+        structured = MagicMock()
+        structured.invoke.return_value = report
+        llm = MagicMock()
+        llm.with_structured_output.return_value = structured
+
+        state = {
+            "company_of_interest": "BTC-USD" if asset_type == "crypto" else "NVDA",
+            "trade_date": "2026-08-06",
+            "asset_type": asset_type,
+            "messages": [],
+        }
+
+        with mock.patch(
+            "tradingagents.agents.analysts.sentiment_analyst.fetch_reddit_posts",
+            side_effect=lambda ticker, subreddits: captured.__setitem__("subreddits", subreddits) or "",
+        ), mock.patch(
+            "tradingagents.agents.analysts.sentiment_analyst.fetch_stocktwits_messages",
+            return_value="",
+        ), mock.patch(
+            "tradingagents.agents.analysts.sentiment_analyst.get_news"
+        ) as get_news:
+            get_news.func.return_value = ""
+            create_sentiment_analyst(llm)(state)
+        return captured["subreddits"]
+
+    def test_crypto_asset_uses_crypto_subreddits(self):
+        self.assertEqual(self._run("crypto"), CRYPTO_SUBREDDITS)
+
+    def test_stock_asset_uses_default_subreddits(self):
+        self.assertEqual(self._run("stock"), DEFAULT_SUBREDDITS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_market_toolnode.py
+++ b/tests/test_market_toolnode.py
@@ -21,3 +21,19 @@ def test_market_toolnode_can_execute_verified_snapshot():
     )
     # the other core market tools must remain too
     assert {"get_stock_data", "get_indicators"} <= market_tools
+
+
+@pytest.mark.unit
+def test_market_toolnode_can_execute_crypto_signals():
+    # Same wiring-gap class as above: the market analyst binds these four
+    # tools to the LLM when asset_type == "crypto" (see market_analyst.py),
+    # so the executor ToolNode must register them too or the calls fail with
+    # "not a valid tool" instead of returning data.
+    nodes = TradingAgentsGraph._create_tool_nodes(None)
+    market_tools = set(nodes["market"].tools_by_name)
+    assert {
+        "get_crypto_funding_rate",
+        "get_crypto_open_interest",
+        "get_crypto_fear_greed_index",
+        "get_bitcoin_network_hashrate",
+    } <= market_tools

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -1,6 +1,10 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from tradingagents.agents.utils.agent_utils import (
+    get_bitcoin_network_hashrate,
+    get_crypto_fear_greed_index,
+    get_crypto_funding_rate,
+    get_crypto_open_interest,
     get_indicators,
     get_instrument_context_from_state,
     get_language_instruction,
@@ -14,12 +18,20 @@ def create_market_analyst(llm):
     def market_analyst_node(state):
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
+        is_crypto = state.get("asset_type") == "crypto"
 
         tools = [
             get_stock_data,
             get_indicators,
             get_verified_market_snapshot,
         ]
+        if is_crypto:
+            tools += [
+                get_crypto_funding_rate,
+                get_crypto_open_interest,
+                get_crypto_fear_greed_index,
+                get_bitcoin_network_hashrate,
+            ]
 
         system_message = (
             """You are a trading assistant tasked with analyzing financial markets. Your role is to select the **most relevant indicators** for a given market condition or trading strategy from the following list. The goal is to choose up to **8 indicators** that provide complementary insights without redundancy. Categories and each category's indicators are:
@@ -51,6 +63,19 @@ Volume-Based Indicators:
 Before writing the final report, call get_verified_market_snapshot for this ticker and the current date, and treat it as the source of truth for any exact OHLCV, price-level, or indicator-value claim. If another tool's output conflicts with the verified snapshot, flag the discrepancy rather than inventing a reconciled number. Do not claim historical validation, support/resistance bounces, or exact percentage moves unless they are directly supported by tool output with concrete dates and prices.
 
 Write a very detailed and nuanced report of the trends you observe. Provide specific, actionable insights with supporting evidence to help traders make informed decisions."""
+            + (
+                """
+
+Derivatives / On-Chain Indicators (crypto only):
+- get_crypto_funding_rate: Perpetual futures funding rate. Persistent positive funding = crowded/expensive longs (contrarian caution); persistent negative = crowded shorts (squeeze fuel).
+- get_crypto_open_interest: Current perpetual open interest. Rising OI + rising price = trend confirmation; rising OI + falling price = aggressive new shorts; falling OI = deleveraging.
+- get_crypto_fear_greed_index: Market-wide sentiment gauge (0=Extreme Fear, 100=Extreme Greed). Extreme readings are often contrarian signals.
+- get_bitcoin_network_hashrate: Bitcoin-only. Falling hashrate can precede/accompany miner-driven sell pressure.
+
+Call all four of these when the instrument is a crypto asset, and weave their read into your report alongside the price-based indicators above."""
+                if is_crypto
+                else ""
+            )
             + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
             + get_language_instruction()
         )

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -40,7 +40,11 @@ from tradingagents.agents.utils.structured import (
     bind_structured,
     invoke_structured_or_freetext,
 )
-from tradingagents.dataflows.reddit import fetch_reddit_posts
+from tradingagents.dataflows.reddit import (
+    CRYPTO_SUBREDDITS,
+    DEFAULT_SUBREDDITS,
+    fetch_reddit_posts,
+)
 from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
 
 
@@ -69,7 +73,14 @@ def create_sentiment_analyst(llm):
         # always sees something — either real data or a clear placeholder.
         news_block = get_news.func(ticker, start_date, end_date)
         stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+        # Crypto tickers get crypto-native subreddits instead of the
+        # equities-default set (wallstreetbets/stocks/investing barely
+        # discuss crypto tickers, as seen live — a run returned "no posts
+        # found" for BTC-USD across all three).
+        subreddits = (
+            CRYPTO_SUBREDDITS if state.get("asset_type") == "crypto" else DEFAULT_SUBREDDITS
+        )
+        reddit_block = fetch_reddit_posts(ticker, subreddits=subreddits)
 
         system_message = _build_system_message(
             ticker=ticker,

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -8,6 +8,12 @@ from langchain_core.messages import HumanMessage, RemoveMessage
 
 # Import tools from separate utility files
 from tradingagents.agents.utils.core_stock_tools import get_stock_data
+from tradingagents.agents.utils.crypto_signals_tools import (
+    get_bitcoin_network_hashrate,
+    get_crypto_fear_greed_index,
+    get_crypto_funding_rate,
+    get_crypto_open_interest,
+)
 from tradingagents.agents.utils.fundamental_data_tools import (
     get_balance_sheet,
     get_cashflow,
@@ -29,6 +35,10 @@ from tradingagents.agents.utils.technical_indicators_tools import get_indicators
 __all__ = [
     "get_stock_data",
     "get_indicators",
+    "get_crypto_funding_rate",
+    "get_crypto_open_interest",
+    "get_crypto_fear_greed_index",
+    "get_bitcoin_network_hashrate",
     "get_fundamentals",
     "get_balance_sheet",
     "get_cashflow",

--- a/tradingagents/agents/utils/crypto_signals_tools.py
+++ b/tradingagents/agents/utils/crypto_signals_tools.py
@@ -1,0 +1,79 @@
+from typing import Annotated
+
+from langchain_core.tools import tool
+
+from tradingagents.dataflows.interface import route_to_vendor
+
+
+@tool
+def get_crypto_funding_rate(
+    ticker: Annotated[str, "Crypto ticker, e.g. 'BTC-USD'"],
+) -> str:
+    """
+    Retrieve the recent perpetual futures funding rate history for a crypto
+    ticker. Funding is paid between longs and shorts every 8 hours to keep
+    the perpetual price anchored to spot; persistently positive rates mean
+    longs are paying shorts (crowded/expensive long positioning, a
+    contrarian caution signal), persistently negative rates mean the
+    opposite (crowded shorts, potential short-squeeze fuel). Uses the
+    configured crypto_signals vendor.
+
+    Args:
+        ticker (str): Crypto ticker, e.g. "BTC-USD"
+
+    Returns:
+        str: A formatted markdown report of the last few funding rate prints.
+    """
+    return route_to_vendor("get_crypto_funding_rate", ticker)
+
+
+@tool
+def get_crypto_open_interest(
+    ticker: Annotated[str, "Crypto ticker, e.g. 'BTC-USD'"],
+) -> str:
+    """
+    Retrieve current perpetual futures open interest for a crypto ticker.
+    Rising open interest alongside a rising price usually confirms a trend
+    (new money entering); rising OI with a falling price often signals
+    aggressive new shorts; falling OI signals position unwinding /
+    deleveraging. Uses the configured crypto_signals vendor.
+
+    Args:
+        ticker (str): Crypto ticker, e.g. "BTC-USD"
+
+    Returns:
+        str: A formatted markdown report with current open interest.
+    """
+    return route_to_vendor("get_crypto_open_interest", ticker)
+
+
+@tool
+def get_crypto_fear_greed_index() -> str:
+    """
+    Retrieve the market-wide Crypto Fear & Greed Index, a composite of
+    volatility, momentum, social volume, dominance, and search trends.
+    0-24 = Extreme Fear (often a contrarian buy zone), 25-49 = Fear,
+    50-74 = Greed, 75-100 = Extreme Greed (often a contrarian caution zone).
+    This is a whole-market gauge, not ticker-specific. Uses the configured
+    crypto_signals vendor.
+
+    Returns:
+        str: A formatted markdown report of the last few daily readings.
+    """
+    return route_to_vendor("get_crypto_fear_greed_index")
+
+
+@tool
+def get_bitcoin_network_hashrate() -> str:
+    """
+    Retrieve Bitcoin network hashrate and difficulty. A rising hashrate
+    signals miner confidence/network security strength; a sharp drop can
+    precede or accompany capitulation-driven sell pressure from miners.
+    Bitcoin-specific — not meaningful for other assets. Uses the configured
+    crypto_signals vendor.
+
+    Returns:
+        str: A formatted markdown report with current hashrate/difficulty
+        and a short recent trend.
+    """
+    return route_to_vendor("get_bitcoin_network_hashrate")

--- a/tradingagents/dataflows/binance.py
+++ b/tradingagents/dataflows/binance.py
@@ -1,0 +1,117 @@
+"""Binance perpetual futures vendor.
+
+Surfaces derivatives positioning for crypto assets — funding rate and open
+interest — that the stock-oriented dataflow layer has no equivalent for.
+Complements price/technical data (what happened) with what leveraged traders
+are currently positioned for.
+
+Uses Binance's public Futures API (https://fapi.binance.com) — no key, no
+auth.
+"""
+import datetime as _dt
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+FAPI_BASE = "https://fapi.binance.com/fapi/v1"
+
+# Network timeout (seconds), consistent with the other vendors.
+REQUEST_TIMEOUT = 15
+
+# Funding prints every 8h; 6 covers the last 2 days.
+DEFAULT_FUNDING_LIMIT = 6
+
+
+def _request(path: str, params: dict) -> list | dict:
+    response = requests.get(f"{FAPI_BASE}/{path}", params=params, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def _binance_symbol(ticker: str) -> str:
+    """``BTC-USD`` / ``BTCUSD`` -> ``BTCUSDT`` (Binance's perpetual quote asset)."""
+    base = ticker.upper().replace("-USD", "").replace("USD", "").replace("-USDT", "")
+    return f"{base}USDT"
+
+
+def get_funding_rate(ticker: str) -> str:
+    """Return the recent perpetual futures funding rate history for a crypto ticker.
+
+    Funding is paid between longs and shorts every 8 hours to keep the
+    perpetual price anchored to spot. Persistently positive rates mean longs
+    are paying shorts (crowded/expensive long positioning, a contrarian
+    caution signal); persistently negative rates mean the opposite (crowded
+    shorts, potential short-squeeze fuel).
+
+    Args:
+        ticker: Crypto ticker, e.g. "BTC-USD".
+
+    Returns:
+        A markdown report of the last DEFAULT_FUNDING_LIMIT funding prints.
+    """
+    symbol = _binance_symbol(ticker)
+    try:
+        rows = _request("fundingRate", {"symbol": symbol, "limit": DEFAULT_FUNDING_LIMIT})
+    except requests.RequestException as e:
+        logger.warning("Binance funding rate fetch failed for %s: %s", symbol, e)
+        return f"Funding rate data is currently unavailable for {symbol} ({e})."
+
+    if not rows:
+        return f"No funding rate data returned for {symbol}."
+
+    lines = [
+        f"### Perpetual Funding Rate ({symbol}, Binance)",
+        "",
+        "| Time (UTC) | Funding Rate | Mark Price |",
+        "| --- | ---: | ---: |",
+    ]
+    for row in rows:
+        ts = _dt.datetime.utcfromtimestamp(row["fundingTime"] / 1000).strftime("%Y-%m-%d %H:%M")
+        rate_pct = float(row["fundingRate"]) * 100
+        lines.append(f"| {ts} | {rate_pct:+.4f}% | {float(row['markPrice']):,.2f} |")
+
+    latest = float(rows[-1]["fundingRate"]) * 100
+    if latest > 0.02:
+        note = (
+            "Elevated positive funding: longs are paying a premium — crowded "
+            "long positioning, contrarian caution."
+        )
+    elif latest < -0.02:
+        note = "Negative funding: shorts are paying — crowded short positioning, potential squeeze fuel."
+    else:
+        note = "Funding rate near neutral — no strong positioning skew."
+    lines.append("")
+    lines.append(f"**Read:** {note}")
+    return "\n".join(lines)
+
+
+def get_open_interest(ticker: str) -> str:
+    """Return current perpetual futures open interest for a crypto ticker.
+
+    Rising open interest alongside a rising price usually confirms a trend
+    (new money entering); rising OI with a falling price often signals
+    aggressive new shorts; falling OI signals position unwinding/deleveraging.
+
+    Args:
+        ticker: Crypto ticker, e.g. "BTC-USD".
+
+    Returns:
+        A markdown report with current open interest (in base units).
+    """
+    symbol = _binance_symbol(ticker)
+    try:
+        data = _request("openInterest", {"symbol": symbol})
+    except requests.RequestException as e:
+        logger.warning("Binance open interest fetch failed for %s: %s", symbol, e)
+        return f"Open interest data is currently unavailable for {symbol} ({e})."
+
+    oi = float(data.get("openInterest", 0))
+    return (
+        f"### Open Interest ({symbol}, Binance perpetual)\n\n"
+        f"**Current open interest:** {oi:,.2f} {symbol.replace('USDT', '')} contracts\n\n"
+        "Compare this figure across consecutive calls/days (no built-in history here) "
+        "to judge whether OI is expanding (trend confirmation / rising leverage) or "
+        "contracting (deleveraging)."
+    )

--- a/tradingagents/dataflows/feargreed.py
+++ b/tradingagents/dataflows/feargreed.py
@@ -1,0 +1,54 @@
+"""Crypto Fear & Greed Index vendor (alternative.me).
+
+Surfaces a market-wide crypto sentiment composite (volatility, momentum,
+social volume, dominance, search trends) — a keyless complement to the
+ticker-specific news/social sentiment the sentiment analyst already builds.
+
+Uses alternative.me's public Fear & Greed API — no key, no auth.
+"""
+import datetime as _dt
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+FNG_API = "https://api.alternative.me/fng/"
+
+# Network timeout (seconds), consistent with the other vendors.
+REQUEST_TIMEOUT = 15
+
+DEFAULT_LIMIT = 5
+
+
+def get_fear_greed_index() -> str:
+    """Return the market-wide Crypto Fear & Greed Index.
+
+    0-24 = Extreme Fear (often a contrarian buy zone), 25-49 = Fear,
+    50-74 = Greed, 75-100 = Extreme Greed (often a contrarian caution zone).
+    This is a whole-market gauge, not ticker-specific.
+
+    Returns:
+        A markdown report of the last DEFAULT_LIMIT daily readings.
+    """
+    try:
+        response = requests.get(FNG_API, params={"limit": DEFAULT_LIMIT}, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        rows = response.json().get("data", [])
+    except requests.RequestException as e:
+        logger.warning("Fear & Greed Index fetch failed: %s", e)
+        return f"Fear & Greed Index is currently unavailable ({e})."
+
+    if not rows:
+        return "No Fear & Greed Index data returned."
+
+    lines = [
+        "### Crypto Fear & Greed Index (alternative.me, market-wide)",
+        "",
+        "| Date | Value | Classification |",
+        "| --- | ---: | --- |",
+    ]
+    for row in rows:
+        date = _dt.datetime.utcfromtimestamp(int(row["timestamp"])).strftime("%Y-%m-%d")
+        lines.append(f"| {date} | {row['value']} | {row['value_classification']} |")
+    return "\n".join(lines)

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -11,13 +11,19 @@ from .alpha_vantage import (
     get_news as get_alpha_vantage_news,
     get_stock as get_alpha_vantage_stock,
 )
+from .binance import (
+    get_funding_rate as get_binance_funding_rate,
+    get_open_interest as get_binance_open_interest,
+)
 from .config import get_config
 from .errors import (
     NoMarketDataError,
     VendorNotConfiguredError,
     VendorRateLimitError,
 )
+from .feargreed import get_fear_greed_index as get_feargreed_index
 from .fred import get_macro_data as get_fred_macro_data
+from .mempool import get_network_hashrate as get_mempool_hashrate
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
@@ -74,6 +80,15 @@ TOOLS_CATEGORIES = {
         "tools": [
             "get_prediction_markets",
         ]
+    },
+    "crypto_signals": {
+        "description": "Crypto derivatives positioning and on-chain/sentiment signals",
+        "tools": [
+            "get_crypto_funding_rate",
+            "get_crypto_open_interest",
+            "get_crypto_fear_greed_index",
+            "get_bitcoin_network_hashrate",
+        ]
     }
 }
 
@@ -82,6 +97,9 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "binance",
+    "feargreed",
+    "mempool",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -89,7 +107,7 @@ VENDOR_LIST = [
 # sentinel instead of aborting the run (a bad LLM-supplied indicator, a missing
 # key, or a network blip should not crash an analysis over flavour data). Core
 # categories (prices, fundamentals, news) still raise so a broken primary is loud.
-OPTIONAL_CATEGORIES = {"macro_data", "prediction_markets"}
+OPTIONAL_CATEGORIES = {"macro_data", "prediction_markets", "crypto_signals"}
 
 # Mapping of methods to their vendor-specific implementations
 VENDOR_METHODS = {
@@ -140,6 +158,19 @@ VENDOR_METHODS = {
     # prediction_markets
     "get_prediction_markets": {
         "polymarket": get_polymarket_prediction_markets,
+    },
+    # crypto_signals
+    "get_crypto_funding_rate": {
+        "binance": get_binance_funding_rate,
+    },
+    "get_crypto_open_interest": {
+        "binance": get_binance_open_interest,
+    },
+    "get_crypto_fear_greed_index": {
+        "feargreed": get_feargreed_index,
+    },
+    "get_bitcoin_network_hashrate": {
+        "mempool": get_mempool_hashrate,
     },
 }
 

--- a/tradingagents/dataflows/mempool.py
+++ b/tradingagents/dataflows/mempool.py
@@ -1,0 +1,55 @@
+"""Bitcoin network hashrate vendor (mempool.space).
+
+Surfaces Bitcoin miner/network-health signal that no equity-oriented vendor
+covers. A rising hashrate signals miner confidence/network security
+strength; a sharp drop can precede or accompany capitulation-driven sell
+pressure from miners.
+
+Uses mempool.space's public API — no key, no auth. Bitcoin-only: hashrate
+is not a meaningful signal for other assets.
+"""
+import datetime as _dt
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+HASHRATE_API = "https://mempool.space/api/v1/mining/hashrate/3d"
+
+# Network timeout (seconds), consistent with the other vendors.
+REQUEST_TIMEOUT = 15
+
+
+def get_network_hashrate() -> str:
+    """Return current Bitcoin network hashrate and difficulty, with a short trend.
+
+    Returns:
+        A markdown report with the current hashrate/difficulty and the last
+        3 daily average-hashrate readings.
+    """
+    try:
+        response = requests.get(HASHRATE_API, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as e:
+        logger.warning("mempool.space hashrate fetch failed: %s", e)
+        return f"Network hashrate data is currently unavailable ({e})."
+
+    current = data.get("currentHashrate", 0) / 1e18
+    difficulty = data.get("currentDifficulty", 0)
+    series = data.get("hashrates", [])[-3:]
+
+    lines = [
+        "### Bitcoin Network Hashrate (mempool.space)",
+        "",
+        f"**Current hashrate:** {current:,.1f} EH/s",
+        f"**Current difficulty:** {difficulty:,.0f}",
+        "",
+        "| Date (UTC) | Avg Hashrate (EH/s) |",
+        "| --- | ---: |",
+    ]
+    for point in series:
+        date = _dt.datetime.utcfromtimestamp(point["timestamp"]).strftime("%Y-%m-%d")
+        lines.append(f"| {date} | {point['avgHashrate'] / 1e18:,.1f} |")
+    return "\n".join(lines)

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -48,6 +48,11 @@ _ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
 # investing trend more measured. Caller can override.
 DEFAULT_SUBREDDITS = ("wallstreetbets", "stocks", "investing")
 
+# Equity-oriented subreddits barely discuss crypto tickers (a live BTC-USD run
+# returned zero posts across all three) — callers analyzing a crypto asset
+# should pass this set instead.
+CRYPTO_SUBREDDITS = ("CryptoCurrency", "Bitcoin", "CryptoMarkets")
+
 
 def _search_qs(ticker: str, limit: int) -> str:
     return urlencode({

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -137,6 +137,11 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "news_data": "yfinance",             # Options: alpha_vantage, yfinance
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
+        # "default" here resolves per-tool: get_crypto_funding_rate/
+        # get_crypto_open_interest -> binance, get_crypto_fear_greed_index ->
+        # feargreed, get_bitcoin_network_hashrate -> mempool (each has exactly
+        # one vendor registered, all keyless).
+        "crypto_signals": "default",
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -14,7 +14,11 @@ from langgraph.prebuilt import ToolNode
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_balance_sheet,
+    get_bitcoin_network_hashrate,
     get_cashflow,
+    get_crypto_fear_greed_index,
+    get_crypto_funding_rate,
+    get_crypto_open_interest,
     get_fundamentals,
     get_global_news,
     get_income_statement,
@@ -198,6 +202,14 @@ class TradingAgentsGraph:
                     # LLM and required by its prompt; must be executable here or
                     # the call fails and the model reports it "unavailable").
                     get_verified_market_snapshot,
+                    # Crypto derivatives/on-chain signals. Only bound to the LLM
+                    # when asset_type == "crypto" (see market_analyst.py), but
+                    # harmless to register here unconditionally since ToolNode
+                    # only executes what's actually requested.
+                    get_crypto_funding_rate,
+                    get_crypto_open_interest,
+                    get_crypto_fear_greed_index,
+                    get_bitcoin_network_hashrate,
                 ]
             ),
             "social": ToolNode(


### PR DESCRIPTION
## Summary
- The market analyst had no signal for crypto-specific positioning: perpetual
  funding rate, open interest, market-wide sentiment, or network health.
- Adds a keyless `crypto_signals` vendor category (Binance funding rate/open
  interest, alternative.me Fear & Greed Index, mempool.space Bitcoin hashrate),
  bound to the market analyst only when `asset_type == "crypto"`.
- Fixes the sentiment analyst's Reddit source for crypto assets: the
  equities-default subreddits (wallstreetbets/stocks/investing) return
  near-zero signal for a ticker like BTC-USD in practice; a crypto asset now
  searches CryptoCurrency/Bitcoin/CryptoMarkets instead.

## Test plan
- [x] All 392 existing + new unit tests pass (`pytest tests/ -m unit`)
- [x] `ruff check` clean on all changed/new files
- [x] New tests cover: symbol normalization, output formatting, graceful
      degradation on network errors, vendor routing, and a regression guard
      ensuring the new tools are registered in both the LLM binding and the
      executor ToolNode (the same wiring-gap class as an existing test)
- [x] Manually verified live against BTC-USD end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)