### PR TITLE
fix(researchers): guard bull/bear prompts against empty current_respo…

### DIFF
--- a/tests/test_researcher_empty_response.py
+++ b/tests/test_researcher_empty_response.py
@@ -1,0 +1,85 @@
+"""The debate opener must not be handed an empty opponent argument (#1176).
+
+`current_response` starts as `""`, and the graph fixes a speaking order, so
+whichever researcher runs first used to receive a bare ``Last bear argument:``
+(or ``Last bull argument:``) with nothing after it — which the model reads as
+an argument it should rebut, and fabricates one to rebut.
+
+These assert against the *rendered* prompt each researcher actually sends.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradingagents.agents.researchers.bear_researcher import create_bear_researcher
+from tradingagents.agents.researchers.bull_researcher import create_bull_researcher
+
+
+def _capturing_llm(captured: dict):
+    llm = MagicMock()
+    llm.invoke.side_effect = lambda prompt: (
+        captured.__setitem__("prompt", prompt) or MagicMock(content="argument text")
+    )
+    return llm
+
+
+def _state(current_response: str, count: int) -> dict:
+    return {
+        "company_of_interest": "NVDA",
+        "market_report": "market",
+        "sentiment_report": "sentiment",
+        "news_report": "news",
+        "fundamentals_report": "fundamentals",
+        "investment_debate_state": {
+            "history": "" if count == 0 else "prior turns",
+            "bull_history": "",
+            "bear_history": "",
+            "current_response": current_response,
+            "judge_decision": "",
+            "count": count,
+        },
+    }
+
+
+@pytest.mark.unit
+def test_bull_opening_turn_omits_empty_bear_argument():
+    captured = {}
+    create_bull_researcher(_capturing_llm(captured))(_state("", 0))
+    prompt = captured["prompt"]
+    assert "Last bear argument:" not in prompt
+    assert "no responses from the bear analyst yet" in prompt
+
+
+@pytest.mark.unit
+def test_bear_opening_turn_omits_empty_bull_argument():
+    # Reachable by reversing the debate order, or from a state built without a
+    # prior bull turn; the guard must not depend on who the graph runs first.
+    captured = {}
+    create_bear_researcher(_capturing_llm(captured))(_state("", 0))
+    prompt = captured["prompt"]
+    assert "Last bull argument:" not in prompt
+    assert "no responses from the bull analyst yet" in prompt
+
+
+@pytest.mark.unit
+def test_bull_still_receives_a_real_bear_argument():
+    captured = {}
+    create_bull_researcher(_capturing_llm(captured))(
+        _state("Bear Analyst: valuation is stretched", 1)
+    )
+    prompt = captured["prompt"]
+    assert "Last bear argument: Bear Analyst: valuation is stretched" in prompt
+    assert "no responses from the bear analyst yet" not in prompt
+
+
+@pytest.mark.unit
+def test_bear_still_receives_a_real_bull_argument():
+    captured = {}
+    create_bear_researcher(_capturing_llm(captured))(
+        _state("Bull Analyst: margins keep expanding", 1)
+    )
+    prompt = captured["prompt"]
+    assert "Last bull argument: Bull Analyst: margins keep expanding" in prompt
+    assert "no responses from the bull analyst yet" not in prompt

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -11,6 +11,15 @@ def create_bear_researcher(llm):
         bear_history = investment_debate_state.get("bear_history", "")
 
         current_response = investment_debate_state.get("current_response", "")
+        # Empty when the bear speaks first (a reversed debate order, or a state
+        # built without a prior bull turn). Handing the model an empty "Last
+        # bull argument:" makes it invent one and argue against it (#1176), so
+        # state the absence explicitly instead.
+        last_bull_argument = (
+            f"Last bull argument: {current_response}"
+            if current_response
+            else "There are no responses from the bull analyst yet; present your own argument based on the available data."
+        )
         market_research_report = state["market_report"]
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
@@ -42,7 +51,7 @@ Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 {fundamentals_label}: {fundamentals_report}
 Conversation history of the debate: {history}
-Last bull argument: {current_response}
+{last_bull_argument}
 Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the {target_label}.
 """ + get_language_instruction()
 

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -11,6 +11,15 @@ def create_bull_researcher(llm):
         bull_history = investment_debate_state.get("bull_history", "")
 
         current_response = investment_debate_state.get("current_response", "")
+        # The bull opens the debate, so on the first turn there is no bear
+        # argument to rebut. Handing the model an empty "Last bear argument:"
+        # makes it invent one and argue against it (#1176), so state the
+        # absence explicitly instead — same guard the risk debators carry.
+        last_bear_argument = (
+            f"Last bear argument: {current_response}"
+            if current_response
+            else "There are no responses from the bear analyst yet; present your own argument based on the available data."
+        )
         market_research_report = state["market_report"]
         sentiment_report = state["sentiment_report"]
         news_report = state["news_report"]
@@ -40,7 +49,7 @@ Social media sentiment report: {sentiment_report}
 Latest world affairs news: {news_report}
 {fundamentals_label}: {fundamentals_report}
 Conversation history of the debate: {history}
-Last bear argument: {current_response}
+{last_bear_argument}
 Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.
 """ + get_language_instruction()
 


### PR DESCRIPTION
…nse (#1176)

`investment_debate_state["current_response"]` starts as `""`, and the graph fixes a speaking order, so whichever researcher runs first was handed a bare `Last bear argument:` / `Last bull argument:` with nothing after it. The model reads that as an argument it is supposed to rebut and invents one, opening the debate by arguing against a position the other side never took.

Build the opponent-argument line conditionally: when `current_response` is empty, state the absence explicitly instead of rendering an empty labelled field. The wording mirrors the guard the risk debators already carry ("If there are no responses from the other viewpoints yet, present your own argument based on the available data").

Applied to both researchers rather than only the bull. The bull is the opener under the current wiring, but the bear reaches the same state under a reversed debate order or from a state built without a prior bull turn, and the guard should not depend on graph wiring.

This removes the empty-field trigger; it does not claim to eliminate fabrication in general. #1176 notes the risk debators still fabricate despite carrying an equivalent instruction, so the prompt-level cue alone is not reliable. The remaining rebuttal cues in the opener are left untouched to keep this change minimal.

Adds tests/test_researcher_empty_response.py, which asserts against the rendered prompt each researcher actually sends: no empty labelled field on the opening turn, and a real opponent argument still passes through unchanged.