### PR TITLE
feat(scripts): harden structured-output smoke test with fail-fast errors

### DIFF
--- a/scripts/smoke_structured_output.py
+++ b/scripts/smoke_structured_output.py
@@ -28,15 +28,16 @@ from tradingagents.agents.managers.research_manager import create_research_manag
 from tradingagents.agents.trader.trader import create_trader
 from tradingagents.graph.signal_processing import SignalProcessor
 from tradingagents.llm_clients import create_llm_client
+from tradingagents.testing.smoke_helpers import check_structure, require_api_key, run_agent_call
 
 PROVIDER_DEFAULTS = {
-    "openai": ("gpt-5.4-mini", None),
-    "google": ("gemini-3.5-flash", None),
-    "anthropic": ("claude-sonnet-4-6", None),
-    "deepseek": ("deepseek-v4-flash", None),
-    "qwen": ("qwen3.7-plus", None),
-    "glm": ("glm-5", None),
-    "xai": ("grok-4.3", None),
+    "openai": ("gpt-5.4-mini", "OPENAI_API_KEY"),
+    "google": ("gemini-3.5-flash", "GOOGLE_API_KEY"),
+    "anthropic": ("claude-sonnet-4-6", "ANTHROPIC_API_KEY"),
+    "deepseek": ("deepseek-v4-flash", "DEEPSEEK_API_KEY"),
+    "qwen": ("qwen3.7-plus", "DASHSCOPE_API_KEY"),
+    "glm": ("glm-5", "ZHIPU_API_KEY"),
+    "xai": ("grok-4.3", "XAI_API_KEY"),
 }
 
 
@@ -109,13 +110,16 @@ def main() -> int:
     parser.add_argument("--quick-model", default=None, help="Override quick_think_llm")
     args = parser.parse_args()
 
-    default_model, _ = PROVIDER_DEFAULTS[args.provider]
+    default_model, key_env = PROVIDER_DEFAULTS[args.provider]
     deep_model = args.deep_model or default_model
     quick_model = args.quick_model or default_model
 
     print(f"Provider: {args.provider}")
     print(f"Deep model:  {deep_model}")
     print(f"Quick model: {quick_model}")
+
+    # Fail fast with a clear message when the provider credential is absent.
+    require_api_key(key_env, args.provider)
 
     # Build the LLM clients via the framework's factory.
     deep_client = create_llm_client(provider=args.provider, model=deep_model)
@@ -125,25 +129,30 @@ def main() -> int:
 
     # 1) Research Manager
     rm = create_research_manager(deep_llm)
-    rm_result = rm(_make_rm_state())
+    rm_result = run_agent_call("Research Manager", lambda: rm(_make_rm_state()))
     investment_plan = rm_result["investment_plan"]
     _print_section("[1] Research Manager — investment_plan", investment_plan)
 
     # 2) Trader (consumes RM's plan)
     trader = create_trader(quick_llm)
-    trader_result = trader(_make_trader_state(investment_plan))
+    trader_result = run_agent_call(
+        "Trader", lambda: trader(_make_trader_state(investment_plan))
+    )
     trader_plan = trader_result["trader_investment_plan"]
     _print_section("[2] Trader — trader_investment_plan", trader_plan)
 
     # 3) Portfolio Manager (consumes both)
     pm = create_portfolio_manager(deep_llm)
-    pm_result = pm(_make_pm_state(investment_plan, trader_plan))
+    pm_result = run_agent_call(
+        "Portfolio Manager",
+        lambda: pm(_make_pm_state(investment_plan, trader_plan)),
+    )
     final_decision = pm_result["final_trade_decision"]
     _print_section("[3] Portfolio Manager — final_trade_decision", final_decision)
 
     # 4) SignalProcessor extracts the rating with zero LLM calls.
     sp = SignalProcessor()
-    rating = sp.process_signal(final_decision)
+    rating = run_agent_call("SignalProcessor", lambda: sp.process_signal(final_decision))
     _print_section("[4] SignalProcessor → rating", rating)
 
     # 5) Lightweight checks: each rendered output should carry the expected
@@ -155,16 +164,18 @@ def main() -> int:
         ("Portfolio Manager", final_decision, ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:"]),
     ]
     print("\n" + "=" * 70 + "\nStructure checks\n" + "=" * 70)
-    failures = 0
+    failures: list[str] = []
     for name, text, required in checks:
-        for marker in required:
-            ok = marker in text
-            print(f"  {'PASS' if ok else 'FAIL'}  {name}: contains {marker!r}")
-            failures += int(not ok)
+        section_failures = check_structure(name, text, required)
+        for failure in section_failures:
+            print(f"  FAIL  {failure}")
+        if not section_failures:
+            print(f"  PASS  {name}: all required markers present")
+        failures.extend(section_failures)
 
     print()
     if failures:
-        print(f"Smoke FAILED: {failures} structure check(s) missing.")
+        print(f"Smoke FAILED: {len(failures)} structure check(s) missing.")
         return 1
     print("Smoke PASSED: structured output → rendered markdown chain works for", args.provider)
     return 0

--- a/tests/test_smoke_helpers.py
+++ b/tests/test_smoke_helpers.py
@@ -1,0 +1,92 @@
+"""Unit tests for the structured-output smoke helpers (issue #1216).
+
+The smoke script (scripts/smoke_structured_output.py) should fail fast with
+clear, actionable errors instead of an opaque traceback when a provider
+credential is missing, an agent call raises, or a rendered output is empty.
+These helpers keep that logic pure and unit-testable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradingagents.testing.smoke_helpers import (
+    check_structure,
+    require_api_key,
+    run_agent_call,
+)
+
+API_KEY_ENV = "TRADINGAGENTS_TEST_SMOKE_KEY"
+
+
+@pytest.mark.unit
+class TestRequireApiKey:
+    def test_missing_key_raises_clear_error(self, monkeypatch, capsys):
+        monkeypatch.delenv(API_KEY_ENV, raising=False)
+        with pytest.raises(SystemExit) as exc:
+            require_api_key(API_KEY_ENV, "openai")
+        assert exc.value.code == 2
+        # The message must name the env var and the provider so the user
+        # knows exactly what to set.
+        err = capsys.readouterr().err
+        assert "TRADINGAGENTS_TEST_SMOKE_KEY" in err
+        assert "openai" in err
+
+    def test_present_key_returns_value(self, monkeypatch):
+        monkeypatch.setenv(API_KEY_ENV, "sk-test")
+        assert require_api_key(API_KEY_ENV, "openai") == "sk-test"
+
+    def test_blank_key_is_treated_as_missing(self, monkeypatch):
+        monkeypatch.setenv(API_KEY_ENV, "")
+        with pytest.raises(SystemExit) as exc:
+            require_api_key(API_KEY_ENV, "openai")
+        assert exc.value.code == 2
+
+
+@pytest.mark.unit
+class TestRunAgentCall:
+    def test_returns_result_on_success(self):
+        def ok():
+            return {"investment_plan": "plan"}
+
+        result = run_agent_call("Research Manager", ok)
+        assert result == {"investment_plan": "plan"}
+
+    def test_raises_system_exit_on_exception(self, capsys):
+        def boom():
+            raise RuntimeError("provider timeout")
+
+        with pytest.raises(SystemExit) as exc:
+            run_agent_call("Trader", boom)
+        assert exc.value.code == 2
+        assert "Trader" in capsys.readouterr().err
+
+    def test_empty_result_raises_clear_error(self, capsys):
+        def empty():
+            return {}
+
+        with pytest.raises(SystemExit) as exc:
+            run_agent_call("Portfolio Manager", empty)
+        assert exc.value.code == 2
+        assert "Portfolio Manager" in capsys.readouterr().err
+
+
+@pytest.mark.unit
+class TestCheckStructure:
+    def test_all_markers_present_returns_empty_failures(self):
+        failures = check_structure("Research Manager", "**Recommendation**: Buy", ["**Recommendation**:"])
+        assert failures == []
+
+    def test_missing_marker_reported_with_name_and_marker(self):
+        failures = check_structure("Trader", "**Action**: Buy", ["FINAL TRANSACTION PROPOSAL:"])
+        assert len(failures) == 1
+        assert "Trader" in failures[0]
+        assert "FINAL TRANSACTION PROPOSAL:" in failures[0]
+
+    def test_empty_text_flags_every_marker(self):
+        failures = check_structure("PM", "", ["**Rating**:", "**Executive Summary**:"])
+        assert len(failures) == 2
+
+    def test_multiple_missing_markers_all_reported(self):
+        failures = check_structure("PM", "**Rating**: Hold", ["**Rating**:", "**Executive Summary**:", "**Investment Thesis**:"])
+        assert len(failures) == 2

--- a/tradingagents/testing/__init__.py
+++ b/tradingagents/testing/__init__.py
@@ -1,0 +1,3 @@
+"""Testing support package for TradingAgents."""
+
+from tradingagents.testing import smoke_helpers  # noqa: F401

--- a/tradingagents/testing/smoke_helpers.py
+++ b/tradingagents/testing/smoke_helpers.py
@@ -1,0 +1,66 @@
+"""Pure helpers for the structured-output smoke script (issue #1216).
+
+The smoke script calls real LLM providers, so a missing credential or a
+provider error must fail fast with a clear, actionable message instead of a
+raw traceback.  Keeping the checks here (pure functions) makes them
+unit-testable without network access.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Callable, Sequence
+
+
+def require_api_key(env_var: str, provider: str) -> str:
+    """Return the API key for *provider* or exit(2) with a clear message.
+
+    A missing or blank env var is a configuration error, not a runtime
+    failure: the operator needs to know exactly which variable to set.
+    """
+    key = os.environ.get(env_var, "")
+    if not key:
+        print(
+            f"ERROR: missing {env_var} for provider '{provider}'.\n"
+            f"Set it in your environment (or .env) and re-run, e.g.:\n"
+            f"    {env_var}=... python scripts/smoke_structured_output.py {provider}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return key
+
+
+def run_agent_call(label: str, fn: Callable[[], Any]) -> Any:
+    """Run *fn* and return its result, or exit(2) on failure.
+
+    Provider timeouts, empty outputs and exceptions are all surfaced as a
+    labelled error so a partial run is easy to diagnose.
+    """
+    try:
+        result = fn()
+    except Exception as exc:  # noqa: BLE001 - the smoke must not traceback
+        print(f"ERROR: {label} call raised: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if not result:
+        print(
+            f"ERROR: {label} returned an empty result — check the model and "
+            "provider configuration.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return result
+
+
+def check_structure(name: str, text: str, required: Sequence[str]) -> list[str]:
+    """Return a list of missing-marker failures for *text*.
+
+    Each failure is a human-readable string naming the section and the
+    marker that was absent, so the smoke output tells the operator exactly
+    which downstream consumer would break.
+    """
+    failures: list[str] = []
+    for marker in required:
+        if marker not in text:
+            failures.append(f"{name}: missing {marker!r}")
+    return failures


### PR DESCRIPTION
Fixes #1216

## Problem
`scripts/smoke_structured_output.py` fails with an opaque traceback when a provider credential is missing, an agent call raises, or an output comes back empty — hard to diagnose in CI or for a new contributor running the smoke for the first time.

## Changes
- **`tradingagents/testing/smoke_helpers.py`** (new): pure, unit-testable helpers:
  - `require_api_key` — exits with code 2 and names the exact env var to set when a provider credential is missing or blank (fail-fast before any network call).
  - `run_agent_call` — wraps each agent invocation, labels provider exceptions and empty results with the failing section.
  - `check_structure` — returns one human-readable failure per missing rendered marker.
- **`scripts/smoke_structured_output.py`**: uses the helpers; provider table now maps each backend to its credential env var (e.g. `openai → OPENAI_API_KEY`, `deepseek → DEEPSEEK_API_KEY`).
- **`tests/test_smoke_helpers.py`** (new): 10 unit tests covering missing/blank credentials, successful and failing agent calls, empty outputs, and all marker-check paths.

## Verification
- `pytest tests/` → **603 passed, 2 skipped** (pre-existing skips: bedrock extra not installed, live DeepSeek call).
- `env -u OPENAI_API_KEY python scripts/smoke_structured_output.py openai` → exits **2** with: `ERROR: missing OPENAI_API_KEY for provider 'openai'.`

No behavioral change to the successful path — same structure checks, same exit code 1 on missing markers.