### PR TITLE
feat(dataflows): add Firecrawl web-search news vendor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ NVIDIA_API_KEY=
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=
 
+# Firecrawl (optional news vendor: ticker + macro headlines from a web search
+# instead of a single provider's wire). Enable it per tool via tool_vendors,
+# e.g. "get_news": "yfinance,firecrawl". Key: https://www.firecrawl.dev
+#FIRECRAWL_API_KEY=
+
 # Optional: a custom OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp,
 # relay). Select provider "openai_compatible" and set the base URL; the key is
 # optional (local servers need none).

--- a/README.md
+++ b/README.md
@@ -170,10 +170,15 @@ news" rather than "nothing happened". [Firecrawl](https://docs.firecrawl.dev)
 searches the open web instead, and works well chained behind the default:
 
 ```python
-config = DEFAULT_CONFIG.copy()
+import copy
+
+config = copy.deepcopy(DEFAULT_CONFIG)  # .copy() is shallow: nested dicts would be shared
 config["tool_vendors"]["get_news"] = "yfinance,firecrawl"        # ticker news
 config["tool_vendors"]["get_global_news"] = "yfinance,firecrawl" # macro headlines
 ```
+
+Chained this way Yahoo stays the primary and Firecrawl is consulted only when it
+comes back empty or fails.
 
 Set `FIRECRAWL_API_KEY` ([get a key](https://www.firecrawl.dev)); without it the
 vendor reports itself unavailable and the chain falls through to the next one.

--- a/README.md
+++ b/README.md
@@ -172,9 +172,15 @@ searches the open web instead, and works well chained behind the default:
 ```python
 import copy
 
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
 config = copy.deepcopy(DEFAULT_CONFIG)  # .copy() is shallow: nested dicts would be shared
 config["tool_vendors"]["get_news"] = "yfinance,firecrawl"        # ticker news
 config["tool_vendors"]["get_global_news"] = "yfinance,firecrawl" # macro headlines
+
+ta = TradingAgentsGraph(config=config)
+_, decision = ta.propagate("NVDA", "2026-01-15")
 ```
 
 Chained this way Yahoo stays the primary and Firecrawl is consulted only when it

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io)
 export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com)
 export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
+export FIRECRAWL_API_KEY=...       # Firecrawl (optional web-search news vendor)
 ```
 
 For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
@@ -159,6 +160,27 @@ Alternatively, copy `.env.example` to `.env` and fill in your keys:
 ```bash
 cp .env.example .env
 ```
+
+### News from a web search (Firecrawl)
+
+News defaults to Yahoo Finance, with Alpha Vantage as an alternative. Both return
+one provider's wire, so a ticker they cover thinly — a non-US listing, a small cap,
+anything whose coverage sits in trade press or a company newsroom — reads as "no
+news" rather than "nothing happened". [Firecrawl](https://docs.firecrawl.dev)
+searches the open web instead, and works well chained behind the default:
+
+```python
+config = DEFAULT_CONFIG.copy()
+config["tool_vendors"]["get_news"] = "yfinance,firecrawl"        # ticker news
+config["tool_vendors"]["get_global_news"] = "yfinance,firecrawl" # macro headlines
+```
+
+Set `FIRECRAWL_API_KEY` ([get a key](https://www.firecrawl.dev)); without it the
+vendor reports itself unavailable and the chain falls through to the next one.
+Queries are pinned to the analysis window server-side, so a historical run cannot
+pull in articles published after its end date. Firecrawl serves `get_news` and
+`get_global_news` only — set it per tool as above rather than on the whole
+`news_data` category, which also covers `get_insider_transactions`.
 
 ### CLI Usage
 

--- a/tests/test_firecrawl_news.py
+++ b/tests/test_firecrawl_news.py
@@ -32,15 +32,24 @@ _ARTICLES = [
 ]
 
 
+# Payload marker for a body that isn't JSON at all (an HTML error page).
+_NOT_JSON = object()
+
+
 class _Response:
     """Minimal stand-in for ``requests.Response``."""
 
-    def __init__(self, payload=None, status_code=200, text=""):
-        self._payload = payload if payload is not None else {}
+    _SENTINEL = object()
+
+    def __init__(self, payload=_SENTINEL, status_code=200, text="", headers=None):
+        self._payload = {} if payload is self._SENTINEL else payload
         self.status_code = status_code
         self.text = text
+        self.headers = headers or {}
 
     def json(self):
+        if self._payload is _NOT_JSON:
+            raise ValueError("no JSON body")
         return self._payload
 
     def raise_for_status(self):
@@ -50,6 +59,10 @@ class _Response:
 
 def _ok(articles=_ARTICLES):
     return _Response({"success": True, "data": {"news": list(articles)}})
+
+
+def _empty():
+    return _Response({"success": True, "data": {"news": []}})
 
 
 @pytest.mark.unit
@@ -131,7 +144,7 @@ class FirecrawlFormattingTests(unittest.TestCase):
     @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
     def test_empty_result_raises_so_the_chain_continues(self):
         with mock.patch.object(
-            firecrawl_news.requests, "post", return_value=_Response({"data": {"news": []}})
+            firecrawl_news.requests, "post", return_value=_empty()
         ), self.assertRaises(NoNewsError) as ctx:
             firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
         self.assertEqual(
@@ -153,6 +166,137 @@ class FirecrawlFormattingTests(unittest.TestCase):
 
 
 @pytest.mark.unit
+@mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+class FirecrawlRetryTests(unittest.TestCase):
+    """Firecrawl documents 408/429/500/502/503/504 as transient.
+
+    It is usually the last vendor in a chain, so a throttling burst that isn't
+    ridden out costs the run its news coverage outright.
+    """
+
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+        # Assert on the delays instead of serving them.
+        sleep = mock.patch.object(firecrawl_news.time, "sleep")
+        self.sleep = sleep.start()
+        self.addCleanup(sleep.stop)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def _post(self, *responses):
+        return mock.patch.object(firecrawl_news.requests, "post", side_effect=responses)
+
+    def test_throttled_then_served(self):
+        throttled = _Response(status_code=429, text="slow down", headers={"Retry-After": "3"})
+        with self._post(throttled, _ok()):
+            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertIn("### Chipmaker beats estimates", out)
+        self.sleep.assert_called_once_with(3.0)  # Retry-After honoured, not the curve
+
+    def test_transient_5xx_then_served(self):
+        with self._post(_Response(status_code=503, text="down"), _ok()):
+            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertIn("### Chipmaker beats estimates", out)
+        self.sleep.assert_called_once_with(firecrawl_news.BASE_RETRY_DELAY)
+
+    def test_backoff_doubles_without_a_retry_after_header(self):
+        with self._post(*[_Response(status_code=500, text="boom")] * 3), \
+                self.assertRaises(requests.HTTPError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertEqual([c.args[0] for c in self.sleep.call_args_list], [2.0, 4.0])
+
+    def test_retries_are_bounded(self):
+        # MAX_RETRIES retries, then the typed error — never an unbounded loop.
+        posts = [_Response(status_code=429, text="slow down")] * (firecrawl_news.MAX_RETRIES + 1)
+        with self._post(*posts) as post, \
+                self.assertRaises(firecrawl_news.FirecrawlRateLimitError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertEqual(post.call_count, firecrawl_news.MAX_RETRIES + 1)
+        self.assertEqual(self.sleep.call_count, firecrawl_news.MAX_RETRIES)
+
+    def test_outsized_retry_after_is_capped(self):
+        # A server asking for an hour must not stall the analysis run.
+        throttled = _Response(status_code=429, headers={"Retry-After": "3600"})
+        with self._post(throttled, _ok()):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.sleep.assert_called_once_with(firecrawl_news.MAX_RETRY_DELAY)
+
+    def test_http_date_retry_after_falls_back_to_the_curve(self):
+        # Retry-After's HTTP-date form isn't parsed; back off rather than guess.
+        throttled = _Response(
+            status_code=429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        )
+        with self._post(throttled, _ok()):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.sleep.assert_called_once_with(firecrawl_news.BASE_RETRY_DELAY)
+
+    def test_rejected_key_is_not_retried(self):
+        # A rejected key will be rejected again; failing fast keeps the chain moving.
+        with self._post(_Response(status_code=401, text="unauthorized")) as post, \
+                self.assertRaises(firecrawl_news.FirecrawlNotConfiguredError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertEqual(post.call_count, 1)
+        self.sleep.assert_not_called()
+
+    def test_non_retryable_4xx_is_not_retried(self):
+        with self._post(_Response(status_code=400, text="bad request")) as post, \
+                self.assertRaises(requests.HTTPError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertEqual(post.call_count, 1)
+
+
+@pytest.mark.unit
+@mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+class FirecrawlResponseValidationTests(unittest.TestCase):
+    """An unreadable body is a fault, never a quiet news window.
+
+    The callers turn an empty result into ``NoNewsError``, so anything that
+    silently degrades to "no articles" would report a client-side failure to the
+    analyst as a market that had nothing to say.
+    """
+
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def _assert_rejects(self, payload):
+        with mock.patch.object(
+            firecrawl_news.requests, "post", return_value=_Response(payload)
+        ), self.assertRaises(firecrawl_news.FirecrawlResponseError) as ctx:
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        # Specifically not NoNewsError, which would end the chain as "quiet week".
+        self.assertNotIsInstance(ctx.exception, NoNewsError)
+
+    def test_unsuccessful_body_is_rejected(self):
+        self._assert_rejects({"success": False, "error": "something broke"})
+
+    def test_missing_success_flag_is_rejected(self):
+        self._assert_rejects({"data": {"news": []}})
+
+    def test_missing_or_malformed_news_list_is_rejected(self):
+        self._assert_rejects({"success": True})
+        self._assert_rejects({"success": True, "data": {}})
+        self._assert_rejects({"success": True, "data": {"news": None}})
+        self._assert_rejects({"success": True, "data": "not-a-dict"})
+
+    def test_non_json_body_is_rejected(self):
+        with mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response(_NOT_JSON, text="<html>gateway</html>"),
+        ), self.assertRaises(firecrawl_news.FirecrawlResponseError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+
+@pytest.mark.unit
 class FirecrawlErrorTests(unittest.TestCase):
     def setUp(self):
         config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
@@ -163,30 +307,6 @@ class FirecrawlErrorTests(unittest.TestCase):
     @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": ""})
     def test_missing_key_raises_not_configured(self):
         with self.assertRaises(firecrawl_news.FirecrawlNotConfiguredError):
-            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
-
-    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
-    def test_rate_limit_is_classified(self):
-        with mock.patch.object(
-            firecrawl_news.requests, "post",
-            return_value=_Response(status_code=429, text="too many requests"),
-        ), self.assertRaises(firecrawl_news.FirecrawlRateLimitError):
-            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
-
-    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
-    def test_rejected_key_is_not_confused_with_an_outage(self):
-        # A bad key must read as "vendor unavailable" (skip to the next vendor);
-        # a 5xx must stay a hard error so a broken primary is loud.
-        with mock.patch.object(
-            firecrawl_news.requests, "post",
-            return_value=_Response(status_code=401, text="unauthorized"),
-        ), self.assertRaises(firecrawl_news.FirecrawlNotConfiguredError):
-            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
-
-        with mock.patch.object(
-            firecrawl_news.requests, "post",
-            return_value=_Response(status_code=503, text="upstream down"),
-        ), self.assertRaises(requests.HTTPError):
             firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
 
 
@@ -265,12 +385,38 @@ class FirecrawlRoutingTests(unittest.TestCase):
         set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
 
         with self._yahoo_returning([]), mock.patch.object(
-            firecrawl_news.requests, "post", return_value=_Response({"data": {"news": []}})
+            firecrawl_news.requests, "post", return_value=_empty()
         ):
             out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
 
         self.assertEqual(out, "No news found for AAPL")
         self.assertNotIn("NO_DATA_AVAILABLE", out)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_unreadable_response_fails_loudly_rather_than_reading_as_no_news(self):
+        set_config({"tool_vendors": {"get_news": "firecrawl"}})
+
+        with mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response({"success": False, "error": "broke"}),
+        ), self.assertRaises(firecrawl_news.FirecrawlResponseError):
+            interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_a_broken_fallback_is_logged_even_when_the_primary_had_no_news(self):
+        # Established router behaviour (#989) applied to the news path: the
+        # reported outcome is still "no news" — no vendor produced any — but the
+        # fallback's failure must leave a trace instead of vanishing.
+        set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
+
+        with self._yahoo_returning([]), mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response({"success": False, "error": "broke"}),
+        ), self.assertLogs("tradingagents.dataflows.interface", level="WARNING") as logs:
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+
+        self.assertEqual(out, "No news found for AAPL")
+        self.assertTrue(any("errored earlier" in m for m in logs.output))
 
     def test_missing_key_falls_through_to_the_next_vendor(self):
         set_config({"tool_vendors": {"get_news": "firecrawl,yfinance"}})

--- a/tests/test_firecrawl_news.py
+++ b/tests/test_firecrawl_news.py
@@ -1,0 +1,246 @@
+"""Firecrawl news vendor: date-window pinning, response formatting, snippet
+hygiene, error classification, deduplication, and router integration.
+
+All API access is mocked, so these run without a network connection or a key.
+"""
+import copy
+import unittest
+from unittest import mock
+
+import pytest
+import requests
+
+import tradingagents.dataflows.config as config_module
+import tradingagents.default_config as default_config
+from tradingagents.dataflows import firecrawl_news, interface
+from tradingagents.dataflows.config import set_config
+
+_ARTICLES = [
+    {
+        "title": "Chipmaker beats estimates",
+        "url": "https://www.reuters.com/markets/chip-beat",
+        "snippet": "Revenue rose 12% on datacenter demand.",
+        "date": "2 days ago",
+    },
+    {
+        "title": "Analysts lift price target",
+        "url": "https://seekingalpha.com/news/4612631",
+        "snippet": "Two desks raised targets after the print.",
+        "date": "1 day ago",
+    },
+]
+
+
+class _Response:
+    """Minimal stand-in for ``requests.Response``."""
+
+    def __init__(self, payload=None, status_code=200, text=""):
+        self._payload = payload if payload is not None else {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+def _ok(articles=_ARTICLES):
+    return _Response({"success": True, "data": {"news": list(articles)}})
+
+
+@pytest.mark.unit
+class FirecrawlQueryTests(unittest.TestCase):
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def test_date_range_uses_us_style_unpadded_bounds(self):
+        # The engine's cdr filter wants M/D/YYYY; zero-padding is not accepted
+        # and the strftime directive for it is platform-specific.
+        self.assertEqual(
+            firecrawl_news._date_range_tbs("2026-01-05", "2026-11-30"),
+            "cdr:1,cd_min:1/5/2026,cd_max:11/30/2026",
+        )
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_window_is_pinned_server_side(self):
+        # Look-ahead safety: the requested window is sent as the search filter,
+        # so the API cannot return an article published after end_date.
+        with mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()) as post:
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        payload = post.call_args.kwargs["json"]
+        self.assertEqual(payload["tbs"], "cdr:1,cd_min:3/1/2026,cd_max:3/8/2026")
+        self.assertEqual(payload["sources"], [{"type": "news"}])
+        self.assertIn("NVDA", payload["query"])
+        self.assertEqual(
+            post.call_args.kwargs["headers"]["Authorization"], "Bearer test-key"
+        )
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_article_limit_comes_from_config(self):
+        set_config({"news_article_limit": 3})
+        with mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()) as post:
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.assertEqual(post.call_args.kwargs["json"]["limit"], 3)
+
+
+@pytest.mark.unit
+class FirecrawlFormattingTests(unittest.TestCase):
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_report_matches_the_other_news_vendors(self):
+        with mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()):
+            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        self.assertTrue(out.startswith("## NVDA News, from 2026-03-01 to 2026-03-08\n"))
+        self.assertIn("### Chipmaker beats estimates (source: reuters.com)", out)
+        self.assertIn("Revenue rose 12% on datacenter demand.", out)
+        self.assertIn("Link: https://www.reuters.com/markets/chip-beat", out)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_article_age_is_not_rendered(self):
+        # Recent results carry an age relative to *now*, not to the analysis
+        # date, so rendering it would misdate every article in a historical run.
+        with mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()):
+            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.assertNotIn("days ago", out)
+
+    def test_snippet_images_are_dropped_and_length_capped(self):
+        cleaned = firecrawl_news._clean_snippet(
+            "Before ![alt](data:image/gif;base64,R0lGODlh) after\n\nmore   text"
+        )
+        self.assertEqual(cleaned, "Before after more text")
+
+        long_snippet = "word " * 400
+        capped = firecrawl_news._clean_snippet(long_snippet)
+        self.assertLessEqual(len(capped), firecrawl_news.MAX_SNIPPET_CHARS + 3)
+        self.assertTrue(capped.endswith("..."))
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_empty_result_says_so_instead_of_an_empty_body(self):
+        with mock.patch.object(
+            firecrawl_news.requests, "post", return_value=_Response({"data": {"news": []}})
+        ):
+            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.assertEqual(out, "No news found for NVDA between 2026-03-01 and 2026-03-08")
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_global_news_dedupes_across_queries(self):
+        # The macro queries overlap; the same story must not be listed twice.
+        set_config({
+            "global_news_queries": ["fed rates", "inflation outlook"],
+            "global_news_article_limit": 10,
+        })
+        with mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()):
+            out = firecrawl_news.get_global_news_firecrawl("2026-03-08")
+
+        self.assertEqual(out.count("### Chipmaker beats estimates"), 1)
+        self.assertIn("## Global Market News, from 2026-03-01 to 2026-03-08", out)
+
+
+@pytest.mark.unit
+class FirecrawlErrorTests(unittest.TestCase):
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": ""})
+    def test_missing_key_raises_not_configured(self):
+        with self.assertRaises(firecrawl_news.FirecrawlNotConfiguredError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_rate_limit_is_classified(self):
+        with mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response(status_code=429, text="too many requests"),
+        ), self.assertRaises(firecrawl_news.FirecrawlRateLimitError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_rejected_key_is_not_confused_with_an_outage(self):
+        # A bad key must read as "vendor unavailable" (skip to the next vendor);
+        # a 5xx must stay a hard error so a broken primary is loud.
+        with mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response(status_code=401, text="unauthorized"),
+        ), self.assertRaises(firecrawl_news.FirecrawlNotConfiguredError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+        with mock.patch.object(
+            firecrawl_news.requests, "post",
+            return_value=_Response(status_code=503, text="upstream down"),
+        ), self.assertRaises(requests.HTTPError):
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+
+
+@pytest.mark.unit
+class FirecrawlRoutingTests(unittest.TestCase):
+    def setUp(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def tearDown(self):
+        config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
+
+    def test_registered_for_both_news_methods(self):
+        self.assertIn("firecrawl", interface.VENDOR_LIST)
+        self.assertIs(
+            interface.VENDOR_METHODS["get_news"]["firecrawl"],
+            firecrawl_news.get_news_firecrawl,
+        )
+        self.assertIs(
+            interface.VENDOR_METHODS["get_global_news"]["firecrawl"],
+            firecrawl_news.get_global_news_firecrawl,
+        )
+
+    def test_chained_behind_yfinance_it_serves_the_fallback(self):
+        # The documented setup: Firecrawl picks up tickers the default covers thinly.
+        set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
+
+        def _no_news(*a, **k):
+            raise requests.ConnectionError("yahoo down")
+
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_news": {
+                "yfinance": _no_news,
+                "firecrawl": lambda *a, **k: "FIRECRAWL_NEWS",
+            }},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+        self.assertEqual(out, "FIRECRAWL_NEWS")
+
+    def test_missing_key_falls_through_to_the_next_vendor(self):
+        set_config({"tool_vendors": {"get_news": "firecrawl,yfinance"}})
+
+        def _unconfigured(*a, **k):
+            raise firecrawl_news.FirecrawlNotConfiguredError("FIRECRAWL_API_KEY not set")
+
+        with mock.patch.dict(
+            interface.VENDOR_METHODS,
+            {"get_news": {
+                "firecrawl": _unconfigured,
+                "yfinance": lambda *a, **k: "YF_NEWS",
+            }},
+            clear=False,
+        ):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+        self.assertEqual(out, "YF_NEWS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_firecrawl_news.py
+++ b/tests/test_firecrawl_news.py
@@ -12,8 +12,9 @@ import requests
 
 import tradingagents.dataflows.config as config_module
 import tradingagents.default_config as default_config
-from tradingagents.dataflows import firecrawl_news, interface
+from tradingagents.dataflows import firecrawl_news, interface, yfinance_news
 from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows.errors import NoNewsError
 
 _ARTICLES = [
     {
@@ -128,12 +129,14 @@ class FirecrawlFormattingTests(unittest.TestCase):
         self.assertTrue(capped.endswith("..."))
 
     @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
-    def test_empty_result_says_so_instead_of_an_empty_body(self):
+    def test_empty_result_raises_so_the_chain_continues(self):
         with mock.patch.object(
             firecrawl_news.requests, "post", return_value=_Response({"data": {"news": []}})
-        ):
-            out = firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
-        self.assertEqual(out, "No news found for NVDA between 2026-03-01 and 2026-03-08")
+        ), self.assertRaises(NoNewsError) as ctx:
+            firecrawl_news.get_news_firecrawl("NVDA", "2026-03-01", "2026-03-08")
+        self.assertEqual(
+            str(ctx.exception), "No news found for NVDA between 2026-03-01 and 2026-03-08"
+        )
 
     @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
     def test_global_news_dedupes_across_queries(self):
@@ -195,6 +198,28 @@ class FirecrawlRoutingTests(unittest.TestCase):
     def tearDown(self):
         config_module._config = copy.deepcopy(default_config.DEFAULT_CONFIG)
 
+    @staticmethod
+    def _yahoo_returning(articles):
+        """Patch the real yfinance news path to return ``articles``."""
+        stock = mock.Mock()
+        stock.get_news.return_value = articles
+        return mock.patch.multiple(
+            yfinance_news,
+            yf=mock.Mock(Ticker=mock.Mock(return_value=stock)),
+            yf_retry=lambda fn: fn(),
+        )
+
+    @staticmethod
+    def _yahoo_raising(exc):
+        """Patch the real yfinance news path to fail the way a live outage does."""
+        stock = mock.Mock()
+        stock.get_news.side_effect = exc
+        return mock.patch.multiple(
+            yfinance_news,
+            yf=mock.Mock(Ticker=mock.Mock(return_value=stock)),
+            yf_retry=lambda fn: fn(),
+        )
+
     def test_registered_for_both_news_methods(self):
         self.assertIn("firecrawl", interface.VENDOR_LIST)
         self.assertIs(
@@ -206,23 +231,46 @@ class FirecrawlRoutingTests(unittest.TestCase):
             firecrawl_news.get_global_news_firecrawl,
         )
 
-    def test_chained_behind_yfinance_it_serves_the_fallback(self):
-        # The documented setup: Firecrawl picks up tickers the default covers thinly.
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_quiet_yahoo_window_reaches_firecrawl(self):
+        # The documented setup, exercised through the real vendor functions and
+        # the real router: Yahoo has nothing for this ticker, so Firecrawl — the
+        # vendor configured precisely for that case — must get its turn. A vendor
+        # that returned "No news found..." as a string would end the chain here.
         set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
 
-        def _no_news(*a, **k):
-            raise requests.ConnectionError("yahoo down")
-
-        with mock.patch.dict(
-            interface.VENDOR_METHODS,
-            {"get_news": {
-                "yfinance": _no_news,
-                "firecrawl": lambda *a, **k: "FIRECRAWL_NEWS",
-            }},
-            clear=False,
+        with self._yahoo_returning([]), mock.patch.object(
+            firecrawl_news.requests, "post", return_value=_ok()
         ):
             out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
-        self.assertEqual(out, "FIRECRAWL_NEWS")
+
+        self.assertIn("### Chipmaker beats estimates (source: reuters.com)", out)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_yahoo_outage_reaches_firecrawl(self):
+        # A fetch failure must not read as a valid empty report either.
+        set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
+
+        with self._yahoo_raising(requests.ConnectionError("yahoo down")), \
+                mock.patch.object(firecrawl_news.requests, "post", return_value=_ok()):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+
+        self.assertIn("### Chipmaker beats estimates (source: reuters.com)", out)
+
+    @mock.patch.dict("os.environ", {"FIRECRAWL_API_KEY": "test-key"})
+    def test_whole_chain_empty_returns_the_primary_message(self):
+        # Genuinely quiet week: the analyst gets the primary's wording back, not
+        # a raised exception and not the "may be invalid, delisted" market-data
+        # sentinel — an empty news window says nothing about the symbol.
+        set_config({"tool_vendors": {"get_news": "yfinance,firecrawl"}})
+
+        with self._yahoo_returning([]), mock.patch.object(
+            firecrawl_news.requests, "post", return_value=_Response({"data": {"news": []}})
+        ):
+            out = interface.route_to_vendor("get_news", "AAPL", "2026-03-01", "2026-03-08")
+
+        self.assertEqual(out, "No news found for AAPL")
+        self.assertNotIn("NO_DATA_AVAILABLE", out)
 
     def test_missing_key_falls_through_to_the_next_vendor(self):
         set_config({"tool_vendors": {"get_news": "firecrawl,yfinance"}})

--- a/tests/test_news_lookahead.py
+++ b/tests/test_news_lookahead.py
@@ -99,6 +99,10 @@ def test_global_news_empty_after_filter_is_informative(monkeypatch):
             self.news = [only_future]
 
     monkeypatch.setattr(ynews.yf, "Search", FakeSearch)
-    out = ynews.get_global_news_yfinance("2025-05-09", look_back_days=7, limit=10)
-    assert "No global news found" in out
-    assert "###" not in out  # no empty article body
+    with pytest.raises(ynews.NoNewsError) as excinfo:
+        ynews.get_global_news_yfinance("2025-05-09", look_back_days=7, limit=10)
+    # The informative message is carried by the error and returned verbatim by
+    # the router when no vendor in the chain has news, so #993's contract holds
+    # end to end while a later vendor still gets its turn.
+    assert "No global news found" in str(excinfo.value)
+    assert "###" not in str(excinfo.value)  # no empty article body

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
+import tradingagents.agents.analysts.sentiment_analyst as sentiment_analyst_module
 from tradingagents.agents.analysts.sentiment_analyst import create_sentiment_analyst
 from tradingagents.agents.managers.research_manager import create_research_manager
 from tradingagents.agents.schemas import (
@@ -367,6 +368,25 @@ def _structured_sentiment_llm(captured: dict, report: SentimentReport | None = N
 
 @pytest.mark.unit
 class TestSentimentAnalystAgent:
+    @pytest.fixture(autouse=True)
+    def _stub_sentiment_sources(self, monkeypatch):
+        """Keep structured-agent unit tests independent of live data providers."""
+        monkeypatch.setattr(
+            sentiment_analyst_module.get_news,
+            "func",
+            lambda *args, **kwargs: "No news available for this test.",
+        )
+        monkeypatch.setattr(
+            sentiment_analyst_module,
+            "fetch_stocktwits_messages",
+            lambda *args, **kwargs: "No StockTwits messages available for this test.",
+        )
+        monkeypatch.setattr(
+            sentiment_analyst_module,
+            "fetch_reddit_posts",
+            lambda *args, **kwargs: "No Reddit posts available for this test.",
+        )
+
     def test_structured_path_produces_rendered_markdown(self):
         captured = {}
         report = SentimentReport(

--- a/tests/test_symbol_normalization_paths.py
+++ b/tests/test_symbol_normalization_paths.py
@@ -6,6 +6,7 @@ the news path: a broker symbol like XAUUSD must resolve to the same Yahoo symbol
 hit the right instrument instead of failing/mismatching.
 """
 import pandas as pd
+import pytest
 
 import tradingagents.agents.utils.agent_utils as au
 import tradingagents.dataflows.yfinance_news as ynews
@@ -68,7 +69,11 @@ def test_news_lookup_normalizes_symbol(monkeypatch):
     monkeypatch.setattr(ynews.yf, "Ticker", FakeTicker)
     monkeypatch.setattr(ynews, "yf_retry", lambda fn: fn())
 
-    out = ynews.get_news_yfinance("XAUUSD", "2025-01-01", "2025-01-10")
+    # An empty window raises so the router can try the next vendor; the message
+    # it carries is what the analyst ends up seeing.
+    with pytest.raises(ynews.NoNewsError) as excinfo:
+        ynews.get_news_yfinance("XAUUSD", "2025-01-01", "2025-01-10")
+    out = str(excinfo.value)
 
     assert seen["symbol"] == "GC=F"   # news queried with the canonical symbol
     assert "XAUUSD" in out            # the user's ticker stays in the report

--- a/tradingagents/dataflows/errors.py
+++ b/tradingagents/dataflows/errors.py
@@ -7,6 +7,7 @@ these (or a thin vendor-named subclass) and needs no new ``except`` clause.
 
     VendorError
     ├── NoMarketDataError          no usable rows (empty result OR stale data)
+    ├── NoNewsError                empty news window -> next vendor, keep wording
     ├── VendorRateLimitError       transient throttle -> skip to next vendor
     └── VendorNotConfiguredError   missing API key/config -> vendor unavailable
 
@@ -41,6 +42,26 @@ class NoMarketDataError(VendorError):
         if detail:
             msg += f": {detail}"
         super().__init__(msg)
+
+
+class NoNewsError(VendorError):
+    """A news vendor found no articles in the requested window.
+
+    A distinct router reaction from ``NoMarketDataError``, not a synonym: an
+    empty news window is ordinary — a quiet week, or a wire that simply does not
+    follow this ticker — and says nothing about whether the symbol is valid, so
+    the "may be invalid, delisted, or stale" market-data sentinel would be
+    actively misleading. The router tries the next vendor in the chain and, if
+    none has articles, returns this error's own message verbatim.
+
+    Returning the empty case as a plain string instead would end the chain: the
+    router treats any returned value as success, so a vendor with no news would
+    mask a later vendor that has some.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
 
 
 class VendorRateLimitError(VendorError):

--- a/tradingagents/dataflows/firecrawl_news.py
+++ b/tradingagents/dataflows/firecrawl_news.py
@@ -27,13 +27,19 @@ treats it as "unavailable" rather than a hard crash.
 import logging
 import os
 import re
+import time
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
 import requests
 
 from .config import get_config
-from .errors import NoNewsError, VendorNotConfiguredError, VendorRateLimitError
+from .errors import (
+    NoNewsError,
+    VendorError,
+    VendorNotConfiguredError,
+    VendorRateLimitError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +48,21 @@ FIRECRAWL_API_BASE = "https://api.firecrawl.dev/v2"
 # Network timeout (seconds). Higher than the other vendors' 30: a search is a
 # live web query plus aggregation, and an empty result set alone takes ~6s.
 REQUEST_TIMEOUT = 60
+
+# Statuses Firecrawl documents as transient
+# (https://docs.firecrawl.dev/api-reference/errors).
+RETRYABLE_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+# Bounded backoff: two retries, doubling from 2s. Deliberately tighter than
+# ``yf_retry``'s budget — each attempt can already take REQUEST_TIMEOUT, and news
+# sits on the interactive path, so the worst case is two waits rather than a
+# multi-minute stall.
+MAX_RETRIES = 2
+BASE_RETRY_DELAY = 2.0
+
+# Ceiling on a server-supplied ``Retry-After``, matching the Reddit vendor: an
+# outsized or malformed header must not stall an analysis run.
+MAX_RETRY_DELAY = 30.0
 
 # Snippets are page extracts and can run to several paragraphs of markdown.
 # Cap them so a news report stays within a sensible share of the agent prompt.
@@ -62,7 +83,19 @@ class FirecrawlNotConfiguredError(VendorNotConfiguredError):
 
 
 class FirecrawlRateLimitError(VendorRateLimitError):
-    """Raised when the Firecrawl API rate limit is exceeded."""
+    """Raised when the Firecrawl API rate limit is exceeded, retries included."""
+
+
+class FirecrawlResponseError(VendorError):
+    """Raised when Firecrawl returns a body this client cannot interpret.
+
+    Intentionally not one of the router's typed reactions: an uninterpretable
+    response is a real fault, so the generic handler logs it, tries the next
+    vendor, and surfaces it if none can serve the call. Kept distinct from
+    ``NoNewsError`` because a ``success: false`` body or a shape change is not a
+    quiet news window — reporting it as "no news" would tell the analyst the
+    market was silent when the client merely failed to read the answer.
+    """
 
 
 def get_api_key() -> str:
@@ -91,30 +124,94 @@ def _date_range_tbs(start_date: str, end_date: str) -> str:
     )
 
 
+def _retry_delay(response, attempt: int) -> float:
+    """Seconds to wait before retrying ``response``.
+
+    Firecrawl sends ``Retry-After`` (in seconds) on a 429; honour it when
+    present, otherwise back off exponentially. The header's HTTP-date form is
+    not parsed — it falls back to the curve rather than guessing at a date.
+    """
+    header = (response.headers or {}).get("Retry-After")
+    if header:
+        try:
+            return min(float(header), MAX_RETRY_DELAY)
+        except (TypeError, ValueError):
+            pass
+    return min(BASE_RETRY_DELAY * (2**attempt), MAX_RETRY_DELAY)
+
+
+def _news_results(response) -> list[dict]:
+    """Extract ``data.news`` from a 2xx body, rejecting anything else.
+
+    Strict on purpose. The callers turn an empty list into ``NoNewsError``, so
+    treating an unreadable body as "no results" would report a client-side
+    failure to the analyst as a genuinely quiet news window — and, with Firecrawl
+    last in a chain, silently cost the run its news coverage.
+    """
+    try:
+        payload = response.json()
+    except ValueError as e:
+        raise FirecrawlResponseError(
+            f"Firecrawl returned a non-JSON body: {response.text[:200]}"
+        ) from e
+
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        raise FirecrawlResponseError(
+            f"Firecrawl search did not succeed: {str(payload)[:200]}"
+        )
+
+    data = payload.get("data")
+    news = data.get("news") if isinstance(data, dict) else None
+    if not isinstance(news, list):
+        raise FirecrawlResponseError(
+            f"Firecrawl response has no 'data.news' list: {str(payload)[:200]}"
+        )
+    return news
+
+
 def _search_news(query: str, start_date: str, end_date: str, limit: int) -> list[dict]:
-    """POST /search restricted to news results inside the date window."""
+    """POST /search restricted to news results inside the date window.
+
+    Transient statuses are retried with bounded backoff before the error is
+    raised. Firecrawl is typically the *last* vendor in a chain, so there is
+    nothing left to fall through to: a throttling burst that isn't ridden out
+    costs the run its news coverage outright.
+    """
     payload = {
         "query": query,
         "sources": [{"type": "news"}],
         "limit": limit,
         "tbs": _date_range_tbs(start_date, end_date),
     }
-    response = requests.post(
-        f"{FIRECRAWL_API_BASE}/search",
-        json=payload,
-        headers={"Authorization": f"Bearer {get_api_key()}"},
-        timeout=REQUEST_TIMEOUT,
-    )
+    headers = {"Authorization": f"Bearer {get_api_key()}"}
+
+    for attempt in range(MAX_RETRIES + 1):
+        response = requests.post(
+            f"{FIRECRAWL_API_BASE}/search",
+            json=payload,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code not in RETRYABLE_STATUSES or attempt == MAX_RETRIES:
+            break
+        delay = _retry_delay(response, attempt)
+        logger.warning(
+            "Firecrawl returned %s for %r; retrying in %.1fs (attempt %d/%d).",
+            response.status_code, query, delay, attempt + 1, MAX_RETRIES,
+        )
+        time.sleep(delay)
+
     if response.status_code == 429:
         raise FirecrawlRateLimitError(f"Firecrawl rate limit exceeded: {response.text}")
     if response.status_code in (401, 403):
         # Distinguish a bad/expired key from a real outage: the router can skip
-        # to the next vendor for "not configured" but must not hide a 5xx.
+        # to the next vendor for "not configured" but must not hide a 5xx. Not
+        # retried — a rejected key will be rejected again.
         raise FirecrawlNotConfiguredError(
             f"Firecrawl API key rejected ({response.status_code}): {response.text}"
         )
     response.raise_for_status()
-    return response.json().get("data", {}).get("news") or []
+    return _news_results(response)
 
 
 def _clean_snippet(snippet: str) -> str:

--- a/tradingagents/dataflows/firecrawl_news.py
+++ b/tradingagents/dataflows/firecrawl_news.py
@@ -1,0 +1,216 @@
+"""Firecrawl news vendor.
+
+Ticker and macro news pulled from the open web via Firecrawl's search API
+(https://docs.firecrawl.dev/api-reference/endpoint/search), as a complement to
+the single-feed vendors: Yahoo and Alpha Vantage return whatever their own wire
+carries, so a ticker they cover thinly — non-US listings, small caps, anything
+whose coverage lives in trade press or a company newsroom — reads as "no news"
+rather than "nothing happened". A web search reaches those sources.
+
+Look-ahead safety is enforced *server-side*: every query pins the search engine's
+custom date range (``tbs=cdr:1,cd_min:...,cd_max:...``) to the requested window,
+so the API cannot return an article published after ``end_date``. Per-article
+dates are deliberately not rendered into the report: recent results carry a
+relative age ("1 day ago") measured from now rather than from the analysis date,
+which misdates every article in a historical run, and older results carry an
+absolute date ("Apr 9, 2024") — mixing the two would read as inconsistent. The
+window in the report header is the authoritative date range.
+
+Called over plain REST with ``requests``, like the other vendors here, rather
+than through the ``firecrawl-py`` SDK: one endpoint is used, and the SDK would
+add aiohttp/websockets/nest-asyncio to the core install for it.
+
+A key (https://www.firecrawl.dev) is read from ``FIRECRAWL_API_KEY``; if it is
+unset the vendor raises ``FirecrawlNotConfiguredError`` so the routing layer
+treats it as "unavailable" rather than a hard crash.
+"""
+import logging
+import os
+import re
+from datetime import datetime, timedelta
+from urllib.parse import urlparse
+
+import requests
+
+from .config import get_config
+from .errors import VendorNotConfiguredError, VendorRateLimitError
+
+logger = logging.getLogger(__name__)
+
+FIRECRAWL_API_BASE = "https://api.firecrawl.dev/v2"
+
+# Network timeout (seconds). Higher than the other vendors' 30: a search is a
+# live web query plus aggregation, and an empty result set alone takes ~6s.
+REQUEST_TIMEOUT = 60
+
+# Snippets are page extracts and can run to several paragraphs of markdown.
+# Cap them so a news report stays within a sensible share of the agent prompt.
+MAX_SNIPPET_CHARS = 500
+
+# Markdown images in a snippet are decoration (often inline base64 blobs) and
+# carry no signal for an analyst — drop them before truncating.
+_MARKDOWN_IMAGE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+
+
+class FirecrawlNotConfiguredError(VendorNotConfiguredError):
+    """Raised when Firecrawl is selected but no API key is configured.
+
+    A VendorNotConfiguredError (and thus still a ValueError), so the routing
+    layer's "vendor unavailable" handling and existing ValueError callers both
+    keep working.
+    """
+
+
+class FirecrawlRateLimitError(VendorRateLimitError):
+    """Raised when the Firecrawl API rate limit is exceeded."""
+
+
+def get_api_key() -> str:
+    """Retrieve the Firecrawl API key from the environment."""
+    api_key = os.getenv("FIRECRAWL_API_KEY")
+    if not api_key:
+        raise FirecrawlNotConfiguredError(
+            "FIRECRAWL_API_KEY environment variable is not set. Get a key at "
+            "https://www.firecrawl.dev."
+        )
+    return api_key
+
+
+def _date_range_tbs(start_date: str, end_date: str) -> str:
+    """Build the custom-date-range time filter for a ``yyyy-mm-dd`` window.
+
+    The search engine expects US-style ``M/D/YYYY`` bounds. Built by hand rather
+    than with ``strftime`` because the no-zero-pad directive differs across
+    platforms (``%-m`` on Linux, ``%#m`` on Windows).
+    """
+    start = datetime.strptime(start_date, "%Y-%m-%d")
+    end = datetime.strptime(end_date, "%Y-%m-%d")
+    return (
+        f"cdr:1,cd_min:{start.month}/{start.day}/{start.year},"
+        f"cd_max:{end.month}/{end.day}/{end.year}"
+    )
+
+
+def _search_news(query: str, start_date: str, end_date: str, limit: int) -> list[dict]:
+    """POST /search restricted to news results inside the date window."""
+    payload = {
+        "query": query,
+        "sources": [{"type": "news"}],
+        "limit": limit,
+        "tbs": _date_range_tbs(start_date, end_date),
+    }
+    response = requests.post(
+        f"{FIRECRAWL_API_BASE}/search",
+        json=payload,
+        headers={"Authorization": f"Bearer {get_api_key()}"},
+        timeout=REQUEST_TIMEOUT,
+    )
+    if response.status_code == 429:
+        raise FirecrawlRateLimitError(f"Firecrawl rate limit exceeded: {response.text}")
+    if response.status_code in (401, 403):
+        # Distinguish a bad/expired key from a real outage: the router can skip
+        # to the next vendor for "not configured" but must not hide a 5xx.
+        raise FirecrawlNotConfiguredError(
+            f"Firecrawl API key rejected ({response.status_code}): {response.text}"
+        )
+    response.raise_for_status()
+    return response.json().get("data", {}).get("news") or []
+
+
+def _clean_snippet(snippet: str) -> str:
+    """Strip markdown images, collapse whitespace, and cap the length."""
+    text = " ".join(_MARKDOWN_IMAGE.sub("", snippet or "").split())
+    if len(text) > MAX_SNIPPET_CHARS:
+        text = text[:MAX_SNIPPET_CHARS].rstrip() + "..."
+    return text
+
+
+def _format_articles(header: str, articles: list[dict]) -> str:
+    """Render search results in the same shape as the other news vendors.
+
+    The publishing outlet is taken from the URL host — Firecrawl's news results
+    carry no separate publisher field.
+    """
+    news_str = ""
+    for article in articles:
+        url = article.get("url", "")
+        publisher = urlparse(url).netloc.removeprefix("www.") or "Unknown"
+        news_str += f"### {article.get('title', 'No title')} (source: {publisher})\n"
+        snippet = _clean_snippet(article.get("snippet", ""))
+        if snippet:
+            news_str += f"{snippet}\n"
+        if url:
+            news_str += f"Link: {url}\n"
+        news_str += "\n"
+    return f"## {header}\n\n{news_str}"
+
+
+def get_news_firecrawl(ticker: str, start_date: str, end_date: str) -> str:
+    """Retrieve news for a specific ticker via Firecrawl web search.
+
+    Args:
+        ticker: Ticker symbol (e.g., "AAPL"). Used verbatim in the query — the
+            symbol a human would search is a better search term than the
+            Yahoo-canonical form other vendors need (``XAUUSD`` beats ``GC=F``).
+        start_date: Start date in yyyy-mm-dd format
+        end_date: End date in yyyy-mm-dd format
+
+    Returns:
+        Formatted string containing news articles
+    """
+    limit = get_config()["news_article_limit"]
+    articles = _search_news(f"{ticker} stock news", start_date, end_date, limit)
+
+    if not articles:
+        return f"No news found for {ticker} between {start_date} and {end_date}"
+
+    return _format_articles(f"{ticker} News, from {start_date} to {end_date}", articles)
+
+
+def get_global_news_firecrawl(
+    curr_date: str,
+    look_back_days: int | None = None,
+    limit: int | None = None,
+) -> str:
+    """Retrieve global/macro news via Firecrawl web search.
+
+    Args:
+        curr_date: Current date in yyyy-mm-dd format
+        look_back_days: Number of days to look back. ``None`` falls back to
+            ``global_news_lookback_days`` from the active config.
+        limit: Maximum number of articles to return. ``None`` falls back to
+            ``global_news_article_limit`` from the active config.
+
+    Returns:
+        Formatted string containing global news articles
+    """
+    config = get_config()
+    if look_back_days is None:
+        look_back_days = config["global_news_lookback_days"]
+    if limit is None:
+        limit = config["global_news_article_limit"]
+
+    start_date = (
+        datetime.strptime(curr_date, "%Y-%m-%d") - timedelta(days=look_back_days)
+    ).strftime("%Y-%m-%d")
+
+    all_news = []
+    seen_urls = set()
+    for query in config["global_news_queries"]:
+        for article in _search_news(query, start_date, curr_date, limit):
+            url = article.get("url")
+            # Deduplicate by URL: the macro queries overlap, and the same wire
+            # story is syndicated under slightly different titles.
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                all_news.append(article)
+
+        if len(all_news) >= limit:
+            break
+
+    if not all_news:
+        return f"No global news found between {start_date} and {curr_date}"
+
+    return _format_articles(
+        f"Global Market News, from {start_date} to {curr_date}", all_news[:limit]
+    )

--- a/tradingagents/dataflows/firecrawl_news.py
+++ b/tradingagents/dataflows/firecrawl_news.py
@@ -33,7 +33,7 @@ from urllib.parse import urlparse
 import requests
 
 from .config import get_config
-from .errors import VendorNotConfiguredError, VendorRateLimitError
+from .errors import NoNewsError, VendorNotConfiguredError, VendorRateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -157,12 +157,16 @@ def get_news_firecrawl(ticker: str, start_date: str, end_date: str) -> str:
 
     Returns:
         Formatted string containing news articles
+
+    Raises:
+        NoNewsError: The search returned nothing in the window, so the router
+            can try the next vendor in the chain.
     """
     limit = get_config()["news_article_limit"]
     articles = _search_news(f"{ticker} stock news", start_date, end_date, limit)
 
     if not articles:
-        return f"No news found for {ticker} between {start_date} and {end_date}"
+        raise NoNewsError(f"No news found for {ticker} between {start_date} and {end_date}")
 
     return _format_articles(f"{ticker} News, from {start_date} to {end_date}", articles)
 
@@ -183,6 +187,10 @@ def get_global_news_firecrawl(
 
     Returns:
         Formatted string containing global news articles
+
+    Raises:
+        NoNewsError: The search returned nothing in the window, so the router
+            can try the next vendor in the chain.
     """
     config = get_config()
     if look_back_days is None:
@@ -209,7 +217,7 @@ def get_global_news_firecrawl(
             break
 
     if not all_news:
-        return f"No global news found between {start_date} and {curr_date}"
+        raise NoNewsError(f"No global news found between {start_date} and {curr_date}")
 
     return _format_articles(
         f"Global Market News, from {start_date} to {curr_date}", all_news[:limit]

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -17,6 +17,10 @@ from .errors import (
     VendorNotConfiguredError,
     VendorRateLimitError,
 )
+from .firecrawl_news import (
+    get_global_news_firecrawl,
+    get_news_firecrawl,
+)
 from .fred import get_macro_data as get_fred_macro_data
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
@@ -82,6 +86,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "firecrawl",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -124,10 +129,12 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "firecrawl": get_news_firecrawl,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
         "alpha_vantage": get_alpha_vantage_global_news,
+        "firecrawl": get_global_news_firecrawl,
     },
     "get_insider_transactions": {
         "alpha_vantage": get_alpha_vantage_insider_transactions,

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -14,6 +14,7 @@ from .alpha_vantage import (
 from .config import get_config
 from .errors import (
     NoMarketDataError,
+    NoNewsError,
     VendorNotConfiguredError,
     VendorRateLimitError,
 )
@@ -200,6 +201,7 @@ def route_to_vendor(method: str, *args, **kwargs):
         vendor_chain = all_available_vendors
 
     last_no_data: NoMarketDataError | None = None
+    first_no_news: NoNewsError | None = None
     first_error: Exception | None = None
     for vendor in vendor_chain:
         vendor_impl = VENDOR_METHODS[method][vendor]
@@ -217,6 +219,14 @@ def route_to_vendor(method: str, *args, **kwargs):
             continue
         except NoMarketDataError as e:
             last_no_data = e  # No data here; another configured vendor may have it
+            continue
+        except NoNewsError as e:
+            # An empty news window is not a failure, so nothing is logged — but it
+            # must not end the chain either: one wire having no articles is exactly
+            # when a broader-coverage vendor earns its place (e.g.
+            # tool_vendors={"get_news": "yfinance,firecrawl"}).
+            if first_no_news is None:
+                first_no_news = e  # Keep the primary's wording if nobody has news.
             continue
         except Exception as e:
             # Don't let one vendor's failure crash the call when another can
@@ -252,6 +262,18 @@ def route_to_vendor(method: str, *args, **kwargs):
             f"not covered, or the vendor returned stale data. Do not estimate or "
             f"fabricate values — report that data is unavailable for this symbol."
         )
+
+    # No vendor in the chain had articles. Return the primary's own message
+    # rather than the market-data sentinel above: an empty news window carries no
+    # verdict on the symbol, so "may be invalid, delisted, or stale" would be a
+    # false claim for a ticker that simply had a quiet week.
+    if first_no_news is not None:
+        if first_error is not None:
+            logger.warning(
+                "Returning no-news for %s, but a vendor errored earlier: %s",
+                method, first_error,
+            )
+        return str(first_no_news)
 
     # No vendor returned data and none reported clean "no data" — surface the
     # first real error (e.g. the primary vendor's network failure). Optional

--- a/tradingagents/dataflows/yfinance_news.py
+++ b/tradingagents/dataflows/yfinance_news.py
@@ -1,4 +1,12 @@
-"""yfinance-based news data fetching functions."""
+"""yfinance-based news data fetching functions.
+
+An empty window raises ``NoNewsError`` and a fetch failure propagates, rather
+than both being flattened into a returned string. The routing layer treats any
+returned value as a served request, so a string ended the vendor chain: with
+``get_news="yfinance,firecrawl"`` a quiet week at Yahoo masked the vendor
+configured precisely to cover it, and a Yahoo outage read as a valid report of
+"no news" instead of the loud failure a core category is meant to produce.
+"""
 
 import contextlib
 from datetime import datetime, timedelta, timezone
@@ -7,6 +15,7 @@ import yfinance as yf
 from dateutil.relativedelta import relativedelta
 
 from .config import get_config
+from .errors import NoNewsError
 from .stockstats_utils import yf_retry
 from .symbol_utils import normalize_symbol
 
@@ -99,6 +108,10 @@ def get_news_yfinance(
 
     Returns:
         Formatted string containing news articles
+
+    Raises:
+        NoNewsError: No articles fell inside the window, so the router can try
+            the next vendor in the chain.
     """
     article_limit = get_config()["news_article_limit"]
     # Query Yahoo with the canonical symbol, like every other yfinance path —
@@ -106,42 +119,40 @@ def get_news_yfinance(
     # returns no news. Keep the user's ticker in the report header.
     canonical = normalize_symbol(ticker)
     resolved = "" if canonical == ticker else f" (resolved to {canonical})"
-    try:
-        stock = yf.Ticker(canonical)
-        news = yf_retry(lambda: stock.get_news(count=article_limit))
+    stock = yf.Ticker(canonical)
+    news = yf_retry(lambda: stock.get_news(count=article_limit))
 
-        if not news:
-            return f"No news found for {ticker}{resolved}"
+    if not news:
+        raise NoNewsError(f"No news found for {ticker}{resolved}")
 
-        # Parse date range for filtering
-        start_dt = datetime.strptime(start_date, "%Y-%m-%d")
-        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+    # Parse date range for filtering
+    start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d")
 
-        news_str = ""
-        filtered_count = 0
+    news_str = ""
+    filtered_count = 0
 
-        for article in news:
-            data = _extract_article_data(article)
+    for article in news:
+        data = _extract_article_data(article)
 
-            # Keep only articles within the requested window (look-ahead safe).
-            if not _in_news_window(data["pub_date"], start_dt, end_dt):
-                continue
+        # Keep only articles within the requested window (look-ahead safe).
+        if not _in_news_window(data["pub_date"], start_dt, end_dt):
+            continue
 
-            news_str += f"### {data['title']} (source: {data['publisher']})\n"
-            if data["summary"]:
-                news_str += f"{data['summary']}\n"
-            if data["link"]:
-                news_str += f"Link: {data['link']}\n"
-            news_str += "\n"
-            filtered_count += 1
+        news_str += f"### {data['title']} (source: {data['publisher']})\n"
+        if data["summary"]:
+            news_str += f"{data['summary']}\n"
+        if data["link"]:
+            news_str += f"Link: {data['link']}\n"
+        news_str += "\n"
+        filtered_count += 1
 
-        if filtered_count == 0:
-            return f"No news found for {ticker}{resolved} between {start_date} and {end_date}"
+    if filtered_count == 0:
+        raise NoNewsError(
+            f"No news found for {ticker}{resolved} between {start_date} and {end_date}"
+        )
 
-        return f"## {ticker}{resolved} News, from {start_date} to {end_date}:\n\n{news_str}"
-
-    except Exception as e:
-        return f"Error fetching news for {ticker}: {str(e)}"
+    return f"## {ticker}{resolved} News, from {start_date} to {end_date}:\n\n{news_str}"
 
 
 def get_global_news_yfinance(
@@ -161,6 +172,10 @@ def get_global_news_yfinance(
 
     Returns:
         Formatted string containing global news articles
+
+    Raises:
+        NoNewsError: No articles fell inside the window, so the router can try
+            the next vendor in the chain.
     """
     config = get_config()
     if look_back_days is None:
@@ -172,61 +187,57 @@ def get_global_news_yfinance(
     all_news = []
     seen_titles = set()
 
-    try:
-        for query in search_queries:
-            search = yf_retry(lambda q=query: yf.Search(
-                query=q,
-                news_count=limit,
-                enable_fuzzy_query=True,
-            ))
+    for query in search_queries:
+        search = yf_retry(lambda q=query: yf.Search(
+            query=q,
+            news_count=limit,
+            enable_fuzzy_query=True,
+        ))
 
-            if search.news:
-                for article in search.news:
-                    # Handle both flat and nested structures
-                    if "content" in article:
-                        data = _extract_article_data(article)
-                        title = data["title"]
-                    else:
-                        title = article.get("title", "")
+        if search.news:
+            for article in search.news:
+                # Handle both flat and nested structures
+                if "content" in article:
+                    data = _extract_article_data(article)
+                    title = data["title"]
+                else:
+                    title = article.get("title", "")
 
-                    # Deduplicate by title
-                    if title and title not in seen_titles:
-                        seen_titles.add(title)
-                        all_news.append(article)
+                # Deduplicate by title
+                if title and title not in seen_titles:
+                    seen_titles.add(title)
+                    all_news.append(article)
 
-            if len(all_news) >= limit:
-                break
+        if len(all_news) >= limit:
+            break
 
-        if not all_news:
-            return f"No global news found for {curr_date}"
+    if not all_news:
+        raise NoNewsError(f"No global news found for {curr_date}")
 
-        # Calculate date range
-        curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
-        start_dt = curr_dt - relativedelta(days=look_back_days)
-        start_date = start_dt.strftime("%Y-%m-%d")
+    # Calculate date range
+    curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    start_dt = curr_dt - relativedelta(days=look_back_days)
+    start_date = start_dt.strftime("%Y-%m-%d")
 
-        news_str = ""
-        kept = 0
-        for article in all_news[:limit]:
-            # Extract uniformly (flat + nested) and apply the same look-ahead-safe
-            # window filter, so flat articles can't leak future news (#1007).
-            data = _extract_article_data(article)
-            if not _in_news_window(data["pub_date"], start_dt, curr_dt):
-                continue
-            news_str += f"### {data['title']} (source: {data['publisher']})\n"
-            if data["summary"]:
-                news_str += f"{data['summary']}\n"
-            if data["link"]:
-                news_str += f"Link: {data['link']}\n"
-            news_str += "\n"
-            kept += 1
+    news_str = ""
+    kept = 0
+    for article in all_news[:limit]:
+        # Extract uniformly (flat + nested) and apply the same look-ahead-safe
+        # window filter, so flat articles can't leak future news (#1007).
+        data = _extract_article_data(article)
+        if not _in_news_window(data["pub_date"], start_dt, curr_dt):
+            continue
+        news_str += f"### {data['title']} (source: {data['publisher']})\n"
+        if data["summary"]:
+            news_str += f"{data['summary']}\n"
+        if data["link"]:
+            news_str += f"Link: {data['link']}\n"
+        news_str += "\n"
+        kept += 1
 
-        # All candidates fell outside the window -> say so rather than return an
-        # empty-bodied report (#993).
-        if kept == 0:
-            return f"No global news found between {start_date} and {curr_date}"
+    # All candidates fell outside the window -> say so rather than return an
+    # empty-bodied report (#993).
+    if kept == 0:
+        raise NoNewsError(f"No global news found between {start_date} and {curr_date}")
 
-        return f"## Global Market News, from {start_date} to {curr_date}:\n\n{news_str}"
-
-    except Exception as e:
-        return f"Error fetching global news: {str(e)}"
+    return f"## Global Market News, from {start_date} to {curr_date}:\n\n{news_str}"

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -134,13 +134,19 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
         "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "news_data": "yfinance",             # Options: alpha_vantage, yfinance (+ firecrawl per tool, see below)
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {
         # Example: "get_stock_data": "alpha_vantage",  # Override category default
+        # Firecrawl (needs FIRECRAWL_API_KEY) covers get_news / get_global_news
+        # only, so set it per tool rather than for the whole news_data category,
+        # which also serves get_insider_transactions. It searches the open web
+        # instead of one vendor's wire — useful as a fallback for tickers Yahoo
+        # and Alpha Vantage cover thinly.
+        # Example: "get_news": "yfinance,firecrawl",
     },
     # Benchmark for alpha calculation in the reflection layer.
     # ``benchmark_ticker`` (when set) overrides the suffix map for all


### PR DESCRIPTION
## Summary

- add an optional Firecrawl vendor for ticker and global market news
- constrain searches to the requested date window to preserve historical-run integrity
- let empty Yahoo and Firecrawl news results continue through configured vendor chains
- retry documented transient Firecrawl responses and reject malformed response envelopes
- document configuration, credentials, and an executable usage example

## Configuration

Set `FIRECRAWL_API_KEY`, then configure the vendor per news tool, for example:

```python
config["tool_vendors"]["get_news"] = "yfinance,firecrawl"
config["tool_vendors"]["get_global_news"] = "yfinance,firecrawl"
```

Firecrawl remains optional and is not selected by default.

## Validation

- `pytest -q` — 604 passed, 2 skipped, 69 subtests passed
- `ruff check .` — passed
