### PR TITLE
Avoid look-ahead bias in historical sentiment analysis

### DIFF
--- a/tests/test_sentiment_lookahead.py
+++ b/tests/test_sentiment_lookahead.py
@@ -1,0 +1,83 @@
+"""Sentiment analysis must not inject current social posts into backtests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+import tradingagents.agents.analysts.sentiment_analyst as sentiment
+from tradingagents.agents.schemas import SentimentBand, SentimentReport
+
+
+def _capturing_llm(captured: dict):
+    structured = MagicMock()
+    structured.invoke.side_effect = lambda prompt: (
+        captured.__setitem__("prompt", prompt)
+        or SentimentReport(
+            overall_band=SentimentBand.NEUTRAL,
+            overall_score=5.0,
+            confidence="low",
+            narrative="Historical social data is unavailable.",
+        )
+    )
+    llm = MagicMock()
+    llm.with_structured_output.return_value = structured
+    return llm
+
+
+def _run(captured: dict, trade_date: str):
+    return sentiment.create_sentiment_analyst(_capturing_llm(captured))(
+        {
+            "company_of_interest": "NVDA",
+            "trade_date": trade_date,
+            "asset_type": "stock",
+            "messages": [],
+        }
+    )
+
+
+def _prompt_text(prompt) -> str:
+    return "\n".join(str(getattr(message, "content", message)) for message in prompt)
+
+
+@pytest.mark.unit
+def test_historical_run_omits_current_social_sources(monkeypatch):
+    monkeypatch.setattr(sentiment.get_news, "func", lambda *args, **kwargs: "historical news")
+
+    def unexpected_fetch(*args, **kwargs):
+        pytest.fail("current social data must not be fetched for a historical run")
+
+    monkeypatch.setattr(sentiment, "fetch_stocktwits_messages", unexpected_fetch)
+    monkeypatch.setattr(sentiment, "fetch_reddit_posts", unexpected_fetch)
+
+    captured = {}
+    _run(captured, "2020-01-15")
+
+    prompt = _prompt_text(captured["prompt"])
+    assert "StockTwits unavailable for historical analysis ending 2020-01-15" in prompt
+    assert "Reddit unavailable for historical analysis ending 2020-01-15" in prompt
+
+
+@pytest.mark.unit
+def test_current_run_still_fetches_social_sources(monkeypatch):
+    monkeypatch.setattr(sentiment.get_news, "func", lambda *args, **kwargs: "current news")
+    monkeypatch.setattr(
+        sentiment,
+        "fetch_stocktwits_messages",
+        lambda *args, **kwargs: "current StockTwits posts",
+    )
+    monkeypatch.setattr(
+        sentiment,
+        "fetch_reddit_posts",
+        lambda *args, **kwargs: "current Reddit posts",
+    )
+
+    captured = {}
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    _run(captured, today)
+
+    prompt = _prompt_text(captured["prompt"])
+    assert "current StockTwits posts" in prompt
+    assert "current Reddit posts" in prompt

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -24,7 +24,7 @@ See: https://github.com/TauricResearch/TradingAgents/issues/557
 See: https://github.com/TauricResearch/TradingAgents/issues/796
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -48,6 +48,18 @@ def _seven_days_back(trade_date: str) -> str:
     return (datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=7)).strftime("%Y-%m-%d")
 
 
+def _is_historical_date(trade_date: str) -> bool:
+    """Return whether ``trade_date`` precedes the current UTC date."""
+    return datetime.strptime(trade_date, "%Y-%m-%d").date() < datetime.now(timezone.utc).date()
+
+
+def _historical_social_placeholder(source: str, end_date: str) -> str:
+    return (
+        f"<{source} unavailable for historical analysis ending {end_date}: "
+        "the source provides current data only>"
+    )
+
+
 def create_sentiment_analyst(llm):
     """Create a sentiment analyst node for the trading graph.
 
@@ -64,12 +76,16 @@ def create_sentiment_analyst(llm):
         start_date = _seven_days_back(end_date)
         instrument_context = get_instrument_context_from_state(state)
 
-        # Pre-fetch all three sources. Each fetcher degrades gracefully and
-        # returns a string (no exceptions surface from here), so the LLM
-        # always sees something — either real data or a clear placeholder.
+        # Pre-fetch the date-bounded news source. The social endpoints expose
+        # only current data, so using them for a backtest would introduce
+        # look-ahead bias; keep their absence explicit in the prompt instead.
         news_block = get_news.func(ticker, start_date, end_date)
-        stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+        if _is_historical_date(end_date):
+            stocktwits_block = _historical_social_placeholder("StockTwits", end_date)
+            reddit_block = _historical_social_placeholder("Reddit", end_date)
+        else:
+            stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
+            reddit_block = fetch_reddit_posts(ticker)
 
         system_message = _build_system_message(
             ticker=ticker,
@@ -91,8 +107,7 @@ def create_sentiment_analyst(llm):
                     # prompt, so tool-range wording would only invite a
                     # hallucinated tool call (#1130).
                     " Today's date is {current_date}; treat it as 'now' for all analysis. {instrument_context}"
-                    " " + NO_EXTERNAL_TOOLS +
-                    "\n{system_message}",
+                    " " + NO_EXTERNAL_TOOLS + "\n{system_message}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]
@@ -144,14 +159,14 @@ Institutional framing. Fact-driven, slower-moving signal.
 {news_block}
 <end_of_news>
 
-### StockTwits messages — retail-trader social platform indexed by cashtag
+### StockTwits messages — current retail-trader stream indexed by cashtag
 Fast-moving signal. Each message carries a user-labeled sentiment tag (Bullish / Bearish / no-label) plus the message body.
 
 <start_of_stocktwits>
 {stocktwits_block}
 <end_of_stocktwits>
 
-### Reddit posts — r/wallstreetbets, r/stocks, r/investing (past 7 days)
+### Reddit posts — current trailing-week feed from r/wallstreetbets, r/stocks, r/investing
 Community discussion. Engagement signal via upvote score and comment count. Subreddit character matters (r/wallstreetbets is often contrarian/exuberant; r/stocks more measured; r/investing longer-term).
 
 <start_of_reddit>
@@ -201,6 +216,7 @@ def create_social_media_analyst(llm):
         Import :func:`create_sentiment_analyst` directly instead.
     """
     import warnings
+
     warnings.warn(
         "create_social_media_analyst is deprecated and will be removed in a "
         "future version. Use create_sentiment_analyst instead.",


### PR DESCRIPTION
## Summary

- skip the current StockTwits and Reddit feeds when `trade_date` is before the current UTC date
- inject explicit historical-data-unavailable placeholders instead of presenting current posts as period data
- label the social sections as current feeds and cover both historical and current execution paths with regression tests

Closes #1220

## Root cause

The sentiment analyst date-bounded Yahoo news, but always fetched the current StockTwits stream and Reddit's current trailing-week feed. Historical analyses therefore received observations created after their requested end date.

## Validation

- `python -m pytest -q` — 578 passed, 2 skipped, 69 subtests passed
- `ruff check .`
- `ruff format --check tradingagents/agents/analysts/sentiment_analyst.py tests/test_sentiment_lookahead.py`

The two skips are the repository's optional Bedrock dependency test and the live DeepSeek API test without credentials.
