### PR TITLE
fix: support MiniMax-M3 thinking controls

### DIFF
--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -33,7 +33,7 @@ class TestExactIdMatches:
 
 @pytest.mark.unit
 class TestPatternMatches:
-    """Forward-compat regex patterns catch unknown DeepSeek and MiniMax variants."""
+    """Forward-compat regex patterns catch known provider model families."""
 
     def test_future_deepseek_v5_inherits_thinking_quirks(self):
         caps = get_capabilities("deepseek-v5-flash")
@@ -48,24 +48,27 @@ class TestPatternMatches:
         caps = get_capabilities("deepseek-reasoner-pro")
         assert caps.supports_tool_choice is False
 
-    def test_minimax_m3_inherits_thinking_quirks(self):
-        caps = get_capabilities("MiniMax-M3")
+    def test_future_minimax_m2_variant_inherits_thinking_quirks(self):
+        caps = get_capabilities("MiniMax-M2.9-highspeed")
         assert caps.supports_tool_choice is False
-
-    def test_future_minimax_m4_highspeed_inherits_thinking_quirks(self):
-        caps = get_capabilities("MiniMax-M4-highspeed")
-        assert caps.supports_tool_choice is False
+        assert caps.thinking_modes == ("always_on",)
 
 
 @pytest.mark.unit
 class TestMinimaxExactMatches:
-    """MiniMax M2.x models reject langchain's function-spec dict tool_choice
-    (official API enum: none/auto only)."""
+    """MiniMax M-series capabilities vary by model generation."""
+
+    def test_m3_supports_configurable_thinking(self):
+        caps = get_capabilities("MiniMax-M3")
+        assert caps.supports_tool_choice is False
+        assert caps.requires_reasoning_split is True
+        assert caps.thinking_modes == ("adaptive", "disabled")
 
     def test_m2_7_rejects_tool_choice(self):
         caps = get_capabilities("MiniMax-M2.7")
         assert caps.supports_tool_choice is False
         assert caps.supports_json_mode is False  # only MiniMax-Text-01 supports json_object
+        assert caps.thinking_modes == ("always_on",)
 
     def test_m2_7_highspeed_rejects_tool_choice(self):
         assert get_capabilities("MiniMax-M2.7-highspeed").supports_tool_choice is False
@@ -81,9 +84,6 @@ class TestMinimaxExactMatches:
         # land in reasoning_details instead of content (#826).
         for model in ("MiniMax-M2.7", "MiniMax-M2.5-highspeed", "MiniMax-M2"):
             assert get_capabilities(model).requires_reasoning_split is True
-
-    def test_future_m3_inherits_reasoning_split(self):
-        assert get_capabilities("MiniMax-M3-highspeed").requires_reasoning_split is True
 
     def test_non_reasoning_minimax_does_not_get_reasoning_split(self):
         # Coding Plan, MiniMax-Text-01, and any non-M2-prefixed MiniMax model

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,7 +1,7 @@
 """Tests for MinimaxChatOpenAI quirks.
 
 Verifies the subclass injects ``reasoning_split=True`` into outgoing
-requests so M2.x reasoning models put their <think> block into
+requests so MiniMax M-series reasoning models put their <think> block into
 ``reasoning_details`` instead of polluting ``message.content``.
 """
 
@@ -11,15 +11,16 @@ import pytest
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 
-from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI
+from tradingagents.llm_clients.openai_client import MinimaxChatOpenAI, OpenAIClient
 
 
-def _client(model: str = "MiniMax-M2.7"):
+def _client(model: str = "MiniMax-M2.7", **kwargs):
     os.environ.setdefault("MINIMAX_API_KEY", "placeholder")
     return MinimaxChatOpenAI(
         model=model,
         api_key="placeholder",
         base_url="https://api.minimax.io/v1",
+        **kwargs,
     )
 
 
@@ -32,8 +33,36 @@ class TestMinimaxReasoningSplit:
         assert payload.get("extra_body", {}).get("reasoning_split") is True
         assert "reasoning_split" not in payload  # never top-level
 
+    def test_m3_uses_reasoning_split_for_response_formatting(self):
+        payload = _client("MiniMax-M3")._get_request_payload([HumanMessage(content="hi")])
+        assert payload.get("extra_body", {}).get("reasoning_split") is True
+        assert payload.get("extra_body", {}).get("thinking") == {"type": "adaptive"}
+
+    def test_m3_preserves_disabled_thinking_control(self):
+        payload = _client(
+            "MiniMax-M3", extra_body={"thinking": {"type": "disabled"}}
+        )._get_request_payload([HumanMessage(content="hi")])
+        assert payload.get("extra_body", {}).get("thinking") == {"type": "disabled"}
+
+    def test_m2_rejects_configurable_thinking(self):
+        client = _client(
+            "MiniMax-M2.7", extra_body={"thinking": {"type": "disabled"}}
+        )
+        with pytest.raises(ValueError, match="does not support thinking type"):
+            client._get_request_payload([HumanMessage(content="hi")])
+
+    def test_high_level_client_forwards_thinking_control(self):
+        client = OpenAIClient(
+            model="MiniMax-M3",
+            provider="minimax",
+            api_key="placeholder",
+            extra_body={"thinking": {"type": "disabled"}},
+        ).get_llm()
+        payload = client._get_request_payload([HumanMessage(content="hi")])
+        assert payload.get("extra_body", {}).get("thinking") == {"type": "disabled"}
+
     def test_non_reasoning_minimax_does_not_inject_reasoning_split(self):
-        """Coding Plan / MiniMax-Text-01 / any non-M2-prefixed model must NOT
+        """Coding Plan / MiniMax-Text-01 / any non-M-series model must NOT
         receive reasoning_split at all (top-level or extra_body) (#826)."""
         for model in ("minimax-text-01", "MiniMax-Coding-Plan"):
             payload = _client(model)._get_request_payload(
@@ -45,7 +74,7 @@ class TestMinimaxReasoningSplit:
 
 @pytest.mark.unit
 class TestMinimaxStructuredOutputDispatch:
-    """M2.x models route through the capability table — tool_choice is
+    """MiniMax M-series models route through the capability table — tool_choice is
     suppressed but the schema is still bound as a tool."""
 
     class _Pick(BaseModel):
@@ -57,6 +86,11 @@ class TestMinimaxStructuredOutputDispatch:
 
     def test_m2_7_suppresses_tool_choice(self):
         bound = _client("MiniMax-M2.7").with_structured_output(self._Pick)
+        kwargs = self._bound_kwargs(bound)
+        assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
+
+    def test_m3_suppresses_tool_choice(self):
+        bound = _client("MiniMax-M3").with_structured_output(self._Pick)
         kwargs = self._bound_kwargs(bound)
         assert kwargs.get("tool_choice") is None or "tool_choice" not in kwargs
 

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -24,6 +24,7 @@ StructuredMethod = Literal[
     "json_schema",       # uses response_format={"type":"json_schema",...}
     "none",              # no structured output available; caller falls back to free-text
 ]
+ThinkingMode = Literal["always_on", "adaptive", "disabled"]
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,9 @@ class ModelCapabilities:
     # (Coding Plan, MiniMax-Text-01, etc.), so we only set it where the
     # model actually consumes it. (#826)
     requires_reasoning_split: bool = False
+    # Supported thinking controls. An empty tuple means the provider does not
+    # publish a model-specific thinking mode through this compatibility layer.
+    thinking_modes: tuple[ThinkingMode, ...] = ()
 
 
 # DeepSeek's thinking models accept the ``tools`` array but reject the
@@ -66,20 +70,32 @@ _DEEPSEEK_CHAT = ModelCapabilities(
     preferred_structured_method="function_calling",
 )
 
-# MiniMax M2.x reasoning models accept the tools array, but their
+# MiniMax M-series reasoning models accept the tools array, but their
 # tool_choice parameter is restricted to the enum {"none", "auto"}
 # (platform.minimax.io/docs/api-reference/text-post). Langchain's
 # function_calling path sends tool_choice as a function-spec dict, which
 # MiniMax 400s — same shape as the DeepSeek bug. supports_tool_choice=False
 # makes the dispatch in NormalizedChatOpenAI suppress the kwarg; the schema
 # still ships as a tool. json_mode response_format is only for
-# MiniMax-Text-01, not M2.x.
-_MINIMAX_THINKING = ModelCapabilities(
+# MiniMax-Text-01, not M-series reasoning models.
+_MINIMAX_M2 = ModelCapabilities(
     supports_tool_choice=False,
     supports_json_mode=False,
     supports_json_schema=False,
     preferred_structured_method="function_calling",
     requires_reasoning_split=True,
+    thinking_modes=("always_on",),
+)
+
+# MiniMax-M3 keeps the same OpenAI-compatible response and tool quirks, but
+# unlike M2.x its thinking can be adaptive or disabled per request.
+_MINIMAX_M3 = ModelCapabilities(
+    supports_tool_choice=False,
+    supports_json_mode=False,
+    supports_json_schema=False,
+    preferred_structured_method="function_calling",
+    requires_reasoning_split=True,
+    thinking_modes=("adaptive", "disabled"),
 )
 
 _DEFAULT = ModelCapabilities(
@@ -98,21 +114,22 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "deepseek-v4-pro": _DEEPSEEK_THINKING,
     # MiniMax — full official model lineup per
     # platform.minimax.io/docs/api-reference/text-openai-api
-    "MiniMax-M2.7": _MINIMAX_THINKING,
-    "MiniMax-M2.7-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2.5": _MINIMAX_THINKING,
-    "MiniMax-M2.5-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2.1": _MINIMAX_THINKING,
-    "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
-    "MiniMax-M2": _MINIMAX_THINKING,
+    "MiniMax-M3": _MINIMAX_M3,
+    "MiniMax-M2.7": _MINIMAX_M2,
+    "MiniMax-M2.7-highspeed": _MINIMAX_M2,
+    "MiniMax-M2.5": _MINIMAX_M2,
+    "MiniMax-M2.5-highspeed": _MINIMAX_M2,
+    "MiniMax-M2.1": _MINIMAX_M2,
+    "MiniMax-M2.1-highspeed": _MINIMAX_M2,
+    "MiniMax-M2": _MINIMAX_M2,
 }
 
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
-# or ``MiniMax-M3*`` variants inherit the thinking-mode quirks automatically.
+# or MiniMax M2.x variants inherit the established thinking-mode quirks.
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
-    (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    (re.compile(r"^MiniMax-M2(?:\D|$)"), _MINIMAX_M2),
 ]
 
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -132,7 +132,7 @@ class DeepSeekChatOpenAI(NormalizedChatOpenAI):
 class MinimaxChatOpenAI(NormalizedChatOpenAI):
     """MiniMax-specific overrides on top of the OpenAI-compatible client.
 
-    M2.x reasoning models embed ``<think>...</think>`` blocks directly in
+    MiniMax M-series reasoning models embed ``<think>...</think>`` blocks directly in
     ``message.content`` by default, which would pollute saved reports.
     Per platform.minimax.io/docs/api-reference/text-openai-api,
     ``reasoning_split=True`` redirects the thinking block into
@@ -141,10 +141,10 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
     top-level params and rejects unknown ones like reasoning_split (#826).
 
     The flag is gated by ``ModelCapabilities.requires_reasoning_split`` so
-    only M2.x reasoning models receive it; non-reasoning MiniMax endpoints
+    only M-series reasoning models receive it; non-reasoning MiniMax endpoints
     (Coding Plan, MiniMax-Text-01) never see it.
 
-    Tool-choice handling for M2.x — those models accept only the string
+    Tool-choice handling for M-series models — those models accept only the string
     enum ``{"none", "auto"}`` and reject langchain's function-spec dict —
     is handled by the capability dispatch in
     ``NormalizedChatOpenAI.with_structured_output``, not here.
@@ -152,20 +152,45 @@ class MinimaxChatOpenAI(NormalizedChatOpenAI):
 
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        if get_capabilities(self.model_name).requires_reasoning_split:
+        caps = get_capabilities(self.model_name)
+        extra_body = payload.setdefault("extra_body", {})
+
+        # M3 supports per-request thinking control. Keep thinking enabled by
+        # default, while preserving an explicit {"type": "disabled"} supplied
+        # by the caller. M2.x exposes only always-on thinking, so no control is
+        # sent for those models.
+        configurable_modes = tuple(
+            mode for mode in caps.thinking_modes if mode != "always_on"
+        )
+        if "adaptive" in configurable_modes:
+            extra_body.setdefault("thinking", {"type": "adaptive"})
+
+        thinking = extra_body.get("thinking")
+        if isinstance(thinking, dict) and thinking.get("type") not in (
+            None,
+            *configurable_modes,
+        ):
+            raise ValueError(
+                f"Model {self.model_name} does not support thinking type "
+                f"{thinking.get('type')!r}"
+            )
+
+        if caps.requires_reasoning_split:
             # Pass via extra_body, not as a top-level kwarg: the openai SDK
             # (>=1.56) validates top-level params against Completions.create
             # and rejects unknown ones like reasoning_split (#826). extra_body
             # is forwarded into the request body untouched.
-            extra_body = payload.setdefault("extra_body", {})
             extra_body.setdefault("reasoning_split", True)
+
+        if not extra_body:
+            payload.pop("extra_body")
         return payload
 
 
 # Kwargs forwarded from user config to ChatOpenAI
 _PASSTHROUGH_KWARGS = (
     "timeout", "max_retries", "reasoning_effort", "temperature",
-    "api_key", "callbacks", "http_client", "http_async_client",
+    "api_key", "callbacks", "http_client", "http_async_client", "extra_body",
 )
 
 # OpenAI's ``reasoning_effort`` is only accepted by reasoning models — the GPT-5


### PR DESCRIPTION
Reason: MiniMax-M3 supports adaptive and disabled thinking, while M2.x models remain always-on.

## Summary

- distinguish M3 adaptive/disabled thinking from always-on M2.x models
- send adaptive thinking by default for M3 while preserving explicit disabled requests
- keep reasoning output splitting independent from thinking control

## Testing

- `.venv/bin/pytest -q` (580 passed, 2 skipped, 69 subtests passed)
- `.venv/bin/ruff check tradingagents/llm_clients/capabilities.py tradingagents/llm_clients/openai_client.py tests/test_capabilities.py tests/test_minimax.py`
- `git diff --check`