### PR TITLE
fix: filter social sentiment sources by analysis window (#1220)

### DIFF
--- a/tests/test_social_lookahead.py
+++ b/tests/test_social_lookahead.py
@@ -1,0 +1,223 @@
+"""Social-sentiment sources must not leak current posts into historical runs.
+
+Regressions for #1220: StockTwits and Reddit fetchers accepted no date
+window, so a historical analysis pulled today's posts and presented them as
+covering the requested historical period. Both fetchers now filter on the
+analysis window and return window-specific placeholders when nothing
+survives the filter (the public APIs cannot serve true historical data).
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+import tradingagents.dataflows.reddit as reddit
+import tradingagents.dataflows.stocktwits as stocktwits
+from tradingagents.agents.analysts.sentiment_analyst import _build_system_message
+
+
+def _epoch(date_str: str) -> int:
+    """Epoch seconds for UTC midnight of ``date_str`` (host-timezone independent)."""
+    return int(datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp())
+
+
+class _FakeResp:
+    """Minimal context-manager response whose ``read()`` returns JSON bytes."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Window helper semantics (shared by both fetchers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stocktwits_in_window_boundaries():
+    start, end = stocktwits._window_epochs("2025-05-01", "2025-05-09")
+    assert stocktwits._in_window(_epoch("2025-05-05"), start, end) is True
+    assert stocktwits._in_window(_epoch("2025-05-09"), start, end) is True  # whole end day kept
+    assert stocktwits._in_window(_epoch("2025-06-01"), start, end) is False  # future blocked
+    assert stocktwits._in_window(_epoch("2025-05-10"), start, end) is False  # next midnight excluded
+    assert stocktwits._in_window(None, start, end) is False  # undated excluded in backtest
+    assert stocktwits._in_window(_epoch("2025-05-05"), None, None) is True  # no bounds -> pass
+    assert stocktwits._in_window(None, None, None) is True  # undated kept in live mode
+
+
+@pytest.mark.unit
+def test_reddit_in_window_boundaries():
+    start, end = reddit._window_epochs("2025-05-01", "2025-05-09")
+    assert reddit._in_window(_epoch("2025-05-05"), start, end) is True
+    assert reddit._in_window(_epoch("2025-05-09"), start, end) is True
+    assert reddit._in_window(_epoch("2025-06-01"), start, end) is False
+    assert reddit._in_window(_epoch("2025-05-10"), start, end) is False
+    assert reddit._in_window(None, start, end) is False
+    assert reddit._in_window(_epoch("2025-05-05"), None, None) is True
+    assert reddit._in_window(None, None, None) is True  # undated kept in live mode
+
+
+# ---------------------------------------------------------------------------
+# StockTwits end-to-end filtering
+# ---------------------------------------------------------------------------
+
+
+def _stocktwits_payload():
+    return {
+        "messages": [
+            {
+                "created_at": "2025-05-05T10:00:00Z",
+                "user": {"username": "u1"},
+                "entities": {"sentiment": {"basic": "Bullish"}},
+                "body": "INSIDE POST",
+            },
+            {
+                "created_at": "2025-06-01T10:00:00Z",
+                "user": {"username": "u2"},
+                "entities": {"sentiment": {"basic": "Bearish"}},
+                "body": "FUTURE POST",
+            },
+            {
+                "created_at": "2025-05-10T00:00:00Z",
+                "user": {"username": "u3"},
+                "entities": {},
+                "body": "NEXT DAY POST",
+            },
+        ]
+    }
+
+
+@pytest.mark.unit
+def test_stocktwits_filters_out_of_window_messages(monkeypatch):
+    monkeypatch.setattr(
+        stocktwits, "urlopen", lambda req, timeout=10.0: _FakeResp(_stocktwits_payload())
+    )
+    out = stocktwits.fetch_stocktwits_messages(
+        "AAPL", start_date="2025-05-01", end_date="2025-05-09"
+    )
+    assert "INSIDE POST" in out
+    assert "FUTURE POST" not in out
+    assert "NEXT DAY POST" not in out
+
+
+@pytest.mark.unit
+def test_stocktwits_all_filtered_returns_window_placeholder(monkeypatch):
+    payload = {"messages": [_stocktwits_payload()["messages"][1]]}  # future only
+    monkeypatch.setattr(
+        stocktwits, "urlopen", lambda req, timeout=10.0: _FakeResp(payload)
+    )
+    out = stocktwits.fetch_stocktwits_messages(
+        "AAPL", start_date="2025-05-01", end_date="2025-05-09"
+    )
+    assert "no StockTwits messages found" in out
+    assert "requested window" in out
+    assert "FUTURE POST" not in out
+
+
+@pytest.mark.unit
+def test_stocktwits_live_window_keeps_recent_messages(monkeypatch):
+    # No date window: current behavior must be unchanged (no filtering).
+    monkeypatch.setattr(
+        stocktwits, "urlopen", lambda req, timeout=10.0: _FakeResp(_stocktwits_payload())
+    )
+    out = stocktwits.fetch_stocktwits_messages("AAPL")
+    assert "INSIDE POST" in out
+    assert "FUTURE POST" in out
+    assert "NEXT DAY POST" in out
+
+
+# ---------------------------------------------------------------------------
+# Reddit end-to-end filtering
+# ---------------------------------------------------------------------------
+
+
+def _reddit_posts():
+    return [
+        {
+            "title": "INSIDE POST",
+            "score": None,
+            "num_comments": None,
+            "created_utc": _epoch("2025-05-05"),
+            "selftext": "",
+            "source": "rss",
+        },
+        {
+            "title": "FUTURE POST",
+            "score": None,
+            "num_comments": None,
+            "created_utc": _epoch("2025-06-01"),
+            "selftext": "",
+            "source": "rss",
+        },
+        {
+            "title": "UNDATED POST",
+            "score": None,
+            "num_comments": None,
+            "created_utc": None,
+            "selftext": "",
+            "source": "rss",
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_reddit_filters_out_of_window_posts(monkeypatch):
+    monkeypatch.setattr(reddit, "_fetch_subreddit", lambda *a, **k: _reddit_posts())
+    out = reddit.fetch_reddit_posts(
+        "AAPL", start_date="2025-05-01", end_date="2025-05-09", inter_request_delay=0
+    )
+    assert "INSIDE POST" in out
+    assert "FUTURE POST" not in out
+    assert "UNDATED POST" not in out
+    assert "2025-05-01 to 2025-05-09" in out
+
+
+@pytest.mark.unit
+def test_reddit_all_filtered_returns_window_placeholder(monkeypatch):
+    monkeypatch.setattr(
+        reddit, "_fetch_subreddit", lambda *a, **k: [_reddit_posts()[1]]
+    )
+    out = reddit.fetch_reddit_posts(
+        "AAPL", start_date="2025-05-01", end_date="2025-05-09", inter_request_delay=0
+    )
+    assert "no Reddit posts found mentioning" in out
+    assert "2025-05-01 to 2025-05-09" in out
+    assert "FUTURE POST" not in out
+
+
+@pytest.mark.unit
+def test_reddit_live_window_keeps_recent_posts(monkeypatch):
+    monkeypatch.setattr(reddit, "_fetch_subreddit", lambda *a, **k: _reddit_posts())
+    out = reddit.fetch_reddit_posts("AAPL", inter_request_delay=0)
+    assert "INSIDE POST" in out
+    assert "FUTURE POST" in out
+    assert "UNDATED POST" in out
+
+
+# ---------------------------------------------------------------------------
+# Sentiment analyst prompt labels the actual data window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sentiment_prompt_labels_requested_window():
+    msg = _build_system_message(
+        ticker="AAPL",
+        start_date="2025-05-01",
+        end_date="2025-05-09",
+        news_block="N",
+        stocktwits_block="S",
+        reddit_block="R",
+    )
+    assert "2025-05-01 to 2025-05-09" in msg
+    assert "past 7 days" not in msg

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -68,8 +68,12 @@ def create_sentiment_analyst(llm):
         # returns a string (no exceptions surface from here), so the LLM
         # always sees something — either real data or a clear placeholder.
         news_block = get_news.func(ticker, start_date, end_date)
-        stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+        stocktwits_block = fetch_stocktwits_messages(
+            ticker, limit=30, start_date=start_date, end_date=end_date
+        )
+        reddit_block = fetch_reddit_posts(
+            ticker, start_date=start_date, end_date=end_date
+        )
 
         system_message = _build_system_message(
             ticker=ticker,
@@ -137,7 +141,7 @@ def _build_system_message(
 
 ## Data sources (pre-fetched, in this prompt)
 
-### News headlines — Yahoo Finance, past 7 days
+### News headlines — Yahoo Finance, {start_date} to {end_date}
 Institutional framing. Fact-driven, slower-moving signal.
 
 <start_of_news>
@@ -151,7 +155,7 @@ Fast-moving signal. Each message carries a user-labeled sentiment tag (Bullish /
 {stocktwits_block}
 <end_of_stocktwits>
 
-### Reddit posts — r/wallstreetbets, r/stocks, r/investing (past 7 days)
+### Reddit posts — r/wallstreetbets, r/stocks, r/investing ({start_date} to {end_date})
 Community discussion. Engagement signal via upvote score and comment count. Subreddit character matters (r/wallstreetbets is often contrarian/exuberant; r/stocks more measured; r/investing longer-term).
 
 <start_of_reddit>

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -25,7 +25,7 @@ import re
 import time
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -57,6 +57,41 @@ def _search_qs(ticker: str, limit: int) -> str:
         "t": "week",  # last 7 days
         "limit": limit,
     })
+
+
+def _window_epochs(start_date: str | None, end_date: str | None) -> tuple[float | None, float | None]:
+    """UTC window [start midnight, end+1 day midnight) for inclusive date bounds.
+
+    ``end_date`` stays inclusive for the whole day (mirrors the yfinance-news
+    convention: a post timestamped anywhere on ``end_date`` belongs to the
+    window; anything on the following midnight does not).
+    """
+    start_ts = None
+    if start_date:
+        start_ts = datetime.strptime(start_date, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ).timestamp()
+    end_ts = None
+    if end_date:
+        end_ts = (
+            datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            + timedelta(days=1)
+        ).timestamp()
+    return start_ts, end_ts
+
+
+def _in_window(epoch: float | None, start_ts: float | None, end_ts: float | None) -> bool:
+    """True when ``epoch`` is in [start_ts, end_ts).
+
+    Undated rows are excluded from a dated window (they could be anything,
+    including future posts); in live mode with no window they are kept,
+    mirroring the yfinance-news convention.
+    """
+    if epoch is None:
+        return start_ts is None and end_ts is None
+    if start_ts is not None and epoch < start_ts:
+        return False
+    return not (end_ts is not None and epoch >= end_ts)
 
 
 def _iso_to_timestamp(iso_str: str | None) -> float | None:
@@ -194,6 +229,8 @@ def fetch_reddit_posts(
     limit_per_sub: int = 5,
     timeout: float = 10.0,
     inter_request_delay: float = 1.0,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> str:
     """Fetch recent Reddit posts mentioning ``ticker`` across finance
     subreddits and return them as a formatted plaintext block.
@@ -201,23 +238,36 @@ def fetch_reddit_posts(
     ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests to
     stay under Reddit's public per-IP rate limit; combined with the RSS-first
     path it makes 429s rare even when several analyses run back-to-back.
+
+    When ``start_date`` / ``end_date`` are provided (e.g. a historical
+    backtest trade date), posts timestamped outside the window are dropped and
+    a window-specific placeholder is returned when nothing survives the
+    filter -- Reddit's public search only serves recent posts, so a historical
+    analysis must not present today's posts as historical signal (#1220).
     """
     # Crypto reaches us as a Yahoo pair (BTC-USD); search Reddit for the base
     # ("BTC") so the query actually matches discussion instead of near-nothing.
     ticker = crypto_base(ticker) or ticker
+    start_ts, end_ts = _window_epochs(start_date, end_date)
+    window_label = "past 7 days"
+    if start_date and end_date:
+        window_label = f"{start_date} to {end_date}"
+    elif end_date:
+        window_label = f"through {end_date}"
     blocks = []
     total_posts = 0
     for i, sub in enumerate(subreddits):
         if i > 0:
             time.sleep(inter_request_delay)
         posts = _fetch_subreddit(ticker, sub, limit_per_sub, timeout)
+        posts = [p for p in posts if _in_window(p.get("created_utc"), start_ts, end_ts)]
         total_posts += len(posts)
         if not posts:
-            blocks.append(f"r/{sub}: <no posts found mentioning {ticker.upper()} in the past 7 days>")
+            blocks.append(f"r/{sub}: <no posts found mentioning {ticker.upper()} in the {window_label}>")
             continue
 
         via_rss = any(p.get("source") == "rss" for p in posts)
-        header = f"r/{sub} — {len(posts)} recent posts mentioning {ticker.upper()}"
+        header = f"r/{sub} — {len(posts)} posts in the {window_label} mentioning {ticker.upper()}"
         header += " (via RSS feed; scores/comments unavailable):" if via_rss else ":"
         lines = [header]
         for p in posts:
@@ -245,6 +295,6 @@ def fetch_reddit_posts(
     if total_posts == 0:
         return (
             f"<no Reddit posts found mentioning {ticker.upper()} across "
-            f"{', '.join(f'r/{s}' for s in subreddits)} in the past 7 days>"
+            f"{', '.join(f'r/{s}' for s in subreddits)} in the {window_label}>"
         )
     return "\n\n".join(blocks)

--- a/tradingagents/dataflows/stocktwits.py
+++ b/tradingagents/dataflows/stocktwits.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import http.client
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 from urllib.request import Request, urlopen
 
 from .symbol_utils import crypto_base
@@ -25,6 +26,52 @@ logger = logging.getLogger(__name__)
 
 _API = "https://api.stocktwits.com/api/2/streams/symbol/{ticker}.json"
 _UA = "tradingagents/0.2 (+https://github.com/TauricResearch/TradingAgents)"
+
+
+def _iso_to_epoch(iso_str: str | None) -> float | None:
+    """Parse StockTwits' ISO-8601 ``created_at`` to a UTC epoch, or None."""
+    if not iso_str:
+        return None
+    try:
+        normalized = iso_str[:-1] + "+00:00" if iso_str.endswith("Z") else iso_str
+        return datetime.fromisoformat(normalized).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _window_epochs(start_date: str | None, end_date: str | None) -> tuple[float | None, float | None]:
+    """UTC window [start midnight, end+1 day midnight) for inclusive date bounds.
+
+    ``end_date`` stays inclusive for the whole day (mirrors the yfinance-news
+    convention: a message timestamped anywhere on ``end_date`` belongs to the
+    window; anything on the following midnight does not).
+    """
+    start_ts = None
+    if start_date:
+        start_ts = datetime.strptime(start_date, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ).timestamp()
+    end_ts = None
+    if end_date:
+        end_ts = (
+            datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            + timedelta(days=1)
+        ).timestamp()
+    return start_ts, end_ts
+
+
+def _in_window(epoch: float | None, start_ts: float | None, end_ts: float | None) -> bool:
+    """True when ``epoch`` is in [start_ts, end_ts).
+
+    Undated rows are excluded from a dated window (they could be anything,
+    including future posts); in live mode with no window they are kept,
+    mirroring the yfinance-news convention.
+    """
+    if epoch is None:
+        return start_ts is None and end_ts is None
+    if start_ts is not None and epoch < start_ts:
+        return False
+    return not (end_ts is not None and epoch >= end_ts)
 
 
 def _stocktwits_symbol(ticker: str) -> str:
@@ -38,9 +85,22 @@ def _stocktwits_symbol(ticker: str) -> str:
     return f"{base}.X" if base else ticker.strip().upper()
 
 
-def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.0) -> str:
+def fetch_stocktwits_messages(
+    ticker: str,
+    limit: int = 30,
+    timeout: float = 10.0,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
     """Fetch recent StockTwits messages for ``ticker`` and return them as a
     formatted plaintext block ready for prompt injection.
+
+    When ``start_date`` / ``end_date`` are provided (e.g. a historical
+    backtest trade date), messages timestamped outside the window are dropped
+    and a window-specific placeholder is returned when nothing survives the
+    filter -- StockTwits' public stream only serves current posts, so a
+    historical analysis must not present today's posts as historical signal
+    (#1220).
 
     Returns a placeholder string when the endpoint is unreachable, the
     symbol has no messages, or the response shape is unexpected — the
@@ -59,6 +119,21 @@ def fetch_stocktwits_messages(ticker: str, limit: int = 30, timeout: float = 10.
 
     messages = data.get("messages", []) if isinstance(data, dict) else []
     if not messages:
+        return f"<no StockTwits messages found for ${ticker.upper()}>"
+
+    start_ts, end_ts = _window_epochs(start_date, end_date)
+    messages = [
+        m
+        for m in messages
+        if _in_window(_iso_to_epoch(m.get("created_at")), start_ts, end_ts)
+    ]
+    if not messages:
+        if end_date:
+            return (
+                f"<no StockTwits messages found for ${ticker.upper()} in the "
+                f"requested window (through {end_date}); historical social "
+                f"data may be unavailable>"
+            )
         return f"<no StockTwits messages found for ${ticker.upper()}>"
 
     lines = []


### PR DESCRIPTION
## Summary
Fixes #1220: the Sentiment Analyst fetched current StockTwits/Reddit posts
for historical runs and presented them as covering the requested period,
introducing look-ahead bias in backtests.

## Changes
- `tradingagents/dataflows/stocktwits.py`: fetch_stocktwits_messages now
  accepts start_date/end_date and filters messages by `created_at`; returns
  a window-specific placeholder when nothing survives.
- `tradingagents/dataflows/reddit.py`: fetch_reddit_posts filters posts by
  their RSS publish timestamp; undated posts are excluded from dated windows.
- `tradingagents/agents/analysts/sentiment_analyst.py`: passes the analysis
  window to both fetchers; data-source labels now show the real window.
- `tests/test_social_lookahead.py`: 9 regression tests (window boundaries,
  end-to-end filtering, live-mode compatibility, prompt labels).

## Testing
- `pytest tests/test_social_lookahead.py`: 9 passed
- Related suites (stocktwits/reddit/news lookahead/crypto/structured prompts): 64 passed
- Full suite: 576 passed, 2 skipped

Fixes #1220