### PR TITLE
feat(cli): persist interactive preferences safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,10 @@ cython_debug/
 #   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #   and can be added to the global gitignore or merged into this file.  For a more nuclear
 #   option (not recommended) you can uncomment the following to ignore the entire idea folder.
-# .idea/
+.idea/
+
+# Local agent state and scratch artifacts
+.agents/
 
 # Abstra
 #   Abstra is an AI-powered process automation framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes within the 0.x line are called out explicitly.
 
+## [Unreleased]
+
+### Added
+
+- **Saved CLI preferences.** Interactive users can persist provider, model,
+  research-depth, language, and reasoning settings in
+  `~/.tradingagents/preferences.json`, reuse them on later runs, inspect them
+  with `config show`, update them with `config set`, or clear them with
+  `config reset`.
+
+### Fixed
+
+- Preserved the legacy root analysis options alongside the explicit `analyze`
+  command and applied the Windows no-console guard consistently to analysis and
+  preference commands.
+- Prevented incomplete or newer-version preference files from being silently
+  reused or overwritten, and kept provider changes from combining incompatible
+  saved models, endpoints, or reasoning settings.
+- Avoided the first-run save prompt in non-interactive sessions and stopped
+  cleanly when the saved-preferences prompt is cancelled.
+
 ## [0.3.1] — 2026-07-05
 
 Correctness and stability patch: data look-ahead, graph-router crash-safety,

--- a/README.md
+++ b/README.md
@@ -169,6 +169,34 @@ python -m cli.main     # alternative: run directly from source
 ```
 You will see a screen where you can select your desired tickers, analysis date, LLM provider, research depth, and more.
 
+### Saved CLI preferences
+
+If you use the CLI interactively, you can save the settings that normally stay
+the same between runs:
+
+```bash
+tradingagents config set             # configure and save provider/model settings
+tradingagents config show            # display saved settings
+tradingagents analyze                 # reuse saved settings for a new analysis
+tradingagents analyze --configure    # run setup again and replace saved settings
+tradingagents config reset            # remove saved settings
+```
+
+Saved preferences are stored at `~/.tradingagents/preferences.json`. They cover
+the provider, models, research depth, output language, and provider-specific
+reasoning options. The ticker, analysis date, and analyst team remain per-run
+choices. Explicit `TRADINGAGENTS_*` environment variables take precedence over
+saved preferences, and API keys remain in the environment or `.env` file rather
+than in the preferences file.
+
+The legacy root form remains supported, so `tradingagents --checkpoint` and
+`tradingagents --no-checkpoint` are equivalent to the corresponding options on
+`tradingagents analyze`. If `TRADINGAGENTS_LLM_PROVIDER` changes the provider
+from the one saved in preferences, the CLI does not mix provider-specific
+models, endpoints, or reasoning settings: matching environment overrides are
+used, otherwise the new provider's defaults are selected. Custom-only providers
+require matching model environment variables or `--configure`.
+
 ### Markets and tickers
 
 TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Company identity and the alpha benchmark resolve automatically per market.

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,6 +20,16 @@ from rich.table import Table
 from rich.text import Text
 
 from cli.announcements import display_announcements, fetch_announcements
+from cli.preferences import (
+    PREFERENCES_PATH,
+    clear_preferences,
+    config_to_preferences,
+    display_preferences_summary,
+    load_preferences_result,
+    preferences_to_selections,
+    prompt_use_preferences,
+    save_preferences,
+)
 from cli.stats_handler import StatsCallbackHandler
 from cli.utils import (
     ask_anthropic_effort,
@@ -69,7 +79,106 @@ app = typer.Typer(
     name="TradingAgents",
     help="TradingAgents CLI: Multi-Agents LLM Financial Trading Framework",
     add_completion=True,  # Enable shell completion
+    invoke_without_command=True,
 )
+
+
+def _run_with_console_guard(callback, *args, **kwargs):
+    try:
+        return callback(*args, **kwargs)
+    except _NO_CONSOLE_ERRORS:
+        # A terminal with no console buffer cannot host the interactive prompts.
+        # Emit one actionable line on stderr instead of a prompt_toolkit
+        # traceback; plain text, since rich may not render here either (#1138).
+        typer.echo(
+            "Error: no Windows console available. The interactive CLI needs a real "
+            "console buffer — run it from Windows Terminal, PowerShell, or cmd.exe "
+            "rather than a piped or embedded terminal.",
+            err=True,
+        )
+        raise typer.Exit(code=1) from None
+
+
+def _run_analysis_with_console_guard(
+    checkpoint: bool | None = None,
+    configure: bool = False,
+):
+    return _run_with_console_guard(
+        run_analysis,
+        checkpoint=checkpoint,
+        configure=configure,
+    )
+
+
+def _run_analysis_command(
+    checkpoint: bool | None = None,
+    clear_checkpoints: bool = False,
+    configure: bool = False,
+):
+    if clear_checkpoints:
+        from tradingagents.graph.checkpointer import clear_all_checkpoints
+
+        n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
+        console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
+    return _run_analysis_with_console_guard(
+        checkpoint=checkpoint,
+        configure=configure,
+    )
+
+
+def _resolve_provider_selection(
+    provider: str, backend_url: str | None
+) -> tuple[str, str | None]:
+    """Resolve the provider's region, endpoint, and credentials in one path."""
+    if provider == "qwen":
+        provider, backend_url = ask_qwen_region()
+    elif provider == "minimax":
+        provider, backend_url = ask_minimax_region()
+    elif provider == "glm":
+        provider, backend_url = ask_glm_region()
+
+    backend_url = resolve_backend_url(
+        provider,
+        backend_url,
+        env_url=DEFAULT_CONFIG["backend_url"],
+    )
+
+    if provider == "openai_compatible" and not backend_url:
+        backend_url = prompt_openai_compatible_url()
+    if provider == "ollama":
+        confirm_ollama_endpoint(backend_url)
+
+    ensure_api_key(provider)
+    return provider, backend_url
+
+
+@app.callback()
+def _default(
+    ctx: typer.Context,
+    checkpoint: bool | None = typer.Option(
+        None,
+        "--checkpoint/--no-checkpoint",
+        help="Enable/disable checkpoint-resume for the default analysis command.",
+    ),
+    clear_checkpoints: bool = typer.Option(
+        False,
+        "--clear-checkpoints",
+        help="Delete all saved checkpoints before the default analysis command.",
+    ),
+    configure: bool = typer.Option(
+        False,
+        "--configure",
+        "-C",
+        help="Ignore saved preferences and run the full interactive setup.",
+    ),
+):
+    """Run the interactive analysis (default action when no subcommand is specified)."""
+    if ctx.invoked_subcommand is None:
+        _run_analysis_command(
+            checkpoint=checkpoint,
+            clear_checkpoints=clear_checkpoints,
+            configure=configure,
+        )
 
 
 # Create a deque to store recent messages with a maximum length
@@ -492,8 +601,12 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
     layout["footer"].update(Panel(stats_table, border_style="grey50"))
 
 
-def get_user_selections():
-    """Get all user selections before starting the analysis display."""
+def get_user_selections(configure: bool = False):
+    """Get all user selections before starting the analysis display.
+
+    When saved preferences exist and ``configure`` is False, a summary is shown
+    and the user is asked whether to reuse, skip (one-off), or reconfigure.
+    """
     # Display ASCII art welcome message
     with open(Path(__file__).parent / "static" / "welcome.txt", encoding="utf-8") as f:
         welcome_ascii = f.read()
@@ -523,6 +636,21 @@ def get_user_selections():
     announcements = fetch_announcements()
     display_announcements(console, announcements)
 
+    # Check for saved preferences (skip when --configure is passed)
+    prefs = None
+    prefs_action = None
+    prefs_status = "missing"
+    if not configure:
+        prefs_result = load_preferences_result()
+        prefs_status = prefs_result.status
+        prefs = prefs_result.preferences
+        if prefs:
+            display_preferences_summary(prefs)
+            prefs_action = prompt_use_preferences() if sys.stdin.isatty() else "use"
+            if prefs_action is None:
+                console.print("[yellow]Cancelled.[/yellow]")
+                raise typer.Exit(code=1)
+
     # Create a boxed questionnaire for each step
     def create_question_box(title, prompt, default=None):
         box_content = f"[bold]{title}[/bold]\n"
@@ -544,6 +672,75 @@ def get_user_selections():
             return value
         console.print(create_question_box(box_title, box_body))
         return prompt_fn()
+
+    # If the user chose to reuse saved preferences, skip the full questionnaire
+    # and only ask for the per-run values (ticker, date, analysts).
+    if prefs_action == "use":
+        try:
+            selections = preferences_to_selections(prefs, defaults=DEFAULT_CONFIG)
+        except ValueError as exc:
+            console.print(f"[red]Cannot reuse saved preferences: {exc}[/red]")
+            raise typer.Exit(code=1) from None
+
+        # Step 1: Ticker symbol
+        console.print(
+            create_question_box(
+                "Step 1: Ticker Symbol",
+                "Enter the ticker, with exchange suffix when needed (e.g. SPY, 0700.HK, BTC-USD)",
+                "SPY",
+            )
+        )
+        selected_ticker = get_ticker()
+        asset_type = detect_asset_type(selected_ticker)
+        if asset_type.value != "stock":
+            console.print(
+                f"[green]Detected asset type:[/green] {asset_type.value}"
+            )
+
+        # Step 2: Analysis date
+        default_date = datetime.datetime.now().strftime("%Y-%m-%d")
+        console.print(
+            create_question_box(
+                "Step 2: Analysis Date",
+                "Enter the analysis date (YYYY-MM-DD)",
+                default_date,
+            )
+        )
+        analysis_date = get_analysis_date()
+
+        # Step 4: Select analysts (no step 3 — language is from prefs)
+        console.print(
+            create_question_box(
+                "Step 3: Analysts Team",
+                "Select your LLM analyst agents for the analysis"
+            )
+        )
+        selected_analysts = select_analysts(asset_type)
+        console.print(
+            f"[green]Selected analysts:[/green] {', '.join(analyst.value for analyst in selected_analysts)}"
+        )
+
+        # Confirm the API key for the saved provider is available
+        ensure_api_key(selections["llm_provider"])
+
+        return {
+            "ticker": selected_ticker,
+            "asset_type": asset_type.value,
+            "analysis_date": analysis_date,
+            "analysts": selected_analysts,
+            "research_depth": selections["research_depth"],
+            "max_debate_rounds": selections["max_debate_rounds"],
+            "max_risk_discuss_rounds": selections["max_risk_discuss_rounds"],
+            "llm_provider": selections["llm_provider"],
+            "backend_url": selections["backend_url"],
+            "shallow_thinker": selections["shallow_thinker"],
+            "deep_thinker": selections["deep_thinker"],
+            "google_thinking_level": selections.get("google_thinking_level"),
+            "openai_reasoning_effort": selections.get("openai_reasoning_effort"),
+            "anthropic_effort": selections.get("anthropic_effort"),
+            "output_language": selections.get("output_language", "English"),
+            "_prefs_action": None,
+        }
 
     # Step 1: Ticker symbol
     console.print(
@@ -643,36 +840,10 @@ def get_user_selections():
         )
         selected_llm_provider, backend_url = select_llm_provider()
 
-        # Providers with regional endpoints prompt for the region as a secondary
-        # step so the main dropdown stays clean (mainland China and international
-        # accounts cannot share API keys).
-        if selected_llm_provider == "qwen":
-            selected_llm_provider, backend_url = ask_qwen_region()
-        elif selected_llm_provider == "minimax":
-            selected_llm_provider, backend_url = ask_minimax_region()
-        elif selected_llm_provider == "glm":
-            selected_llm_provider, backend_url = ask_glm_region()
-
-        # Honor an explicit env backend URL even when the provider was chosen
-        # interactively, so it isn't overwritten by the menu default (#978).
-        backend_url = resolve_backend_url(
-            selected_llm_provider, backend_url, env_url=DEFAULT_CONFIG["backend_url"]
+        selected_llm_provider, backend_url = _resolve_provider_selection(
+            selected_llm_provider,
+            backend_url,
         )
-
-        # The generic OpenAI-compatible endpoint has no default; ask for it if
-        # neither the menu nor the environment supplied one.
-        if selected_llm_provider == "openai_compatible" and not backend_url:
-            backend_url = prompt_openai_compatible_url()
-
-        # For Ollama, surface the resolved endpoint (OLLAMA_BASE_URL vs default)
-        # before model selection so it's obvious where we're connecting.
-        if selected_llm_provider == "ollama":
-            confirm_ollama_endpoint(backend_url)
-
-        # Confirm the provider's API key is present; prompt the user to paste
-        # one and persist it to .env if it's missing, so the analysis run
-        # doesn't fail later at the first API call.
-        ensure_api_key(selected_llm_provider)
 
     # Step 7: Thinking agents (skipped when either model is set via environment)
     if os.environ.get("TRADINGAGENTS_QUICK_THINK_LLM") or os.environ.get("TRADINGAGENTS_DEEP_THINK_LLM"):
@@ -702,9 +873,12 @@ def get_user_selections():
 
     provider_lower = selected_llm_provider.lower()
     if provider_from_env:
-        thinking_level = DEFAULT_CONFIG["google_thinking_level"]
-        reasoning_effort = DEFAULT_CONFIG["openai_reasoning_effort"]
-        anthropic_effort = DEFAULT_CONFIG["anthropic_effort"]
+        if provider_lower == "google":
+            thinking_level = DEFAULT_CONFIG["google_thinking_level"]
+        elif provider_lower == "openai":
+            reasoning_effort = DEFAULT_CONFIG["openai_reasoning_effort"]
+        elif provider_lower == "anthropic":
+            anthropic_effort = DEFAULT_CONFIG["anthropic_effort"]
     elif provider_lower == "google":
         thinking_level = thinking_value_or_prompt(
             "TRADINGAGENTS_GOOGLE_THINKING_LEVEL", "google_thinking_level",
@@ -724,12 +898,28 @@ def get_user_selections():
             "Configure Claude effort level", ask_anthropic_effort,
         )
 
+    # Determine whether to save preferences after the run:
+    #   "reconfigure" — user chose to reconfigure or passed --configure → auto-save
+    #   "first_time"  — no preferences file existed → prompt to save
+    #   "skip"        — user chose one-off → don't save
+    #   None          — preferences were reused → don't save (already handled above)
+    if configure or prefs_action == "reconfigure":
+        _prefs_action = "reconfigure"
+    elif prefs_action == "skip":
+        _prefs_action = "skip"
+    elif prefs_action is None and prefs is None and prefs_status == "missing":
+        _prefs_action = "first_time"
+    else:
+        _prefs_action = None
+
     return {
         "ticker": selected_ticker,
         "asset_type": asset_type.value,
         "analysis_date": analysis_date,
         "analysts": selected_analysts,
         "research_depth": selected_research_depth,
+        "max_debate_rounds": selected_research_depth,
+        "max_risk_discuss_rounds": selected_research_depth,
         "llm_provider": selected_llm_provider.lower(),
         "backend_url": backend_url,
         "shallow_thinker": selected_shallow_thinker,
@@ -738,6 +928,7 @@ def get_user_selections():
         "openai_reasoning_effort": reasoning_effort,
         "anthropic_effort": anthropic_effort,
         "output_language": output_language,
+        "_prefs_action": _prefs_action,
     }
 
 
@@ -982,9 +1173,13 @@ def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     # (TRADINGAGENTS_MAX_DEBATE_ROUNDS / _MAX_RISK_ROUNDS) wins over the
     # interactive selection — leave the env-applied value in place (#977).
     if not os.environ.get("TRADINGAGENTS_MAX_DEBATE_ROUNDS"):
-        config["max_debate_rounds"] = selections["research_depth"]
+        config["max_debate_rounds"] = selections.get(
+            "max_debate_rounds", selections["research_depth"]
+        )
     if not os.environ.get("TRADINGAGENTS_MAX_RISK_ROUNDS"):
-        config["max_risk_discuss_rounds"] = selections["research_depth"]
+        config["max_risk_discuss_rounds"] = selections.get(
+            "max_risk_discuss_rounds", selections["research_depth"]
+        )
     config["quick_think_llm"] = selections["shallow_thinker"]
     config["deep_think_llm"] = selections["deep_thinker"]
     config["backend_url"] = selections["backend_url"]
@@ -1001,11 +1196,27 @@ def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     return config
 
 
-def run_analysis(checkpoint: bool | None = None):
+def run_analysis(checkpoint: bool | None = None, configure: bool = False):
     # First get all user selections
-    selections = get_user_selections()
+    selections = get_user_selections(configure=configure)
 
     config = _build_run_config(selections, checkpoint)
+
+    # Save preferences when applicable
+    _prefs_action = selections.pop("_prefs_action", None)
+    if _prefs_action == "reconfigure":
+        # Auto-save — user explicitly chose to reconfigure or passed --configure
+        if save_preferences(config_to_preferences(config)):
+            console.print("[green]✓ Preferences saved. Future runs will use these settings.[/green]")
+    elif _prefs_action == "first_time" and sys.stdin.isatty():
+        # Prompt to save after first run
+        import questionary
+        save_choice = questionary.confirm(
+            "Save these settings as your defaults for future runs?",
+            default=True,
+        ).ask()
+        if save_choice and save_preferences(config_to_preferences(config)):
+            console.print("[green]✓ Preferences saved. Future runs will use these settings.[/green]")
 
     # Create stats callback handler for tracking LLM/tool calls
     stats_handler = StatsCallbackHandler()
@@ -1293,24 +1504,138 @@ def analyze(
         "--clear-checkpoints",
         help="Delete all saved checkpoints before running (force fresh start).",
     ),
+    configure: bool = typer.Option(
+        False,
+        "--configure",
+        "-C",
+        help="Ignore saved preferences and run the full interactive setup. "
+        "New selections will be saved as preferences.",
+    ),
 ):
-    if clear_checkpoints:
-        from tradingagents.graph.checkpointer import clear_all_checkpoints
-        n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
-        console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
-    try:
-        run_analysis(checkpoint=checkpoint)
-    except _NO_CONSOLE_ERRORS:
-        # A terminal with no console buffer cannot host the interactive prompts.
-        # Emit one actionable line on stderr instead of a prompt_toolkit
-        # traceback; plain text, since rich may not render here either (#1138).
-        typer.echo(
-            "Error: no Windows console available. The interactive CLI needs a real "
-            "console buffer — run it from Windows Terminal, PowerShell, or cmd.exe "
-            "rather than a piped or embedded terminal.",
-            err=True,
+    _run_analysis_command(
+        checkpoint=checkpoint,
+        clear_checkpoints=clear_checkpoints,
+        configure=configure,
+    )
+
+
+config_app = typer.Typer(help="Manage saved preferences for future runs")
+app.add_typer(config_app, name="config")
+
+
+@config_app.command(name="show")
+def config_show():
+    """Display current saved preferences."""
+    result = load_preferences_result()
+    if result.status == "missing":
+        console.print("[yellow]No saved preferences found.[/yellow]")
+        console.print(
+            "Run 'tradingagents config set' to configure and save your preferences."
         )
-        raise typer.Exit(code=1) from None
+    elif result.status == "future":
+        console.print(
+            "[yellow]Saved preferences require a newer TradingAgents version. "
+            "Upgrade before reusing them.[/yellow]"
+        )
+    elif result.status == "invalid":
+        console.print(
+            "[yellow]Saved preferences are invalid or incomplete. "
+            "Run 'tradingagents config set' to replace them.[/yellow]"
+        )
+    else:
+        display_preferences_summary(result.preferences)
+
+
+def _config_set_impl():
+    """Interactively configure and save preferences (no analysis run)."""
+
+    def _box(title, prompt, default=None):
+        box_content = f"[bold]{title}[/bold]\n[dim]{prompt}[/dim]"
+        if default:
+            box_content += f"\n[dim]Default: {default}[/dim]"
+        return Panel(box_content, border_style="blue", padding=(1, 2))
+
+    # Output language
+    console.print(_box("Output Language", "Select the language for analyst reports and final decision"))
+    output_language = ask_output_language()
+
+    # Research depth
+    console.print(_box("Research Depth", "Select your research depth level"))
+    research_depth = select_research_depth()
+
+    # LLM Provider
+    console.print(_box("LLM Provider", "Select your LLM provider"))
+    llm_provider, backend_url = select_llm_provider()
+    llm_provider, backend_url = _resolve_provider_selection(
+        llm_provider,
+        backend_url,
+    )
+
+    # Thinking agents
+    console.print(_box("Thinking Agents", "Select your thinking agents for analysis"))
+    shallow = select_shallow_thinking_agent(llm_provider)
+    deep = select_deep_thinking_agent(llm_provider)
+
+    # Provider-specific reasoning config
+    thinking_level = None
+    reasoning_effort = None
+    anthropic_effort = None
+    provider_lower = llm_provider.lower()
+    if provider_lower == "google":
+        console.print(_box("Thinking Mode", "Configure Gemini thinking mode"))
+        thinking_level = ask_gemini_thinking_config()
+    elif provider_lower == "openai":
+        console.print(_box("Reasoning Effort", "Configure OpenAI reasoning effort level"))
+        reasoning_effort = ask_openai_reasoning_effort()
+    elif provider_lower == "anthropic":
+        console.print(_box("Effort Level", "Configure Claude effort level"))
+        anthropic_effort = ask_anthropic_effort()
+
+    prefs = {
+        "llm_provider": llm_provider.lower(),
+        "backend_url": backend_url,
+        "quick_think_llm": shallow,
+        "deep_think_llm": deep,
+        "output_language": output_language,
+        "max_debate_rounds": research_depth,
+        "max_risk_discuss_rounds": research_depth,
+        "google_thinking_level": thinking_level,
+        "openai_reasoning_effort": reasoning_effort,
+        "anthropic_effort": anthropic_effort,
+    }
+
+    if save_preferences(prefs):
+        console.print("\n[green]✓ Preferences saved successfully![/green]")
+        display_preferences_summary(prefs)
+
+
+@config_app.command(name="set")
+def config_set():
+    """Interactively configure and save preferences (no analysis run)."""
+    return _run_with_console_guard(_config_set_impl)
+
+
+def _config_reset_impl():
+    """Clear all saved preferences."""
+    import questionary
+    if not PREFERENCES_PATH.exists():
+        console.print("[yellow]No saved preferences to reset.[/yellow]")
+        return
+    confirm_clear = questionary.confirm(
+        "Clear all saved preferences?",
+        default=False,
+    ).ask()
+    if confirm_clear:
+        if clear_preferences():
+            console.print("[green]✓ Preferences cleared.[/green]")
+    else:
+        console.print("Cancelled.")
+
+
+@config_app.command(name="reset")
+def config_reset():
+    """Clear all saved preferences."""
+    return _run_with_console_guard(_config_reset_impl)
 
 
 if __name__ == "__main__":

--- a/cli/preferences.py
+++ b/cli/preferences.py
@@ -1,0 +1,433 @@
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+import questionary
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from cli.utils import provider_default_url
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.llm_clients.model_catalog import get_model_options
+
+_TRADINGAGENTS_HOME = Path.home() / ".tradingagents"
+PREFERENCES_PATH = _TRADINGAGENTS_HOME / "preferences.json"
+
+PREFERENCE_KEYS = [
+    "llm_provider",
+    "quick_think_llm",
+    "deep_think_llm",
+    "backend_url",
+    "output_language",
+    "max_debate_rounds",
+    "max_risk_discuss_rounds",
+    "google_thinking_level",
+    "openai_reasoning_effort",
+    "anthropic_effort",
+]
+
+CURRENT_VERSION = 1
+
+_ROUND_KEYS = {"max_debate_rounds", "max_risk_discuss_rounds"}
+_OPTIONAL_STRING_KEYS = {
+    "backend_url",
+    "google_thinking_level",
+    "openai_reasoning_effort",
+    "anthropic_effort",
+}
+_REQUIRED_STRING_KEYS = {
+    "llm_provider",
+    "quick_think_llm",
+    "deep_think_llm",
+    "output_language",
+}
+
+
+@dataclass(frozen=True)
+class PreferenceLoadResult:
+    status: Literal["missing", "valid", "invalid", "future"]
+    preferences: dict | None = None
+
+console = Console()
+
+_PROVIDER_DISPLAY = {
+    "openai": "OpenAI",
+    "google": "Google (Gemini)",
+    "anthropic": "Anthropic (Claude)",
+    "xai": "xAI",
+    "deepseek": "DeepSeek",
+    "qwen": "Qwen (International)",
+    "qwen-cn": "Qwen (China)",
+    "glm": "GLM (Z.AI)",
+    "glm-cn": "GLM (BigModel China)",
+    "minimax": "MiniMax (Global)",
+    "minimax-cn": "MiniMax (China)",
+    "openrouter": "OpenRouter",
+    "mistral": "Mistral",
+    "kimi": "Kimi (Moonshot)",
+    "groq": "Groq",
+    "nvidia": "NVIDIA NIM",
+    "azure": "Azure OpenAI",
+    "bedrock": "AWS Bedrock",
+    "ollama": "Ollama",
+    "openai_compatible": "OpenAI-compatible",
+}
+
+
+def _pretty_provider(provider: str) -> str:
+    return _PROVIDER_DISPLAY.get(provider.lower(), provider)
+
+
+def _is_valid_preference(key: str, value: Any) -> bool:
+    if key in _ROUND_KEYS:
+        return isinstance(value, int) and not isinstance(value, bool) and value > 0
+    if key in _OPTIONAL_STRING_KEYS:
+        return value is None or (isinstance(value, str) and bool(value.strip()))
+    if key in _REQUIRED_STRING_KEYS:
+        return isinstance(value, str) and bool(value.strip())
+    return False
+
+
+def _validate_preference_bundle(prefs: dict) -> str | None:
+    required_keys = _REQUIRED_STRING_KEYS | _ROUND_KEYS
+    missing_keys = sorted(required_keys - prefs.keys())
+    if missing_keys:
+        return f"missing: {', '.join(missing_keys)}"
+    invalid_keys = [
+        key for key in PREFERENCE_KEYS
+        if key in prefs and not _is_valid_preference(key, prefs[key])
+    ]
+    if invalid_keys:
+        return f"invalid: {', '.join(invalid_keys)}"
+    try:
+        get_model_options(prefs["llm_provider"], "quick")
+        get_model_options(prefs["llm_provider"], "deep")
+    except KeyError:
+        return f"unknown provider: {prefs['llm_provider']}"
+    return None
+
+
+def load_preferences_result() -> PreferenceLoadResult:
+    if not PREFERENCES_PATH.exists():
+        return PreferenceLoadResult("missing")
+    try:
+        data = json.loads(PREFERENCES_PATH.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return PreferenceLoadResult("invalid")
+        version = data.get("_version", 0)
+        if not isinstance(version, int) or isinstance(version, bool):
+            console.print(
+                "[yellow]Preferences file has an invalid version. "
+                "Running full setup.[/yellow]"
+            )
+            return PreferenceLoadResult("invalid")
+        if version > CURRENT_VERSION:
+            console.print(
+                "[yellow]Preferences file is from a newer version of TradingAgents. "
+                "Run 'tradingagents config reset' and then reconfigure.[/yellow]"
+            )
+            return PreferenceLoadResult("future")
+        prefs = {}
+        invalid_keys = []
+        for key in PREFERENCE_KEYS:
+            if key in data and _is_valid_preference(key, data[key]):
+                prefs[key] = data[key]
+            elif key in data:
+                invalid_keys.append(key)
+        if invalid_keys:
+            console.print(
+                "[yellow]Ignoring invalid saved preference(s): "
+                f"{', '.join(invalid_keys)}.[/yellow]"
+            )
+        bundle_error = _validate_preference_bundle(prefs)
+        if bundle_error:
+            console.print(
+                "[yellow]Saved preferences are incomplete or invalid ("
+                f"{bundle_error}). Running full setup.[/yellow]"
+            )
+            return PreferenceLoadResult("invalid")
+        return PreferenceLoadResult("valid", prefs)
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        console.print("[yellow]Preferences file is corrupted. Running full setup.[/yellow]")
+        return PreferenceLoadResult("invalid")
+
+
+def load_preferences() -> dict | None:
+    return load_preferences_result().preferences
+
+
+def save_preferences(prefs: dict) -> bool:
+    bundle_error = _validate_preference_bundle(prefs)
+    if bundle_error:
+        console.print(
+            "[red]Cannot save incomplete or invalid preferences ("
+            f"{bundle_error}).[/red]"
+        )
+        return False
+    data = {
+        "_version": CURRENT_VERSION,
+        "_updated": datetime.now(timezone.utc).isoformat(),
+    }
+    for key in PREFERENCE_KEYS:
+        if key in prefs:
+            data[key] = prefs[key]
+    temporary_path = None
+    try:
+        _TRADINGAGENTS_HOME.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=_TRADINGAGENTS_HOME,
+            prefix=f".{PREFERENCES_PATH.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            temporary_file.write(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+
+        if os.name != "nt":
+            temporary_path.chmod(0o600)
+        os.replace(temporary_path, PREFERENCES_PATH)
+        return True
+    except OSError:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        console.print(f"[red]Failed to write preferences to {PREFERENCES_PATH}[/red]")
+        return False
+
+
+def clear_preferences() -> bool:
+    try:
+        if PREFERENCES_PATH.exists():
+            PREFERENCES_PATH.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def display_preferences_summary(prefs: dict):
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("Key", style="dim")
+    table.add_column("Value")
+
+    provider = prefs.get("llm_provider", "")
+    table.add_row("LLM Provider", _pretty_provider(provider))
+
+    deep_model = prefs.get("deep_think_llm") or "-"
+    quick_model = prefs.get("quick_think_llm") or "-"
+    table.add_row("Deep Think Model", str(deep_model))
+    table.add_row("Quick Think Model", str(quick_model))
+
+    backend = prefs.get("backend_url")
+    if backend:
+        table.add_row("Backend URL", str(backend))
+    else:
+        table.add_row("Backend URL", "[dim]provider default[/dim]")
+
+    table.add_row("Output Language", str(prefs.get("output_language", "English")))
+    table.add_row(
+        "Research Depth",
+        f"{prefs.get('max_debate_rounds', 1)} debate / "
+        f"{prefs.get('max_risk_discuss_rounds', 1)} risk rounds",
+    )
+
+    reasoning_effort = prefs.get("openai_reasoning_effort")
+    if reasoning_effort:
+        table.add_row("Reasoning Effort", str(reasoning_effort))
+    thinking_level = prefs.get("google_thinking_level")
+    if thinking_level:
+        table.add_row("Gemini Thinking", str(thinking_level))
+    anthropic_effort = prefs.get("anthropic_effort")
+    if anthropic_effort:
+        table.add_row("Claude Effort", str(anthropic_effort))
+
+    panel = Panel(
+        table,
+        title="[bold]Saved Preferences[/bold]",
+        border_style="blue",
+        padding=(1, 2),
+    )
+    console.print()
+    console.print(panel)
+
+
+def prompt_use_preferences() -> Literal["use", "skip", "reconfigure"] | None:
+    return questionary.select(
+        "Use these preferences?",
+        choices=[
+            questionary.Choice(
+                "Yes — use saved settings (Recommended)",
+                value="use",
+            ),
+            questionary.Choice(
+                "No — run full setup, without saving (one-off)",
+                value="skip",
+            ),
+            questionary.Choice(
+                "Reconfigure — run full setup and save new preferences",
+                value="reconfigure",
+            ),
+        ],
+        style=questionary.Style([
+            ("selected", "fg:green noinherit"),
+            ("highlighted", "fg:green noinherit"),
+            ("pointer", "fg:green noinherit"),
+        ]),
+    ).ask()
+
+
+def _env_or_pref(
+    env_var: str,
+    config_key: str,
+    pref_key: str,
+    prefs: dict,
+    defaults: dict,
+) -> Any:
+    if os.environ.get(env_var):
+        return defaults[config_key]
+    return prefs.get(pref_key, defaults[config_key])
+
+
+def _provider_default_model(provider: str, mode: str) -> str:
+    for _, model in get_model_options(provider, mode):
+        if model != "custom":
+            return model
+    raise ValueError(
+        f"Provider '{provider}' has no default {mode} model. Set the matching "
+        f"TRADINGAGENTS_{'QUICK' if mode == 'quick' else 'DEEP'}_THINK_LLM "
+        "environment variable or run 'tradingagents analyze --configure'."
+    )
+
+
+def preferences_to_selections(prefs: dict, defaults: dict | None = None) -> dict:
+    defaults = DEFAULT_CONFIG if defaults is None else defaults
+    saved_provider = str(prefs.get("llm_provider", "")).lower()
+    env_provider = os.environ.get("TRADINGAGENTS_LLM_PROVIDER")
+    effective_provider = (
+        env_provider.strip().lower() if env_provider else saved_provider or defaults["llm_provider"]
+    )
+    provider_changed = bool(env_provider) and effective_provider != saved_provider
+
+    if provider_changed:
+        backend_url = (
+            defaults["backend_url"]
+            if os.environ.get("TRADINGAGENTS_LLM_BACKEND_URL")
+            else provider_default_url(effective_provider)
+        )
+        shallow_thinker = (
+            defaults["quick_think_llm"]
+            if os.environ.get("TRADINGAGENTS_QUICK_THINK_LLM")
+            else _provider_default_model(effective_provider, "quick")
+        )
+        deep_thinker = (
+            defaults["deep_think_llm"]
+            if os.environ.get("TRADINGAGENTS_DEEP_THINK_LLM")
+            else _provider_default_model(effective_provider, "deep")
+        )
+        google_thinking_level = (
+            defaults["google_thinking_level"]
+            if effective_provider == "google"
+            and os.environ.get("TRADINGAGENTS_GOOGLE_THINKING_LEVEL")
+            else None
+        )
+        openai_reasoning_effort = (
+            defaults["openai_reasoning_effort"]
+            if effective_provider == "openai"
+            and os.environ.get("TRADINGAGENTS_OPENAI_REASONING_EFFORT")
+            else None
+        )
+        anthropic_effort = (
+            defaults["anthropic_effort"]
+            if effective_provider == "anthropic"
+            and os.environ.get("TRADINGAGENTS_ANTHROPIC_EFFORT")
+            else None
+        )
+    else:
+        backend_url = _env_or_pref(
+            "TRADINGAGENTS_LLM_BACKEND_URL",
+            "backend_url",
+            "backend_url",
+            prefs,
+            defaults,
+        )
+        shallow_thinker = _env_or_pref(
+            "TRADINGAGENTS_QUICK_THINK_LLM",
+            "quick_think_llm",
+            "quick_think_llm",
+            prefs,
+            defaults,
+        )
+        deep_thinker = _env_or_pref(
+            "TRADINGAGENTS_DEEP_THINK_LLM",
+            "deep_think_llm",
+            "deep_think_llm",
+            prefs,
+            defaults,
+        )
+        google_thinking_level = _env_or_pref(
+            "TRADINGAGENTS_GOOGLE_THINKING_LEVEL",
+            "google_thinking_level",
+            "google_thinking_level",
+            prefs,
+            defaults,
+        )
+        openai_reasoning_effort = _env_or_pref(
+            "TRADINGAGENTS_OPENAI_REASONING_EFFORT",
+            "openai_reasoning_effort",
+            "openai_reasoning_effort",
+            prefs,
+            defaults,
+        )
+        anthropic_effort = _env_or_pref(
+            "TRADINGAGENTS_ANTHROPIC_EFFORT",
+            "anthropic_effort",
+            "anthropic_effort",
+            prefs,
+            defaults,
+        )
+
+    max_debate_rounds = _env_or_pref(
+        "TRADINGAGENTS_MAX_DEBATE_ROUNDS",
+        "max_debate_rounds",
+        "max_debate_rounds",
+        prefs,
+        defaults,
+    )
+    max_risk_discuss_rounds = _env_or_pref(
+        "TRADINGAGENTS_MAX_RISK_ROUNDS",
+        "max_risk_discuss_rounds",
+        "max_risk_discuss_rounds",
+        prefs,
+        defaults,
+    )
+
+    return {
+        "research_depth": max_debate_rounds,
+        "max_debate_rounds": max_debate_rounds,
+        "max_risk_discuss_rounds": max_risk_discuss_rounds,
+        "shallow_thinker": shallow_thinker,
+        "deep_thinker": deep_thinker,
+        "backend_url": backend_url,
+        "llm_provider": effective_provider,
+        "google_thinking_level": google_thinking_level,
+        "openai_reasoning_effort": openai_reasoning_effort,
+        "anthropic_effort": anthropic_effort,
+        "output_language": _env_or_pref(
+            "TRADINGAGENTS_OUTPUT_LANGUAGE",
+            "output_language",
+            "output_language",
+            prefs,
+            defaults,
+        ),
+    }
+
+
+def config_to_preferences(config: dict) -> dict:
+    return {k: config.get(k) for k in PREFERENCE_KEYS}

--- a/tests/test_cli_env_skip.py
+++ b/tests/test_cli_env_skip.py
@@ -144,6 +144,47 @@ class TestReasoningEffortSkippedFromEnv(unittest.TestCase):
         prompt_effort.assert_not_called()
         self.assertEqual(sel["openai_reasoning_effort"], "high")
 
+    def test_provider_env_only_keeps_matching_reasoning_setting(self):
+        import cli.main as m
+
+        env = {
+            "TRADINGAGENTS_LLM_PROVIDER": "google",
+            "TRADINGAGENTS_GOOGLE_THINKING_LEVEL": "high",
+            "TRADINGAGENTS_OPENAI_REASONING_EFFORT": "high",
+            "TRADINGAGENTS_ANTHROPIC_EFFORT": "low",
+            "TRADINGAGENTS_OUTPUT_LANGUAGE": "English",
+        }
+        fake_cfg = dict(m.DEFAULT_CONFIG)
+        fake_cfg.update({
+            "llm_provider": "google",
+            "google_thinking_level": "high",
+            "openai_reasoning_effort": "high",
+            "anthropic_effort": "low",
+            "output_language": "English",
+        })
+
+        with mock.patch.dict(os.environ, env, clear=False), \
+             mock.patch.object(m, "DEFAULT_CONFIG", fake_cfg), \
+             mock.patch.object(
+                 m,
+                 "load_preferences_result",
+                 return_value=mock.Mock(status="missing", preferences=None),
+             ), \
+             mock.patch.object(m, "fetch_announcements", return_value=None), \
+             mock.patch.object(m, "display_announcements"), \
+             mock.patch.object(m, "get_ticker", return_value="AAPL"), \
+             mock.patch.object(m, "get_analysis_date", return_value="2026-05-29"), \
+             mock.patch.object(m, "select_analysts", return_value=[]), \
+             mock.patch.object(m, "select_research_depth", return_value=1), \
+             mock.patch.object(m, "ensure_api_key"), \
+             mock.patch.object(m, "select_shallow_thinking_agent", return_value="gemini-3.5-flash"), \
+             mock.patch.object(m, "select_deep_thinking_agent", return_value="gemini-3.1-pro-preview"):
+            sel = m.get_user_selections()
+
+        self.assertEqual(sel["google_thinking_level"], "high")
+        self.assertIsNone(sel["openai_reasoning_effort"])
+        self.assertIsNone(sel["anthropic_effort"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_no_console.py
+++ b/tests/test_cli_no_console.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+import questionary
 from typer.testing import CliRunner
 
 import cli.main as m
@@ -55,3 +57,108 @@ def test_unrelated_errors_still_propagate(monkeypatch):
     monkeypatch.setattr(m, "run_analysis", _boom)
     result = CliRunner().invoke(m.app, [])
     assert isinstance(result.exception, ValueError)
+
+
+def test_default_callback_does_not_run_for_subcommands(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "run_analysis",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(m.app, ["config", "show"])
+
+    assert result.exit_code == 0
+    assert calls == []
+
+
+def test_analyze_subcommand_runs_analysis_once(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "run_analysis",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(m.app, ["analyze"])
+
+    assert result.exit_code == 0
+    assert calls == [((), {"checkpoint": None, "configure": False})]
+
+
+@pytest.mark.parametrize(
+    ("option", "checkpoint"),
+    [("--checkpoint", True), ("--no-checkpoint", False)],
+)
+def test_root_analysis_preserves_legacy_checkpoint_options(monkeypatch, option, checkpoint):
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "run_analysis",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    result = CliRunner().invoke(m.app, [option])
+
+    assert result.exit_code == 0
+    assert calls == [((), {"checkpoint": checkpoint, "configure": False})]
+
+
+def test_root_analysis_preserves_clear_checkpoint_option(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "_run_analysis_command",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = CliRunner().invoke(m.app, ["--clear-checkpoints"])
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "checkpoint": None,
+            "clear_checkpoints": True,
+            "configure": False,
+        }
+    ]
+
+
+def test_config_set_translates_missing_console(monkeypatch):
+    class _NoConsole(Exception):
+        pass
+
+    monkeypatch.setattr(m, "_NO_CONSOLE_ERRORS", (_NoConsole,))
+    monkeypatch.setattr(
+        m,
+        "ask_output_language",
+        lambda: (_ for _ in ()).throw(_NoConsole("no console")),
+    )
+
+    result = CliRunner().invoke(m.app, ["config", "set"])
+
+    assert result.exit_code == 1
+    assert "no Windows console available" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_config_reset_translates_missing_console(monkeypatch, tmp_path):
+    class _NoConsole(Exception):
+        pass
+
+    preferences_path = tmp_path / "preferences.json"
+    preferences_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(m, "PREFERENCES_PATH", preferences_path)
+    monkeypatch.setattr(m, "_NO_CONSOLE_ERRORS", (_NoConsole,))
+    monkeypatch.setattr(
+        questionary,
+        "confirm",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(_NoConsole("no console")),
+    )
+
+    result = CliRunner().invoke(m.app, ["config", "reset"])
+
+    assert result.exit_code == 1
+    assert "no Windows console available" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_cli_preferences.py
+++ b/tests/test_cli_preferences.py
@@ -1,0 +1,452 @@
+"""Tests for persisted CLI preference behavior."""
+
+import io
+import json
+import os
+import stat
+
+import pytest
+import questionary
+import typer
+
+import cli.main as m
+import cli.preferences as preferences
+from cli.utils import provider_default_url
+from tradingagents.llm_clients.model_catalog import get_model_options
+
+
+def _valid_preferences(**overrides):
+    prefs = {
+        "llm_provider": "openai",
+        "backend_url": "https://api.openai.com/v1",
+        "quick_think_llm": "gpt-5.4-mini",
+        "deep_think_llm": "gpt-5.5",
+        "output_language": "English",
+        "max_debate_rounds": 1,
+        "max_risk_discuss_rounds": 1,
+        "google_thinking_level": None,
+        "openai_reasoning_effort": None,
+        "anthropic_effort": None,
+    }
+    prefs.update(overrides)
+    return prefs
+
+
+def test_saved_preferences_are_utf8_and_private(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+
+    assert preferences.save_preferences(
+        _valid_preferences(
+            output_language="中文",
+            OPENAI_API_KEY="must-not-be-persisted",
+        )
+    )
+
+    saved = json.loads(preferences_path.read_text(encoding="utf-8"))
+    assert saved["output_language"] == "中文"
+    assert "OPENAI_API_KEY" not in saved
+    if os.name != "nt":
+        assert stat.S_IMODE(preferences_path.stat().st_mode) == 0o600
+
+
+def test_failed_preferences_replace_preserves_previous_file(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+
+    assert preferences.save_preferences(_valid_preferences(llm_provider="openai"))
+
+    def fail_replace(*_args):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(preferences.os, "replace", fail_replace)
+
+    assert not preferences.save_preferences(_valid_preferences(llm_provider="deepseek"))
+    assert preferences.load_preferences()["llm_provider"] == "openai"
+
+
+def test_save_preferences_rejects_incomplete_bundle(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+
+    assert not preferences.save_preferences({"llm_provider": "openai"})
+    assert not preferences_path.exists()
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "azure"])
+def test_dynamic_model_providers_can_be_saved(monkeypatch, tmp_path, provider):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+
+    assert preferences.save_preferences(
+        _valid_preferences(
+            llm_provider=provider,
+            backend_url="https://provider.example/v1",
+            quick_think_llm="provider-quick-deployment",
+            deep_think_llm="provider-deep-deployment",
+        )
+    )
+    assert preferences.load_preferences_result().status == "valid"
+
+
+def test_load_preferences_ignores_invalid_known_values(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    preferences_home.mkdir()
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+    preferences_path.write_text(
+        json.dumps(
+            {
+                "_version": 1,
+                "llm_provider": "deepseek",
+                "output_language": 42,
+                "max_debate_rounds": "many",
+                "max_risk_discuss_rounds": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = preferences.load_preferences_result()
+
+    assert result.status == "invalid"
+    assert result.preferences is None
+    assert preferences.load_preferences() is None
+
+
+def test_config_show_explains_pre_run_configuration(monkeypatch, capsys):
+    monkeypatch.setattr(
+        m,
+        "load_preferences_result",
+        lambda: preferences.PreferenceLoadResult("missing"),
+    )
+
+    m.config_show()
+
+    output = capsys.readouterr().out
+    assert "tradingagents config set" in output
+    assert "saved after the first run" not in output
+
+
+def test_load_preferences_handles_invalid_version(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    preferences_home.mkdir()
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+    preferences_path.write_text(
+        json.dumps({"_version": "future", "llm_provider": "openai"}),
+        encoding="utf-8",
+    )
+
+    assert preferences.load_preferences() is None
+
+
+def test_load_preferences_handles_invalid_utf8(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    preferences_home.mkdir()
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+    preferences_path.write_bytes(b"\xff\xfe")
+
+    assert preferences.load_preferences() is None
+
+
+def test_partial_preferences_are_not_reusable(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    preferences_home.mkdir()
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+    preferences_path.write_text(
+        json.dumps({"_version": 1, "llm_provider": "deepseek"}),
+        encoding="utf-8",
+    )
+
+    result = preferences.load_preferences_result()
+
+    assert result.status == "invalid"
+    assert result.preferences is None
+    assert preferences.load_preferences() is None
+
+
+def test_future_preferences_are_distinguished_from_missing(monkeypatch, tmp_path):
+    preferences_home = tmp_path / "tradingagents"
+    preferences_path = preferences_home / "preferences.json"
+    preferences_home.mkdir()
+    monkeypatch.setattr(preferences, "_TRADINGAGENTS_HOME", preferences_home)
+    monkeypatch.setattr(preferences, "PREFERENCES_PATH", preferences_path)
+    original = json.dumps({"_version": 99, "llm_provider": "openai"})
+    preferences_path.write_text(original, encoding="utf-8")
+
+    result = preferences.load_preferences_result()
+
+    assert result.status == "future"
+    assert result.preferences is None
+    assert preferences_path.read_text(encoding="utf-8") == original
+
+
+def test_saved_debate_and_risk_rounds_are_restored_independently(monkeypatch):
+    prefs = {
+        "llm_provider": "openai",
+        "quick_think_llm": "gpt-5.4-mini",
+        "deep_think_llm": "gpt-5.5",
+        "output_language": "English",
+        "max_debate_rounds": 2,
+        "max_risk_discuss_rounds": 4,
+    }
+
+    selections = preferences.preferences_to_selections(prefs, defaults=m.DEFAULT_CONFIG)
+
+    assert selections["max_debate_rounds"] == 2
+    assert selections["max_risk_discuss_rounds"] == 4
+
+
+def test_runtime_config_preserves_distinct_saved_rounds(monkeypatch):
+    monkeypatch.delenv("TRADINGAGENTS_MAX_DEBATE_ROUNDS", raising=False)
+    monkeypatch.delenv("TRADINGAGENTS_MAX_RISK_ROUNDS", raising=False)
+    selections = {
+        "research_depth": 2,
+        "max_debate_rounds": 2,
+        "max_risk_discuss_rounds": 4,
+        "shallow_thinker": "gpt-5.4-mini",
+        "deep_thinker": "gpt-5.5",
+        "backend_url": "https://api.openai.com/v1",
+        "llm_provider": "openai",
+        "google_thinking_level": None,
+        "openai_reasoning_effort": "high",
+        "anthropic_effort": None,
+        "output_language": "English",
+    }
+
+    config = m._build_run_config(selections, checkpoint=None)
+
+    assert config["max_debate_rounds"] == 2
+    assert config["max_risk_discuss_rounds"] == 4
+
+
+def test_saved_preferences_are_reused_without_an_interactive_stdin(monkeypatch):
+    prefs = {
+        "llm_provider": "openai",
+        "backend_url": "https://api.openai.com/v1",
+        "quick_think_llm": "gpt-5.4-mini",
+        "deep_think_llm": "gpt-5.5",
+        "output_language": "English",
+        "max_debate_rounds": 2,
+        "max_risk_discuss_rounds": 2,
+    }
+    monkeypatch.setattr(m.sys, "stdin", io.StringIO())
+    monkeypatch.setattr(
+        m,
+        "load_preferences_result",
+        lambda: preferences.PreferenceLoadResult("valid", prefs),
+    )
+    monkeypatch.setattr(m, "display_preferences_summary", lambda _: None)
+
+    def fail_prompt():
+        raise AssertionError("unexpected interactive prompt")
+
+    monkeypatch.setattr(
+        m,
+        "prompt_use_preferences",
+        fail_prompt,
+    )
+    monkeypatch.setattr(m, "fetch_announcements", lambda: None)
+    monkeypatch.setattr(m, "display_announcements", lambda *_: None)
+    monkeypatch.setattr(m, "get_ticker", lambda: "AAPL")
+    monkeypatch.setattr(m, "get_analysis_date", lambda: "2026-08-15")
+    monkeypatch.setattr(m, "select_analysts", lambda _asset_type: [])
+    monkeypatch.setattr(m, "ensure_api_key", lambda _provider: None)
+
+    selections = m.get_user_selections()
+
+    assert selections["llm_provider"] == "openai"
+    assert selections["deep_thinker"] == "gpt-5.5"
+    assert selections["research_depth"] == 2
+
+
+def test_future_preferences_do_not_trigger_automatic_save(monkeypatch):
+    monkeypatch.setattr(m.sys, "stdin", io.StringIO())
+    monkeypatch.setattr(
+        m,
+        "load_preferences_result",
+        lambda: preferences.PreferenceLoadResult("future"),
+    )
+    monkeypatch.setattr(m, "fetch_announcements", lambda: None)
+    monkeypatch.setattr(m, "display_announcements", lambda *_: None)
+    monkeypatch.setattr(m, "get_ticker", lambda: "AAPL")
+    monkeypatch.setattr(m, "get_analysis_date", lambda: "2026-08-15")
+    monkeypatch.setattr(m, "select_analysts", lambda _asset_type: [])
+    monkeypatch.setattr(m, "ensure_api_key", lambda _provider: None)
+    monkeypatch.setenv("TRADINGAGENTS_OUTPUT_LANGUAGE", "English")
+    monkeypatch.setenv("TRADINGAGENTS_MAX_DEBATE_ROUNDS", "2")
+    monkeypatch.setenv("TRADINGAGENTS_MAX_RISK_ROUNDS", "4")
+    monkeypatch.setenv("TRADINGAGENTS_LLM_PROVIDER", "openai")
+    monkeypatch.setenv("TRADINGAGENTS_QUICK_THINK_LLM", "gpt-5.4-mini")
+    monkeypatch.setenv("TRADINGAGENTS_DEEP_THINK_LLM", "gpt-5.5")
+    monkeypatch.setenv("TRADINGAGENTS_OPENAI_REASONING_EFFORT", "high")
+
+    selections = m.get_user_selections()
+
+    assert selections["_prefs_action"] is None
+
+
+def test_first_run_does_not_prompt_to_save_in_non_tty(monkeypatch):
+    selections = _valid_preferences(
+        ticker="AAPL",
+        asset_type="stock",
+        analysis_date="2026-08-15",
+        analysts=[],
+        research_depth=1,
+        max_debate_rounds=1,
+        max_risk_discuss_rounds=1,
+        shallow_thinker="gpt-5.4-mini",
+        deep_thinker="gpt-5.5",
+        llm_provider="openai",
+        _prefs_action="first_time",
+    )
+    monkeypatch.setattr(m, "get_user_selections", lambda configure=False: selections)
+    monkeypatch.setattr(m, "_build_run_config", lambda _selections, _checkpoint: {})
+    monkeypatch.setattr(m.sys, "stdin", io.StringIO())
+
+    def fail_confirm(*_args, **_kwargs):
+        raise AssertionError("non-TTY first run prompted to save preferences")
+
+    monkeypatch.setattr(questionary, "confirm", fail_confirm)
+
+    class _StoppedBeforeGraph(Exception):
+        pass
+
+    monkeypatch.setattr(m, "StatsCallbackHandler", lambda: object())
+    monkeypatch.setattr(m, "build_analyst_execution_plan", lambda _keys: [])
+    monkeypatch.setattr(m, "AnalystWallTimeTracker", lambda _plan: object())
+    monkeypatch.setattr(
+        m,
+        "TradingAgentsGraph",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(_StoppedBeforeGraph),
+    )
+
+    with pytest.raises(_StoppedBeforeGraph):
+        m.run_analysis()
+
+
+def test_saved_preference_prompt_cancellation_stops_before_setup(monkeypatch):
+    class _TTY:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(m.sys, "stdin", _TTY())
+    monkeypatch.setattr(
+        m,
+        "load_preferences_result",
+        lambda: preferences.PreferenceLoadResult("valid", _valid_preferences()),
+    )
+    monkeypatch.setattr(m, "display_preferences_summary", lambda _: None)
+    monkeypatch.setattr(m, "prompt_use_preferences", lambda: None)
+    monkeypatch.setattr(m, "fetch_announcements", lambda: None)
+    monkeypatch.setattr(m, "display_announcements", lambda *_: None)
+
+    def fail_setup():
+        raise AssertionError("cancelled preference prompt fell through to setup")
+
+    monkeypatch.setattr(m, "get_ticker", fail_setup)
+
+    with pytest.raises(typer.Exit) as error:
+        m.get_user_selections()
+
+    assert error.value.exit_code == 1
+
+
+def test_provider_override_drops_saved_provider_dependent_values(monkeypatch):
+    prefs = {
+        "llm_provider": "openai",
+        "backend_url": "https://api.openai.com/v1",
+        "quick_think_llm": "gpt-5.4-mini",
+        "deep_think_llm": "gpt-5.5",
+        "output_language": "English",
+        "max_debate_rounds": 2,
+        "max_risk_discuss_rounds": 4,
+        "openai_reasoning_effort": "high",
+    }
+    monkeypatch.setenv("TRADINGAGENTS_LLM_PROVIDER", "google")
+    monkeypatch.delenv("TRADINGAGENTS_LLM_BACKEND_URL", raising=False)
+    monkeypatch.delenv("TRADINGAGENTS_QUICK_THINK_LLM", raising=False)
+    monkeypatch.delenv("TRADINGAGENTS_DEEP_THINK_LLM", raising=False)
+
+    selections = preferences.preferences_to_selections(prefs, defaults=m.DEFAULT_CONFIG)
+
+    assert selections["llm_provider"] == "google"
+    assert selections["backend_url"] == provider_default_url("google")
+    assert selections["shallow_thinker"] == get_model_options("google", "quick")[0][1]
+    assert selections["deep_thinker"] == get_model_options("google", "deep")[0][1]
+    assert selections["openai_reasoning_effort"] is None
+
+
+def test_provider_override_only_applies_matching_reasoning_env(monkeypatch):
+    prefs = _valid_preferences(
+        openai_reasoning_effort="high",
+        google_thinking_level="minimal",
+    )
+    defaults = dict(
+        m.DEFAULT_CONFIG,
+        google_thinking_level="minimal",
+        openai_reasoning_effort="high",
+        anthropic_effort="low",
+    )
+    monkeypatch.setenv("TRADINGAGENTS_LLM_PROVIDER", "google")
+    monkeypatch.setenv("TRADINGAGENTS_GOOGLE_THINKING_LEVEL", "minimal")
+    monkeypatch.setenv("TRADINGAGENTS_OPENAI_REASONING_EFFORT", "high")
+    monkeypatch.setenv("TRADINGAGENTS_ANTHROPIC_EFFORT", "low")
+    for env_var in (
+        "TRADINGAGENTS_LLM_BACKEND_URL",
+        "TRADINGAGENTS_QUICK_THINK_LLM",
+        "TRADINGAGENTS_DEEP_THINK_LLM",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    selections = preferences.preferences_to_selections(prefs, defaults=defaults)
+
+    assert selections["google_thinking_level"] == "minimal"
+    assert selections["openai_reasoning_effort"] is None
+    assert selections["anthropic_effort"] is None
+
+
+@pytest.mark.parametrize("provider", ["openai_compatible", "openrouter", "azure"])
+def test_custom_only_provider_requires_matching_model_override(monkeypatch, provider):
+    monkeypatch.setenv("TRADINGAGENTS_LLM_PROVIDER", provider)
+    monkeypatch.delenv("TRADINGAGENTS_QUICK_THINK_LLM", raising=False)
+    monkeypatch.delenv("TRADINGAGENTS_DEEP_THINK_LLM", raising=False)
+
+    with pytest.raises(ValueError, match="TRADINGAGENTS_QUICK_THINK_LLM"):
+        preferences.preferences_to_selections(_valid_preferences())
+
+
+def test_custom_only_provider_error_is_actionable_in_cli(monkeypatch, capsys):
+    monkeypatch.setattr(m.sys, "stdin", io.StringIO())
+    monkeypatch.setenv("TRADINGAGENTS_LLM_PROVIDER", "openai_compatible")
+    monkeypatch.delenv("TRADINGAGENTS_QUICK_THINK_LLM", raising=False)
+    monkeypatch.delenv("TRADINGAGENTS_DEEP_THINK_LLM", raising=False)
+    monkeypatch.setattr(
+        m,
+        "load_preferences_result",
+        lambda: preferences.PreferenceLoadResult("valid", _valid_preferences()),
+    )
+    monkeypatch.setattr(m, "display_preferences_summary", lambda _: None)
+    monkeypatch.setattr(m, "fetch_announcements", lambda: None)
+    monkeypatch.setattr(m, "display_announcements", lambda *_: None)
+
+    with pytest.raises(typer.Exit) as error:
+        m.get_user_selections()
+
+    assert error.value.exit_code == 1
+    assert "TRADINGAGENTS_QUICK_THINK_LLM" in capsys.readouterr().out

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -43,8 +43,8 @@ class ModelValidationTests(unittest.TestCase):
         self.assertIn("not-a-real-openai-model", str(caught[0].message))
         self.assertIn("openai", str(caught[0].message))
 
-    def test_openrouter_and_ollama_accept_custom_models_without_warning(self):
-        for provider in ("openrouter", "ollama"):
+    def test_dynamic_providers_accept_custom_models_without_warning(self):
+        for provider in ("openrouter", "ollama", "azure"):
             client = DummyLLMClient(provider, "custom-model-name")
 
             with self.subTest(provider=provider):

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -153,7 +153,11 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # so the two provider keys share one model list.
     "minimax": _MINIMAX_MODELS,
     "minimax-cn": _MINIMAX_MODELS,
-    # OpenRouter: fetched dynamically. Azure: any deployed model name.
+    # OpenRouter: fetched dynamically. Azure: any deployed model name. Both
+    # still register a custom-only sentinel so shared preference validation can
+    # recognize them as supported providers without inventing stale model IDs.
+    "openrouter": _CUSTOM_ONLY,
+    "azure": _CUSTOM_ONLY,
     # Ollama display labels intentionally omit a "local" marker — the
     # endpoint is now configurable via OLLAMA_BASE_URL, so the same labels
     # apply whether the user runs ollama-serve on localhost or against a

--- a/tradingagents/llm_clients/validators.py
+++ b/tradingagents/llm_clients/validators.py
@@ -7,7 +7,7 @@ from .model_catalog import get_known_models
 # accepted without warning.
 _ANY_MODEL_PROVIDERS = (
     "ollama", "openrouter", "openai_compatible",
-    "mistral", "kimi", "groq", "nvidia", "bedrock",
+    "mistral", "kimi", "groq", "nvidia", "bedrock", "azure",
 )
 
 VALID_MODELS = {
@@ -20,7 +20,7 @@ VALID_MODELS = {
 def validate_model(provider: str, model: str) -> bool:
     """Check if model name is valid for the given provider.
 
-    For ollama, openrouter, and openai_compatible - any model is accepted.
+    For user-defined deployment providers, any model name is accepted.
     """
     provider_lower = provider.lower()
 


### PR DESCRIPTION
## Summary

- Save CLI preferences so the same setup choices do not have to be entered every time.
- Add `config show`, `config set`, and `config reset` commands.
- Let users reuse saved preferences, run a one-off setup, or reconfigure them.
- Handle incomplete, invalid, or newer preference files safely.
- Preserve the existing Windows no-console behavior.
- Add tests and update the README and changelog.

## Motivation

I found it frustrating to sit through the same setup questions and select the same settings every time I ran the CLI. This change saves those choices so the setup only needs to be done once, while still allowing users to change them or run the setup again when needed.

## What it looks like
<img width="1728" height="1051" alt="image" src="https://github.com/user-attachments/assets/c6955a3c-c647-41bd-a2ed-cc56bd484510" />
