### PR TITLE
fix(dataflows): keep API keys out of vendor error messages

### DIFF
--- a/tests/test_alpha_vantage_hardening.py
+++ b/tests/test_alpha_vantage_hardening.py
@@ -11,6 +11,7 @@ import pytest
 
 import tradingagents.dataflows.alpha_vantage_common as av
 import tradingagents.dataflows.alpha_vantage_fundamentals as avf
+from tradingagents.dataflows import http_utils
 
 
 class _FakeResponse:
@@ -32,7 +33,7 @@ def _patched_get(body, capture=None):
 @pytest.mark.unit
 def test_request_passes_timeout(monkeypatch):
     captured = {}
-    monkeypatch.setattr(av.requests, "get", _patched_get("Date,Close\n2025-01-02,1.0", captured))
+    monkeypatch.setattr(http_utils.requests, "get", _patched_get("Date,Close\n2025-01-02,1.0", captured))
     av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
     assert captured.get("timeout") == av.REQUEST_TIMEOUT  # #990
 
@@ -40,7 +41,7 @@ def test_request_passes_timeout(monkeypatch):
 @pytest.mark.unit
 def test_rate_limit_detected(monkeypatch):
     body = '{"Information": "Our standard API rate limit is 25 requests per day. ... your API key ..."}'
-    monkeypatch.setattr(av.requests, "get", _patched_get(body))
+    monkeypatch.setattr(http_utils.requests, "get", _patched_get(body))
     with pytest.raises(av.AlphaVantageRateLimitError):
         av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
 
@@ -51,11 +52,11 @@ def test_invalid_key_not_mislabeled_as_rate_limit(monkeypatch):
     # (transient) rate limit, but surface as a real configuration error (#991).
     body = ('{"Information": "the parameter apikey is invalid or missing. '
             'Please claim your free API key on (https://www.alphavantage.co/support/#api-key)."}')
-    monkeypatch.setattr(av.requests, "get", _patched_get(body))
+    monkeypatch.setattr(http_utils.requests, "get", _patched_get(body))
     with pytest.raises(av.AlphaVantageNotConfiguredError):
         av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
     with pytest.raises(av.AlphaVantageRateLimitError):  # sanity: rate-limit path still distinct
-        monkeypatch.setattr(av.requests, "get", _patched_get('{"Note": "API call frequency is 5 calls per minute."}'))
+        monkeypatch.setattr(http_utils.requests, "get", _patched_get('{"Note": "API call frequency is 5 calls per minute."}'))
         av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
 
 

--- a/tests/test_secret_redaction.py
+++ b/tests/test_secret_redaction.py
@@ -1,0 +1,179 @@
+"""API keys must never reach an error message.
+
+FRED and Alpha Vantage authenticate with a query parameter, so any ``requests``
+exception stringifies to include the full URL — key and all. Those strings are
+logged, returned to the model as the ``DATA_UNAVAILABLE:`` sentinel for optional
+categories, and handed to the LLM verbatim by the indicators tool, from where
+they land in ``message_tool.log`` and the saved markdown report.
+"""
+import logging
+
+import pytest
+import requests
+
+import tradingagents.dataflows.alpha_vantage_common as av
+import tradingagents.dataflows.fred as fred
+from tradingagents.dataflows import http_utils
+from tradingagents.dataflows.http_utils import raise_for_status, redact_secrets
+
+SECRET = "abcdef0123456789abcdef0123456789"
+
+
+def _response(status_code, url, body=b"boom"):
+    response = requests.Response()
+    response.status_code = status_code
+    response.reason = "Internal Server Error"
+    response.url = url
+    response._content = body
+    return response
+
+
+@pytest.mark.unit
+def test_redact_secrets_masks_key_and_keeps_other_params():
+    url = f"https://api.stlouisfed.org/fred/series?series_id=CPIAUCSL&api_key={SECRET}&file_type=json"
+    redacted = redact_secrets(f"500 Server Error: for url: {url}")
+    assert SECRET not in redacted
+    assert "series_id=CPIAUCSL" in redacted
+    assert "file_type=json" in redacted
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("param", ["api_key", "apikey", "token", "access_token"])
+def test_redact_secrets_covers_common_key_param_names(param):
+    assert SECRET not in redact_secrets(f"https://x.test/q?{param}={SECRET}&a=1")
+
+
+@pytest.mark.unit
+def test_raise_for_status_redacts_the_url():
+    response = _response(500, f"https://x.test/q?apikey={SECRET}")
+    with pytest.raises(requests.HTTPError) as excinfo:
+        raise_for_status(response)
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_raise_for_status_does_not_chain_the_unredacted_original():
+    # A chained __cause__/__context__ would print the raw URL in any traceback.
+    response = _response(500, f"https://x.test/q?apikey={SECRET}")
+    with pytest.raises(requests.HTTPError) as excinfo:
+        raise_for_status(response)
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+@pytest.mark.unit
+def test_fred_http_error_does_not_leak_the_key(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", SECRET)
+    url = f"{fred.FRED_API_BASE}/series?series_id=CPIAUCSL&api_key={SECRET}&file_type=json"
+    monkeypatch.setattr(http_utils.requests, "get", lambda *a, **kw: _response(500, url))
+    with pytest.raises(requests.RequestException) as excinfo:
+        fred._request("series", {"series_id": "CPIAUCSL"})
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_fred_connection_error_does_not_leak_the_key(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", SECRET)
+
+    def boom(*a, **kw):
+        raise requests.ConnectionError(
+            f"HTTPSConnectionPool(host='api.stlouisfed.org', port=443): Max retries "
+            f"exceeded with url: /fred/series?series_id=CPIAUCSL&api_key={SECRET}"
+        )
+
+    monkeypatch.setattr(http_utils.requests, "get", boom)
+    with pytest.raises(requests.RequestException) as excinfo:
+        fred._request("series", {"series_id": "CPIAUCSL"})
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_fred_400_body_path_still_reports_fred_message(monkeypatch):
+    monkeypatch.setenv("FRED_API_KEY", SECRET)
+    url = f"{fred.FRED_API_BASE}/series?series_id=NOPE&api_key={SECRET}&file_type=json"
+    body = b'{"error_message": "Bad Request. The series does not exist."}'
+    monkeypatch.setattr(http_utils.requests, "get", lambda *a, **kw: _response(400, url, body))
+    with pytest.raises(ValueError) as excinfo:
+        fred._request("series", {"series_id": "NOPE"})
+    assert "does not exist" in str(excinfo.value)
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_alpha_vantage_http_error_does_not_leak_the_key(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", SECRET)
+    url = f"{av.API_BASE_URL}?function=TIME_SERIES_DAILY&symbol=AAPL&apikey={SECRET}"
+    monkeypatch.setattr(http_utils.requests, "get", lambda *a, **kw: _response(500, url))
+    with pytest.raises(requests.RequestException) as excinfo:
+        av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_alpha_vantage_connection_error_does_not_leak_the_key(monkeypatch):
+    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", SECRET)
+
+    def boom(*a, **kw):
+        raise requests.Timeout(
+            f"HTTPSConnectionPool(host='www.alphavantage.co', port=443): Read timed "
+            f"out. url: /query?function=TIME_SERIES_DAILY&apikey={SECRET}"
+        )
+
+    monkeypatch.setattr(http_utils.requests, "get", boom)
+    with pytest.raises(requests.RequestException) as excinfo:
+        av._make_api_request("TIME_SERIES_DAILY", {"symbol": "AAPL"})
+    assert SECRET not in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_indicators_tool_redacts_a_vendor_error(monkeypatch):
+    """Backstop: the tool hands this string to the LLM verbatim."""
+    from tradingagents.agents.utils import technical_indicators_tools as tools
+
+    def boom(*a, **kw):
+        raise ValueError(f"boom for url: https://x.test/query?function=RSI&apikey={SECRET}")
+
+    monkeypatch.setattr(tools, "route_to_vendor", boom)
+    result = tools.get_indicators.invoke(
+        {"symbol": "AAPL", "indicator": "rsi", "curr_date": "2025-01-02"}
+    )
+    assert SECRET not in result
+
+
+@pytest.mark.unit
+def test_optional_category_sentinel_redacts_a_raw_vendor_error(monkeypatch, caplog):
+    """Backstop for a vendor that raises without going through http_utils."""
+    from tradingagents.dataflows import interface
+    from tradingagents.dataflows.config import set_config
+
+    def boom(*a, **kw):
+        raise RuntimeError(f"boom for url: https://x.test/fred?api_key={SECRET}")
+
+    monkeypatch.setitem(interface.VENDOR_METHODS["get_macro_indicators"], "fred", boom)
+    set_config({"data_vendors": {"macro_data": "fred"}})
+
+    with caplog.at_level(logging.WARNING):
+        result = interface.route_to_vendor("get_macro_indicators", "cpi", "2025-01-02")
+
+    assert result.startswith("DATA_UNAVAILABLE:")
+    assert SECRET not in result
+    assert SECRET not in caplog.text
+
+
+@pytest.mark.unit
+def test_optional_category_sentinel_carries_no_key(monkeypatch, caplog):
+    """The macro_data degradation path returns the error text to the model."""
+    from tradingagents.dataflows import interface
+    from tradingagents.dataflows.config import set_config
+
+    monkeypatch.setenv("FRED_API_KEY", SECRET)
+    url = f"{fred.FRED_API_BASE}/series?series_id=CPIAUCSL&api_key={SECRET}&file_type=json"
+    monkeypatch.setattr(http_utils.requests, "get", lambda *a, **kw: _response(500, url))
+    set_config({"data_vendors": {"macro_data": "fred"}})
+
+    with caplog.at_level(logging.WARNING):
+        result = interface.route_to_vendor("get_macro_indicators", "cpi", "2025-01-02")
+
+    assert result.startswith("DATA_UNAVAILABLE:")
+    assert SECRET not in result
+    assert SECRET not in caplog.text

--- a/tradingagents/agents/utils/technical_indicators_tools.py
+++ b/tradingagents/agents/utils/technical_indicators_tools.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from langchain_core.tools import tool
 
+from tradingagents.dataflows.http_utils import redact_secrets
 from tradingagents.dataflows.interface import route_to_vendor
 
 
@@ -31,5 +32,8 @@ def get_indicators(
         try:
             results.append(route_to_vendor("get_indicators", symbol, ind, curr_date, look_back_days))
         except ValueError as e:
-            results.append(str(e))
+            # This string goes straight into the model's context and the saved
+            # report; redact as a backstop in case a vendor error still carries
+            # a credential-bearing URL.
+            results.append(redact_secrets(str(e)))
     return "\n\n".join(results)

--- a/tradingagents/dataflows/alpha_vantage_common.py
+++ b/tradingagents/dataflows/alpha_vantage_common.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from io import StringIO
 
 import pandas as pd
-import requests
 
 from .errors import VendorNotConfiguredError, VendorRateLimitError
+from .http_utils import raise_for_status, request_get
 
 API_BASE_URL = "https://www.alphavantage.co/query"
 
@@ -83,8 +83,11 @@ def _make_api_request(function_name: str, params: dict) -> dict | str:
         # Remove entitlement if it's None or empty
         api_params.pop("entitlement", None)
 
-    response = requests.get(API_BASE_URL, params=api_params, timeout=REQUEST_TIMEOUT)
-    response.raise_for_status()
+    # The key travels as a query parameter, so a raw requests error would carry
+    # it into the logs, the model's context, and the saved report; these helpers
+    # redact the URL before re-raising.
+    response = request_get(API_BASE_URL, params=api_params, timeout=REQUEST_TIMEOUT)
+    raise_for_status(response)
 
     response_text = response.text
 

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -12,9 +12,8 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-import requests
-
 from .errors import VendorNotConfiguredError
+from .http_utils import raise_for_status, request_get
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +117,10 @@ def _resolve_series_id(indicator: str) -> str:
 def _request(path: str, params: dict) -> dict:
     """GET a FRED endpoint, surfacing FRED's JSON error body on a bad request."""
     api_params = {**params, "api_key": get_api_key(), "file_type": "json"}
-    response = requests.get(
+    # FRED only accepts the key as a query parameter, so every requests error
+    # would stringify with the key in it — and those strings reach the model and
+    # the saved report. request_get/raise_for_status redact before re-raising.
+    response = request_get(
         f"{FRED_API_BASE}/{path}", params=api_params, timeout=REQUEST_TIMEOUT
     )
     # FRED returns 400 with a JSON {"error_message": ...} for unknown series IDs
@@ -129,7 +131,7 @@ def _request(path: str, params: dict) -> dict:
         except ValueError:
             message = response.text
         raise ValueError(f"FRED request failed: {message}")
-    response.raise_for_status()
+    raise_for_status(response)
     return response.json()
 
 

--- a/tradingagents/dataflows/http_utils.py
+++ b/tradingagents/dataflows/http_utils.py
@@ -1,0 +1,86 @@
+"""HTTP helpers that keep API keys out of error messages.
+
+FRED and Alpha Vantage both authenticate with a query parameter, so every
+``requests`` exception they raise stringifies to include the full request URL —
+key and all. Those strings do not stay in the process: they are logged, returned
+to the model as the ``DATA_UNAVAILABLE:`` sentinel for optional categories
+(``macro_data`` is FRED), and passed straight to the LLM by the indicators tool,
+which puts them in ``message_tool.log`` and the saved markdown report.
+
+Neither vendor accepts the key in a header, so the fix is at the boundary:
+route requests through :func:`request_get` and status checks through
+:func:`raise_for_status`, both of which re-raise with the secret masked.
+"""
+from __future__ import annotations
+
+import re
+
+import requests
+
+# Query parameters whose value is a credential. Matched case-insensitively, so
+# ``apiKey`` and ``API_KEY`` are covered too.
+SENSITIVE_QUERY_PARAMS = (
+    "api_key",
+    "apikey",
+    "access_token",
+    "auth_token",
+    "token",
+    "secret",
+    "password",
+    "signature",
+    "key",
+)
+
+REDACTED = "***REDACTED***"
+
+# Match ``?param=value`` / ``&param=value`` anywhere in free text, not just in a
+# parsable URL: the leaks come from exception messages, where the URL is already
+# embedded in prose ("... for url: https://...").
+_SENSITIVE_RE = re.compile(
+    r"(?i)([?&](?:" + "|".join(SENSITIVE_QUERY_PARAMS) + r")=)([^&\s\"'>]*)"
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Mask credential-bearing query parameter values in ``text``."""
+    return _SENSITIVE_RE.sub(lambda m: m.group(1) + REDACTED, text)
+
+
+def _redacted_copy(exc: Exception) -> Exception:
+    """Rebuild ``exc`` with its message redacted, preserving the type."""
+    message = redact_secrets(str(exc))
+    try:
+        return type(exc)(
+            message,
+            response=getattr(exc, "response", None),
+            request=getattr(exc, "request", None),
+        )
+    except TypeError:
+        # A subclass with a different signature; the type matters less than
+        # never re-raising the unredacted message.
+        return requests.RequestException(message)
+
+
+def raise_for_status(response: requests.Response) -> None:
+    """``response.raise_for_status()`` with the URL's secrets masked.
+
+    Raised ``from None``: chaining would keep the original, unredacted message
+    reachable via ``__cause__`` and print it in any traceback.
+    """
+    try:
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise _redacted_copy(exc) from None
+
+
+def request_get(url: str, **kwargs) -> requests.Response:
+    """``requests.get`` with secrets masked in any transport-level failure.
+
+    Connection, timeout and SSL errors embed the full URL in their message just
+    as HTTP errors do, so the call itself needs wrapping — not only the status
+    check.
+    """
+    try:
+        return requests.get(url, **kwargs)
+    except requests.RequestException as exc:
+        raise _redacted_copy(exc) from None

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -18,6 +18,7 @@ from .errors import (
     VendorRateLimitError,
 )
 from .fred import get_macro_data as get_fred_macro_data
+from .http_utils import redact_secrets
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
@@ -215,7 +216,7 @@ def route_to_vendor(method: str, *args, **kwargs):
             # Don't let one vendor's failure crash the call when another can
             # serve it, but never swallow silently: a broken primary must be
             # visible in the logs (#989), not hidden behind a fallback's verdict.
-            logger.warning("Vendor %r failed for %s: %s", vendor, method, e)
+            logger.warning("Vendor %r failed for %s: %s", vendor, method, redact_secrets(str(e)))
             if first_error is None:
                 first_error = e
             continue
@@ -230,7 +231,7 @@ def route_to_vendor(method: str, *args, **kwargs):
             # verdict can't hide a broken primary (network/auth/etc.).
             logger.warning(
                 "Returning NO_DATA for %s, but a vendor errored earlier: %s",
-                method, first_error,
+                method, redact_secrets(str(first_error)),
             )
         sym = last_no_data.symbol
         canonical = last_no_data.canonical
@@ -252,10 +253,17 @@ def route_to_vendor(method: str, *args, **kwargs):
     # abort the run.
     if first_error is not None:
         if category in OPTIONAL_CATEGORIES:
-            logger.warning("Optional %s unavailable for %s: %s", category, method, first_error)
+            logger.warning(
+                "Optional %s unavailable for %s: %s",
+                category, method, redact_secrets(str(first_error)),
+            )
+            # The error text is returned to the model and saved into the report,
+            # so redact as a backstop against a vendor error that still embeds a
+            # credential-bearing URL.
             return (
                 f"DATA_UNAVAILABLE: optional {category} could not be retrieved "
-                f"({first_error}). Proceed without it; do not fabricate values."
+                f"({redact_secrets(str(first_error))}). Proceed without it; "
+                f"do not fabricate values."
             )
         raise first_error
 


### PR DESCRIPTION
FRED and Alpha Vantage authenticate with a query parameter, so any requests exception stringified to include the full URL — key and all. Those strings reach a logger, the DATA_UNAVAILABLE: sentinel returned to the model for optional categories, and the indicators tool's str(e), from where they land in message_tool.log and the saved report.

Neither vendor accepts the key in a header, so redact at the boundary: http_utils.request_get / raise_for_status re-raise the same exception type with credential query params masked, `from None` so the original message is not reachable via __cause__. Wrapping the get() call matters too — connection and timeout errors embed the URL just as HTTP errors do. FRED's existing 400/JSON-body path is unchanged.

The three sinks also redact as a backstop, so a vendor that raises outside http_utils cannot reopen the hole.