### PR TITLE
feat(dataflows): add native Binance vendor for crypto OHLCV data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ MISTRAL_API_KEY=
 MOONSHOT_API_KEY=
 GROQ_API_KEY=
 NVIDIA_API_KEY=
+# Optional: override Binance API base URL. Needed if you're in a region
+# where api.binance.com is restricted (e.g. the US) — use
+# https://api.us.binance.com/api/v3/klines instead. Leave unset to use
+# the default global endpoint.
+#BINANCE_BASE_URL=
 
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=

--- a/tests/test_binance_vendor.py
+++ b/tests/test_binance_vendor.py
@@ -1,0 +1,108 @@
+"""Binance vendor: native OHLCV data for crypto assets.
+
+Covers symbol resolution, date-boundary inclusivity (#binance-pagination),
+pagination past the 1000-candle-per-request cap, and the
+NoMarketDataError contract for unrecognized symbols / empty responses.
+"""
+import pytest
+
+import tradingagents.dataflows.binance as binance
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def _kline_row(date_str, price=50000.0, volume=100.0):
+    """Build one Binance-shaped kline row for a given date."""
+    import pandas as pd
+    open_ms = int(pd.Timestamp(date_str, tz="UTC").timestamp() * 1000)
+    return [
+        open_ms, str(price), str(price + 10), str(price - 10), str(price + 5),
+        str(volume), open_ms + 86399999, "0", 1, "0", "0", "0",
+    ]
+
+
+@pytest.mark.unit
+def test_unrecognized_symbol_raises_no_market_data_error():
+    with pytest.raises(binance.NoMarketDataError):
+        binance.get_binance_stock("NOTACOIN-USD", "2026-06-01", "2026-06-10")
+
+
+@pytest.mark.unit
+def test_empty_response_raises_no_market_data_error(monkeypatch):
+    monkeypatch.setattr(
+        binance.requests, "get",
+        lambda *a, **k: _FakeResponse([]),
+    )
+    with pytest.raises(binance.NoMarketDataError):
+        binance.get_binance_stock("BTC-USD", "2026-06-01", "2026-06-10")
+
+
+@pytest.mark.unit
+def test_normal_path_returns_expected_format(monkeypatch):
+    rows = [_kline_row(d) for d in
+            ["2026-06-01", "2026-06-02", "2026-06-03"]]
+    monkeypatch.setattr(
+        binance.requests, "get",
+        lambda *a, **k: _FakeResponse(rows),
+    )
+    result = binance.get_binance_stock("BTC-USD", "2026-06-01", "2026-06-03")
+    assert "Total records: 3" in result
+    assert "2026-06-03" in result  # end_date must be included
+    assert "BTCUSDT" in result
+
+
+@pytest.mark.unit
+def test_end_date_inclusive_even_at_batch_boundary(monkeypatch):
+    # Simulate Binance returning one extra day past end_date (the buffered
+    # request); the vendor must locally filter it out.
+    rows = [_kline_row(d) for d in
+            ["2026-06-01", "2026-06-02", "2026-06-03"]]  # 06-03 is the buffer day
+    monkeypatch.setattr(
+        binance.requests, "get",
+        lambda *a, **k: _FakeResponse(rows),
+    )
+    result = binance.get_binance_stock("BTC-USD", "2026-06-01", "2026-06-02")
+    assert "Total records: 2" in result
+    assert "2026-06-03" not in result  # buffer day must be filtered out
+
+
+@pytest.mark.unit
+def test_pagination_stops_when_batch_smaller_than_limit(monkeypatch):
+    calls = []
+
+    def fake_get(url, params=None, **kwargs):
+        calls.append(params)
+        # First call: full page (simulated as MAX_LIMIT rows) triggers a
+        # second call; second call returns fewer rows, ending pagination.
+        if len(calls) == 1:
+            return _FakeResponse(
+                [_kline_row(f"2020-01-{d:02d}") for d in range(1, 32)]
+                * (binance._MAX_LIMIT // 31 + 1)
+            )
+        return _FakeResponse([_kline_row("2026-06-01")])
+
+    monkeypatch.setattr(binance.requests, "get", fake_get)
+    binance.get_binance_stock("BTC-USD", "2020-01-01", "2026-06-01")
+    assert len(calls) == 2  # confirms pagination actually looped
+
+
+@pytest.mark.unit
+def test_symbol_resolution_uses_usdt_pair(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, **kwargs):
+        captured.update(params)
+        return _FakeResponse([_kline_row("2026-06-01")])
+
+    monkeypatch.setattr(binance.requests, "get", fake_get)
+    binance.get_binance_stock("BTC-USD", "2026-06-01", "2026-06-01")
+    assert captured["symbol"] == "BTCUSDT"

--- a/tradingagents/dataflows/binance.py
+++ b/tradingagents/dataflows/binance.py
@@ -1,0 +1,130 @@
+"""Binance vendor: native OHLCV market data for crypto assets.
+
+Binance's public klines endpoint requires no API key. Symbol resolution
+mirrors symbol_utils.crypto_base(): a user-facing symbol like BTC-USD or
+BTCUSD resolves to Binance's USDT-quoted pair (BTCUSDT), matching the
+project's existing "-USD -> USDT" convention for exchanges that don't
+quote directly against fiat.
+
+Unlike yfinance (which returns full daily history in a single call with
+no row cap), Binance's REST klines endpoint caps each request at 1000
+candles (~2.7 years of daily bars). Requests spanning more than 1000 days
+are paginated: each batch's last candle timestamp seeds the next batch's
+startTime, until the requested range is fully covered.
+"""
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import requests
+
+from .errors import NoMarketDataError
+from .symbol_utils import crypto_base
+
+_BASE_URL = "https://api.binance.com/api/v3/klines"
+_MAX_LIMIT = 1000  # Binance hard cap per request
+
+
+def _to_binance_symbol(symbol: str) -> str | None:
+    """Resolve a user symbol (BTC-USD, BTCUSD, BTC-USDT...) to Binance's
+    pair format (BTCUSDT). Returns None if not a recognized crypto symbol.
+    """
+    base = crypto_base(symbol)
+    return f"{base}USDT" if base else None
+
+
+def _fetch_klines_paginated(binance_symbol: str, start_ms: int, end_ms: int) -> list:
+    """Fetch all klines between start_ms and end_ms, paginating past
+    Binance's 1000-candle-per-request cap. Each batch's last candle
+    timestamp seeds the next batch's startTime (+1ms to avoid re-fetching
+    the same candle twice).
+    """
+    all_rows: list = []
+    current_start = start_ms
+
+    while current_start < end_ms:
+        params = {
+            "symbol": binance_symbol,
+            "interval": "1d",
+            "startTime": current_start,
+            "endTime": end_ms,
+            "limit": _MAX_LIMIT,
+        }
+        resp = requests.get(_BASE_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        batch = resp.json()
+
+        if not batch:
+            break  # No more data in range.
+
+        all_rows.extend(batch)
+
+        last_open_time = batch[-1][0]  # First column: kline open time (ms)
+        current_start = last_open_time + 1  # Advance past the last candle.
+
+        # Fewer rows than the cap means we've reached the end of available data.
+        if len(batch) < _MAX_LIMIT:
+            break
+
+    return all_rows
+
+
+def get_binance_stock(
+    symbol: str,
+    start_date: str,
+    end_date: str,
+):
+    """Fetch daily OHLCV from Binance's public klines endpoint.
+
+    Mirrors get_YFin_data_online's contract: same params, same header +
+    CSV-string return shape, same NoMarketDataError-on-empty behavior.
+    """
+    binance_symbol = _to_binance_symbol(symbol)
+    if binance_symbol is None:
+        raise NoMarketDataError(
+            symbol, symbol, "not a recognized crypto symbol for Binance"
+        )
+
+    start_dt = datetime.strptime(start_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    end_dt = datetime.strptime(end_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    start_ms = int(start_dt.timestamp() * 1000)
+    # Request one extra day past end_date, then filter locally — this
+    # guarantees end_date is included regardless of whether Binance's
+    # endTime boundary is inclusive or exclusive (unverified either way;
+    # local filtering makes the boundary semantics irrelevant).
+    end_ms_buffered = int((end_dt.timestamp() + 86400) * 1000)
+
+    raw = _fetch_klines_paginated(binance_symbol, start_ms, end_ms_buffered)
+
+    if not raw:
+        raise NoMarketDataError(
+            symbol, binance_symbol, f"no rows between {start_date} and {end_date}"
+        )
+
+    data = pd.DataFrame(raw, columns=[
+        "Open Time", "Open", "High", "Low", "Close", "Volume",
+        "Close Time", "Quote Asset Volume", "Number of Trades",
+        "Taker Buy Base", "Taker Buy Quote", "Unused",
+    ])
+    data["Date"] = pd.to_datetime(data["Open Time"], unit="ms")
+    data = data.set_index("Date")[["Open", "High", "Low", "Close", "Volume"]]
+    data = data.astype(float)
+    data[["Open", "High", "Low", "Close"]] = data[["Open", "High", "Low", "Close"]].round(2)
+
+    # Local filter: drop anything past end_date, regardless of what
+    # Binance's boundary actually returned, and drop duplicate rows that
+    # can arise at pagination batch boundaries.
+    data = data[~data.index.duplicated(keep="first")]
+    data = data[data.index.date <= end_dt.date()]
+
+    if data.empty:
+        raise NoMarketDataError(
+            symbol, binance_symbol, f"no rows between {start_date} and {end_date}"
+        )
+
+    csv_string = data.to_csv()
+    header = f"# Stock data for {binance_symbol} (from {symbol}) from {start_date} to {end_date}\n"
+    header += f"# Total records: {len(data)}\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+
+    return header + csv_string

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -11,6 +11,7 @@ from .alpha_vantage import (
     get_news as get_alpha_vantage_news,
     get_stock as get_alpha_vantage_stock,
 )
+from .binance import get_binance_stock
 from .config import get_config
 from .errors import (
     NoMarketDataError,
@@ -28,6 +29,7 @@ from .y_finance import (
     get_stock_stats_indicators_window,
     get_YFin_data_online,
 )
+from .binance import get_binance_stock
 from .yfinance_news import get_global_news_yfinance, get_news_yfinance
 
 logger = logging.getLogger(__name__)
@@ -82,6 +84,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "binance",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -97,6 +100,7 @@ VENDOR_METHODS = {
     "get_stock_data": {
         "alpha_vantage": get_alpha_vantage_stock,
         "yfinance": get_YFin_data_online,
+        "binance": get_binance_stock,
     },
     # technical_indicators
     "get_indicators": {

--- a/tradingagents/dataflows/symbol_utils.py
+++ b/tradingagents/dataflows/symbol_utils.py
@@ -41,9 +41,20 @@ _FOREX_CURRENCIES = frozenset(
     }
 )
 
-# Crypto bases that brokers quote against USD without a separator.
+# Crypto bases recognized across vendors (yfinance, binance). Sourced from
+# CoinMarketCap's CMC20 index constituents (top 20 by market cap, excluding
+# stablecoins and wrapped/pegged tokens), cross-checked against Binance's
+# exchangeInfo endpoint for actual USDT pair availability as of 2026-08-19.
+# 2 of the 20 CMC20 constituents (HYPE, CC) have no corresponding Binance
+# USDT pair and are excluded. DOT (previously supported) has fallen out of
+# the CMC20 top 20 and is removed.
+# https://coinmarketcap.com/charts/cmc20/
 _CRYPTO_BASES = frozenset(
-    {"BTC", "ETH", "SOL", "XRP", "ADA", "DOGE", "LTC", "BCH", "DOT", "AVAX", "LINK"}
+    {
+        "BTC", "ETH", "BNB", "XRP", "SOL", "TRX", "DOGE", "ZEC",
+        "LINK", "ADA", "XLM", "BCH", "TON", "LTC", "HBAR", "AVAX",
+        "SUI", "SHIB",
+    }
 )
 
 # Explicit aliases for instruments whose broker symbol does not map to a


### PR DESCRIPTION
## Problem

Crypto market data currently only resolves through yfinance's BTC-USD
-style pairs via symbol_utils.crypto_base(), which routes through Yahoo
Finance rather than querying an exchange natively. This has two concrete
costs: yfinance is an unofficial, non-authenticated library subject to
rate limiting (observed directly during this PR's testing — see Testing
section), and the crypto whitelist (_CRYPTO_BASES) was a manually curated
11-coin list with no documented selection criteria.

See #974 and #1056, which independently point at gaps in this area.

## Solution

Adds a `binance` vendor for the `core_stock_apis` category (OHLCV data
only — no indicators/fundamentals/news, since those don't map cleanly to
crypto), following the existing vendor registration pattern (VENDOR_LIST
+ VENDOR_METHODS in interface.py). Symbol resolution reuses
symbol_utils.crypto_base(), converting to Binance's USDT-quoted pairs
(e.g. BTC-USD -> BTCUSDT).

Also refreshes the shared _CRYPTO_BASES whitelist from 11 hand-picked
coins to the current CMC20 index constituents (CoinMarketCap's top-20-
by-market-cap index, excluding stablecoins and wrapped tokens), cross-
checked against Binance's exchangeInfo endpoint for actual USDT pair
availability. 2 of the 20 CMC20 constituents (HYPE, CC) have no Binance
USDT pair and are excluded; DOT, previously in the 11-coin list, has
fallen out of the CMC20 top 20 and is removed. This whitelist is a
static list, refreshed manually — matching the existing maintenance
pattern for this file, not auto-synced from any external index API.

Handles two Binance-specific technical differences from the yfinance
path:
- Binance's klines endpoint caps each request at 1000 candles (~2.7
  years of daily bars), unlike yfinance which returns full daily
  history in one call. Implemented pagination: each batch's last
  candle timestamp seeds the next batch's startTime.
- Binance restricts access from some regions (including the US) on
  api.binance.com, returning HTTP 451. Added a BINANCE_BASE_URL env
  var (documented in .env.example) so affected users can point to
  api.us.binance.com instead of relying on unreliable IP-based
  auto-detection.

Not in scope: dynamically syncing the whitelist from CMC's API,
automatic crypto-vs-equity vendor routing at the config layer (both
considered and deliberately deferred — see PR discussion).

## Changes

- New: `tradingagents/dataflows/binance.py`
- New: `tests/test_binance_vendor.py`
- Modified: `tradingagents/dataflows/interface.py` (vendor registration)
- Modified: `tradingagents/dataflows/symbol_utils.py` (whitelist refresh)
- Modified: `.env.example` (BINANCE_BASE_URL documentation)

## Testing

Manual testing (real Binance API calls):
- Short-range query (10 days, BTC): correct record count, correct
  end-date inclusivity
- Long-range query (2020-01-01 to 2026-06-10, 2353 days, exceeding the
  1000-candle pagination threshold): record count matched exact
  calendar-day math, no gaps or duplicates
- Low-decimal-precision coin (DOGE): price rounding and large-volume
  formatting correct
- Unsupported symbol (SHIB before whitelist update): correctly raised
  NoMarketDataError instead of returning empty/fabricated data
- Whitelist expansion: verified all 18 final symbols against Binance's
  live exchangeInfo endpoint (not assumed from CMC20 alone)
- Regression: re-ran the original BTC test after the whitelist change
  to confirm no breakage to the existing symbol resolution path

Automated tests (tests/test_binance_vendor.py, 6 cases, all passing):
unrecognized symbol, empty API response, normal path format, end-date
inclusivity at pagination boundaries, pagination loop termination,
correct symbol-to-USDT-pair resolution. Network calls are mocked
(monkeypatch on requests.get), following the existing pattern in
test_alpha_vantage_hardening.py.

Routing integration: verified via route_to_vendor() with
core_stock_apis configured to "binance" and to "binance,yfinance" —
confirmed crypto symbols route to Binance, non-crypto symbols correctly
fall through to yfinance.

Known limitation: get_verified_market_snapshot, a separate
hallucination-prevention tool used by the market analyst, calls
load_ohlcv directly and does not go through vendor routing — it has no
Binance fallback regardless of core_stock_apis configuration. This
surfaced during end-to-end CLI testing as a YFRateLimitError aborting
an otherwise-successful run (the routed get_stock_data tool worked
correctly in the same run). Confirmed via isolated testing that this
is a pre-existing yfinance rate-limit issue unrelated to this PR's
changes, not a regression. Fixing it is out of scope here since it
touches a path shared by all asset types.