### PR TITLE
fix(cli): integrate checkpoint resume

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1127,131 +1127,157 @@ def run_analysis(checkpoint: bool | None = None):
         # (LLM tracking is handled separately via LLM constructor)
         args = graph.propagator.get_graph_args(callbacks=[stats_handler])
 
-        # Stream the analysis
-        trace = []
-        for chunk in graph.graph.stream(init_agent_state, **args):
-            # Process all messages in chunk, deduplicating by message ID
-            for message in chunk.get("messages", []):
-                msg_id = getattr(message, "id", None)
-                if msg_id is not None:
-                    if msg_id in message_buffer._processed_message_ids:
-                        continue
-                    message_buffer._processed_message_ids.add(msg_id)
-
-                msg_type, content = classify_message_type(message)
-                if content and content.strip():
-                    message_buffer.add_message(msg_type, content)
-
-                if hasattr(message, "tool_calls") and message.tool_calls:
-                    for tool_call in message.tool_calls:
-                        if isinstance(tool_call, dict):
-                            message_buffer.add_tool_call(tool_call["name"], tool_call["args"])
-                        else:
-                            message_buffer.add_tool_call(tool_call.name, tool_call.args)
-
-            # Update analyst statuses based on report state (runs on every chunk)
-            update_analyst_statuses(
-                message_buffer,
-                chunk,
-                wall_time_tracker=analyst_wall_time_tracker,
+        try:
+            checkpoint_info = graph.setup_checkpoint(
+                selections["ticker"],
+                selections["analysis_date"],
+                asset_type=selections["asset_type"],
             )
-
-            # Research Team - Handle Investment Debate State
-            if chunk.get("investment_debate_state"):
-                debate_state = chunk["investment_debate_state"]
-                bull_hist = debate_state.get("bull_history", "").strip()
-                bear_hist = debate_state.get("bear_history", "").strip()
-                judge = debate_state.get("judge_decision", "").strip()
-
-                # Only update status when there's actual content
-                if bull_hist or bear_hist:
-                    update_research_team_status("in_progress")
-                if bull_hist:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Bull Researcher Analysis\n{bull_hist}"
+            if checkpoint_info is not None:
+                tid, step = checkpoint_info
+                args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = tid
+                stream_input = None if step is not None else init_agent_state
+                if step is not None:
+                    message_buffer.add_message(
+                        "System", f"Resuming from checkpoint (step {step})"
                     )
-                if bear_hist:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Bear Researcher Analysis\n{bear_hist}"
-                    )
-                if judge:
-                    message_buffer.update_report_section(
-                        "investment_plan", f"### Research Manager Decision\n{judge}"
-                    )
-                    update_research_team_status("completed")
-                    message_buffer.update_agent_status("Trader", "in_progress")
+            else:
+                stream_input = init_agent_state
 
-            # Trading Team
-            if chunk.get("trader_investment_plan"):
-                message_buffer.update_report_section(
-                    "trader_investment_plan", chunk["trader_investment_plan"]
+            # Stream the analysis
+            trace = []
+            for chunk in graph.graph.stream(stream_input, **args):
+                # Process all messages in chunk, deduplicating by message ID
+                for message in chunk.get("messages", []):
+                    msg_id = getattr(message, "id", None)
+                    if msg_id is not None:
+                        if msg_id in message_buffer._processed_message_ids:
+                            continue
+                        message_buffer._processed_message_ids.add(msg_id)
+
+                    msg_type, content = classify_message_type(message)
+                    if content and content.strip():
+                        message_buffer.add_message(msg_type, content)
+
+                    if hasattr(message, "tool_calls") and message.tool_calls:
+                        for tool_call in message.tool_calls:
+                            if isinstance(tool_call, dict):
+                                message_buffer.add_tool_call(tool_call["name"], tool_call["args"])
+                            else:
+                                message_buffer.add_tool_call(tool_call.name, tool_call.args)
+
+                # Update analyst statuses based on report state (runs on every chunk)
+                update_analyst_statuses(
+                    message_buffer,
+                    chunk,
+                    wall_time_tracker=analyst_wall_time_tracker,
                 )
-                if message_buffer.agent_status.get("Trader") != "completed":
-                    message_buffer.update_agent_status("Trader", "completed")
-                    message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
 
-            # Risk Management Team - Handle Risk Debate State
-            if chunk.get("risk_debate_state"):
-                risk_state = chunk["risk_debate_state"]
-                agg_hist = risk_state.get("aggressive_history", "").strip()
-                con_hist = risk_state.get("conservative_history", "").strip()
-                neu_hist = risk_state.get("neutral_history", "").strip()
-                judge = risk_state.get("judge_decision", "").strip()
+                # Research Team - Handle Investment Debate State
+                if chunk.get("investment_debate_state"):
+                    debate_state = chunk["investment_debate_state"]
+                    bull_hist = debate_state.get("bull_history", "").strip()
+                    bear_hist = debate_state.get("bear_history", "").strip()
+                    judge = debate_state.get("judge_decision", "").strip()
 
-                if agg_hist:
-                    if message_buffer.agent_status.get("Aggressive Analyst") != "completed":
+                    # Only update status when there's actual content
+                    if bull_hist or bear_hist:
+                        update_research_team_status("in_progress")
+                    if bull_hist:
+                        message_buffer.update_report_section(
+                            "investment_plan", f"### Bull Researcher Analysis\n{bull_hist}"
+                        )
+                    if bear_hist:
+                        message_buffer.update_report_section(
+                            "investment_plan", f"### Bear Researcher Analysis\n{bear_hist}"
+                        )
+                    if judge:
+                        message_buffer.update_report_section(
+                            "investment_plan", f"### Research Manager Decision\n{judge}"
+                        )
+                        update_research_team_status("completed")
+                        message_buffer.update_agent_status("Trader", "in_progress")
+
+                # Trading Team
+                if chunk.get("trader_investment_plan"):
+                    message_buffer.update_report_section(
+                        "trader_investment_plan", chunk["trader_investment_plan"]
+                    )
+                    if message_buffer.agent_status.get("Trader") != "completed":
+                        message_buffer.update_agent_status("Trader", "completed")
                         message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Aggressive Analyst Analysis\n{agg_hist}"
-                    )
-                if con_hist:
-                    if message_buffer.agent_status.get("Conservative Analyst") != "completed":
-                        message_buffer.update_agent_status("Conservative Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Conservative Analyst Analysis\n{con_hist}"
-                    )
-                if neu_hist:
-                    if message_buffer.agent_status.get("Neutral Analyst") != "completed":
-                        message_buffer.update_agent_status("Neutral Analyst", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Neutral Analyst Analysis\n{neu_hist}"
-                    )
-                if judge and message_buffer.agent_status.get("Portfolio Manager") != "completed":
-                    message_buffer.update_agent_status("Portfolio Manager", "in_progress")
-                    message_buffer.update_report_section(
-                        "final_trade_decision", f"### Portfolio Manager Decision\n{judge}"
-                    )
-                    message_buffer.update_agent_status("Aggressive Analyst", "completed")
-                    message_buffer.update_agent_status("Conservative Analyst", "completed")
-                    message_buffer.update_agent_status("Neutral Analyst", "completed")
-                    message_buffer.update_agent_status("Portfolio Manager", "completed")
 
-            # Update the display
+                # Risk Management Team - Handle Risk Debate State
+                if chunk.get("risk_debate_state"):
+                    risk_state = chunk["risk_debate_state"]
+                    agg_hist = risk_state.get("aggressive_history", "").strip()
+                    con_hist = risk_state.get("conservative_history", "").strip()
+                    neu_hist = risk_state.get("neutral_history", "").strip()
+                    judge = risk_state.get("judge_decision", "").strip()
+
+                    if agg_hist:
+                        if message_buffer.agent_status.get("Aggressive Analyst") != "completed":
+                            message_buffer.update_agent_status("Aggressive Analyst", "in_progress")
+                        message_buffer.update_report_section(
+                            "final_trade_decision", f"### Aggressive Analyst Analysis\n{agg_hist}"
+                        )
+                    if con_hist:
+                        if message_buffer.agent_status.get("Conservative Analyst") != "completed":
+                            message_buffer.update_agent_status("Conservative Analyst", "in_progress")
+                        message_buffer.update_report_section(
+                            "final_trade_decision", f"### Conservative Analyst Analysis\n{con_hist}"
+                        )
+                    if neu_hist:
+                        if message_buffer.agent_status.get("Neutral Analyst") != "completed":
+                            message_buffer.update_agent_status("Neutral Analyst", "in_progress")
+                        message_buffer.update_report_section(
+                            "final_trade_decision", f"### Neutral Analyst Analysis\n{neu_hist}"
+                        )
+                    if judge and message_buffer.agent_status.get("Portfolio Manager") != "completed":
+                        message_buffer.update_agent_status("Portfolio Manager", "in_progress")
+                        message_buffer.update_report_section(
+                            "final_trade_decision", f"### Portfolio Manager Decision\n{judge}"
+                        )
+                        message_buffer.update_agent_status("Aggressive Analyst", "completed")
+                        message_buffer.update_agent_status("Conservative Analyst", "completed")
+                        message_buffer.update_agent_status("Neutral Analyst", "completed")
+                        message_buffer.update_agent_status("Portfolio Manager", "completed")
+
+                # Update the display
+                update_display(layout, stats_handler=stats_handler, start_time=start_time)
+
+                trace.append(chunk)
+
+            # Streamed chunks are per-node deltas, not full state. Merge them
+            # so every report field populated across the run is present.
+            final_state = {}
+            for chunk in trace:
+                final_state.update(chunk)
+
+            # Update all agent statuses to completed
+            for agent in message_buffer.agent_status:
+                message_buffer.update_agent_status(agent, "completed")
+
+            message_buffer.add_message(
+                "System", f"Completed analysis for {selections['analysis_date']}"
+            )
+            message_buffer.add_message("System", analyst_wall_time_tracker.format_summary())
+
+            # Update final report sections
+            for section in message_buffer.report_sections:
+                if section in final_state:
+                    message_buffer.update_report_section(section, final_state[section])
+
             update_display(layout, stats_handler=stats_handler, start_time=start_time)
 
-            trace.append(chunk)
-
-        # Streamed chunks are per-node deltas, not full state. Merge them
-        # so every report field populated across the run is present.
-        final_state = {}
-        for chunk in trace:
-            final_state.update(chunk)
-
-        # Update all agent statuses to completed
-        for agent in message_buffer.agent_status:
-            message_buffer.update_agent_status(agent, "completed")
-
-        message_buffer.add_message(
-            "System", f"Completed analysis for {selections['analysis_date']}"
-        )
-        message_buffer.add_message("System", analyst_wall_time_tracker.format_summary())
-
-        # Update final report sections
-        for section in message_buffer.report_sections:
-            if section in final_state:
-                message_buffer.update_report_section(section, final_state[section])
-
-        update_display(layout, stats_handler=stats_handler, start_time=start_time)
+            # Clear checkpoint on successful completion to avoid stale state.
+            graph.clear_checkpoint(
+                selections["ticker"],
+                selections["analysis_date"],
+                asset_type=selections["asset_type"],
+            )
+        finally:
+            graph.close_checkpoint()
 
     # Post-analysis prompts (outside Live context for clean interaction)
     console.print("\n[bold cyan]Analysis Complete![/bold cyan]\n")

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -3,9 +3,12 @@
 import tempfile
 import unittest
 from typing import TypedDict
+from unittest import mock
 
 from langgraph.graph import END, StateGraph
 
+import cli.main as cli_main
+from cli.models import AnalystType
 from tradingagents.graph.checkpointer import (
     checkpoint_step,
     clear_checkpoint,
@@ -13,9 +16,11 @@ from tradingagents.graph.checkpointer import (
     has_checkpoint,
     thread_id,
 )
+from tradingagents.graph.propagation import Propagator
 
 # Mutable flag to simulate crash on first run
 _should_crash = False
+_analyst_calls = 0
 
 
 class _SimpleState(TypedDict):
@@ -23,13 +28,15 @@ class _SimpleState(TypedDict):
 
 
 def _node_a(state: _SimpleState) -> dict:
-    return {"count": state["count"] + 1}
+    global _analyst_calls
+    _analyst_calls += 1
+    return {"count": state.get("count", 0) + 1}
 
 
 def _node_b(state: _SimpleState) -> dict:
     if _should_crash:
         raise RuntimeError("simulated mid-analysis crash")
-    return {"count": state["count"] + 10}
+    return {"count": state.get("count", 0) + 10}
 
 
 def _build_graph() -> StateGraph:
@@ -212,6 +219,84 @@ class TestCheckpointSignature(unittest.TestCase):
         # Stable for identical inputs.
         g.config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
         self.assertEqual(base, g._run_signature("stock"))
+
+
+class TestCLICheckpointResume(unittest.TestCase):
+    def setUp(self):
+        global _should_crash, _analyst_calls
+        _should_crash = False
+        _analyst_calls = 0
+        self.tmpdir = tempfile.mkdtemp()
+        self.ticker = "TEST"
+        self.date = "2026-08-23"
+
+    def test_cli_checkpoint_crash_and_resume(self):
+        """When checkpoint=True, CLI must compile checkpointer, save state on crash,
+        resume on re-run, and clear checkpoint on success."""
+        global _should_crash
+
+        selections = {
+            "ticker": self.ticker,
+            "analysis_date": self.date,
+            "asset_type": "stock",
+            "analysts": [AnalystType.MARKET],
+            "research_depth": 1,
+            "shallow_thinker": "gpt-5.4-mini",
+            "deep_thinker": "gpt-5.5",
+            "backend_url": None,
+            "llm_provider": "openai",
+            "google_thinking_level": None,
+            "openai_reasoning_effort": None,
+            "anthropic_effort": None,
+            "output_language": "English",
+        }
+
+        test_workflow = _build_graph()
+
+        def _mock_graph_init(graph_self, selected_analysts, *args, **kwargs):
+            graph_self.selected_analysts = tuple(selected_analysts)
+            graph_self.config = kwargs.get("config", {})
+            graph_self.debug = True
+            graph_self._checkpointer_ctx = None
+            graph_self.workflow = test_workflow
+            graph_self.graph = test_workflow.compile()
+            graph_self.propagator = Propagator(max_recur_limit=100)
+
+        patched_config = dict(cli_main.DEFAULT_CONFIG, data_cache_dir=self.tmpdir, results_dir=self.tmpdir)
+
+        with mock.patch("cli.main.get_user_selections", return_value=selections), \
+            mock.patch.object(cli_main, "DEFAULT_CONFIG", patched_config), \
+            mock.patch("cli.main.TradingAgentsGraph.__init__", _mock_graph_init), \
+            mock.patch("cli.main.Live"), \
+            mock.patch("cli.main.typer.prompt", return_value="N"):
+
+            # Run 1: crash in trader node
+            _should_crash = True
+            with self.assertRaises(RuntimeError):
+                cli_main.run_analysis(checkpoint=True)
+            self.assertEqual(
+                _analyst_calls, 1, "Initial analyst node should run exactly once"
+            )
+
+            # Checkpoint MUST exist after crash
+            sig = f"analysts=market|debate={patched_config['max_debate_rounds']}|risk={patched_config['max_risk_discuss_rounds']}|asset=stock"
+            self.assertTrue(
+                has_checkpoint(self.tmpdir, self.ticker, self.date, sig),
+                "Checkpoint DB should have saved state for crashed run"
+            )
+
+            # Run 2: resume
+            _should_crash = False
+            cli_main.run_analysis(checkpoint=True)
+            self.assertEqual(
+                _analyst_calls, 1, "Resume should not rerun the completed analyst node"
+            )
+
+            # Checkpoint should be cleared after successful completion
+            self.assertFalse(
+                has_checkpoint(self.tmpdir, self.ticker, self.date, sig),
+                "Checkpoint should be cleared after successful completion"
+            )
 
 
 if __name__ == "__main__":

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -359,6 +359,53 @@ class TradingAgentsGraph:
             f"asset={asset_type}",
         ])
 
+    def setup_checkpoint(
+        self, company_name: str, trade_date: str, asset_type: str = "stock"
+    ) -> tuple[str, int | None] | None:
+        """Set up checkpointer context and compile graph if checkpointing is enabled."""
+        if not self.config.get("checkpoint_enabled"):
+            return None
+
+        self._checkpointer_ctx = get_checkpointer(
+            self.config["data_cache_dir"], company_name
+        )
+        saver = self._checkpointer_ctx.__enter__()
+        self.graph = self.workflow.compile(checkpointer=saver)
+
+        sig = self._run_signature(asset_type)
+        step = checkpoint_step(
+            self.config["data_cache_dir"], company_name, str(trade_date), sig
+        )
+        if step is not None:
+            logger.info(
+                "Resuming from step %d for %s on %s", step, company_name, trade_date
+            )
+        else:
+            logger.info("Starting fresh for %s on %s", company_name, trade_date)
+
+        tid = thread_id(company_name, str(trade_date), sig)
+        return tid, step
+
+    def clear_checkpoint(
+        self, company_name: str, trade_date: str, asset_type: str = "stock"
+    ) -> None:
+        """Clear saved checkpoint rows for this ticker+date+signature."""
+        if not self.config.get("checkpoint_enabled"):
+            return
+        clear_checkpoint(
+            self.config["data_cache_dir"],
+            company_name,
+            str(trade_date),
+            self._run_signature(asset_type),
+        )
+
+    def close_checkpoint(self) -> None:
+        """Exit checkpointer context and restore plain compiled graph."""
+        if self._checkpointer_ctx is not None:
+            self._checkpointer_ctx.__exit__(None, None, None)
+            self._checkpointer_ctx = None
+            self.graph = self.workflow.compile()
+
     def propagate(self, company_name, trade_date, asset_type: str = "stock"):
         """Run the trading agents graph for a company on a specific date.
 
@@ -374,32 +421,11 @@ class TradingAgentsGraph:
         # Resolve any pending memory-log entries for this ticker before the pipeline runs.
         self._resolve_pending_entries(company_name)
 
-        # Recompile with a checkpointer if the user opted in.
-        if self.config.get("checkpoint_enabled"):
-            self._checkpointer_ctx = get_checkpointer(
-                self.config["data_cache_dir"], company_name
-            )
-            saver = self._checkpointer_ctx.__enter__()
-            self.graph = self.workflow.compile(checkpointer=saver)
-
-            step = checkpoint_step(
-                self.config["data_cache_dir"], company_name, str(trade_date),
-                self._run_signature(asset_type),
-            )
-            if step is not None:
-                logger.info(
-                    "Resuming from step %d for %s on %s", step, company_name, trade_date
-                )
-            else:
-                logger.info("Starting fresh for %s on %s", company_name, trade_date)
-
+        self.setup_checkpoint(company_name, trade_date, asset_type=asset_type)
         try:
             return self._run_graph(company_name, trade_date, asset_type=asset_type)
         finally:
-            if self._checkpointer_ctx is not None:
-                self._checkpointer_ctx.__exit__(None, None, None)
-                self._checkpointer_ctx = None
-                self.graph = self.workflow.compile()
+            self.close_checkpoint()
 
     def save_reports(self, final_state, ticker, save_path=None) -> Path:
         """Write the markdown report tree for a completed run, like the CLI does.
@@ -473,11 +499,7 @@ class TradingAgentsGraph:
         )
 
         # Clear checkpoint on successful completion to avoid stale state.
-        if self.config.get("checkpoint_enabled"):
-            clear_checkpoint(
-                self.config["data_cache_dir"], company_name, str(trade_date),
-                self._run_signature(asset_type),
-            )
+        self.clear_checkpoint(company_name, trade_date, asset_type=asset_type)
 
         return final_state, self.process_signal(final_state["final_trade_decision"])
 


### PR DESCRIPTION
Fixes #1249 

### Problem

The CLI accepted `--checkpoint`, but `run_analysis()` directly streamed a graph compiled without a checkpointer or stable
`thread_id`. Crashed CLI runs therefore could not resume.

### Changes

- Configure the SQLite checkpointer on the CLI streaming path.
- Propagate the deterministic checkpoint `thread_id`.
- Pass `None` when resuming so completed nodes are not replayed.
- Clear checkpoints after successful completion.
- Close the checkpointer in `finally`.
- Expose checkpoint lifecycle methods as public graph methods because the CLI uses them.
- Add a regression test that asserts completed nodes execute only once across crash and resume.