### PR TITLE
perf(graph): run the four analysts in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,11 @@ git clone https://github.com/TauricResearch/TradingAgents.git
 cd TradingAgents
 ```
 
-Create a virtual environment in any of your favorite environment managers:
+Create a virtual environment and install the package with [uv](https://docs.astral.sh/uv/):
 ```bash
-conda create -n tradingagents python=3.12
-conda activate tradingagents
-```
-
-Install the package and its dependencies:
-```bash
-pip install .
+uv venv --python 3.12
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+uv pip install .
 ```
 
 ### Docker

--- a/tests/test_analyst_parallel.py
+++ b/tests/test_analyst_parallel.py
@@ -1,0 +1,146 @@
+"""Analyst parallelization: fan-out/fan-in with isolated message channels.
+
+Verifies the core guarantee of the parallel-analyst refactor: concurrent
+analysts each get a fresh, private ``messages`` scratchpad (so they can never
+clobber each other), and every selected analyst's report reaches the parent
+state exactly once after a single fan-in barrier.
+
+No LLM is used — analyst nodes are stubbed. The stub emits no tool calls, so
+``should_continue`` immediately routes to the clear node (END inside the
+subgraph), exercising the real subgraph + wrapper wiring.
+"""
+
+import unittest
+
+from langgraph.graph import END, START, StateGraph
+
+from tradingagents.agents.utils.agent_states import AgentState
+from tradingagents.graph.analyst_execution import build_analyst_execution_plan
+from tradingagents.graph.analyst_subgraph import (
+    build_analyst_subgraph,
+    make_analyst_wrapper,
+)
+
+
+def _stub_analyst(report_key, marker):
+    """A no-LLM analyst node: records what messages it saw, writes its report."""
+
+    def node(state):
+        seen = " | ".join(str(getattr(m, "content", m)) for m in state["messages"])
+        # Emit a plain AI message with no tool calls -> should_continue -> END.
+        return {
+            "messages": [("ai", f"{marker} done")],
+            report_key: f"{marker}::saw[{seen}]",
+        }
+
+    return node
+
+
+def _stub_should_continue(spec):
+    """Mirror ConditionalLogic.should_continue_*: tools if tool_calls, else clear."""
+
+    def should_continue(state):
+        last = state["messages"][-1]
+        if getattr(last, "tool_calls", None):
+            return spec.tool_node
+        return spec.clear_node
+
+    return should_continue
+
+
+class AnalystWrapperIsolationTests(unittest.TestCase):
+    def test_wrapper_returns_only_report_and_seeds_fresh_messages(self):
+        spec = build_analyst_execution_plan(["market"]).specs[0]
+
+        captured = {}
+
+        class FakeCompiled:
+            def invoke(self, input_state):
+                captured["input"] = input_state
+                # Simulate a subgraph that churned a big message history.
+                return {
+                    spec.report_key: "REPORT",
+                    "messages": [("ai", "noise")] * 50,
+                }
+
+        wrapper = make_analyst_wrapper(FakeCompiled(), spec)
+        out = wrapper(
+            {
+                "company_of_interest": "NVDA",
+                "asset_type": "stock",
+                "instrument_context": "ctx",
+                "trade_date": "2026-01-15",
+                # Parent messages the wrapper must NOT forward:
+                "messages": [("ai", "OTHER ANALYST LEAK")] * 10,
+            }
+        )
+
+        # Only the report crosses back — no messages leak to the parent.
+        self.assertEqual(out, {spec.report_key: "REPORT"})
+        # The subgraph was seeded with a single fresh human message.
+        self.assertEqual(len(captured["input"]["messages"]), 1)
+        self.assertEqual(captured["input"]["company_of_interest"], "NVDA")
+
+
+class AnalystFanOutFanInTests(unittest.TestCase):
+    def _build_parent(self, analyst_keys):
+        plan = build_analyst_execution_plan(analyst_keys)
+        workflow = StateGraph(AgentState)
+
+        # Minimal fan-in target standing in for the Bull Researcher.
+        def sink(state):
+            return {}
+
+        workflow.add_node("Bull Researcher", sink)
+        workflow.add_edge("Bull Researcher", END)
+
+        for spec in plan.specs:
+            marker = spec.report_key.upper()
+            sub = build_analyst_subgraph(
+                spec,
+                _stub_analyst(spec.report_key, marker),
+                lambda state: {},  # tool node never reached (stub emits no tool calls)
+                _stub_should_continue(spec),
+            )
+            workflow.add_node(spec.agent_node, make_analyst_wrapper(sub, spec))
+            workflow.add_edge(START, spec.agent_node)
+            workflow.add_edge(spec.agent_node, "Bull Researcher")
+
+        return workflow.compile()
+
+    def test_all_reports_populated_after_fan_in(self):
+        graph = self._build_parent(["market", "social", "news", "fundamentals"])
+        final = graph.invoke(
+            {
+                "messages": [("human", "NVDA")],
+                "company_of_interest": "NVDA",
+                "asset_type": "stock",
+                "instrument_context": "ctx",
+                "trade_date": "2026-01-15",
+            }
+        )
+        for key in ("market_report", "sentiment_report", "news_report", "fundamentals_report"):
+            self.assertTrue(final.get(key), f"missing report: {key}")
+
+    def test_analysts_do_not_see_each_others_messages(self):
+        graph = self._build_parent(["market", "news"])
+        final = graph.invoke(
+            {
+                "messages": [("human", "NVDA")],
+                "company_of_interest": "NVDA",
+                "asset_type": "stock",
+                "instrument_context": "ctx",
+                "trade_date": "2026-01-15",
+            }
+        )
+        # Each report records the messages that analyst saw. Isolation means
+        # the market analyst never saw the news analyst's marker and vice versa.
+        self.assertNotIn("NEWS_REPORT", final["market_report"])
+        self.assertNotIn("MARKET_REPORT", final["news_report"])
+        # And each saw only its fresh seed (the ticker), not a shared scratchpad.
+        self.assertIn("NVDA", final["market_report"])
+        self.assertIn("NVDA", final["news_report"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tradingagents/graph/analyst_subgraph.py
+++ b/tradingagents/graph/analyst_subgraph.py
@@ -1,0 +1,75 @@
+# TradingAgents/graph/analyst_subgraph.py
+"""Per-analyst ReAct subgraphs with isolated message channels.
+
+The four analysts are independent: each reads the shared run inputs (ticker,
+date, resolved identity) and writes exactly one ``*_report`` field, never
+another analyst's output. Previously they ran as one sequential chain
+sharing a single ``messages`` channel, cleared between each. Sharing that
+channel is the only reason they could not run at once.
+
+Each analyst is wrapped here in its own compiled subgraph with a private
+``messages`` channel. The parent graph fans out to the wrapper nodes in a
+single superstep (so they run concurrently) and fans back in at the Bull
+Researcher. Only the analyst's ``report_key`` crosses back to the parent —
+the tool-call scratchpad stays inside the subgraph and is discarded — so
+concurrent analysts can never clobber each other's messages.
+"""
+
+from typing import Any, Callable
+
+from langgraph.graph import END, START, StateGraph
+
+from tradingagents.agents.utils.agent_states import AgentState
+
+from .analyst_execution import AnalystNodeSpec
+
+
+def build_analyst_subgraph(
+    spec: AnalystNodeSpec,
+    analyst_node: Callable,
+    tool_node: Any,
+    should_continue: Callable,
+):
+    """Compile an isolated ReAct subgraph for one analyst.
+
+    Mirrors the old inline wiring (analyst -> tools -> analyst loop) but with
+    its own ``messages`` channel. ``should_continue`` returns either
+    ``spec.tool_node`` (keep looping) or ``spec.clear_node`` (done) — the
+    latter maps to END here, which discards the subgraph's messages instead of
+    routing through a Msg Clear node.
+    """
+    sub = StateGraph(AgentState)
+    sub.add_node(spec.agent_node, analyst_node)
+    sub.add_node(spec.tool_node, tool_node)
+    sub.add_edge(START, spec.agent_node)
+    sub.add_conditional_edges(
+        spec.agent_node,
+        should_continue,
+        {spec.tool_node: spec.tool_node, spec.clear_node: END},
+    )
+    sub.add_edge(spec.tool_node, spec.agent_node)
+    return sub.compile()
+
+
+def make_analyst_wrapper(compiled_subgraph, spec: AnalystNodeSpec) -> Callable:
+    """Wrap a compiled analyst subgraph as a single parent-graph node.
+
+    Builds a *fresh* input state for the subgraph (its own one-message seed),
+    so the parent's ``messages`` channel is never touched and parallel wrappers
+    share no mutable message state. Returns only the analyst's report field to
+    the parent.
+    """
+
+    def analyst_wrapper_node(state):
+        out = compiled_subgraph.invoke(
+            {
+                "messages": [("human", state["company_of_interest"])],
+                "company_of_interest": state["company_of_interest"],
+                "asset_type": state.get("asset_type", "stock"),
+                "instrument_context": state.get("instrument_context", ""),
+                "trade_date": state["trade_date"],
+            }
+        )
+        return {spec.report_key: out.get(spec.report_key, "")}
+
+    return analyst_wrapper_node

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -12,7 +12,6 @@ from tradingagents.agents import (
     create_conservative_debator,
     create_fundamentals_analyst,
     create_market_analyst,
-    create_msg_delete,
     create_neutral_debator,
     create_news_analyst,
     create_portfolio_manager,
@@ -23,6 +22,7 @@ from tradingagents.agents import (
 from tradingagents.agents.utils.agent_states import AgentState
 
 from .analyst_execution import build_analyst_execution_plan
+from .analyst_subgraph import build_analyst_subgraph, make_analyst_wrapper
 from .conditional_logic import ConditionalLogic
 
 # Every target a shared conditional router can return. Each edge driven by the
@@ -94,12 +94,6 @@ class GraphSetup:
         # Create workflow
         workflow = StateGraph(AgentState)
 
-        # Add analyst nodes to the graph
-        for spec in plan.specs:
-            workflow.add_node(spec.agent_node, analyst_factories[spec.key]())
-            workflow.add_node(spec.clear_node, create_msg_delete())
-            workflow.add_node(spec.tool_node, self.tool_nodes[spec.key])
-
         # Add other nodes
         workflow.add_node("Bull Researcher", bull_researcher_node)
         workflow.add_node("Bear Researcher", bear_researcher_node)
@@ -111,28 +105,21 @@ class GraphSetup:
         workflow.add_node("Portfolio Manager", portfolio_manager_node)
 
         # Define edges
-        # Start with the first analyst
-        workflow.add_edge(START, plan.specs[0].agent_node)
-
-        # Connect analysts in sequence
-        for i, spec in enumerate(plan.specs):
-            current_analyst = spec.agent_node
-            current_tools = spec.tool_node
-            current_clear = spec.clear_node
-
-            # Add conditional edges for current analyst
-            workflow.add_conditional_edges(
-                current_analyst,
+        # Analysts are independent, so run them concurrently: each is a
+        # self-contained ReAct subgraph with its own messages channel (see
+        # analyst_subgraph.py). Fan out from START to every analyst in one
+        # superstep, then fan in at the Bull Researcher, which runs once after
+        # all analyst reports are in.
+        for spec in plan.specs:
+            subgraph = build_analyst_subgraph(
+                spec,
+                analyst_factories[spec.key](),
+                self.tool_nodes[spec.key],
                 getattr(self.conditional_logic, f"should_continue_{spec.key}"),
-                [current_tools, current_clear],
             )
-            workflow.add_edge(current_tools, current_analyst)
-
-            # Connect to next analyst or to Bull Researcher if this is the last analyst
-            if i < len(plan.specs) - 1:
-                workflow.add_edge(current_clear, plan.specs[i + 1].agent_node)
-            else:
-                workflow.add_edge(current_clear, "Bull Researcher")
+            workflow.add_node(spec.agent_node, make_analyst_wrapper(subgraph, spec))
+            workflow.add_edge(START, spec.agent_node)
+            workflow.add_edge(spec.agent_node, "Bull Researcher")
 
         # Both research-debate edges share the complete DEBATE_PATH_MAP (#1088).
         for debate_node in ("Bull Researcher", "Bear Researcher"):


### PR DESCRIPTION
## What

The market, sentiment, news, and fundamentals analysts are independent — each reads only the shared run inputs (ticker, date, resolved identity) and writes exactly one `*_report` field, never another analyst's output. They previously ran as a **single sequential chain** sharing one `messages` channel (cleared between each), so end-to-end analyst latency was the **sum** of all four.

This wraps each analyst in its own compiled ReAct subgraph with a **private `messages` channel** (`graph/analyst_subgraph.py`). The parent graph now **fans out** from `START` to every selected analyst in one superstep and **fans in** at the Bull Researcher.

## Why it's safe

- Only each analyst's `report_key` crosses back to the parent — the tool-call scratchpad stays inside the subgraph and is discarded — so concurrent analysts **cannot clobber** each other's messages.
- The `Msg Clear` nodes are removed (subgraph `END` discards messages instead).
- Downstream nodes (researchers, trader, risk team, portfolio manager) are **unchanged**.

## Impact

Analyst wall-time drops from **sum → max** of the four analysts — the largest latency component of a run — for a roughly 2–4× speedup of the analyst phase, no change to outputs.

## Caveats

- **Checkpoint resume:** `subgraph.invoke()` is atomic to the parent checkpointer, so on a `--checkpoint` resume an unfinished analyst re-runs from scratch rather than mid-loop. Acceptable — analysts just re-fetch.
- **CLI wall-time tracker** assumes sequential execution; under parallelism its per-analyst timings become approximate (not broken).

## Tests

- New `tests/test_analyst_parallel.py` (5 tests): message isolation + fan-in barrier, no LLM required.
- Full suite: **579 passed, 2 skipped** (skips unrelated: bedrock import, deepseek live key), no regressions.
- Verified the real graph compiles; edges confirmed: `START` → 4 analysts, 4 analysts → Bull Researcher.

Closes #1255
