### PR TITLE
fix(memory): keep future-resolved lessons out of point-in-time prompts

### DIFF
--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -284,6 +284,52 @@ class TestTradingMemoryLogCore:
         assert "AAPL" not in ctx
         assert "META" in ctx
 
+    # Point-in-time guard (as_of_date)
+
+    def test_as_of_date_excludes_future_resolved_entries(self, tmp_path):
+        """An entry resolved after the current trade date must not leak in.
+
+        This is the lookahead guard: running date D1 after a later run for
+        D2 would otherwise inject D2's reflection (which encodes knowledge
+        of prices after D1) into the D1 prompt (#1251).
+        """
+        log = make_log(tmp_path)
+        _seed_completed(tmp_path, "NVDA", "2026-01-05", "Buy NVDA.", "Past lesson.")
+        _seed_completed(tmp_path, "NVDA", "2026-01-20", "Sell NVDA.", "Future lesson.")
+        ctx = log.get_past_context("NVDA", as_of_date="2026-01-10")
+        assert "Past lesson." in ctx
+        assert "Future lesson." not in ctx
+
+    def test_as_of_date_includes_same_day_entry(self, tmp_path):
+        """Entries resolved on the as-of date itself are safe to include."""
+        log = make_log(tmp_path)
+        _seed_completed(tmp_path, "NVDA", "2026-01-10", "Buy NVDA.", "Same-day lesson.")
+        ctx = log.get_past_context("NVDA", as_of_date="2026-01-10")
+        assert "Same-day lesson." in ctx
+
+    def test_as_of_date_applies_to_cross_ticker_too(self, tmp_path):
+        """Cross-ticker lessons are held to the same point-in-time rule."""
+        log = make_log(tmp_path)
+        _seed_completed(tmp_path, "MSFT", "2026-01-20", "Buy MSFT.", "Future cross lesson.")
+        ctx = log.get_past_context("NVDA", as_of_date="2026-01-10")
+        assert ctx == ""
+
+    def test_no_as_of_date_keeps_all_entries(self, tmp_path):
+        """Without as_of_date the behaviour is unchanged (back-compat)."""
+        log = make_log(tmp_path)
+        _seed_completed(tmp_path, "NVDA", "2026-01-05", "Buy NVDA.", "Old lesson.")
+        _seed_completed(tmp_path, "NVDA", "2026-01-20", "Sell NVDA.", "New lesson.")
+        ctx = log.get_past_context("NVDA")
+        assert "Old lesson." in ctx
+        assert "New lesson." in ctx
+
+    def test_unparseable_entry_date_is_excluded(self, tmp_path):
+        """A malformed tag date must never be trusted as point-in-time-safe."""
+        log = make_log(tmp_path)
+        _seed_completed(tmp_path, "NVDA", "not-a-date", "Buy NVDA.", "Weird lesson.")
+        ctx = log.get_past_context("NVDA", as_of_date="2026-01-10")
+        assert ctx == ""
+
     # No-op when config is None
 
     def test_no_log_path_is_noop(self):

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -67,9 +67,23 @@ class TradingMemoryLog:
         """Return entries with outcome:pending (for Phase B)."""
         return [e for e in self.load_entries() if e.get("pending")]
 
-    def get_past_context(self, ticker: str, n_same: int = 5, n_cross: int = 3) -> str:
-        """Return formatted past context string for agent prompt injection."""
+    def get_past_context(
+        self,
+        ticker: str,
+        n_same: int = 5,
+        n_cross: int = 3,
+        as_of_date: str | None = None,
+    ) -> str:
+        """Return formatted past context string for agent prompt injection.
+
+        When ``as_of_date`` is given (YYYY-MM-DD), entries whose outcome
+        resolved on a later date are excluded. Their reflections encode
+        knowledge of prices the current run has not seen yet, so injecting
+        them would leak future information into a backtest (#1251).
+        """
         entries = [e for e in self.load_entries() if not e.get("pending")]
+        if as_of_date:
+            entries = [e for e in entries if self._date_key(e["date"]) <= self._date_key(as_of_date)]
         if not entries:
             return ""
 
@@ -216,6 +230,18 @@ class TradingMemoryLog:
         tmp_path.replace(self._log_path)
 
     # --- Helpers ---
+
+    @staticmethod
+    def _date_key(date_str: str) -> tuple:
+        """Parse a YYYY-MM-DD tag date into a comparable tuple.
+
+        Unparseable dates sort last so a malformed entry is never silently
+        trusted as point-in-time-safe context.
+        """
+        try:
+            return tuple(int(p) for p in date_str.split("-"))
+        except (ValueError, AttributeError):
+            return (9999, 12, 31)
 
     def _apply_rotation(self, blocks: list[str]) -> list[str]:
         """Drop oldest resolved blocks when their count exceeds max_entries.

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -418,9 +418,11 @@ class TradingAgentsGraph:
 
     def _run_graph(self, company_name, trade_date, asset_type: str = "stock"):
         """Execute the graph and write the resulting state to disk and memory log."""
-        # Initialize state — inject memory log context for PM and the
-        # deterministically resolved instrument identity for all agents.
-        past_context = self.memory_log.get_past_context(company_name)
+        # Inject memory log context for PM and the deterministically resolved
+        # instrument identity for all agents. as_of_date keeps lessons from
+        # outcomes that resolve after this run's trade date out of the prompt,
+        # so out-of-order backtests cannot leak future information (#1251).
+        past_context = self.memory_log.get_past_context(company_name, as_of_date=str(trade_date))
         instrument_context = self.resolve_instrument_context(company_name, asset_type)
         init_agent_state = self.propagator.create_initial_state(
             company_name,


### PR DESCRIPTION
Hi! First time contributing here, so thanks in advance for your patience with me.

Thank you as well to whoever wrote up #1251 so carefully; the file pointers made it genuinely easy to dig into, and out-of-order backtests are such an easy trap to fall into when you're iterating on dates.

I've had a go at a small fix. The idea: `get_past_context()` now takes an optional `as_of_date`, and any lesson whose outcome resolved after that date simply doesn't get shown to the agents. Same-day lessons stay in, since those are fair game. `trading_graph.py` passes the run's trade date through automatically, so nobody has to remember to opt in. And if you don't pass a date at all, nothing changes, existing behaviour stays exactly as it was.

Entries with unparseable dates are excluded rather than trusted, which seemed the safer side to land on, but happy to flip that if you'd prefer it to fail loud instead.

Tests: five new ones covering future exclusion, same-day inclusion, cross-ticker lessons, backwards compatibility, and malformed dates. Confirmed they fail against main without the change and pass with it, and the full suite is green (581 passed, 2 pre-existing skips).

Really enjoy what this project is building. Happy to tweak whatever doesn't fit the direction you want here. Cheers!