### PR TITLE
Add multi-region stock discovery to the CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .git
 .venv
 .env
+.github/skills/
+.codegraph/
 .claude
 .idea
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ __marimo__/
 # Cache
 **/data_cache/
 
+.github/skills/
+.codegraph/
+
 # Enterprise env file (secrets) and generated run reports
 .env.enterprise
 reports/

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ python -m cli.main     # alternative: run directly from source
 ```
 You will see a screen where you can select your desired tickers, analysis date, LLM provider, research depth, and more.
 
+Before the analysis-date step, the CLI can show a ranked shortlist of active
+equities. First select one or more discovery regions with `Space`, then press
+`Enter` to search those markets. Available regions include the US, Europe,
+Canada, Latin America, Japan, China and Hong Kong, India, Australia, and South
+Korea. The shortlist uses recent price momentum, relative volume, and
+volatility to explain why each stock is currently active; it is a discovery
+heuristic, not a prediction or investment recommendation. Select a listed
+number or enter another supported equity ticker to continue with the normal
+analyst workflow. Disable it with
+`TRADINGAGENTS_DISCOVERY_ENABLED=false`, or tune the number of candidates and
+lookback window with `TRADINGAGENTS_DISCOVERY_LIMIT` and
+`TRADINGAGENTS_DISCOVERY_LOOKBACK`.
+
 ### Markets and tickers
 
 TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Company identity and the alpha benchmark resolve automatically per market.

--- a/cli/main.py
+++ b/cli/main.py
@@ -36,12 +36,18 @@ from cli.utils import (
     prompt_openai_compatible_url,
     resolve_backend_url,
     select_analysts,
+    select_discovery_regions,
     select_deep_thinking_agent,
     select_llm_provider,
     select_research_depth,
     select_shallow_thinking_agent,
 )
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.discovery import (
+    DiscoveryConfig,
+    discover_trending_stocks,
+    symbols_for_regions,
+)
 from tradingagents.graph.analyst_execution import (
     AnalystWallTimeTracker,
     build_analyst_execution_plan,
@@ -545,15 +551,18 @@ def get_user_selections():
         console.print(create_question_box(box_title, box_body))
         return prompt_fn()
 
-    # Step 1: Ticker symbol
-    console.print(
-        create_question_box(
-            "Step 1: Ticker Symbol",
-            "Enter the ticker, with exchange suffix when needed (e.g. SPY, 0700.HK, BTC-USD)",
-            "SPY",
+    # Step 1: Discover or enter a ticker
+    if DEFAULT_CONFIG.get("discovery_enabled", True) and sys.stdin.isatty():
+        selected_ticker = prompt_for_discovery_ticker()
+    else:
+        console.print(
+            create_question_box(
+                "Step 1: Ticker Symbol",
+                "Enter the ticker, with exchange suffix when needed (e.g. SPY, 0700.HK)",
+                "SPY",
+            )
         )
-    )
-    selected_ticker = get_ticker()
+        selected_ticker = get_ticker()
     asset_type = detect_asset_type(selected_ticker)
     # Only announce when it's not the default stock path, to avoid printing
     # "stock" on every run.
@@ -739,6 +748,61 @@ def get_user_selections():
         "anthropic_effort": anthropic_effort,
         "output_language": output_language,
     }
+
+
+def prompt_for_discovery_ticker(
+    discover_fn=discover_trending_stocks,
+    region_selector=None,
+):
+    """Display active stocks from selected regions and return a ticker."""
+    region_selector = region_selector or select_discovery_regions
+    console.print(Panel(
+        "[bold]Step 1: Trending Stocks[/bold]\n"
+        "[dim]Choose a ranked stock or enter another equity ticker[/dim]",
+        border_style="blue",
+        padding=(1, 2),
+    ))
+    try:
+        config = DiscoveryConfig(
+            lookback_days=DEFAULT_CONFIG.get("discovery_lookback_days", 20),
+            candidate_limit=DEFAULT_CONFIG.get("discovery_candidate_limit", 8),
+        )
+        candidates = discover_fn(
+            symbols=symbols_for_regions(region_selector()),
+            config=config,
+        )
+    except Exception as exc:
+        console.print(f"[yellow]Discovery unavailable; enter a ticker manually ({exc})[/yellow]")
+        candidates = []
+
+    if not candidates:
+        return get_ticker()
+
+    table = Table(title="Current market activity", show_lines=True)
+    table.add_column("#", justify="right", style="cyan")
+    table.add_column("Ticker", style="bold green")
+    table.add_column("Score", justify="right")
+    table.add_column("Price", justify="right")
+    table.add_column("Return", justify="right")
+    table.add_column("Reasons")
+    for index, candidate in enumerate(candidates, start=1):
+        table.add_row(
+            str(index),
+            candidate.symbol,
+            f"{candidate.score:.1f}",
+            f"{candidate.latest_price:.2f}",
+            f"{candidate.return_percent:+.1f}%",
+            "; ".join(candidate.reasons),
+        )
+    console.print(table)
+    choice = typer.prompt("Select a number or enter another ticker", default="1").strip()
+    if choice.isdigit() and 1 <= int(choice) <= len(candidates):
+        return candidates[int(choice) - 1].symbol
+    if choice:
+        from cli.utils import normalize_ticker_symbol
+
+        return normalize_ticker_symbol(choice)
+    return candidates[0].symbol
 
 
 def get_analysis_date():

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -164,6 +164,34 @@ def select_analysts(asset_type: AssetType = AssetType.STOCK) -> list[AnalystType
     return choices
 
 
+def select_discovery_regions(default_regions=("us", "europe")) -> list[str]:
+    """Select stock-market regions with Space and confirm with Enter."""
+    from tradingagents.discovery import DISCOVERY_REGION_LABELS, DISCOVERY_REGIONS
+
+    choices = questionary.checkbox(
+        "Select regions for stock discovery:",
+        choices=[
+            questionary.Choice(
+                DISCOVERY_REGION_LABELS[region],
+                value=region,
+                checked=region in default_regions,
+            )
+            for region in DISCOVERY_REGIONS
+        ],
+        instruction="\n- Press Space to select/unselect regions\n- Press 'a' to select/unselect all\n- Press Enter when done",
+        validate=lambda selected: len(selected) > 0 or "Select at least one region.",
+        style=questionary.Style(
+            [
+                ("checkbox-selected", "fg:green"),
+                ("selected", "fg:green noinherit"),
+                ("highlighted", "noinherit"),
+                ("pointer", "noinherit"),
+            ]
+        ),
+    ).ask()
+    return choices or list(default_regions)
+
+
 def select_research_depth() -> int:
     """Select research depth using an interactive selection."""
 

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -1,0 +1,49 @@
+from cli import main as cli_main
+from tradingagents.discovery.stock_discovery import StockCandidate
+
+
+def _candidate(symbol):
+    return StockCandidate(
+        symbol=symbol,
+        score=80.0,
+        latest_price=100.0,
+        return_percent=4.0,
+        relative_volume=2.0,
+        volatility_percent=2.0,
+        reasons=("momentum positivo (+4.0% en el periodo)",),
+    )
+
+
+def test_prompt_for_discovery_ticker_returns_selected_candidate(monkeypatch):
+    monkeypatch.setattr(cli_main.typer, "prompt", lambda *args, **kwargs: "2")
+    monkeypatch.setattr(cli_main, "select_discovery_regions", lambda: ["us", "europe"])
+
+    selected = cli_main.prompt_for_discovery_ticker(
+        discover_fn=lambda **kwargs: [_candidate("AAPL"), _candidate("SAP.DE")]
+    )
+
+    assert selected == "SAP.DE"
+
+
+def test_prompt_for_discovery_ticker_falls_back_to_manual_input(monkeypatch):
+    monkeypatch.setattr(cli_main, "get_ticker", lambda: "MSFT")
+    monkeypatch.setattr(cli_main, "select_discovery_regions", lambda: ["us"])
+
+    selected = cli_main.prompt_for_discovery_ticker(discover_fn=lambda **kwargs: [])
+
+    assert selected == "MSFT"
+
+
+def test_prompt_for_discovery_ticker_passes_selected_region_symbols(monkeypatch):
+    monkeypatch.setattr(cli_main, "select_discovery_regions", lambda: ["japan"])
+    monkeypatch.setattr(cli_main.typer, "prompt", lambda *args, **kwargs: "1")
+    calls = []
+
+    def discover(**kwargs):
+        calls.append(kwargs["symbols"])
+        return [_candidate("7203.T")]
+
+    selected = cli_main.prompt_for_discovery_ticker(discover_fn=discover)
+
+    assert selected == "7203.T"
+    assert calls == [cli_main.symbols_for_regions(["japan"])]

--- a/tests/test_stock_discovery.py
+++ b/tests/test_stock_discovery.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from tradingagents.discovery.stock_discovery import (
+    DiscoveryConfig,
+    DISCOVERY_REGIONS,
+    StockCandidate,
+    discover_trending_stocks,
+    symbols_for_regions,
+)
+
+
+def _history(closes, volumes):
+    dates = [datetime(2026, 8, 1) + timedelta(days=index) for index in range(len(closes))]
+    return pd.DataFrame({"Close": closes, "Volume": volumes}, index=dates)
+
+
+def test_discovery_ranks_momentum_and_volume_candidate_first():
+    histories = {
+        "HOT.US": _history([100, 101, 102, 104, 108, 113], [100, 100, 105, 120, 180, 260]),
+        "FLAT.US": _history([100, 100, 100, 100, 100, 100], [100] * 6),
+    }
+
+    candidates = discover_trending_stocks(
+        symbols=list(histories),
+        config=DiscoveryConfig(lookback_days=5, candidate_limit=2),
+        history_loader=histories.__getitem__,
+    )
+
+    assert [candidate.symbol for candidate in candidates] == ["HOT.US", "FLAT.US"]
+    assert candidates[0].score > candidates[1].score
+    assert "momentum" in " ".join(candidates[0].reasons).lower()
+    assert "volume" in " ".join(candidates[0].reasons).lower()
+
+
+def test_discovery_filters_insufficient_data_and_limits_results():
+    histories = {
+        "SHORT.US": _history([100, 101], [100, 100]),
+        "ONE.US": _history([100, 105, 110, 115, 120, 125], [100] * 6),
+        "TWO.US": _history([100, 99, 98, 97, 96, 95], [100] * 6),
+    }
+
+    candidates = discover_trending_stocks(
+        symbols=list(histories),
+        config=DiscoveryConfig(lookback_days=5, candidate_limit=1),
+        history_loader=histories.__getitem__,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].symbol == "ONE.US"
+
+
+def test_candidate_is_typed_and_score_is_bounded():
+    histories = {
+        "A.US": _history([100, 110, 120, 130, 140, 150], [100, 100, 100, 100, 100, 100])
+    }
+
+    [candidate] = discover_trending_stocks(
+        symbols=list(histories),
+        config=DiscoveryConfig(lookback_days=5),
+        history_loader=histories.__getitem__,
+    )
+
+    assert isinstance(candidate, StockCandidate)
+    assert 0 <= candidate.score <= 100
+    assert candidate.latest_price == 150
+
+
+def test_discovery_config_can_limit_results():
+    histories = {
+        symbol: _history([100, 101, 102, 103, 104, 105], [100] * 6)
+        for symbol in ("A.US", "B.US", "C.US")
+    }
+
+    candidates = discover_trending_stocks(
+        symbols=list(histories),
+        config=DiscoveryConfig(lookback_days=5, candidate_limit=2),
+        history_loader=histories.__getitem__,
+    )
+
+    assert len(candidates) == 2
+
+
+def test_symbols_for_regions_combines_selected_regions_without_duplicates():
+    symbols = symbols_for_regions(["us", "europe"])
+
+    assert symbols
+    assert "AAPL" in symbols
+    assert "SAP.DE" in symbols
+    assert len(symbols) == len(set(symbols))
+
+
+def test_discovery_regions_include_non_us_europe_markets():
+    assert {"canada", "japan", "india", "australia"}.issubset(DISCOVERY_REGIONS)

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -19,6 +19,9 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_BENCHMARK_TICKER":     "benchmark_ticker",
     "TRADINGAGENTS_TEMPERATURE":          "temperature",
     "TRADINGAGENTS_LLM_MAX_RETRIES":      "llm_max_retries",
+    "TRADINGAGENTS_DISCOVERY_ENABLED":    "discovery_enabled",
+    "TRADINGAGENTS_DISCOVERY_LIMIT":     "discovery_candidate_limit",
+    "TRADINGAGENTS_DISCOVERY_LOOKBACK":  "discovery_lookback_days",
     # Provider-specific reasoning/thinking knobs (None = each provider's own
     # default). Settable here for non-interactive runs; the CLI also offers an
     # interactive choice, which is skipped when the matching var is set.
@@ -125,6 +128,11 @@ DEFAULT_CONFIG = _apply_env_overrides({
         "ECB Bank of England BOJ central bank policy",
         "oil commodities supply chain energy",
     ],
+    # Pre-analysis stock discovery. Regions are selected interactively in the CLI.
+    "discovery_enabled": True,
+    "discovery_candidate_limit": 8,
+    "discovery_lookback_days": 20,
+    "discovery_regions": ("us", "europe"),
     # Data vendor configuration
     # Category-level configuration (default for all tools in category).
     # The configured value is the exact vendor chain — requests are NOT silently

--- a/tradingagents/discovery/__init__.py
+++ b/tradingagents/discovery/__init__.py
@@ -1,0 +1,19 @@
+from .stock_discovery import (
+    DEFAULT_DISCOVERY_UNIVERSE,
+    DISCOVERY_REGIONS,
+    DISCOVERY_REGION_LABELS,
+    DiscoveryConfig,
+    StockCandidate,
+    discover_trending_stocks,
+    symbols_for_regions,
+)
+
+__all__ = [
+    "DEFAULT_DISCOVERY_UNIVERSE",
+    "DISCOVERY_REGIONS",
+    "DISCOVERY_REGION_LABELS",
+    "DiscoveryConfig",
+    "StockCandidate",
+    "discover_trending_stocks",
+    "symbols_for_regions",
+]

--- a/tradingagents/discovery/stock_discovery.py
+++ b/tradingagents/discovery/stock_discovery.py
@@ -1,0 +1,155 @@
+"""Explainable discovery of currently active equities by market region."""
+
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+import pandas as pd
+import yfinance as yf
+
+
+DISCOVERY_REGIONS = {
+    "us": ("AAPL", "AMZN", "GOOGL", "META", "MSFT", "NVDA", "TSLA", "AVGO", "AMD", "JPM", "LLY", "NFLX", "ORCL", "PLTR"),
+    "europe": ("AZN.L", "HSBA.L", "SHEL.L", "ULVR.L", "SAP.DE", "SIE.DE", "ALV.DE", "AIR.PA", "MC.PA", "OR.PA", "SU.PA", "ASML.AS", "INGA.AS", "NESN.SW", "NOVN.SW", "ENEL.MI", "ISP.MI", "SAN.MC"),
+    "canada": ("SHOP.TO", "RY.TO", "TD.TO", "CNR.TO", "SU.TO"),
+    "latin_america": ("VALE", "PBR", "ITUB", "NU", "MELI"),
+    "japan": ("7203.T", "6758.T", "9984.T", "8035.T", "6861.T"),
+    "china_hong_kong": ("0700.HK", "9988.HK", "3690.HK", "600519.SS", "601318.SS"),
+    "india": ("RELIANCE.NS", "TCS.NS", "HDFCBANK.NS", "INFY.NS", "ICICIBANK.NS"),
+    "australia": ("BHP.AX", "CBA.AX", "CSL.AX", "WBC.AX", "RIO.AX"),
+    "south_korea": ("005930.KS", "000660.KS", "035420.KS", "035720.KS"),
+}
+DISCOVERY_REGION_LABELS = {
+    "us": "Estados Unidos", "europe": "Europa", "canada": "Canada",
+    "latin_america": "Latinoamerica", "japan": "Japon",
+    "china_hong_kong": "China y Hong Kong", "india": "India",
+    "australia": "Australia", "south_korea": "Corea del Sur",
+}
+DEFAULT_DISCOVERY_UNIVERSE = tuple(
+    symbol for region in DISCOVERY_REGIONS.values() for symbol in region
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryConfig:
+    lookback_days: int = 20
+    candidate_limit: int = 10
+    minimum_history_days: int = 5
+    momentum_weight: float = 0.55
+    volume_weight: float = 0.30
+    volatility_weight: float = 0.15
+
+
+@dataclass(frozen=True)
+class StockCandidate:
+    symbol: str
+    score: float
+    latest_price: float
+    return_percent: float
+    relative_volume: float
+    volatility_percent: float
+    reasons: tuple[str, ...]
+
+
+HistoryLoader = Callable[[str], pd.DataFrame]
+
+
+def symbols_for_regions(regions: Iterable[str]) -> tuple[str, ...]:
+    """Return a stable, de-duplicated universe for selected regions."""
+    symbols = [symbol for region in regions for symbol in DISCOVERY_REGIONS.get(region, ())]
+    return tuple(dict.fromkeys(symbols))
+
+
+def _load_history(symbol: str, lookback_days: int) -> pd.DataFrame:
+    return yf.Ticker(symbol).history(period=f"{max(lookback_days * 3, 60)}d")
+
+
+def _is_equity_symbol(symbol: str) -> bool:
+    """Reject common non-equity Yahoo symbol forms from the discovery universe."""
+    return bool(symbol) and not any(marker in symbol for marker in ("^", "=", "-"))
+
+
+def _bounded_percentile(value: float, low: float, high: float) -> float:
+    if high <= low:
+        return 50.0
+    return max(0.0, min(100.0, (value - low) / (high - low) * 100.0))
+
+
+def _candidate_from_history(
+    symbol: str, history: pd.DataFrame, config: DiscoveryConfig
+) -> StockCandidate | None:
+    if not isinstance(history, pd.DataFrame) or not {"Close", "Volume"}.issubset(history.columns):
+        return None
+
+    clean = history[["Close", "Volume"]].dropna()
+    if len(clean) < config.minimum_history_days + 1:
+        return None
+
+    window = clean.tail(config.lookback_days + 1)
+    if len(window) < config.minimum_history_days + 1:
+        return None
+
+    closes = window["Close"].astype(float)
+    volumes = window["Volume"].astype(float)
+    latest_price = float(closes.iloc[-1])
+    if latest_price <= 0:
+        return None
+
+    return_percent = float((latest_price / closes.iloc[0] - 1.0) * 100.0)
+    prior_volumes = volumes.iloc[:-1]
+    median_volume = float(prior_volumes.median())
+    relative_volume = float(volumes.iloc[-1] / median_volume) if median_volume > 0 else 1.0
+    daily_returns = closes.pct_change().dropna()
+    volatility_percent = float(daily_returns.std(ddof=0) * 100.0)
+
+    momentum_score = _bounded_percentile(return_percent, -10.0, 10.0)
+    volume_score = _bounded_percentile(relative_volume, 0.5, 3.0)
+    volatility_score = _bounded_percentile(volatility_percent, 0.5, 6.0)
+    score = (
+        momentum_score * config.momentum_weight
+        + volume_score * config.volume_weight
+        + volatility_score * config.volatility_weight
+    )
+
+    reasons = []
+    if return_percent >= 3:
+        reasons.append(f"momentum positivo ({return_percent:+.1f}% en el periodo)")
+    elif return_percent <= -3:
+        reasons.append(f"movimiento bajista ({return_percent:+.1f}% en el periodo)")
+    if relative_volume >= 1.5:
+        reasons.append(f"volumen relativo elevado ({relative_volume:.1f}x)")
+    if volatility_percent >= 3:
+        reasons.append(f"volatilidad elevada ({volatility_percent:.1f}%)")
+    if not reasons:
+        reasons.append("actividad de mercado estable, sin catalizador cuantitativo dominante")
+
+    return StockCandidate(
+        symbol=symbol,
+        score=round(max(0.0, min(100.0, score)), 2),
+        latest_price=round(latest_price, 4),
+        return_percent=round(return_percent, 4),
+        relative_volume=round(relative_volume, 4),
+        volatility_percent=round(volatility_percent, 4),
+        reasons=tuple(reasons),
+    )
+
+
+def discover_trending_stocks(
+    symbols: Iterable[str] | None = None,
+    config: DiscoveryConfig | None = None,
+    history_loader: HistoryLoader | None = None,
+) -> list[StockCandidate]:
+    """Return ranked active equities from the configured US/EU universe."""
+    config = config or DiscoveryConfig()
+    selected_symbols = symbols or DEFAULT_DISCOVERY_UNIVERSE
+    loader = history_loader or (lambda symbol: _load_history(symbol, config.lookback_days))
+    candidates = []
+    for symbol in selected_symbols:
+        if not _is_equity_symbol(symbol):
+            continue
+        try:
+            candidate = _candidate_from_history(symbol, loader(symbol), config)
+        except Exception:
+            candidate = None
+        if candidate is not None:
+            candidates.append(candidate)
+    return sorted(candidates, key=lambda item: (-item.score, item.symbol))[: config.candidate_limit]


### PR DESCRIPTION
## Summary

This PR adds a regional stock discovery flow to the interactive CLI.

Users can select one or more markets before the discovery process starts. The selected regions are combined into a single stock universe, and the existing ranking logic is then applied to those symbols.

Supported regions include:

- United States
- Europe
- Canada
- Latin America
- Japan
- China and Hong Kong
- India
- Australia
- South Korea

The default selection remains the United States and Europe, so the existing behavior is preserved for users who do not change the selection.

## Why this is useful

This makes it much easier to get a quick overview of which stocks are currently attracting market activity, without having to manually inspect a large list of tickers.

The discovery step uses recent Yahoo Finance data to rank stocks based on:

- Recent price momentum
- Trading volume compared with its recent average
- Recent volatility

The result is a short, explainable list of stocks that appear to be unusually active. Users can select one of them and continue with the normal analyst workflow.

This is intended as a research and exploration tool, not as a prediction or investment recommendation.

## User experience

Regions can be selected interactively with `Space` and confirmed with `Enter`.

The discovery step can also be skipped entirely through the environment variable:

```bash
TRADINGAGENTS_DISCOVERY_ENABLED=false
```

The number of candidates and the historical lookback window can be adjusted with:

```bash
TRADINGAGENTS_DISCOVERY_LIMIT
TRADINGAGENTS_DISCOVERY_LOOKBACK
```

The selected stock universe is passed to the existing discovery workflow, and the normal ticker selection and analysis flow remain unchanged.

## Testing
Added unit tests for regional universes and symbol deduplication.
Added CLI tests to verify that the selected regions are passed to discovery.
Full test suite: 586 passed, 1 skipped.
The skipped test requires the optional langchain_aws dependency for Bedrock support.