### PR TITLE
fix: add .SH Shanghai A-share suffix to benchmark_map

### DIFF
--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -158,7 +158,9 @@ DEFAULT_CONFIG = _apply_env_overrides({
         ".TO":  "^GSPTSE",     # Toronto (TSX Composite)
         ".AX":  "^AXJO",       # Australia (ASX 200)
         ".SS":  "000001.SS",   # Shanghai (SSE Composite)
+        ".SH":  "000001.SS",   # Shanghai (SSE Composite, alternate suffix)
         ".SZ":  "399001.SZ",   # Shenzhen (SZSE Component)
         "":     "SPY",         # default for US-listed tickers (no suffix)
     },
 })
+


### PR DESCRIPTION
## Summary

The `benchmark_map` in `tradingagents/default_config.py` maps exchange suffixes to benchmark indices for alpha calculation in the reflection layer. While `.SS` (Shanghai) and `.SZ` (Shenzhen) are properly mapped to their respective indices, the `.SH` suffix is missing.

## Why this matters

The `.SH` suffix is explicitly supported by the project:

- The v0.2.5 changelog states: *"Ticker prompt preserves exchange suffixes (`.SH`, `.SZ`, `.SS`, `.HK`, `.T`, etc.)"*
- The CLI and graph accept `.SH` as a valid ticker format

## Impact

When a user passes a `.SH` ticker (e.g., `600519.SH` for Kweichow Moutai), `_resolve_benchmark()` in `trading_graph.py` iterates through `benchmark_map` and finds no matching suffix. It falls through to the empty-string entry (`SPY`), causing the alpha calculation to compare a CNY-denominated Shanghai stock against a USD-denominated US index — producing a meaningless alpha figure in the decision log and reflection.

## Fix

Adds `.SH` to the `benchmark_map`, mapping it to the same SSE Composite Index (`000001.SS`) as `.SS`, since both suffixes refer to Shanghai-listed A-shares.

## Change

```diff
     ".SS":  "000001.SS",   # Shanghai (SSE Composite)
+    ".SH":  "000001.SS",   # Shanghai (SSE Composite, alternate suffix)
     ".SZ":  "399001.SZ",   # Shenzhen (SZSE Component)
```