### PR TITLE
fix(dataflows): pin FRED requests to curr_date vintage to remove look-ahead bias

### DIFF
--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -161,11 +161,33 @@ class FredFormattingTests(unittest.TestCase):
             captured[path] = params
             return _META if path == "series" else _OBS
 
-        with mock.patch.object(fred, "_request", side_effect=_capture):
+        # Pin the clock so the clamp (min(curr_date, FRED's today)) is a no-op
+        # here: FRED's today == curr_date.
+        with mock.patch.object(fred, "_request", side_effect=_capture), \
+                mock.patch.object(fred, "_fred_today", return_value="2025-09-30"):
             fred.get_macro_data("unemployment", "2025-09-30", 90)
         for path in ("series", "series/observations"):
             self.assertEqual(captured[path]["realtime_end"], "2025-09-30", path)
             self.assertEqual(captured[path]["realtime_start"], "2025-07-02", path)
+
+    def test_realtime_end_is_clamped_to_fred_today(self):
+        # A curr_date ahead of FRED's clock (caller in Asia during their
+        # morning) must clamp realtime_end to FRED's today, not 400: FRED
+        # validates realtime dates against US Central time, and the routing
+        # layer turns that 400 into a silent DATA_UNAVAILABLE sentinel
+        # (#1275) - macro data would vanish without any loud failure.
+        captured = {}
+
+        def _capture(path, params):
+            captured[path] = params
+            return _META if path == "series" else _OBS
+
+        # Local 2025-10-31 in Asia == 2025-10-30 in US Central.
+        with mock.patch.object(fred, "_request", side_effect=_capture), \
+                mock.patch.object(fred, "_fred_today", return_value="2025-10-30"):
+            fred.get_macro_data("unemployment", "2025-10-31", 90)
+        self.assertEqual(captured["series/observations"]["realtime_end"], "2025-10-30")
+        self.assertEqual(captured["series"]["realtime_end"], "2025-10-30")
 
     def test_revised_observations_keep_latest_vintage(self):
         # With realtime bounds FRED returns one row per vintage; a revision

--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -121,10 +121,11 @@ class FredFormattingTests(unittest.TestCase):
         self.assertIn("not found", out)
 
     def test_long_series_is_truncated_but_change_uses_full_range(self):
-        # Build > MAX_ROWS observations deterministically.
+        # Build > MAX_ROWS observations deterministically (unique dates: the
+        # report deduplicates revisions by observation date).
         obs = {
             "observations": [
-                {"date": f"2025-01-{(i % 28) + 1:02d}", "value": str(i)}
+                {"date": f"2025-{(i // 28) + 1:02d}-{(i % 28) + 1:02d}", "value": str(i)}
                 for i in range(fred.MAX_ROWS + 10)
             ]
         }
@@ -149,6 +150,49 @@ class FredFormattingTests(unittest.TestCase):
         obs_params = captured["series/observations"]
         self.assertEqual(obs_params["observation_end"], "2025-09-30")
         self.assertEqual(obs_params["observation_start"], "2025-07-02")  # 90d back
+
+    def test_request_is_pinned_to_vintage(self):
+        # realtime bounds must pin both the series and observations requests to
+        # curr_date's vintage, so a backtest never sees unreleased prints or
+        # later revisions (#1275).
+        captured = {}
+
+        def _capture(path, params):
+            captured[path] = params
+            return _META if path == "series" else _OBS
+
+        with mock.patch.object(fred, "_request", side_effect=_capture):
+            fred.get_macro_data("unemployment", "2025-09-30", 90)
+        for path in ("series", "series/observations"):
+            self.assertEqual(captured[path]["realtime_end"], "2025-09-30", path)
+            self.assertEqual(captured[path]["realtime_start"], "2025-07-02", path)
+
+    def test_revised_observations_keep_latest_vintage(self):
+        # With realtime bounds FRED returns one row per vintage; a revision
+        # must not render duplicate rows and the latest value wins.
+        obs = {
+            "observations": [
+                {"date": "2025-08-01", "value": "150", "realtime_start": "2025-09-05"},
+                {"date": "2025-08-01", "value": "160", "realtime_start": "2025-10-08"},
+                {"date": "2025-09-01", "value": "165", "realtime_start": "2025-10-08"},
+            ]
+        }
+        with mock.patch.object(fred, "_request", side_effect=_request_stub(obs=obs)):
+            out = fred.get_macro_data("nonfarm_payrolls", "2025-10-31", 90)
+        body_rows = [ln for ln in out.splitlines() if ln.startswith("| 2025")]
+        self.assertEqual(len(body_rows), 2)
+        self.assertIn("| 2025-08-01 | 160 |", out)  # revised value wins
+        self.assertNotIn("| 2025-08-01 | 150 |", out)
+        self.assertIn("**Latest:** 165 (2025-09-01)", out)
+
+    def test_empty_window_mentions_missing_vintage(self):
+        # Empty under realtime bounds is usually missing ALFRED vintage
+        # coverage, not just a short window; the message must say both.
+        empty = {"observations": []}
+        with mock.patch.object(fred, "_request", side_effect=_request_stub(obs=empty)):
+            out = fred.get_macro_data("unemployment", "2025-09-30", 30)
+        self.assertIn("No observations", out)
+        self.assertIn("vintage", out)
 
 
 @pytest.mark.unit

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -10,13 +10,25 @@ the routing layer treats it as "unavailable" rather than a hard crash.
 """
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import requests
 
 from .errors import VendorNotConfiguredError
 
+try:
+    # FRED validates realtime dates against its own clock (US Central).
+    _FRED_TZ = ZoneInfo("America/Chicago")
+except Exception:  # pragma: no cover - missing tz database (bare Windows)
+    _FRED_TZ = timezone(timedelta(hours=-6))  # US Central, standard time
+
 logger = logging.getLogger(__name__)
+
+
+def _fred_today() -> str:
+    """FRED's current date in its own timezone (US Central)."""
+    return datetime.now(_FRED_TZ).strftime("%Y-%m-%d")
 
 FRED_API_BASE = "https://api.stlouisfed.org/fred"
 
@@ -164,9 +176,18 @@ def get_macro_data(
     # default API serves today's data, which for a past curr_date would leak
     # observations published after curr_date AND later revisions of old ones -
     # a silent look-ahead bias in backtests (#1275).
+    #
+    # FRED validates realtime dates against its own clock (US Central): a
+    # realtime_end in FRED's future is a hard 400. When the caller's local
+    # date is ahead of FRED's (e.g. Asia timezones in their morning), clamp
+    # to FRED's today. For a past curr_date the pin is unchanged - clamping
+    # only ever applies to a date that is already in FRED's future, where no
+    # as-of-curr_date data could exist anyway, so the look-ahead protection
+    # is preserved.
+    fred_today = _fred_today()
     vintage = {
         "realtime_start": start_date,
-        "realtime_end": curr_date,
+        "realtime_end": min(curr_date, fred_today),
     }
 
     # Invalid LLM-supplied indicator: return guidance rather than raising, so a

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -143,8 +143,11 @@ def get_macro_data(
     Args:
         indicator: A friendly alias (e.g. "cpi", "unemployment", "10y_treasury")
             or a raw FRED series ID (e.g. "CPIAUCSL", "DGS10").
-        curr_date: End of the window (yyyy-mm-dd); no later observations are
-            returned, so a past date never leaks future data.
+        curr_date: End of the window (yyyy-mm-dd). The request is pinned to
+            this date's ALFRED vintage (realtime_start/realtime_end), so only
+            observations already published by curr_date are returned, at their
+            as-published values - a past date never leaks future data,
+            unreleased prints, or later revisions (#1275).
         look_back_days: Trailing window length; ``None`` uses DEFAULT_LOOKBACK_DAYS.
 
     Returns:
@@ -157,6 +160,15 @@ def get_macro_data(
     end_dt = datetime.strptime(curr_date, "%Y-%m-%d")
     start_date = (end_dt - timedelta(days=look_back_days)).strftime("%Y-%m-%d")
 
+    # Pin the request to the curr_date vintage via ALFRED realtime bounds: the
+    # default API serves today's data, which for a past curr_date would leak
+    # observations published after curr_date AND later revisions of old ones -
+    # a silent look-ahead bias in backtests (#1275).
+    vintage = {
+        "realtime_start": start_date,
+        "realtime_end": curr_date,
+    }
+
     # Invalid LLM-supplied indicator: return guidance rather than raising, so a
     # bad argument doesn't abort the run (the routing layer also degrades macro
     # data, but a specific message is more useful to the analyst).
@@ -165,7 +177,7 @@ def get_macro_data(
     except ValueError as e:
         return f"FRED: {e}"
 
-    meta = _request("series", {"series_id": series_id}).get("seriess") or []
+    meta = _request("series", {"series_id": series_id, **vintage}).get("seriess") or []
     if not meta:
         return (
             f"FRED series '{series_id}' not found. Pass a known alias "
@@ -184,15 +196,23 @@ def get_macro_data(
             "observation_start": start_date,
             "observation_end": curr_date,
             "sort_order": "asc",
+            **vintage,
         },
     ).get("observations", [])
 
-    # FRED encodes a missing observation as ".".
-    points = [
-        (o["date"], o["value"])
-        for o in observations
-        if o.get("value") not in (".", None, "")
-    ]
+    # FRED encodes a missing observation as ".". With realtime bounds, a
+    # revised observation appears once per vintage in the window; keep only
+    # the latest vintage for each date (the value as most recently known by
+    # curr_date) instead of rendering duplicate rows.
+    latest: dict[str, tuple[str, str]] = {}
+    for o in observations:
+        if o.get("value") in (".", None, ""):
+            continue
+        date = o["date"]
+        realtime = str(o.get("realtime_start", ""))
+        if date not in latest or realtime >= latest[date][1]:
+            latest[date] = (o["value"], realtime)
+    points = [(date, value) for date, (value, _) in sorted(latest.items())]
 
     header = (
         f"## FRED: {title} ({series_id})\n"
@@ -203,9 +223,14 @@ def get_macro_data(
     )
 
     if not points:
+        # With realtime bounds, an empty result usually means the series has no
+        # ALFRED vintage coverage for this window (vintage depth varies per
+        # series and some have none), rather than a too-short window.
         return header + (
-            f"\nNo observations for {series_id} in this window. The series may "
-            f"report less frequently than the window length; widen look_back_days."
+            f"\nNo observations for {series_id} in this window. Either the "
+            f"window is shorter than the series' reporting frequency "
+            f"(widen look_back_days), or no as-first-published vintage data "
+            f"exists for this window on ALFRED."
         )
 
     first_date, first_val = points[0]


### PR DESCRIPTION
## Summary

Fixes #1275.

`get_macro_data()` queried FRED without realtime bounds, so historical backtests silently ingested as-of-today values: unreleased prints (e.g. CPI flash vs final) and later revisions — classic silent look-ahead bias.

This PR:

- Pins both the `series` and `series/observations` requests to the `curr_date` ALFRED vintage via `realtime_start` / `realtime_end`, so a backtest only sees values that were actually published by that date
- Dedups multiple vintages per observation date (revised series otherwise render one row per vintage); the latest vintage in the window wins
- Clarifies the empty-result message: under realtime bounds an empty window usually means no ALFRED vintage coverage for that series, not just a short window

## Testing

- `tests/test_fred.py`: 18/18 passing, including 4 new regression tests (vintage-pinned request params, revision dedup keeps latest vintage, empty-window message, existing lookahead-safe window)
- All tests fully mocked — no FRED key or network needed in CI
- Full test suite shows no new failures (remaining local failures are pre-existing dependency-mismatch issues unrelated to this change, verified by stashing the diff)

## Notes

Vintage depth varies per series on ALFRED; series without vintage coverage now return an explicit "no vintage data" message instead of silently returning current revised values.