### PR TITLE
Make debate and analyst prompts cache-friendly — measured 4.3x prompt cache hit rate (#750)

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -39,9 +39,13 @@ def create_fundamentals_analyst(llm):
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}."
-                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
-                    "{system_message}",
+                    " You have access to the following tools: {tool_names}.\n"
+                    "{system_message}\n"
+                    # Volatile per-run values (trade date, instrument) go LAST
+                    # so the static prefix above stays byte-identical across
+                    # trade dates and tickers, and provider prompt caches can
+                    # reuse it between runs (#750).
+                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -65,9 +65,13 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}."
-                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
-                    "{system_message}",
+                    " You have access to the following tools: {tool_names}.\n"
+                    "{system_message}\n"
+                    # Volatile per-run values (trade date, instrument) go LAST
+                    # so the static prefix above stays byte-identical across
+                    # trade dates and tickers, and provider prompt caches can
+                    # reuse it between runs (#750).
+                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -40,9 +40,13 @@ def create_news_analyst(llm):
                     " will help where you left off. Execute what you can to make progress."
                     " If you or any other assistant has the FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** or deliverable,"
                     " prefix your response with FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL** so the team knows to stop."
-                    " You have access to the following tools: {tool_names}."
-                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
-                    "{system_message}",
+                    " You have access to the following tools: {tool_names}.\n"
+                    "{system_message}\n"
+                    # Volatile per-run values (trade date, instrument) go LAST
+                    # so the static prefix above stays byte-identical across
+                    # trade dates and tickers, and provider prompt caches can
+                    # reuse it between runs (#750).
+                    " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -94,9 +94,13 @@ def create_sentiment_analyst(llm):
                     # No tool-calling here: the data is pre-fetched into the
                     # prompt, so tool-range wording would only invite a
                     # hallucinated tool call (#1130).
-                    " Today's date is {current_date}; treat it as 'now' for all analysis. {instrument_context}"
                     " " + NO_EXTERNAL_TOOLS +
-                    "\n{system_message}",
+                    "\n{system_message}\n"
+                    # Volatile per-run values (trade date, instrument) go LAST
+                    # so the static prefix above stays byte-identical across
+                    # trade dates and tickers, and provider prompt caches can
+                    # reuse it between runs (#750).
+                    " Today's date is {current_date}; treat it as 'now' for all analysis. {instrument_context}",
                 ),
                 MessagesPlaceholder(variable_name="messages"),
             ]

--- a/tradingagents/agents/researchers/bear_researcher.py
+++ b/tradingagents/agents/researchers/bear_researcher.py
@@ -27,7 +27,23 @@ def create_bear_researcher(llm):
             else "Asset fundamentals report (may be unavailable for crypto)"
         )
 
-        prompt = f"""You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the provided research and data to highlight potential downsides and counter bullish arguments effectively.
+        # Prompt layout is cache-aware (#750): the debate-wide shared context
+        # (reports, trader decision where applicable, then the append-only
+        # debate history) leads, and the per-role instructions trail. Every
+        # debate turn therefore extends a byte-identical prefix that provider
+        # prompt caches can serve at the cached-token rate; with the role text
+        # first, no two turns ever share a prefix and every turn bills full
+        # price. Wording is unchanged — sections are only reordered.
+        prompt = f"""Resources available:
+
+{instrument_context}
+Market research report: {market_research_report}
+Social media sentiment report: {sentiment_report}
+Latest world affairs news: {news_report}
+{fundamentals_label}: {fundamentals_report}
+Conversation history of the debate: {history}
+
+You are a Bear Analyst making the case against investing in the {target_label}. Your goal is to present a well-reasoned argument emphasizing risks, challenges, and negative indicators. Leverage the research and data provided above to highlight potential downsides and counter bullish arguments effectively.
 
 Key points to focus on:
 
@@ -37,14 +53,6 @@ Key points to focus on:
 - Bull Counterpoints: Critically analyze the bull argument with specific data and sound reasoning, exposing weaknesses or over-optimistic assumptions.
 - Engagement: Present your argument in a conversational style, directly engaging with the bull analyst's points and debating effectively rather than simply listing facts.
 
-Resources available:
-
-{instrument_context}
-Market research report: {market_research_report}
-Social media sentiment report: {sentiment_report}
-Latest world affairs news: {news_report}
-{fundamentals_label}: {fundamentals_report}
-Conversation history of the debate: {history}
 Last bull argument: {current_response}
 Use this information to deliver a compelling bear argument, refute the bull's claims, and engage in a dynamic debate that demonstrates the risks and weaknesses of investing in the {target_label}.
 """ + get_language_instruction()

--- a/tradingagents/agents/researchers/bull_researcher.py
+++ b/tradingagents/agents/researchers/bull_researcher.py
@@ -27,7 +27,23 @@ def create_bull_researcher(llm):
             else "Asset fundamentals report (may be unavailable for crypto)"
         )
 
-        prompt = f"""You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the provided research and data to address concerns and counter bearish arguments effectively.
+        # Prompt layout is cache-aware (#750): the debate-wide shared context
+        # (reports, trader decision where applicable, then the append-only
+        # debate history) leads, and the per-role instructions trail. Every
+        # debate turn therefore extends a byte-identical prefix that provider
+        # prompt caches can serve at the cached-token rate; with the role text
+        # first, no two turns ever share a prefix and every turn bills full
+        # price. Wording is unchanged — sections are only reordered.
+        prompt = f"""Resources available:
+
+{instrument_context}
+Market research report: {market_research_report}
+Social media sentiment report: {sentiment_report}
+Latest world affairs news: {news_report}
+{fundamentals_label}: {fundamentals_report}
+Conversation history of the debate: {history}
+
+You are a Bull Analyst advocating for investing in the {target_label}. Your task is to build a strong, evidence-based case emphasizing growth potential, competitive advantages, and positive market indicators. Leverage the research and data provided above to address concerns and counter bearish arguments effectively.
 
 Key points to focus on:
 - Growth Potential: Highlight the company's market opportunities, revenue projections, and scalability.
@@ -36,13 +52,6 @@ Key points to focus on:
 - Bear Counterpoints: Critically analyze the bear argument with specific data and sound reasoning, addressing concerns thoroughly and showing why the bull perspective holds stronger merit.
 - Engagement: Present your argument in a conversational style, engaging directly with the bear analyst's points and debating effectively rather than just listing data.
 
-Resources available:
-{instrument_context}
-Market research report: {market_research_report}
-Social media sentiment report: {sentiment_report}
-Latest world affairs news: {news_report}
-{fundamentals_label}: {fundamentals_report}
-Conversation history of the debate: {history}
 Last bear argument: {current_response}
 Use this information to deliver a compelling bull argument, refute the bear's concerns, and engage in a dynamic debate that demonstrates the strengths of the bull position.
 """ + get_language_instruction()

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -26,18 +26,32 @@ def create_aggressive_debator(llm):
 
         trader_decision = state["trader_investment_plan"]
 
-        prompt = f"""As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits—even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative. Here is the trader's decision:
-
-{trader_decision}
-
-Your task is to create a compelling case for the trader's decision by questioning and critiquing the conservative and neutral stances to demonstrate why your high-reward perspective offers the best path forward. Incorporate insights from the following sources into your arguments:
+        # Prompt layout is cache-aware (#750): the debate-wide shared context
+        # (reports, trader decision where applicable, then the append-only
+        # debate history) leads, and the per-role instructions trail. Every
+        # debate turn therefore extends a byte-identical prefix that provider
+        # prompt caches can serve at the cached-token rate; with the role text
+        # first, no two turns ever share a prefix and every turn bills full
+        # price. Wording is unchanged — sections are only reordered.
+        prompt = f"""Resources available:
 
 {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
-Here is the current conversation history: {history} Here are the last arguments from the conservative analyst: {current_conservative_response} Here are the last arguments from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Here is the trader's decision:
+
+{trader_decision}
+
+Here is the current conversation history: {history}
+
+As the Aggressive Risk Analyst, your role is to actively champion high-reward, high-risk opportunities, emphasizing bold strategies and competitive advantages. When evaluating the trader's decision or plan, focus intently on the potential upside, growth potential, and innovative benefits—even when these come with elevated risk. Use the provided market data and sentiment analysis to strengthen your arguments and challenge the opposing views. Specifically, respond directly to each point made by the conservative and neutral analysts, countering with data-driven rebuttals and persuasive reasoning. Highlight where their caution might miss critical opportunities or where their assumptions may be overly conservative.
+
+Your task is to create a compelling case for the trader's decision by questioning and critiquing the conservative and neutral stances to demonstrate why your high-reward perspective offers the best path forward, incorporating insights from the sources above into your arguments.
+
+Here are the last arguments from the conservative analyst: {current_conservative_response} Here are the last arguments from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by addressing any specific concerns raised, refuting the weaknesses in their logic, and asserting the benefits of risk-taking to outpace market norms. Maintain a focus on debating and persuading, not just presenting data. Challenge each counterpoint to underscore why a high-risk approach is optimal. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
 

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -26,18 +26,32 @@ def create_conservative_debator(llm):
 
         trader_decision = state["trader_investment_plan"]
 
-        prompt = f"""As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains. Here is the trader's decision:
-
-{trader_decision}
-
-Your task is to actively counter the arguments of the Aggressive and Neutral Analysts, highlighting where their views may overlook potential threats or fail to prioritize sustainability. Respond directly to their points, drawing from the following data sources to build a convincing case for a low-risk approach adjustment to the trader's decision:
+        # Prompt layout is cache-aware (#750): the debate-wide shared context
+        # (reports, trader decision where applicable, then the append-only
+        # debate history) leads, and the per-role instructions trail. Every
+        # debate turn therefore extends a byte-identical prefix that provider
+        # prompt caches can serve at the cached-token rate; with the role text
+        # first, no two turns ever share a prefix and every turn bills full
+        # price. Wording is unchanged — sections are only reordered.
+        prompt = f"""Resources available:
 
 {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
-Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Here is the trader's decision:
+
+{trader_decision}
+
+Here is the current conversation history: {history}
+
+As the Conservative Risk Analyst, your primary objective is to protect assets, minimize volatility, and ensure steady, reliable growth. You prioritize stability, security, and risk mitigation, carefully assessing potential losses, economic downturns, and market volatility. When evaluating the trader's decision or plan, critically examine high-risk elements, pointing out where the decision may expose the firm to undue risk and where more cautious alternatives could secure long-term gains.
+
+Your task is to actively counter the arguments of the Aggressive and Neutral Analysts, highlighting where their views may overlook potential threats or fail to prioritize sustainability. Respond directly to their points, drawing from the data sources above to build a convincing case for a low-risk approach adjustment to the trader's decision.
+
+Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the neutral analyst: {current_neutral_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage by questioning their optimism and emphasizing the potential downsides they may have overlooked. Address each of their counterpoints to showcase why a conservative stance is ultimately the safest path for the firm's assets. Focus on debating and critiquing their arguments to demonstrate the strength of a low-risk strategy over their approaches. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
 

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -26,18 +26,32 @@ def create_neutral_debator(llm):
 
         trader_decision = state["trader_investment_plan"]
 
-        prompt = f"""As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.Here is the trader's decision:
-
-{trader_decision}
-
-Your task is to challenge both the Aggressive and Conservative Analysts, pointing out where each perspective may be overly optimistic or overly cautious. Use insights from the following data sources to support a moderate, sustainable strategy to adjust the trader's decision:
+        # Prompt layout is cache-aware (#750): the debate-wide shared context
+        # (reports, trader decision where applicable, then the append-only
+        # debate history) leads, and the per-role instructions trail. Every
+        # debate turn therefore extends a byte-identical prefix that provider
+        # prompt caches can serve at the cached-token rate; with the role text
+        # first, no two turns ever share a prefix and every turn bills full
+        # price. Wording is unchanged — sections are only reordered.
+        prompt = f"""Resources available:
 
 {instrument_context}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}
 Company Fundamentals Report: {fundamentals_report}
-Here is the current conversation history: {history} Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the conservative analyst: {current_conservative_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
+
+Here is the trader's decision:
+
+{trader_decision}
+
+Here is the current conversation history: {history}
+
+As the Neutral Risk Analyst, your role is to provide a balanced perspective, weighing both the potential benefits and risks of the trader's decision or plan. You prioritize a well-rounded approach, evaluating the upsides and downsides while factoring in broader market trends, potential economic shifts, and diversification strategies.
+
+Your task is to challenge both the Aggressive and Conservative Analysts, pointing out where each perspective may be overly optimistic or overly cautious. Use insights from the data sources above to support a moderate, sustainable strategy to adjust the trader's decision.
+
+Here is the last response from the aggressive analyst: {current_aggressive_response} Here is the last response from the conservative analyst: {current_conservative_response}. If there are no responses from the other viewpoints yet, present your own argument based on the available data.
 
 Engage actively by analyzing both sides critically, addressing weaknesses in the aggressive and conservative arguments to advocate for a more balanced approach. Challenge each of their points to illustrate why a moderate risk strategy might offer the best of both worlds, providing growth potential while safeguarding against extreme volatility. Focus on debating rather than simply presenting data, aiming to show that a balanced view can lead to the most reliable outcomes. Output conversationally as if you are speaking without any special formatting.""" + get_language_instruction()
 


### PR DESCRIPTION
This addresses the prompt-construction half of #750 (zero prompt cache hit
rate): dynamic values embedded in system prompts, and the debate agents'
f-string prompts that never share a prefix. It does not add a caching
layer — the prompts are restructured so the providers' built-in implicit
prefix caching works on its own.

**The change is a reorder, not a rewrite.** 9 files; the wording of every
instruction is preserved; only section order changes:

- Debate prompts (bull/bear researchers, three risk debaters): the shared
  context (analyst reports, trader decision) comes first, the append-only
  debate history second, and the role-specific instructions last. Within
  each debate group the leading block is byte-identical, so every turn
  extends the previous turn's prefix — the same shape that makes chat
  loops cache well.
- Analyst system templates: the volatile `Today's date is ...` /
  instrument sentence moves to the end of the system message, so analyst
  prefixes are byte-stable across trade dates and tickers (relevant for
  back-to-back runs and backtests).

**Measured effect** (controlled before/after, 3 matched config pairs on
gpt-5.4-mini, runs ≥15 min apart so one run's provider cache can't leak
into the next; design committed before the data was collected):

| Config | Baseline hit rate | Patched | Delta |
|---|---|---|---|
| NVDA 2026-08-14 | 9.7% | 28.4% | +18.8 pts |
| AAPL 2026-08-14 | 4.6% | 34.1% | +29.5 pts |
| NVDA 2026-08-21 | 8.3% | 34.6% | +26.3 pts |

Mean hit rate 7.5% → 32.4% (4.3×), roughly a 25% cut in input cost at
OpenAI's 0.1× cached-read pricing. The gain lands exactly where the
mechanism predicts: the second speaker in each debate (bear researcher,
conservative and neutral risk analysts) goes from 0 to ~6.9k cached tokens
per call. Two untraced control runs (no instrumentation at all, usage read
from response bodies) came in at 8.6% and 3.4%, in line with the traced
baselines and nowhere near the patched arm — the measurement setup isn't
producing the effect. Full experiment — traces, analysis code, prediction-before-data
history, threats to validity:
https://github.com/yashmyeole/tokenaudit/tree/main/experiments/tradingagents-cache-fix
(write-up: https://github.com/yashmyeole/tokenaudit/blob/main/docs/case-studies/tradingagents.md).

**What this deliberately does not do** (possible follow-ups): no
`prompt_cache_key` routing hints (kept out to measure one variable), no
changes to the manager/trader prompts, and no application-level caching
layer from #750's first suggestion. Analysts' first calls also remain
below the 2048-token cacheable minimum — more headroom exists.

**On behavior:** the models see the same information in a different order
(context before role). Decisions from all experiment runs are captured
alongside the traces; this PR measures cost, not decision quality — happy
to run any eval the maintainers would find convincing, or to split the
analyst and debate changes into separate PRs if that's easier to review.
