### PR TITLE
Feat/Alpaca Paper Trading Execution Agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,17 +71,17 @@ NVIDIA_API_KEY=
 #TRADINGAGENTS_GOOGLE_THINKING_LEVEL=high
 #TRADINGAGENTS_ANTHROPIC_EFFORT=high
 
-# Optional Alpaca paper execution. Off by default: you still get a
-# buy/hold/sell recommendation sized as a percent of *available cash*.
-# Set TRADINGAGENTS_EXECUTION_ENABLED=true to place the paper order.
-# Never commit real keys. Paper URL is the default; do not point this at
-# live trading unless you fully intend to.
-#TRADINGAGENTS_EXECUTION_ENABLED=false
+# Alpaca paper execution (on by default in default_config.py). After analysis,
+# the Execution Agent places a paper order sized as a percent of *available cash*.
+# Set false for recommendations only (no order sent).
+TRADINGAGENTS_EXECUTION_ENABLED=true
+# Required for paper orders (keys from alpaca.markets — never commit real values):
+ALPACA_API_KEY=
+ALPACA_SECRET_KEY=
+# Never point at live trading unless you fully intend to.
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 #TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT=10
 #TRADINGAGENTS_EXECUTION_ALLOW_SHORT=false
-#ALPACA_API_KEY=
-#ALPACA_SECRET_KEY=
-#ALPACA_BASE_URL=https://paper-api.alpaca.markets
 #ALPACA_TIME_IN_FORCE=gtc
 #ALPACA_EXTENDED_HOURS=false
 #ALPACA_TIMEOUT_SECONDS=20

--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,18 @@ NVIDIA_API_KEY=
 #TRADINGAGENTS_OPENAI_REASONING_EFFORT=medium
 #TRADINGAGENTS_GOOGLE_THINKING_LEVEL=high
 #TRADINGAGENTS_ANTHROPIC_EFFORT=high
+
+# Optional Alpaca paper execution. Off by default: you still get a
+# buy/hold/sell recommendation sized as a percent of *available cash*.
+# Set TRADINGAGENTS_EXECUTION_ENABLED=true to place the paper order.
+# Never commit real keys. Paper URL is the default; do not point this at
+# live trading unless you fully intend to.
+#TRADINGAGENTS_EXECUTION_ENABLED=false
+#TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT=10
+#TRADINGAGENTS_EXECUTION_ALLOW_SHORT=false
+#ALPACA_API_KEY=
+#ALPACA_SECRET_KEY=
+#ALPACA_BASE_URL=https://paper-api.alpaca.markets
+#ALPACA_TIME_IN_FORCE=gtc
+#ALPACA_EXTENDED_HOURS=false
+#ALPACA_TIMEOUT_SECONDS=20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = p
 
 1. Put a **fake Alpaca client** on `ExecutionAgent(..., client=fake)`. Do not call the real API.
 2. Give the fake distinct `cash` and `equity` (for example cash `$2,000`, equity `$12,000`). A 50% buy must spend **$1,000**, not $6,000.
-3. Assert `submit_order` is **never** called when `execution_enabled` is false.
+3. Assert `submit_order` is **never** called when `execution_enabled` is false (recommendations-only mode).
 4. For horizon tests: open a paper buy on an early date, then either drop `current_price` through the stop (must sell) or jump past `horizon_end_date` with a PM Sell (must sell).
 5. Never hard-code secrets. Empty strings are fine.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,108 +1,129 @@
-# Contributing to this TradingAgents fork
+# Contributing
 
-Thanks for showing up. This repo is a fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents): a multi-agent research desk that studies **one ticker at a time**. The fork's extra job is a small **Execution Agent** that reads the Trader and Portfolio Manager write-up and either:
+Thanks for helping improve this fork. The goal is simple: **turn AI analysis into Alpaca paper trades** — safely, clearly, and with good tests.
 
-- **recommends** buy / hold / sell plus a **percent of available cash**, or
-- when you opt in, **places that ticket** on Alpaca **paper** trading.
+This builds on [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents). Keep their citation in the README.
 
-If you want to help, the highest-leverage work is making that last mile clearer, safer, and better tested — without turning the desk into a basket allocator or a live-trading bot.
+---
 
-Please keep the upstream citation in the README. This is their research framework; we are adding a paper-trade handoff.
-
-## What we are building (and not building)
-
-**In scope**
-
-- Single-ticker analysis
-- A recommendation on every run
-- Optional Alpaca paper fills
-- Sizing against **usable cash**, never against total equity or money already in stocks
-- Honoring the PM **time horizon** and selling on the plan's **stop** (significant loss)
-
-**Out of scope**
-
-- An 8-stock basket or portfolio rotation engine
-- “Fixing” sizing to use total capital / equity
-- Defaulting to live Alpaca
-- Committing `.env` files, API keys, journals, or order dumps
-
-## Dev setup
+## Get started in 5 minutes
 
 ```bash
 git clone https://github.com/Philemon518/TradingAgents.git
 cd TradingAgents
 python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
 pip install ".[dev]"
-cp .env.example .env        # fill keys locally; never commit this file
+cp .env.example .env                 # fill keys locally — never commit this file
 ```
 
-Use paper Alpaca keys if you want a real simulator. Tests do **not** need them.
-
-## Tests
-
-The full suite:
+Run tests (no Alpaca keys needed):
 
 ```bash
 pytest
 ```
 
-The execution subset (fake Alpaca, no network, no keys):
+Run only execution tests:
 
 ```bash
-pytest tests/test_position_plan.py \
-       tests/test_execution_parser.py \
-       tests/test_execution_agent.py \
-       tests/test_execution_reporting.py \
-       tests/test_env_overrides.py -q
+pytest tests/test_execution_*.py tests/test_env_overrides.py -q
 ```
 
-If you touch `default_config.py`, keep `tests/test_env_overrides.py` green.
+Run the CLI locally:
 
-Ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = py310`). Prefer matching nearby style over a repo-wide format pass.
+```bash
+set -a && source .env && set +a
+tradingagents
+```
 
-### How to add an execution test
+Note: the command is `tradingagents`, not `tradingagents analyze`.
 
-1. Put a **fake Alpaca client** on `ExecutionAgent(..., client=fake)`. Do not call the real API.
-2. Give the fake distinct `cash` and `equity` (for example cash `$2,000`, equity `$12,000`). A 50% buy must spend **$1,000**, not $6,000.
-3. Assert `submit_order` is **never** called when `execution_enabled` is false (recommendations-only mode).
-4. For horizon tests: open a paper buy on an early date, then either drop `current_price` through the stop (must sell) or jump past `horizon_end_date` with a PM Sell (must sell).
-5. Never hard-code secrets. Empty strings are fine.
+---
 
-## Where the code lives
+## What belongs in this fork
 
-| Path | Role |
-|------|------|
-| `tradingagents/agents/` | Research desk (analysts, trader, PM) |
-| `tradingagents/graph/` | LangGraph wiring; `execute_trade_decision()` runs after the PM |
-| `tradingagents/execution/parser.py` | Prose → rating, prices, horizon, cash % |
-| `tradingagents/execution/position_plan.py` | Stored hold window + stop |
-| `tradingagents/execution/agent.py` | Recommendation + optional paper order |
-| `tradingagents/execution/journal.py` | Local markdown trail (no keys) |
-| `tradingagents/reporting.py` | Writes `6_execution/execution.md` |
-| `cli/main.py` | Single-ticker CLI display |
-| `tests/test_execution_*.py` | Fake-client contract |
+**Yes**
 
-The research graph still ends at the Portfolio Manager. Execution is a **post-graph** step, not a new debate node.
+- Single-ticker execution (one stock per run)
+- Alpaca **paper** orders by default
+- Buy/hold/sell + **percent of available cash** sizing
+- Respecting PM time horizon and stop-loss rules
+- Tests with a fake Alpaca client (no network)
+- Docs and bug fixes
+
+**No**
+
+- Multi-stock basket / portfolio rotation
+- Sizing against total equity instead of cash
+- Live trading enabled by default
+- Committing `.env`, API keys, journals, or personal `reports/`
+
+---
+
+## Project layout
+
+```
+tradingagents/
+  agents/           # Analysts, trader, PM (upstream research desk)
+  graph/            # LangGraph wiring; execute_trade_decision() after PM
+  execution/
+    parser.py       # PM/trader text → action, prices, horizon, cash %
+    position_plan.py # Hold window + stop-loss tracking
+    agent.py        # Recommendation + Alpaca paper order
+    journal.py      # Local markdown log
+  default_config.py # Defaults + TRADINGAGENTS_* env overrides
+cli/main.py         # Interactive CLI
+tests/test_execution_*.py
+```
+
+Execution runs **after** the research graph finishes. It is not a new debate agent.
+
+---
+
+## Writing tests
+
+Execution tests use a **fake Alpaca client** — never call the real API in CI.
+
+```python
+agent = ExecutionAgent(config, client=fake_client)
+result = agent.run(ticker="NVDA", portfolio_manager_text=pm_text, trade_date="2026-03-01")
+```
+
+Rules:
+
+1. Give the fake different `cash` and `equity` (e.g. cash $2,000, equity $12,000). A 50% buy must spend **$1,000**, not $6,000.
+2. When `execution_enabled=False`, assert `submit_order` is never called.
+3. For horizon tests: buy on date A, then test stop breach or horizon expiry + PM Sell.
+4. No hard-coded secrets.
+
+If you change `default_config.py`, run `tests/test_env_overrides.py`.
+
+Style: Ruff in `pyproject.toml` (line length 100). Match nearby code.
+
+---
 
 ## Pull requests
 
-- One logical change per PR. Split files into focused commits when you can (parser, then agent, then tests).
-- Do not mix a CLI tweak with a sizing-rule change.
-- Do not “improve” cash-percent math into equity-percent math.
-- Paper remains the default. If you add a live-URL path, keep the warning and do not enable it by default.
-- Never stage `.env`, `execution_journal.md` with account data, or `reports/` from a personal run.
+1. One logical change per PR when possible (parser, then agent, then tests).
+2. Run `pytest` before opening.
+3. Do not change cash sizing to use equity.
+4. Paper trading stays the default; live URLs must keep a warning.
+5. Never stage `.env`, journals with account data, or personal reports.
+
+---
 
 ## Reporting bugs
 
 Include:
 
 - Ticker and analysis date
-- Whether `TRADINGAGENTS_EXECUTION_ENABLED` was true
-- The recommendation you expected vs what you saw (`order_action`, `cash_allocation_pct`)
+- Whether execution was on (`TRADINGAGENTS_EXECUTION_ENABLED`)
+- Expected vs actual: `order_action`, `cash_allocation_pct`, error message
 
-Do **not** paste API keys, account numbers, or full Alpaca JSON dumps.
+Do **not** paste API keys, account numbers, or full Alpaca JSON.
+
+---
 
 ## Credit
 
-TradingAgents is the work of Yijia Xiao, Edward Sun, Di Luo, and Wei Wang. Please cite their paper if the framework helps you — the README has the BibTeX. This fork's execution layer is an add-on for paper simulation, not a replacement for that research.
+TradingAgents: Yijia Xiao, Edward Sun, Di Luo, Wei Wang — see README for BibTeX. This fork adds a paper-trade execution layer on top of their research framework.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to this TradingAgents fork
+
+Thanks for showing up. This repo is a fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents): a multi-agent research desk that studies **one ticker at a time**. The fork's extra job is a small **Execution Agent** that reads the Trader and Portfolio Manager write-up and either:
+
+- **recommends** buy / hold / sell plus a **percent of available cash**, or
+- when you opt in, **places that ticket** on Alpaca **paper** trading.
+
+If you want to help, the highest-leverage work is making that last mile clearer, safer, and better tested — without turning the desk into a basket allocator or a live-trading bot.
+
+Please keep the upstream citation in the README. This is their research framework; we are adding a paper-trade handoff.
+
+## What we are building (and not building)
+
+**In scope**
+
+- Single-ticker analysis
+- A recommendation on every run
+- Optional Alpaca paper fills
+- Sizing against **usable cash**, never against total equity or money already in stocks
+- Honoring the PM **time horizon** and selling on the plan's **stop** (significant loss)
+
+**Out of scope**
+
+- An 8-stock basket or portfolio rotation engine
+- “Fixing” sizing to use total capital / equity
+- Defaulting to live Alpaca
+- Committing `.env` files, API keys, journals, or order dumps
+
+## Dev setup
+
+```bash
+git clone https://github.com/Philemon518/TradingAgents.git
+cd TradingAgents
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install ".[dev]"
+cp .env.example .env        # fill keys locally; never commit this file
+```
+
+Use paper Alpaca keys if you want a real simulator. Tests do **not** need them.
+
+## Tests
+
+The full suite:
+
+```bash
+pytest
+```
+
+The execution subset (fake Alpaca, no network, no keys):
+
+```bash
+pytest tests/test_position_plan.py \
+       tests/test_execution_parser.py \
+       tests/test_execution_agent.py \
+       tests/test_execution_reporting.py \
+       tests/test_env_overrides.py -q
+```
+
+If you touch `default_config.py`, keep `tests/test_env_overrides.py` green.
+
+Ruff is configured in `pyproject.toml` (`line-length = 100`, `target-version = py310`). Prefer matching nearby style over a repo-wide format pass.
+
+### How to add an execution test
+
+1. Put a **fake Alpaca client** on `ExecutionAgent(..., client=fake)`. Do not call the real API.
+2. Give the fake distinct `cash` and `equity` (for example cash `$2,000`, equity `$12,000`). A 50% buy must spend **$1,000**, not $6,000.
+3. Assert `submit_order` is **never** called when `execution_enabled` is false.
+4. For horizon tests: open a paper buy on an early date, then either drop `current_price` through the stop (must sell) or jump past `horizon_end_date` with a PM Sell (must sell).
+5. Never hard-code secrets. Empty strings are fine.
+
+## Where the code lives
+
+| Path | Role |
+|------|------|
+| `tradingagents/agents/` | Research desk (analysts, trader, PM) |
+| `tradingagents/graph/` | LangGraph wiring; `execute_trade_decision()` runs after the PM |
+| `tradingagents/execution/parser.py` | Prose → rating, prices, horizon, cash % |
+| `tradingagents/execution/position_plan.py` | Stored hold window + stop |
+| `tradingagents/execution/agent.py` | Recommendation + optional paper order |
+| `tradingagents/execution/journal.py` | Local markdown trail (no keys) |
+| `tradingagents/reporting.py` | Writes `6_execution/execution.md` |
+| `cli/main.py` | Single-ticker CLI display |
+| `tests/test_execution_*.py` | Fake-client contract |
+
+The research graph still ends at the Portfolio Manager. Execution is a **post-graph** step, not a new debate node.
+
+## Pull requests
+
+- One logical change per PR. Split files into focused commits when you can (parser, then agent, then tests).
+- Do not mix a CLI tweak with a sizing-rule change.
+- Do not “improve” cash-percent math into equity-percent math.
+- Paper remains the default. If you add a live-URL path, keep the warning and do not enable it by default.
+- Never stage `.env`, `execution_journal.md` with account data, or `reports/` from a personal run.
+
+## Reporting bugs
+
+Include:
+
+- Ticker and analysis date
+- Whether `TRADINGAGENTS_EXECUTION_ENABLED` was true
+- The recommendation you expected vs what you saw (`order_action`, `cash_allocation_pct`)
+
+Do **not** paste API keys, account numbers, or full Alpaca JSON dumps.
+
+## Credit
+
+TradingAgents is the work of Yijia Xiao, Edward Sun, Di Luo, and Wei Wang. Please cite their paper if the framework helps you — the README has the BibTeX. This fork's execution layer is an add-on for paper simulation, not a replacement for that research.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 # TradingAgents: Multi-Agents LLM Financial Trading Framework
 
 ## News
+- [2026-08] **This fork** adds a single-ticker **Execution Agent**: it turns the Portfolio Manager's memo into a buy/hold/sell recommendation sized as a percent of **available cash**, and can place Alpaca **paper** orders when you opt in. See [Execution Agent](#execution-agent).
 - [2026-08] **TradingAgents v0.4.0** released with look-ahead / point-in-time fixes across FRED macro, social sentiment, and the decision-log memory; clearer decision signals; working CLI checkpoint resume; Trader price grounding; and the GPT-5.6 and GLM-5.3 models. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 - [2026-07] **TradingAgents v0.3.1** released with correctness and stability fixes: Alpha Vantage look-ahead filtering, graph-router crash-safety, graph-shape-aware checkpoint resume, working crypto sentiment sources, a configurable LLM retry budget, Bedrock API-key auth, and Claude Sonnet 5 / Fable 5 support.
 - [2026-06] **TradingAgents v0.3.0** released with a verified data-access contract, an expanded provider registry (NVIDIA, Kimi, Groq, Mistral, Bedrock, and any OpenAI-compatible endpoint), FRED and Polymarket data vendors, a current-generation model catalog, and a CI gate.
@@ -42,13 +43,22 @@
 
 <div align="center">
 
-🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
+🚀 [TradingAgents](#tradingagents-framework) | 🧾 [Execution Agent](#execution-agent) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](CONTRIBUTING.md) | 📄 [Citation](#citation)
 
 </div>
 
 > 🎉 **TradingAgents** officially released! We have received numerous inquiries about the work, and we would like to express our thanks for the enthusiasm in our community.
 >
 > So we decided to fully open-source the framework. Looking forward to building impactful projects with you!
+
+This repository is a fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) that keeps the original one-ticker research desk and adds the missing last mile: an **Execution Agent** that reads the Trader and Portfolio Manager write-up and either recommends a ticket or, if you turn it on, sends that ticket to **Alpaca paper trading**.
+
+Clone this fork:
+
+```bash
+git clone https://github.com/Philemon518/TradingAgents.git
+cd TradingAgents
+```
 
 ## TradingAgents Framework
 
@@ -94,13 +104,69 @@ Our framework decomposes complex trading tasks into specialized roles.
   <img src="assets/risk.png" width="70%" style="display: inline-block; margin: 0 2%;">
 </p>
 
+### Execution Agent
+
+Upstream TradingAgents stops when the Portfolio Manager finishes the memo. In this fork, one more specialist sits at the desk: the Execution Agent. It does not re-run the debate. It reads what the firm already wrote and turns that into a ticket.
+
+**Every run produces a recommendation**, even when no order is sent:
+
+- **Buy / Hold / Sell**
+- **How much**: a percent of **available cash** (Alpaca `cash` — usable money). Not a percent of equity. Not a percent of the stocks you already hold.
+
+Example: you have $10,000 in stocks and $2,000 sitting in cash. A 50% buy is **$1,000** of the $2,000, not $6,000 of $12,000.
+
+**When `TRADINGAGENTS_EXECUTION_ENABLED` is unset or false** (the default): you get that recommendation in the CLI and in `6_execution/execution.md`. You decide what to do with it.
+
+**When it is `true`**: the same recommendation is placed as an Alpaca **paper** order. Live trading is not the default. The base URL is `https://paper-api.alpaca.markets`. If you point it at the live host, the client logs a warning.
+
+The agent pays attention to the plan the desk already produced:
+
+- The **Trader** proposal: action, entry, stop-loss, optional position sizing
+- The **Portfolio Manager** decision: rating, executive summary, price target, **Time Horizon** (for example `3-6 months` — the estimated time until sell)
+
+While a position is open, that time horizon is stored. The desk **holds through the window**. It does not dump the name just because a later run is less enthusiastic. **Significant loss** means the plan's **stop-loss**. If price trades through that stop, the agent sells even during the hold window. When the horizon has elapsed, it is **sell time**: a fresh PM Sell, or a stop breach, can exit the position.
+
+Sizing language such as "25% of available cash" is read from the write-up. If none is given, it falls back to `execution_fallback_cash_pct` (default **10% of cash**). Sells size against the long shares you actually hold. Shorting is off unless you set `TRADINGAGENTS_EXECUTION_ALLOW_SHORT`.
+
+Never commit Alpaca keys. Copy `.env.example` to `.env` and leave placeholders empty in git.
+
+```bash
+cp .env.example .env
+# Fill ALPACA_API_KEY and ALPACA_SECRET_KEY locally (paper keys).
+# TRADINGAGENTS_EXECUTION_ENABLED=true   # only when you want the paper fill
+```
+
+After a CLI run you will see **VI. Execution Agent** on screen (if you display the report) and on disk:
+
+```text
+reports/NVDA_YYYYMMDD_HHMMSS/6_execution/execution.md
+```
+
+Programmatic runs attach the same payload on the state dict:
+
+```python
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+config = DEFAULT_CONFIG.copy()
+# Recommendation always. Uncomment to place a paper order:
+# config["execution_enabled"] = True
+
+ta = TradingAgentsGraph(debug=True, config=config)
+final_state, decision = ta.propagate("NVDA", "2026-01-15")
+print(decision)
+print(final_state.get("execution_report"))
+```
+
+This is a research tool, not financial advice. Paper trading can still surprise you. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run the execution tests (fake Alpaca only — no live keys).
+
 ## Installation and CLI
 
 ### Installation
 
-Clone TradingAgents:
+Clone this fork:
 ```bash
-git clone https://github.com/TauricResearch/TradingAgents.git
+git clone https://github.com/Philemon518/TradingAgents.git
 cd TradingAgents
 ```
 
@@ -286,7 +352,7 @@ Backtest results are not guaranteed to match any published figure. Returns depen
 
 ## Contributing
 
-Contributions are welcome: bug fixes, documentation, and feature ideas; past contributions are credited per release in [`CHANGELOG.md`](CHANGELOG.md).
+Contributions are welcome: bug fixes, documentation, execution-agent tests, and feature ideas. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md). Past upstream contributions are credited per release in [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ Upstream TradingAgents stops when the Portfolio Manager finishes the memo. In th
 
 Example: you have $10,000 in stocks and $2,000 sitting in cash. A 50% buy is **$1,000** of the $2,000, not $6,000 of $12,000.
 
-**When `TRADINGAGENTS_EXECUTION_ENABLED` is unset or false** (the default): you get that recommendation in the CLI and in `6_execution/execution.md`. You decide what to do with it.
+**By default**, execution is **on**: the recommendation is placed as an Alpaca **paper** order. You need paper API keys in `.env` (`ALPACA_API_KEY`, `ALPACA_SECRET_KEY`). Live trading is not the default — the base URL is `https://paper-api.alpaca.markets`. If you point it at the live host, the client logs a warning.
 
-**When it is `true`**: the same recommendation is placed as an Alpaca **paper** order. Live trading is not the default. The base URL is `https://paper-api.alpaca.markets`. If you point it at the live host, the client logs a warning.
+**When `TRADINGAGENTS_EXECUTION_ENABLED=false`**: you still get the recommendation in the CLI and in `6_execution/execution.md`, but no order is sent. Use this for research-only runs.
 
 The agent pays attention to the plan the desk already produced:
 
@@ -133,7 +133,7 @@ Never commit Alpaca keys. Copy `.env.example` to `.env` and leave placeholders e
 ```bash
 cp .env.example .env
 # Fill ALPACA_API_KEY and ALPACA_SECRET_KEY locally (paper keys).
-# TRADINGAGENTS_EXECUTION_ENABLED=true   # only when you want the paper fill
+# TRADINGAGENTS_EXECUTION_ENABLED=false   # optional: recommendations only
 ```
 
 After a CLI run you will see **VI. Execution Agent** on screen (if you display the report) and on disk:
@@ -149,8 +149,8 @@ from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-# Recommendation always. Uncomment to place a paper order:
-# config["execution_enabled"] = True
+# Paper orders on by default. Recommendations only:
+# config["execution_enabled"] = False
 
 ta = TradingAgentsGraph(debug=True, config=config)
 final_state, decision = ta.propagate("NVDA", "2026-01-15")

--- a/README.md
+++ b/README.md
@@ -8,364 +8,245 @@
   <a href="https://x.com/TauricResearch" target="_blank"><img alt="X Follow" src="https://img.shields.io/badge/X-TauricResearch-white?logo=x&logoColor=white"/></a>
   <a href="https://github.com/TauricResearch/" target="_blank"><img alt="Community" src="https://img.shields.io/badge/GitHub_Community-TauricResearch-14C290?logo=discourse"/></a>
 </div>
-<br>
-<div align="center">
-  <a href="https://github.com/TauricResearch" target="_blank"><img alt="TradingAgents #1 Repository of the Day" src="https://trendshift.io/api/badge/repositories/16192" width="250" height="55"/></a>
-</div>
-<br>
-<div align="center">
-  <!-- Keep these links. Translations will automatically update with the README. -->
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=de">Deutsch</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=es">Español</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=fr">français</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ja">日本語</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ko">한국어</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=pt">Português</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ru">Русский</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=zh">中文</a>
-</div>
 
 ---
 
-# TradingAgents: Multi-Agents LLM Financial Trading Framework
+# TradingAgents (Alpaca paper-trading fork)
 
-## News
-- [2026-08] **This fork** adds a single-ticker **Execution Agent**: it turns the Portfolio Manager's memo into a buy/hold/sell recommendation sized as a percent of **available cash**, and can place Alpaca **paper** orders when you opt in. See [Execution Agent](#execution-agent).
-- [2026-08] **TradingAgents v0.4.0** released with look-ahead / point-in-time fixes across FRED macro, social sentiment, and the decision-log memory; clearer decision signals; working CLI checkpoint resume; Trader price grounding; and the GPT-5.6 and GLM-5.3 models. See [CHANGELOG.md](CHANGELOG.md) for the full list.
-- [2026-07] **TradingAgents v0.3.1** released with correctness and stability fixes: Alpha Vantage look-ahead filtering, graph-router crash-safety, graph-shape-aware checkpoint resume, working crypto sentiment sources, a configurable LLM retry budget, Bedrock API-key auth, and Claude Sonnet 5 / Fable 5 support.
-- [2026-06] **TradingAgents v0.3.0** released with a verified data-access contract, an expanded provider registry (NVIDIA, Kimi, Groq, Mistral, Bedrock, and any OpenAI-compatible endpoint), FRED and Polymarket data vendors, a current-generation model catalog, and a CI gate.
-- [2026-05] **TradingAgents v0.2.5** released with the grounded Sentiment Analyst, GPT-5.5 etc. model coverage, Qwen/GLM/MiniMax dual-region support, `TRADINGAGENTS_*` env-var configurability with API-key auto-detection, remote Ollama support, non-US alpha benchmarks, and ticker path-traversal hardening.
-- [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix.
-- [2026-03] **TradingAgents v0.2.3** released with multi-language support, GPT-5.4 family models, unified model catalog, backtesting date fidelity, and proxy support.
-- [2026-03] **TradingAgents v0.2.2** released with GPT-5.4/Gemini 3.1/Claude 4.6 model coverage, five-tier rating scale, OpenAI Responses API, Anthropic effort control, and cross-platform stability.
-- [2026-02] **TradingAgents v0.2.0** released with multi-provider LLM support (GPT-5.x, Gemini 3.x, Claude 4.x, Grok 4.x) and improved system architecture.
-- [2026-01] **Trading-R1** [Technical Report](https://arxiv.org/abs/2509.11420) released, with [Terminal](https://github.com/TauricResearch/Trading-R1) expected to land soon.
+This repo is a fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents).
 
-<div align="center">
+**What upstream does:** a team of LLM agents researches one stock and writes a buy/hold/sell memo.
 
-🚀 [TradingAgents](#tradingagents-framework) | 🧾 [Execution Agent](#execution-agent) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](CONTRIBUTING.md) | 📄 [Citation](#citation)
+**What this fork adds:** an **Execution Agent** that reads that memo and places an **Alpaca paper trade** — sized as a percent of your **available cash**, not your total portfolio value.
 
-</div>
+> Research tool only. Not financial advice. See [Tauric disclaimer](https://tauric.ai/disclaimer/).
 
-> 🎉 **TradingAgents** officially released! We have received numerous inquiries about the work, and we would like to express our thanks for the enthusiasm in our community.
->
-> So we decided to fully open-source the framework. Looking forward to building impactful projects with you!
+---
 
-This repository is a fork of [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) that keeps the original one-ticker research desk and adds the missing last mile: an **Execution Agent** that reads the Trader and Portfolio Manager write-up and either recommends a ticket or, if you turn it on, sends that ticket to **Alpaca paper trading**.
+## Quick start
 
-Clone this fork:
+### 1. Clone and install
 
 ```bash
 git clone https://github.com/Philemon518/TradingAgents.git
 cd TradingAgents
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install .
 ```
 
-## TradingAgents Framework
+### 2. Set up `.env`
 
-TradingAgents is a multi-agent trading framework that mirrors the dynamics of real-world trading firms. By deploying specialized LLM-powered agents: from fundamental analysts, sentiment experts, and technical analysts, to trader, risk management team, the platform collaboratively evaluates market conditions and informs trading decisions. Moreover, these agents engage in dynamic discussions to pinpoint the optimal strategy.
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and fill in at least:
+
+| Variable | What it is |
+|----------|------------|
+| `OPENAI_API_KEY` | Your LLM provider key (or another provider from `.env.example`) |
+| `ALPACA_API_KEY` | Alpaca **Key ID** from the dashboard |
+| `ALPACA_SECRET_KEY` | Alpaca **Secret Key** (shown once when you generate keys) |
+
+Paper execution is **on by default**. You do not need to set `TRADINGAGENTS_EXECUTION_ENABLED=true` unless you want to be explicit — it is already the default in code and in `.env.example`.
+
+### 3. Get Alpaca paper keys
+
+1. Sign in at [app.alpaca.markets](https://app.alpaca.markets)
+2. Switch to **Paper Trading** (upper-left account menu)
+3. Open **API Keys** → **Generate New Key**
+4. Copy both values immediately:
+   - **Key ID** → `ALPACA_API_KEY`
+   - **Secret Key** → `ALPACA_SECRET_KEY` (only shown once; regenerate if you lose it)
+
+Keep the paper endpoint:
+
+```bash
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
+```
+
+### 4. Run
+
+```bash
+set -a && source .env && set +a   # load env vars (Windows: use your shell's equivalent)
+tradingagents
+```
+
+The CLI will ask for a ticker, date, LLM provider, and analysts. A full run takes several minutes.
+
+Alternative:
+
+```bash
+python -m cli.main
+```
+
+### 5. Read the output
+
+When the run finishes, look for **VI. Execution Agent** in the terminal.
+
+On disk:
+
+```text
+reports/<TICKER>_<TIMESTAMP>/6_execution/execution.md
+```
+
+---
+
+## Recommendations only (no orders)
+
+To run analysis without sending paper orders:
+
+```bash
+TRADINGAGENTS_EXECUTION_ENABLED=false
+```
+
+Add that to `.env`, or set it in code:
+
+```python
+config = DEFAULT_CONFIG.copy()
+config["execution_enabled"] = False
+```
+
+You still get buy/hold/sell + cash % in the report; nothing is sent to Alpaca.
+
+---
+
+## How the Execution Agent works
+
+After the Portfolio Manager finishes, the Execution Agent:
+
+1. Reads the Trader + PM write-up (action, entry, stop, target, time horizon, sizing language)
+2. Decides **buy / hold / sell**
+3. Sizes the order as a **percent of available cash** (Alpaca `cash` field)
+
+**Example:** $10,000 in stocks + $2,000 cash. A 50% buy uses **$1,000** (half of $2,000), not half of $12,000.
+
+**Hold rules while a position is open:**
+
+- Respects the PM **time horizon** (e.g. 3–6 months)
+- Sells if price hits the plan's **stop-loss**, even inside the hold window
+- After the horizon, a PM **Sell** or stop breach can exit
+
+If the write-up does not mention sizing, the default is **10% of cash** (`TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT`).
+
+Shorting is off unless you set `TRADINGAGENTS_EXECUTION_ALLOW_SHORT=true`.
+
+---
+
+## Framework overview
+
+TradingAgents mirrors a trading firm: specialized LLM agents collaborate on one ticker.
 
 <p align="center">
   <img src="assets/schema.png" style="width: 100%; height: auto;">
 </p>
 
-> TradingAgents framework is designed for research purposes. Trading performance may vary based on many factors, including the chosen backbone language models, model temperature, trading periods, the quality of data, and other non-deterministic factors. [It is not intended as financial, investment, or trading advice.](https://tauric.ai/disclaimer/)
-
-Our framework decomposes complex trading tasks into specialized roles.
-
-### Analyst Team
-- Fundamentals Analyst: Evaluates company financials and performance metrics, identifying intrinsic values and potential red flags.
-- Sentiment Analyst: Aggregates news headlines, StockTwits, and Reddit chatter into a single sentiment read to gauge short-term market mood.
-- News Analyst: Monitors global news and macroeconomic indicators, interpreting the impact of events on market conditions.
-- Technical Analyst: Utilizes technical indicators (like MACD and RSI) to detect trading patterns and forecast price movements.
+| Team | Role |
+|------|------|
+| **Analysts** | Fundamentals, sentiment, news, technicals |
+| **Researchers** | Bull vs bear debate |
+| **Trader** | Trade proposal with entry/stop/target |
+| **Risk + PM** | Risk review → final buy/hold/sell decision |
+| **Execution** *(this fork)* | Paper order on Alpaca |
 
 <p align="center">
-  <img src="assets/analyst.png" width="100%" style="display: inline-block; margin: 0 2%;">
+  <img src="assets/cli/cli_init.png" width="100%">
 </p>
 
-### Researcher Team
-- Comprises both bullish and bearish researchers who critically assess the insights provided by the Analyst Team. Through structured debates, they balance potential gains against inherent risks.
+### Supported tickers
 
-<p align="center">
-  <img src="assets/researcher.png" width="70%" style="display: inline-block; margin: 0 2%;">
-</p>
+Any market Yahoo Finance covers:
 
-### Trader Agent
-- Composes reports from the analysts and researchers to make informed trading decisions, determining the timing and magnitude of trades.
+- US: `AAPL`, `NVDA`, `SPY`
+- International: `0700.HK`, `7203.T`, `RELIANCE.NS`, `600519.SS`
+- Crypto: `BTC-USD`, `ETH-USD`
 
-<p align="center">
-  <img src="assets/trader.png" width="70%" style="display: inline-block; margin: 0 2%;">
-</p>
+---
 
-### Risk Management and Portfolio Manager
-- Continuously evaluates portfolio risk by assessing market volatility, liquidity, and other risk factors. The risk management team evaluates and adjusts trading strategies, providing assessment reports to the Portfolio Manager for final decision.
-- The Portfolio Manager approves/rejects the transaction proposal. If approved, the order will be sent to the simulated exchange and executed.
-
-<p align="center">
-  <img src="assets/risk.png" width="70%" style="display: inline-block; margin: 0 2%;">
-</p>
-
-### Execution Agent
-
-Upstream TradingAgents stops when the Portfolio Manager finishes the memo. In this fork, one more specialist sits at the desk: the Execution Agent. It does not re-run the debate. It reads what the firm already wrote and turns that into a ticket.
-
-**Every run produces a recommendation**, even when no order is sent:
-
-- **Buy / Hold / Sell**
-- **How much**: a percent of **available cash** (Alpaca `cash` — usable money). Not a percent of equity. Not a percent of the stocks you already hold.
-
-Example: you have $10,000 in stocks and $2,000 sitting in cash. A 50% buy is **$1,000** of the $2,000, not $6,000 of $12,000.
-
-**By default**, execution is **on**: the recommendation is placed as an Alpaca **paper** order. You need paper API keys in `.env` (`ALPACA_API_KEY`, `ALPACA_SECRET_KEY`). Live trading is not the default — the base URL is `https://paper-api.alpaca.markets`. If you point it at the live host, the client logs a warning.
-
-**When `TRADINGAGENTS_EXECUTION_ENABLED=false`**: you still get the recommendation in the CLI and in `6_execution/execution.md`, but no order is sent. Use this for research-only runs.
-
-The agent pays attention to the plan the desk already produced:
-
-- The **Trader** proposal: action, entry, stop-loss, optional position sizing
-- The **Portfolio Manager** decision: rating, executive summary, price target, **Time Horizon** (for example `3-6 months` — the estimated time until sell)
-
-While a position is open, that time horizon is stored. The desk **holds through the window**. It does not dump the name just because a later run is less enthusiastic. **Significant loss** means the plan's **stop-loss**. If price trades through that stop, the agent sells even during the hold window. When the horizon has elapsed, it is **sell time**: a fresh PM Sell, or a stop breach, can exit the position.
-
-Sizing language such as "25% of available cash" is read from the write-up. If none is given, it falls back to `execution_fallback_cash_pct` (default **10% of cash**). Sells size against the long shares you actually hold. Shorting is off unless you set `TRADINGAGENTS_EXECUTION_ALLOW_SHORT`.
-
-Never commit Alpaca keys. Copy `.env.example` to `.env` and leave placeholders empty in git.
-
-```bash
-cp .env.example .env
-# Fill ALPACA_API_KEY and ALPACA_SECRET_KEY locally (paper keys).
-# TRADINGAGENTS_EXECUTION_ENABLED=false   # optional: recommendations only
-```
-
-After a CLI run you will see **VI. Execution Agent** on screen (if you display the report) and on disk:
-
-```text
-reports/NVDA_YYYYMMDD_HHMMSS/6_execution/execution.md
-```
-
-Programmatic runs attach the same payload on the state dict:
+## Python usage
 
 ```python
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-# Paper orders on by default. Recommendations only:
-# config["execution_enabled"] = False
+# config["execution_enabled"] = False   # recommendations only
 
 ta = TradingAgentsGraph(debug=True, config=config)
 final_state, decision = ta.propagate("NVDA", "2026-01-15")
+
 print(decision)
 print(final_state.get("execution_report"))
 ```
 
-This is a research tool, not financial advice. Paper trading can still surprise you. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run the execution tests (fake Alpaca only — no live keys).
+Change models, debate rounds, etc. in `tradingagents/default_config.py` or via `TRADINGAGENTS_*` env vars (see `.env.example`).
 
-## Installation and CLI
+---
 
-### Installation
-
-Clone this fork:
-```bash
-git clone https://github.com/Philemon518/TradingAgents.git
-cd TradingAgents
-```
-
-Create a virtual environment in any of your favorite environment managers:
-```bash
-conda create -n tradingagents python=3.12
-conda activate tradingagents
-```
-
-Install the package and its dependencies:
-```bash
-pip install .
-```
+## Other setup options
 
 ### Docker
 
-Alternatively, run with Docker:
 ```bash
-cp .env.example .env  # add your API keys
+cp .env.example .env
 docker compose run --rm tradingagents
 ```
 
-For local models with Ollama:
-```bash
-docker compose --profile ollama run --rm tradingagents-ollama
-```
+### More LLM providers
 
-### Required APIs
+Set the matching key in `.env` — see `.env.example` for the full list (OpenAI, Google, Anthropic, DeepSeek, Groq, Ollama, Bedrock, etc.).
 
-TradingAgents supports multiple LLM providers. Set the API key for your chosen provider:
+For local models: `llm_provider: "ollama"` with Ollama running at `http://localhost:11434/v1`.
 
-```bash
-export OPENAI_API_KEY=...          # OpenAI (GPT)
-export GOOGLE_API_KEY=...          # Google (Gemini)
-export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
-export XAI_API_KEY=...             # xAI (Grok)
-export DEEPSEEK_API_KEY=...        # DeepSeek
-export DASHSCOPE_API_KEY=...       # Qwen — International (dashscope-intl.aliyuncs.com)
-export DASHSCOPE_CN_API_KEY=...    # Qwen — China (dashscope.aliyuncs.com)
-export ZHIPU_API_KEY=...           # GLM via Z.AI (international)
-export ZHIPU_CN_API_KEY=...        # GLM via BigModel (China, open.bigmodel.cn)
-export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io)
-export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com)
-export OPENROUTER_API_KEY=...      # OpenRouter
-export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
-```
-
-For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
-
-For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_provider: "bedrock"`, configure AWS credentials (environment variables, `~/.aws/credentials`, or an IAM role) and `AWS_DEFAULT_REGION`, and use a Bedrock model ID, e.g. `us.anthropic.claude-opus-4-8-v1:0`.
-
-For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
-
-For any other OpenAI-compatible server (vLLM, LM Studio, llama.cpp, or a custom relay), use `llm_provider: "openai_compatible"` and set the endpoint via `backend_url` (or `TRADINGAGENTS_LLM_BACKEND_URL`), e.g. `http://localhost:8000/v1` for vLLM or `http://localhost:1234/v1` for LM Studio. The model is whatever your server serves. No key is needed for local servers; set `OPENAI_COMPATIBLE_API_KEY` when the endpoint requires one.
-
-Alternatively, copy `.env.example` to `.env` and fill in your keys:
-```bash
-cp .env.example .env
-```
-
-### CLI Usage
-
-Launch the interactive CLI:
-```bash
-tradingagents          # installed command
-python -m cli.main     # alternative: run directly from source
-```
-You will see a screen where you can select your desired tickers, analysis date, LLM provider, research depth, and more.
-
-### Markets and tickers
-
-TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Company identity and the alpha benchmark resolve automatically per market.
-
-- US: `AAPL`, `SPY`
-- Hong Kong: `0700.HK` · Tokyo: `7203.T` · London: `AZN.L`
-- India: `RELIANCE.NS`, `.BO` · Canada: `.TO` · Australia: `.AX`
-- China A-shares: Shanghai `.SS`, Shenzhen `.SZ` (e.g. `600519.SS` for Kweichow Moutai)
-- Crypto: `BTC-USD`, `ETH-USD`
-
-<p align="center">
-  <img src="assets/cli/cli_init.png" width="100%" style="display: inline-block; margin: 0 2%;">
-</p>
-
-An interface will appear showing results as they load, letting you track the agent's progress as it runs.
-
-<p align="center">
-  <img src="assets/cli/cli_news.png" width="100%" style="display: inline-block; margin: 0 2%;">
-</p>
-
-<p align="center">
-  <img src="assets/cli/cli_transaction.png" width="100%" style="display: inline-block; margin: 0 2%;">
-</p>
-
-## TradingAgents Package
-
-### Implementation Details
-
-We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Ollama for local models, and Azure OpenAI for enterprise.
-
-### Python Usage
-
-To use TradingAgents inside your code, you can import the `tradingagents` module and initialize a `TradingAgentsGraph()` object. The `.propagate()` function will return a decision. You can run `main.py`, here's also a quick example:
-
-```python
-from tradingagents.graph.trading_graph import TradingAgentsGraph
-from tradingagents.default_config import DEFAULT_CONFIG
-
-ta = TradingAgentsGraph(debug=True, config=DEFAULT_CONFIG.copy())
-
-# forward propagate
-_, decision = ta.propagate("NVDA", "2026-01-15")
-print(decision)
-```
-
-You can also adjust the default configuration to set your own choice of LLMs, debate rounds, etc.
-
-```python
-from tradingagents.graph.trading_graph import TradingAgentsGraph
-from tradingagents.default_config import DEFAULT_CONFIG
-
-config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"        # e.g. openai, google, anthropic, deepseek, groq, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
-config["deep_think_llm"] = "gpt-5.6"      # Model for complex reasoning
-config["quick_think_llm"] = "gpt-5.6-luna" # Model for quick tasks
-config["max_debate_rounds"] = 2
-
-ta = TradingAgentsGraph(debug=True, config=config)
-_, decision = ta.propagate("NVDA", "2026-01-15")
-print(decision)
-```
-
-See `tradingagents/default_config.py` for all configuration options.
-
-## Persistence and Recovery
-
-TradingAgents persists two kinds of state across runs.
-
-### Decision log
-
-The decision log is always on. Each completed run appends its decision to `~/.tradingagents/memory/trading_memory.md`. On the next run for the same ticker, TradingAgents fetches the realised return (raw and alpha vs SPY), generates a one-paragraph reflection, and injects the most recent same-ticker decisions plus recent cross-ticker lessons into the Portfolio Manager prompt, so each analysis carries forward what worked and what didn't.
-
-Override the path with `TRADINGAGENTS_MEMORY_LOG_PATH`.
+For OpenAI-compatible servers (vLLM, LM Studio): `llm_provider: "openai_compatible"` and set `TRADINGAGENTS_LLM_BACKEND_URL`.
 
 ### Checkpoint resume
 
-Checkpoint resume is opt-in via `--checkpoint`. When enabled, LangGraph saves state after each node so a crashed or interrupted run resumes from the last successful step instead of starting over. On a resume run you will see `Resuming from step N for <TICKER> on <date>` in the logs; on a new run you will see `Starting fresh`. Checkpoints are cleared automatically on successful completion.
-
-Per-ticker SQLite databases live at `~/.tradingagents/cache/checkpoints/<TICKER>.db` (override the base with `TRADINGAGENTS_CACHE_DIR`). Use `--clear-checkpoints` to reset all of them before a run.
+Resume a crashed run instead of starting over:
 
 ```bash
-tradingagents analyze --checkpoint           # enable for this run
-tradingagents analyze --clear-checkpoints    # reset before running
+tradingagents --checkpoint
+tradingagents --clear-checkpoints    # wipe saved checkpoints first
 ```
 
-```python
-config = DEFAULT_CONFIG.copy()
-config["checkpoint_enabled"] = True
-ta = TradingAgentsGraph(config=config)
-_, decision = ta.propagate("NVDA", "2026-01-15")
-```
+Checkpoints live at `~/.tradingagents/cache/checkpoints/<TICKER>.db`.
 
-## Reproducibility
+---
 
-TradingAgents is LLM-driven, so two runs of the same ticker and date can differ. This is expected for a research tool built on language models, not a defect. The variation comes from a few distinct sources, and it helps to separate them.
+## Configuration reference
 
-Language model sampling is non-deterministic. Even at a fixed temperature, providers do not guarantee byte-identical output across calls, and reasoning models (the default GPT-5.x family, and any thinking-mode model) vary the most because their internal reasoning is itself sampled.
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `execution_enabled` | `true` | Place Alpaca paper orders |
+| `execution_fallback_cash_pct` | `10` | Cash % when write-up has no sizing |
+| `alpaca_base_url` | paper API | Do not point at live unless intentional |
+| `TRADINGAGENTS_*` | — | Override any config key via env |
 
-Live data moves. News, StockTwits, and Reddit return different content as time passes, so a run today sees different inputs than a run last week even for the same historical trade date. Pin the analysis date to hold the price and indicator window fixed, but the social and news sources still reflect "now".
+Full list: `tradingagents/default_config.py` and `.env.example`.
 
-To reduce variation you can lower the sampling temperature. Set `temperature` in your config (or `TRADINGAGENTS_TEMPERATURE` in `.env`); lower values make models that honor it more repeatable. The current curated models are reasoning-first and largely ignore temperature, so for tighter reproducibility use a non-reasoning model, which you can set explicitly via the Custom model ID option.
+**Never commit `.env`** — it is gitignored.
 
-```python
-config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"
-config["temperature"] = 0.0
-# Reasoning models ignore temperature. For tighter reproducibility, set a
-# non-reasoning deep/quick model explicitly (e.g. via the Custom model ID option).
-```
-
-What does not vary anymore: the analyzed company identity is resolved deterministically from the ticker before any agent runs, and the market analyst grounds exact price and indicator claims in a verified data snapshot. Earlier reports of "different companies" or fabricated price levels across runs are addressed by these two mechanisms.
-
-Backtest results are not guaranteed to match any published figure. Returns depend on the model, the temperature, the date range, data quality, and the sampling above. Treat the framework as a research scaffold for studying multi-agent analysis, not as a strategy with a fixed, replicable return.
+---
 
 ## Contributing
 
-Contributions are welcome: bug fixes, documentation, execution-agent tests, and feature ideas. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md). Past upstream contributions are credited per release in [`CHANGELOG.md`](CHANGELOG.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, tests, and PR guidelines.
+
+---
 
 ## Citation
 
-Please reference our work if you find *TradingAgents* provides you with some help :)
+If TradingAgents helps your work, please cite the original paper:
 
 ```
 @misc{xiao2025tradingagentsmultiagentsllmfinancial,
-      title={TradingAgents: Multi-Agents LLM Financial Trading Framework}, 
+      title={TradingAgents: Multi-Agents LLM Financial Trading Framework},
       author={Yijia Xiao and Edward Sun and Di Luo and Wei Wang},
       year={2025},
       eprint={2412.20138},
       archivePrefix={arXiv},
       primaryClass={q-fin.TR},
-      url={https://arxiv.org/abs/2412.20138}, 
+      url={https://arxiv.org/abs/2412.20138},
 }
 ```

--- a/cli/main.py
+++ b/cli/main.py
@@ -42,6 +42,7 @@ from cli.utils import (
     select_shallow_thinking_agent,
 )
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.execution import format_execution_report
 from tradingagents.graph.analyst_execution import (
     AnalystWallTimeTracker,
     build_analyst_execution_plan,
@@ -80,6 +81,7 @@ class MessageBuffer:
         "Trading Team": ["Trader"],
         "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
         "Portfolio Management": ["Portfolio Manager"],
+        "Execution": ["Execution Agent"],
     }
 
     # Analyst name mapping
@@ -101,6 +103,7 @@ class MessageBuffer:
         "investment_plan": (None, "Research Manager"),
         "trader_investment_plan": (None, "Trader"),
         "final_trade_decision": (None, "Portfolio Manager"),
+        "execution_report": (None, "Execution Agent"),
     }
 
     def __init__(self, max_length=100):
@@ -209,6 +212,7 @@ class MessageBuffer:
                 "investment_plan": "Research Team Decision",
                 "trader_investment_plan": "Trading Team Plan",
                 "final_trade_decision": "Portfolio Management Decision",
+                "execution_report": "Execution Agent",
             }
             self.current_report = (
                 f"### {section_titles[latest_section]}\n{latest_content}"
@@ -255,6 +259,10 @@ class MessageBuffer:
         if self.report_sections.get("final_trade_decision"):
             report_parts.append("## Portfolio Management Decision")
             report_parts.append(f"{self.report_sections['final_trade_decision']}")
+
+        if self.report_sections.get("execution_report"):
+            report_parts.append("## Execution Agent")
+            report_parts.append(f"{self.report_sections['execution_report']}")
 
         self.final_report = "\n\n".join(report_parts) if report_parts else None
 
@@ -324,6 +332,7 @@ def update_display(layout, spinner_text=None, stats_handler=None, start_time=Non
         "Trading Team": ["Trader"],
         "Risk Management": ["Aggressive Analyst", "Neutral Analyst", "Conservative Analyst"],
         "Portfolio Management": ["Portfolio Manager"],
+        "Execution": ["Execution Agent"],
     }
 
     # Filter teams to only include agents that are in agent_status
@@ -502,7 +511,7 @@ def get_user_selections():
     welcome_content = f"{welcome_ascii}\n"
     welcome_content += "[bold green]TradingAgents: Multi-Agents LLM Financial Trading Framework - CLI[/bold green]\n\n"
     welcome_content += "[bold]Workflow Steps:[/bold]\n"
-    welcome_content += "I. Analyst Team → II. Research Team → III. Trader → IV. Risk Management → V. Portfolio Management\n\n"
+    welcome_content += "I. Analyst Team → II. Research Team → III. Trader → IV. Risk Management → V. Portfolio Management → VI. Execution\n\n"
     welcome_content += (
         "[dim]Built by [Tauric Research](https://github.com/TauricResearch)[/dim]"
     )
@@ -824,6 +833,12 @@ def display_complete_report(final_state):
         if risk.get("judge_decision"):
             console.print(Panel("[bold]V. Portfolio Manager Decision[/bold]", border_style="green"))
             console.print(Panel(Markdown(risk["judge_decision"]), title="Portfolio Manager", border_style="blue", padding=(1, 2)))
+
+    # VI. Execution Agent
+    if final_state.get("execution_report"):
+        execution_text = format_execution_report(final_state["execution_report"])
+        console.print(Panel("[bold]VI. Execution Agent[/bold]", border_style="cyan"))
+        console.print(Panel(Markdown(execution_text), title="Execution Agent", border_style="blue", padding=(1, 2)))
 
 
 def update_research_team_status(status):
@@ -1257,6 +1272,16 @@ def run_analysis(checkpoint: bool | None = None):
         final_state = {}
         for chunk in trace:
             final_state.update(chunk)
+
+        message_buffer.update_agent_status("Execution Agent", "in_progress")
+        execution_result = graph.execute_trade_decision(selections["ticker"], final_state)
+        if execution_result is not None:
+            final_state["execution_report"] = execution_result.to_dict()
+            message_buffer.update_report_section(
+                "execution_report",
+                format_execution_report(final_state["execution_report"]),
+            )
+        message_buffer.update_agent_status("Execution Agent", "completed")
 
         # Update all agent statuses to completed
         for agent in message_buffer.agent_status:

--- a/cli/main.py
+++ b/cli/main.py
@@ -1294,8 +1294,12 @@ def run_analysis(checkpoint: bool | None = None):
 
         # Update final report sections
         for section in message_buffer.report_sections:
-            if section in final_state:
-                message_buffer.update_report_section(section, final_state[section])
+            if section not in final_state:
+                continue
+            content = final_state[section]
+            if section == "execution_report" and isinstance(content, dict):
+                content = format_execution_report(content)
+            message_buffer.update_report_section(section, content)
 
         update_display(layout, stats_handler=stats_handler, start_time=start_time)
 

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -127,3 +127,19 @@ def test_unknown_env_var_is_ignored(monkeypatch):
         TRADINGAGENTS_NONEXISTENT_KEY="oops",
     )
     assert "nonexistent_key" not in dc.DEFAULT_CONFIG
+
+
+def test_execution_defaults_and_overrides(monkeypatch):
+    """Paper execution stays off until TRADINGAGENTS_EXECUTION_ENABLED is set."""
+    dc = _reload_with_env(monkeypatch)
+    assert dc.DEFAULT_CONFIG["execution_enabled"] is False
+    assert dc.DEFAULT_CONFIG["execution_fallback_cash_pct"] == 10.0
+    assert dc.DEFAULT_CONFIG["alpaca_base_url"] == "https://paper-api.alpaca.markets"
+
+    dc = _reload_with_env(
+        monkeypatch,
+        TRADINGAGENTS_EXECUTION_ENABLED="true",
+        TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT="15",
+    )
+    assert dc.DEFAULT_CONFIG["execution_enabled"] is True
+    assert dc.DEFAULT_CONFIG["execution_fallback_cash_pct"] == 15.0

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -130,16 +130,16 @@ def test_unknown_env_var_is_ignored(monkeypatch):
 
 
 def test_execution_defaults_and_overrides(monkeypatch):
-    """Paper execution stays off until TRADINGAGENTS_EXECUTION_ENABLED is set."""
+    """Paper execution is on by default; env can disable or tune it."""
     dc = _reload_with_env(monkeypatch)
-    assert dc.DEFAULT_CONFIG["execution_enabled"] is False
+    assert dc.DEFAULT_CONFIG["execution_enabled"] is True
     assert dc.DEFAULT_CONFIG["execution_fallback_cash_pct"] == 10.0
     assert dc.DEFAULT_CONFIG["alpaca_base_url"] == "https://paper-api.alpaca.markets"
 
     dc = _reload_with_env(
         monkeypatch,
-        TRADINGAGENTS_EXECUTION_ENABLED="true",
+        TRADINGAGENTS_EXECUTION_ENABLED="false",
         TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT="15",
     )
-    assert dc.DEFAULT_CONFIG["execution_enabled"] is True
+    assert dc.DEFAULT_CONFIG["execution_enabled"] is False
     assert dc.DEFAULT_CONFIG["execution_fallback_cash_pct"] == 15.0

--- a/tests/test_execution_agent.py
+++ b/tests/test_execution_agent.py
@@ -1,0 +1,258 @@
+"""Execution agent contract tests using a fake Alpaca client (no network)."""
+
+from __future__ import annotations
+
+import logging
+
+from tradingagents.execution.agent import (
+    ExecutionAgent,
+    is_live_alpaca_url,
+    shares_from_available_cash,
+)
+
+
+class _FakeAlpacaClient:
+    def __init__(
+        self,
+        *,
+        cash: float = 2000.0,
+        equity: float = 12000.0,
+        position: dict | None = None,
+        account_id: str = "acct-paper-12345678",
+        account_number: str = "PA0001111",
+    ) -> None:
+        self.cash = cash
+        self.equity = equity
+        self.position = position
+        self.account_id = account_id
+        self.account_number = account_number
+        self.submitted: list[dict] = []
+
+    def get_account(self) -> dict:
+        return {
+            "id": self.account_id,
+            "account_number": self.account_number,
+            "cash": str(self.cash),
+            "buying_power": str(self.cash),
+            "equity": str(self.equity),
+            "portfolio_value": str(self.equity),
+            "long_market_value": str(self.equity - self.cash),
+            "status": "ACTIVE",
+        }
+
+    def get_positions(self) -> list[dict]:
+        if self.position is None:
+            return []
+        return [self.position]
+
+    def submit_order(self, payload: dict) -> dict:
+        self.submitted.append(payload)
+        return {
+            "id": "paper-order-1",
+            "status": "accepted",
+            "submitted_at": "2026-03-01T14:30:00Z",
+            "filled_qty": "0",
+            "filled_avg_price": None,
+        }
+
+
+PM_BUY_50_CASH = """
+**Rating**: Buy
+
+**Executive Summary**: Buy NVDA at 100 with a stop at 90. Use 50% of available cash.
+
+**Investment Thesis**: Setup is clean.
+
+**Price Target**: 130
+
+**Time Horizon**: 3-6 months
+"""
+
+PM_HOLD = """
+**Rating**: Hold
+
+**Executive Summary**: Stay put.
+
+**Time Horizon**: 3-6 months
+"""
+
+PM_SELL = """
+**Rating**: Sell
+
+**Executive Summary**: Exit NVDA.
+
+**Time Horizon**: 3-6 months
+"""
+
+
+def _agent(tmp_path, client, **config):
+    base = {
+        "execution_enabled": True,
+        "execution_journal_path": str(tmp_path / "journal.md"),
+        "execution_position_plan_path": str(tmp_path / "plans.json"),
+        "execution_fallback_cash_pct": 10.0,
+        "alpaca_time_in_force": "gtc",
+    }
+    base.update(config)
+    return ExecutionAgent(base, client=client)
+
+
+class TestSharesFromCash:
+    def test_fifty_percent_of_cash_not_equity(self):
+        qty = shares_from_available_cash(cash=2000, cash_pct=50, price=100)
+        assert qty == 10
+        assert qty * 100 == 1000
+
+    def test_never_exceeds_cash(self):
+        qty = shares_from_available_cash(cash=2000, cash_pct=100, price=100)
+        assert qty * 100 <= 2000
+
+
+class TestExecutionAgent:
+    def test_disabled_recommends_without_submitting(self, tmp_path):
+        client = _FakeAlpacaClient()
+        agent = _agent(tmp_path, client, execution_enabled=False)
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-03-01",
+        )
+        assert result.enabled is False
+        assert result.order_submitted is False
+        assert result.order_action == "buy"
+        assert result.cash_allocation_pct == 50
+        assert client.submitted == []
+        assert "Recommendation: buy 50% of available cash" in result.message
+
+    def test_enabled_buy_uses_cash_not_equity(self, tmp_path):
+        client = _FakeAlpacaClient(cash=2000, equity=12000)
+        agent = _agent(tmp_path, client)
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-03-01",
+        )
+        assert result.order_submitted is True
+        assert result.order_action == "buy"
+        assert result.quantity == 10
+        assert result.estimated_notional == 1000
+        assert client.submitted
+        notional = float(client.submitted[0]["qty"]) * float(client.submitted[0]["limit_price"])
+        assert notional == 1000
+        assert notional != 6000
+
+    def test_order_never_exceeds_cash(self, tmp_path):
+        client = _FakeAlpacaClient(cash=2000, equity=12000)
+        pm = PM_BUY_50_CASH.replace("50% of available cash", "100% of available cash")
+        agent = _agent(tmp_path, client)
+        result = agent.run(ticker="NVDA", portfolio_manager_text=pm, trade_date="2026-03-01")
+        assert result.order_submitted is True
+        assert result.quantity * 100 <= 2000
+
+    def test_hold_does_not_buy(self, tmp_path):
+        client = _FakeAlpacaClient(
+            position={
+                "symbol": "NVDA",
+                "qty": "5",
+                "current_price": "120",
+                "avg_entry_price": "100",
+                "market_value": "600",
+            }
+        )
+        agent = _agent(tmp_path, client)
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_HOLD,
+            trade_date="2026-03-01",
+        )
+        assert result.order_action == "hold"
+        assert result.order_submitted is False
+        assert client.submitted == []
+
+    def test_stop_loss_while_in_horizon_sells(self, tmp_path):
+        client = _FakeAlpacaClient()
+        agent = _agent(tmp_path, client)
+        opened = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-01-15",
+        )
+        assert opened.order_action == "buy"
+        assert opened.order_submitted is True
+
+        client.submitted.clear()
+        client.position = {
+            "symbol": "NVDA",
+            "qty": str(opened.quantity),
+            "current_price": "85",
+            "avg_entry_price": "100",
+            "market_value": str(opened.quantity * 85),
+        }
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_HOLD,
+            trade_date="2026-03-01",
+        )
+        assert result.order_action == "sell"
+        assert result.order_submitted is True
+        assert result.quantity == opened.quantity
+        assert client.submitted[0]["side"] == "sell"
+
+    def test_horizon_elapsed_and_pm_sell(self, tmp_path):
+        client = _FakeAlpacaClient()
+        agent = _agent(tmp_path, client)
+        opened = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-01-15",
+        )
+        assert opened.order_submitted is True
+
+        client.submitted.clear()
+        client.position = {
+            "symbol": "NVDA",
+            "qty": str(opened.quantity),
+            "current_price": "125",
+            "avg_entry_price": "100",
+            "market_value": str(opened.quantity * 125),
+        }
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_SELL,
+            trade_date="2026-08-01",
+        )
+        assert result.order_action == "sell"
+        assert result.order_submitted is True
+        assert client.submitted[0]["side"] == "sell"
+
+    def test_missing_keys_when_enabled_does_not_crash(self, tmp_path):
+        agent = ExecutionAgent(
+            {
+                "execution_enabled": True,
+                "execution_journal_path": str(tmp_path / "journal.md"),
+                "execution_position_plan_path": str(tmp_path / "plans.json"),
+                "alpaca_api_key": "",
+                "alpaca_secret_key": "",
+            }
+        )
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-03-01",
+        )
+        assert result.order_submitted is False
+        assert "Alpaca API key" in result.message
+        assert result.cash_allocation_pct == 50
+
+    def test_live_url_warning(self, caplog):
+        caplog.set_level(logging.WARNING)
+        from tradingagents.execution.agent import AlpacaPaperClient
+
+        AlpacaPaperClient(
+            api_key="paper-key",
+            secret_key="paper-secret",
+            base_url="https://api.alpaca.markets",
+        )
+        assert any("live trading" in rec.message for rec in caplog.records)
+        assert is_live_alpaca_url("https://api.alpaca.markets") is True
+        assert is_live_alpaca_url("https://paper-api.alpaca.markets") is False

--- a/tests/test_execution_agent.py
+++ b/tests/test_execution_agent.py
@@ -122,7 +122,24 @@ class TestExecutionAgent:
         assert result.order_action == "buy"
         assert result.cash_allocation_pct == 50
         assert client.submitted == []
+        assert "recommendations only" in result.message
         assert "Recommendation: buy 50% of available cash" in result.message
+
+    def test_enabled_without_alpaca_keys_reports_error(self, tmp_path):
+        agent = ExecutionAgent(
+            {
+                "execution_journal_path": str(tmp_path / "journal.md"),
+                "execution_position_plan_path": str(tmp_path / "plans.json"),
+            }
+        )
+        result = agent.run(
+            ticker="NVDA",
+            portfolio_manager_text=PM_BUY_50_CASH,
+            trade_date="2026-03-01",
+        )
+        assert result.enabled is True
+        assert result.order_submitted is False
+        assert "Alpaca API key and secret are required" in result.message
 
     def test_enabled_buy_uses_cash_not_equity(self, tmp_path):
         client = _FakeAlpacaClient(cash=2000, equity=12000)

--- a/tests/test_execution_parser.py
+++ b/tests/test_execution_parser.py
@@ -1,0 +1,78 @@
+"""Parser tests for rating, prices, horizon, and cash-percent sizing."""
+
+from __future__ import annotations
+
+from tradingagents.execution.parser import extract_cash_allocation_pct, parse_trade_decision
+
+
+PM_BUY = """
+**Rating**: Buy
+
+**Executive Summary**: Enter NVDA around 120 with a stop at 110. Allocate 50% of available cash. Hold 3-6 months.
+
+**Investment Thesis**: Strong setup.
+
+**Price Target**: 150
+
+**Time Horizon**: 3-6 months
+"""
+
+TRADER_FALLBACK = """
+**Action**: Buy
+
+**Reasoning**: Setup looks clean.
+
+**Entry Price**: 118.5
+
+**Stop Loss**: 108
+
+**Position Sizing**: 25% of available cash
+
+FINAL TRANSACTION PROPOSAL: **BUY**
+"""
+
+
+class TestParseTradeDecision:
+    def test_buy_rating_entry_stop_horizon(self):
+        decision = parse_trade_decision(PM_BUY)
+        assert decision.rating == "Buy"
+        assert decision.action == "buy"
+        assert decision.entry_price == 120
+        assert decision.stop_loss == 110
+        assert decision.price_target == 150
+        assert decision.time_horizon == "3-6 months"
+        assert decision.cash_allocation_pct == 50
+
+    def test_overweight_maps_to_buy(self):
+        decision = parse_trade_decision("**Rating**: Overweight\n\n**Executive Summary**: Add.")
+        assert decision.action == "buy"
+
+    def test_underweight_maps_to_sell(self):
+        decision = parse_trade_decision("**Rating**: Underweight\n\n**Executive Summary**: Trim.")
+        assert decision.action == "sell"
+
+    def test_hold_is_default_for_unparseable(self):
+        decision = parse_trade_decision("No rating here.")
+        assert decision.action == "hold"
+
+    def test_trader_price_and_sizing_fallback(self):
+        pm = "**Rating**: Buy\n\n**Executive Summary**: Go."
+        decision = parse_trade_decision(pm, TRADER_FALLBACK)
+        assert decision.entry_price == 118.5
+        assert decision.stop_loss == 108
+        assert decision.cash_allocation_pct == 25
+        assert decision.price_source == "trader_fallback"
+
+
+class TestCashPercent:
+    def test_prefers_available_cash_language(self):
+        text = "Use 40% of available cash, not 15% of the portfolio."
+        assert extract_cash_allocation_pct(text) == 40
+
+    def test_position_sizing_line(self):
+        text = "**Position Sizing**: 10% of cash"
+        assert extract_cash_allocation_pct(text) == 10
+
+    def test_rejects_out_of_range(self):
+        assert extract_cash_allocation_pct("Allocate 0% of cash") is None
+        assert extract_cash_allocation_pct("Allocate 150% of cash") is None

--- a/tests/test_execution_parser.py
+++ b/tests/test_execution_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from tradingagents.execution.parser import extract_cash_allocation_pct, parse_trade_decision
 
-
 PM_BUY = """
 **Rating**: Buy
 

--- a/tests/test_execution_reporting.py
+++ b/tests/test_execution_reporting.py
@@ -1,0 +1,50 @@
+"""Execution report tree tests."""
+
+from __future__ import annotations
+
+from tradingagents.execution import format_execution_report
+from tradingagents.reporting import write_report_tree
+
+
+def test_format_execution_report_includes_cash_percent():
+    text = format_execution_report(
+        {
+            "enabled": False,
+            "ticker": "NVDA",
+            "order_action": "buy",
+            "cash_allocation_pct": 50,
+            "time_horizon": "3-6 months",
+            "order_submitted": False,
+            "order_type": "none",
+            "quantity": 0,
+            "decision": {"rating": "Buy"},
+            "message": "Recommendation: buy 50% of available cash.",
+        }
+    )
+    assert "Percent of available cash**: 50" in text
+    assert "NVDA" in text
+    assert "buy" in text.lower()
+
+
+def test_write_report_tree_writes_execution_section(tmp_path):
+    final_state = {
+        "execution_report": {
+            "enabled": False,
+            "ticker": "AAPL",
+            "order_action": "hold",
+            "cash_allocation_pct": 10,
+            "time_horizon": "3-6 months",
+            "order_submitted": False,
+            "order_type": "none",
+            "quantity": 0,
+            "decision": {"rating": "Hold"},
+            "message": "Hold.",
+        }
+    }
+    complete = write_report_tree(final_state, "AAPL", tmp_path)
+    execution_md = tmp_path / "6_execution" / "execution.md"
+    assert execution_md.exists()
+    body = execution_md.read_text(encoding="utf-8")
+    assert "AAPL" in body
+    assert "hold" in body.lower()
+    assert "VI. Execution Agent" in complete.read_text(encoding="utf-8")

--- a/tests/test_position_plan.py
+++ b/tests/test_position_plan.py
@@ -1,0 +1,88 @@
+"""Tests for time-horizon and stop-loss position plans."""
+
+from __future__ import annotations
+
+from tradingagents.execution.position_plan import (
+    extract_time_horizon_from_pm,
+    horizon_elapsed,
+    horizon_end_date,
+    is_within_horizon,
+    plan_blocks_sell,
+    plan_storage_key,
+    stop_loss_breached,
+)
+
+
+class TestTimeHorizon:
+    def test_extract_time_horizon(self):
+        text = "**Rating**: Overweight\n\n**Time Horizon**: 3-6 months\n\n**Executive Summary**: Hold."
+        assert extract_time_horizon_from_pm(text) == "3-6 months"
+
+    def test_horizon_end_uses_longer_bound(self):
+        assert horizon_end_date("2026-01-15", "3-6 months") == "2026-07-15"
+
+    def test_within_horizon_before_end(self):
+        plan = {"horizon_end_date": "2026-07-15", "time_horizon": "3-6 months"}
+        assert is_within_horizon(plan=plan, trade_date="2026-03-01") is True
+        assert horizon_elapsed(plan=plan, trade_date="2026-03-01") is False
+
+    def test_sell_time_after_horizon(self):
+        plan = {"horizon_end_date": "2026-07-15", "time_horizon": "3-6 months"}
+        assert horizon_elapsed(plan=plan, trade_date="2026-07-16") is True
+        assert is_within_horizon(plan=plan, trade_date="2026-07-16") is False
+
+
+class TestStopAndHold:
+    def test_stop_loss_breached(self):
+        assert stop_loss_breached(current_price=90.0, stop_loss=95.0) is True
+        assert stop_loss_breached(current_price=100.0, stop_loss=95.0) is False
+
+    def test_hold_inside_window_even_if_pm_says_sell(self):
+        plan = {
+            "horizon_end_date": "2026-07-15",
+            "time_horizon": "3-6 months",
+            "stop_loss": 90.0,
+        }
+        blocked, reason = plan_blocks_sell(
+            plan=plan,
+            trade_date="2026-03-01",
+            parsed_decision={"rating": "Sell", "stop_loss": 90.0},
+            current_price=120.0,
+        )
+        assert blocked is True
+        assert "Within plan window" in reason
+
+    def test_allow_sell_when_stop_is_breached(self):
+        plan = {
+            "horizon_end_date": "2026-07-15",
+            "time_horizon": "3-6 months",
+            "stop_loss": 95.0,
+        }
+        blocked, reason = plan_blocks_sell(
+            plan=plan,
+            trade_date="2026-03-01",
+            parsed_decision={"rating": "Hold", "stop_loss": 95.0},
+            current_price=90.0,
+        )
+        assert blocked is False
+        assert "Stop-loss" in reason
+
+    def test_sell_time_after_horizon_does_not_block(self):
+        plan = {
+            "horizon_end_date": "2026-07-15",
+            "time_horizon": "3-6 months",
+            "stop_loss": 90.0,
+        }
+        blocked, reason = plan_blocks_sell(
+            plan=plan,
+            trade_date="2026-08-01",
+            parsed_decision={"rating": "Sell", "stop_loss": 90.0},
+            current_price=120.0,
+        )
+        assert blocked is False
+        assert "Sell time" in reason
+
+    def test_storage_key_is_account_scoped(self):
+        assert plan_storage_key(account_scope="alpaca:123:1111", ticker="nvda") == (
+            "alpaca:123:1111:NVDA"
+        )

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -26,7 +26,7 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_GOOGLE_THINKING_LEVEL":   "google_thinking_level",
     "TRADINGAGENTS_OPENAI_REASONING_EFFORT": "openai_reasoning_effort",
     "TRADINGAGENTS_ANTHROPIC_EFFORT":        "anthropic_effort",
-    # Paper-trade execution (single ticker). Submit stays off until opted in.
+    # Paper-trade execution (single ticker). On by default; set false for recommendations only.
     "TRADINGAGENTS_EXECUTION_ENABLED":              "execution_enabled",
     "TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT":    "execution_fallback_cash_pct",
     "TRADINGAGENTS_EXECUTION_JOURNAL_PATH":         "execution_journal_path",
@@ -173,10 +173,11 @@ DEFAULT_CONFIG = _apply_env_overrides({
         ".SZ":  "399001.SZ",   # Shenzhen (SZSE Component)
         "":     "SPY",         # default for US-listed tickers (no suffix)
     },
-    # Optional Alpaca paper execution. Disabled by default so research-only
-    # runs never place simulator orders. Buys are sized as a percent of
-    # Alpaca *cash* (usable money), never of equity or stock holdings.
-    "execution_enabled": False,
+    # Alpaca paper execution (single ticker). Enabled by default — the point of
+    # this fork is to turn AI analysis into paper trades. Set
+    # TRADINGAGENTS_EXECUTION_ENABLED=false for recommendations only. Buys are
+    # sized as a percent of Alpaca *cash* (usable money), never of equity.
+    "execution_enabled": True,
     "execution_fallback_cash_pct": 10.0,
     "execution_journal_path": os.path.join(_TRADINGAGENTS_HOME, "execution", "execution_journal.md"),
     "execution_position_plan_path": os.path.join(_TRADINGAGENTS_HOME, "execution", "position_plans.json"),

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -26,6 +26,12 @@ _ENV_OVERRIDES = {
     "TRADINGAGENTS_GOOGLE_THINKING_LEVEL":   "google_thinking_level",
     "TRADINGAGENTS_OPENAI_REASONING_EFFORT": "openai_reasoning_effort",
     "TRADINGAGENTS_ANTHROPIC_EFFORT":        "anthropic_effort",
+    # Paper-trade execution (single ticker). Submit stays off until opted in.
+    "TRADINGAGENTS_EXECUTION_ENABLED":              "execution_enabled",
+    "TRADINGAGENTS_EXECUTION_FALLBACK_CASH_PCT":    "execution_fallback_cash_pct",
+    "TRADINGAGENTS_EXECUTION_JOURNAL_PATH":         "execution_journal_path",
+    "TRADINGAGENTS_EXECUTION_POSITION_PLAN_PATH":   "execution_position_plan_path",
+    "TRADINGAGENTS_EXECUTION_ALLOW_SHORT":          "execution_allow_short",
 }
 
 
@@ -167,4 +173,18 @@ DEFAULT_CONFIG = _apply_env_overrides({
         ".SZ":  "399001.SZ",   # Shenzhen (SZSE Component)
         "":     "SPY",         # default for US-listed tickers (no suffix)
     },
+    # Optional Alpaca paper execution. Disabled by default so research-only
+    # runs never place simulator orders. Buys are sized as a percent of
+    # Alpaca *cash* (usable money), never of equity or stock holdings.
+    "execution_enabled": False,
+    "execution_fallback_cash_pct": 10.0,
+    "execution_journal_path": os.path.join(_TRADINGAGENTS_HOME, "execution", "execution_journal.md"),
+    "execution_position_plan_path": os.path.join(_TRADINGAGENTS_HOME, "execution", "position_plans.json"),
+    "execution_allow_short": False,
+    "alpaca_api_key": os.getenv("ALPACA_API_KEY"),
+    "alpaca_secret_key": os.getenv("ALPACA_SECRET_KEY"),
+    "alpaca_base_url": os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets"),
+    "alpaca_time_in_force": os.getenv("ALPACA_TIME_IN_FORCE", "gtc"),
+    "alpaca_extended_hours": (os.getenv("ALPACA_EXTENDED_HOURS") or "").strip().lower() in _BOOL_TRUE,
+    "alpaca_timeout_seconds": float(os.getenv("ALPACA_TIMEOUT_SECONDS") or 20),
 })

--- a/tradingagents/execution/__init__.py
+++ b/tradingagents/execution/__init__.py
@@ -1,0 +1,22 @@
+"""Paper-trade execution extension for TradingAgents."""
+
+from .agent import (
+    AlpacaPaperClient,
+    ExecutionAgent,
+    ExecutionResult,
+    format_execution_report,
+    is_live_alpaca_url,
+    shares_from_available_cash,
+)
+from .parser import ParsedTradeDecision, parse_trade_decision
+
+__all__ = [
+    "AlpacaPaperClient",
+    "ExecutionAgent",
+    "ExecutionResult",
+    "ParsedTradeDecision",
+    "format_execution_report",
+    "is_live_alpaca_url",
+    "parse_trade_decision",
+    "shares_from_available_cash",
+]

--- a/tradingagents/execution/agent.py
+++ b/tradingagents/execution/agent.py
@@ -6,7 +6,7 @@ import logging
 import math
 import os
 from dataclasses import asdict, dataclass
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -42,23 +42,23 @@ class ExecutionResult:
     ticker: str
     decision: ParsedTradeDecision
     cash_allocation_pct: float = 0.0
-    account_snapshot: Optional[dict[str, Any]] = None
-    positions_snapshot: Optional[list[dict[str, Any]]] = None
+    account_snapshot: dict[str, Any] | None = None
+    positions_snapshot: list[dict[str, Any]] | None = None
     order_submitted: bool = False
     order_action: str = "hold"
     order_type: str = "none"
     quantity: float = 0
-    limit_price: Optional[float] = None
-    stop_loss: Optional[float] = None
-    take_profit: Optional[float] = None
+    limit_price: float | None = None
+    stop_loss: float | None = None
+    take_profit: float | None = None
     stop_loss_attached: bool = False
-    estimated_notional: Optional[float] = None
-    alpaca_order_id: Optional[str] = None
-    alpaca_status: Optional[str] = None
-    alpaca_submitted_at: Optional[str] = None
-    filled_qty: Optional[float] = None
-    filled_avg_price: Optional[float] = None
-    time_horizon: Optional[str] = None
+    estimated_notional: float | None = None
+    alpaca_order_id: str | None = None
+    alpaca_status: str | None = None
+    alpaca_submitted_at: str | None = None
+    filled_qty: float | None = None
+    filled_avg_price: float | None = None
+    time_horizon: str | None = None
     message: str = ""
 
     def to_dict(self) -> dict[str, Any]:
@@ -358,8 +358,8 @@ class ExecutionAgent:
         ticker: str,
         action: str,
         quantity: float,
-        limit_price: Optional[float],
-        stop_loss: Optional[float],
+        limit_price: float | None,
+        stop_loss: float | None,
     ) -> dict[str, Any]:
         qty = quantity
         attach_stop = action == "buy" and stop_loss is not None and stop_loss > 0
@@ -602,7 +602,7 @@ def _position_qty(ticker: str, positions: list[dict[str, Any]]) -> float:
     return 0.0
 
 
-def _position_price(ticker: str, positions: list[dict[str, Any]]) -> Optional[float]:
+def _position_price(ticker: str, positions: list[dict[str, Any]]) -> float | None:
     for position in positions:
         if str(position.get("symbol") or "").upper() == ticker.upper():
             return _to_float(position.get("current_price"))
@@ -615,7 +615,7 @@ def _format_number(value: float) -> str:
     return f"{value:.4f}".rstrip("0").rstrip(".")
 
 
-def _to_float(value: Any) -> Optional[float]:
+def _to_float(value: Any) -> float | None:
     try:
         return float(value)
     except (TypeError, ValueError):

--- a/tradingagents/execution/agent.py
+++ b/tradingagents/execution/agent.py
@@ -1,0 +1,622 @@
+"""Single-ticker Execution Agent: turn a research write-up into a paper ticket."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+import requests
+
+from .journal import append_execution_journal
+from .parser import ParsedTradeDecision, parse_trade_decision
+from .position_plan import (
+    clear_position_plan,
+    load_position_plans,
+    plan_blocks_sell,
+    plan_storage_key,
+    save_position_plans,
+    stop_loss_breached,
+    upsert_position_plan,
+)
+
+logger = logging.getLogger(__name__)
+
+PAPER_ALPACA_URL = "https://paper-api.alpaca.markets"
+_DEFAULT_FALLBACK_CASH_PCT = 10.0
+
+
+def is_live_alpaca_url(url: str | None) -> bool:
+    """True when the host is Alpaca live trading rather than paper."""
+    lowered = (url or "").lower()
+    return "api.alpaca.markets" in lowered and "paper-api.alpaca.markets" not in lowered
+
+
+@dataclass
+class ExecutionResult:
+    """Observable result of an execution-agent run."""
+
+    enabled: bool
+    ticker: str
+    decision: ParsedTradeDecision
+    cash_allocation_pct: float = 0.0
+    account_snapshot: Optional[dict[str, Any]] = None
+    positions_snapshot: Optional[list[dict[str, Any]]] = None
+    order_submitted: bool = False
+    order_action: str = "hold"
+    order_type: str = "none"
+    quantity: float = 0
+    limit_price: Optional[float] = None
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+    stop_loss_attached: bool = False
+    estimated_notional: Optional[float] = None
+    alpaca_order_id: Optional[str] = None
+    alpaca_status: Optional[str] = None
+    alpaca_submitted_at: Optional[str] = None
+    filled_qty: Optional[float] = None
+    filled_avg_price: Optional[float] = None
+    time_horizon: Optional[str] = None
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["decision"] = asdict(self.decision)
+        return data
+
+
+class AlpacaPaperClient:
+    """Tiny REST client for Alpaca's Trading API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        secret_key: str,
+        base_url: str = PAPER_ALPACA_URL,
+        timeout: float = 20.0,
+    ) -> None:
+        self.api_key = api_key
+        self.secret_key = secret_key
+        self.base_url = (base_url or PAPER_ALPACA_URL).rstrip("/")
+        self.timeout = timeout
+        if is_live_alpaca_url(self.base_url):
+            logger.warning(
+                "ALPACA_BASE_URL points at live trading (%s). "
+                "Paper trading (paper-api.alpaca.markets) is the default.",
+                self.base_url,
+            )
+
+    def get_account(self) -> dict[str, Any]:
+        return self._request("GET", "/v2/account")
+
+    def get_positions(self) -> list[dict[str, Any]]:
+        positions = self._request("GET", "/v2/positions")
+        return positions if isinstance(positions, list) else []
+
+    def submit_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", "/v2/orders", json=payload)
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        response = requests.request(
+            method,
+            f"{self.base_url}{path}",
+            headers={
+                "accept": "application/json",
+                "content-type": "application/json",
+                "APCA-API-KEY-ID": self.api_key,
+                "APCA-API-SECRET-KEY": self.secret_key,
+            },
+            timeout=self.timeout,
+            **kwargs,
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            body = response.text.strip()
+            raise requests.HTTPError(
+                f"Alpaca {method} {path} failed with {response.status_code}: {body}",
+                response=response,
+            ) from exc
+        return response.json() if response.content else {}
+
+
+class ExecutionAgent:
+    """Turn one ticker's PM + Trader write-up into a cash-% recommendation and optional paper order."""
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        client: AlpacaPaperClient | Any = None,
+    ) -> None:
+        self.config = config or {}
+        self._client = client
+
+    def run(
+        self,
+        *,
+        ticker: str,
+        portfolio_manager_text: str,
+        trader_text: str | None = None,
+        trade_date: str | None = None,
+    ) -> ExecutionResult:
+        decision = parse_trade_decision(portfolio_manager_text, trader_text)
+        cash_pct = self._cash_pct(decision)
+        enabled = self._config_bool("execution_enabled", default=False)
+
+        if not enabled:
+            _, reason = resolve_execution_action(
+                decision,
+                held_qty=0.0,
+                current_price=None,
+                position_plan=None,
+                trade_date=trade_date or "",
+            )
+            recommended = decision.action
+            return self._finish(
+                ExecutionResult(
+                    enabled=False,
+                    ticker=ticker,
+                    decision=decision,
+                    cash_allocation_pct=cash_pct,
+                    order_action=recommended,
+                    order_type="none",
+                    quantity=0,
+                    limit_price=decision.entry_price,
+                    stop_loss=decision.stop_loss,
+                    take_profit=decision.price_target,
+                    time_horizon=decision.time_horizon,
+                    message=(
+                        "Execution disabled. Set TRADINGAGENTS_EXECUTION_ENABLED=true "
+                        "to submit Alpaca paper trades. "
+                        f"Recommendation: {recommended} "
+                        f"{cash_pct:g}% of available cash. {reason}"
+                    ).strip(),
+                ),
+                ticker=ticker,
+                trade_date=trade_date,
+                portfolio_manager_text=portfolio_manager_text,
+            )
+
+        try:
+            client = self._get_client()
+        except ValueError as exc:
+            return self._finish(
+                ExecutionResult(
+                    enabled=True,
+                    ticker=ticker,
+                    decision=decision,
+                    cash_allocation_pct=cash_pct,
+                    order_action=decision.action,
+                    limit_price=decision.entry_price,
+                    stop_loss=decision.stop_loss,
+                    take_profit=decision.price_target,
+                    time_horizon=decision.time_horizon,
+                    message=str(exc),
+                ),
+                ticker=ticker,
+                trade_date=trade_date,
+                portfolio_manager_text=portfolio_manager_text,
+            )
+
+        try:
+            account = _compact_account(client.get_account())
+            positions = [_compact_position(p) for p in client.get_positions()]
+        except Exception as exc:
+            logger.warning("Could not load Alpaca account state: %s", exc)
+            return self._finish(
+                ExecutionResult(
+                    enabled=True,
+                    ticker=ticker,
+                    decision=decision,
+                    cash_allocation_pct=cash_pct,
+                    order_action=decision.action,
+                    limit_price=decision.entry_price,
+                    stop_loss=decision.stop_loss,
+                    take_profit=decision.price_target,
+                    time_horizon=decision.time_horizon,
+                    message=f"Could not load Alpaca account state: {exc}",
+                ),
+                ticker=ticker,
+                trade_date=trade_date,
+                portfolio_manager_text=portfolio_manager_text,
+            )
+
+        account_scope = account.get("account_scope")
+        plans = load_position_plans(self._position_plan_path())
+        stored_plan = plans.get(
+            plan_storage_key(account_scope=account_scope, ticker=ticker)
+        )
+        held_qty = _position_qty(ticker, positions)
+        current_price = _position_price(ticker, positions) or decision.entry_price
+
+        action, reason = resolve_execution_action(
+            decision,
+            held_qty=held_qty,
+            current_price=current_price,
+            position_plan=stored_plan,
+            trade_date=trade_date or "",
+            allow_short=self._config_bool("execution_allow_short", default=False),
+        )
+
+        cash = _to_float(account.get("cash")) or 0.0
+        limit_price = decision.entry_price or current_price
+        stop_loss = decision.stop_loss or (stored_plan or {}).get("stop_loss")
+        take_profit = decision.price_target
+        quantity = 0.0
+        estimated_notional = None
+        order_type = "none"
+
+        if action == "buy":
+            quantity = shares_from_available_cash(
+                cash=cash,
+                cash_pct=cash_pct,
+                price=limit_price or 0.0,
+            )
+            estimated_notional = round(quantity * (limit_price or 0.0), 2) if quantity else 0.0
+            order_type = "limit" if limit_price else "market"
+            if quantity <= 0:
+                action = "hold"
+                reason = (
+                    reason
+                    + " No shares could be sized from available cash at the planned price."
+                ).strip()
+                order_type = "none"
+        elif action == "sell":
+            quantity = held_qty
+            estimated_notional = round(quantity * (current_price or limit_price or 0.0), 2)
+            order_type = "limit" if limit_price else "market"
+            if quantity <= 0:
+                action = "hold"
+                reason = "No long position to sell; shorting is disabled."
+                order_type = "none"
+                quantity = 0.0
+
+        result = ExecutionResult(
+            enabled=True,
+            ticker=ticker,
+            decision=decision,
+            cash_allocation_pct=cash_pct,
+            account_snapshot=account,
+            positions_snapshot=positions,
+            order_action=action,
+            order_type=order_type,
+            quantity=quantity,
+            limit_price=limit_price if action == "buy" else (limit_price if action == "sell" else decision.entry_price),
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+            estimated_notional=estimated_notional,
+            time_horizon=decision.time_horizon or (stored_plan or {}).get("time_horizon"),
+            message=reason,
+        )
+
+        if action in {"buy", "sell"} and quantity > 0:
+            payload = self._build_order_payload(
+                ticker=ticker,
+                action=action,
+                quantity=quantity,
+                limit_price=limit_price,
+                stop_loss=stop_loss if action == "buy" else None,
+            )
+            if payload.get("order_class") == "oto":
+                result.stop_loss_attached = True
+            try:
+                response = client.submit_order(payload)
+            except Exception as exc:
+                logger.warning("Alpaca order submit failed: %s", exc)
+                result.message = f"{reason} Alpaca submit failed: {exc}".strip()
+                return self._finish(
+                    result,
+                    ticker=ticker,
+                    trade_date=trade_date,
+                    portfolio_manager_text=portfolio_manager_text,
+                )
+            result.order_submitted = True
+            result.alpaca_order_id = response.get("id")
+            result.alpaca_status = response.get("status")
+            result.alpaca_submitted_at = response.get("submitted_at")
+            result.filled_qty = _to_float(response.get("filled_qty"))
+            result.filled_avg_price = _to_float(response.get("filled_avg_price"))
+            result.message = (
+                f"{reason} Submitted Alpaca paper {action} for {quantity:g} {ticker.upper()}."
+            ).strip()
+
+            if action == "buy":
+                plans = upsert_position_plan(
+                    plans,
+                    account_scope=account_scope,
+                    ticker=ticker,
+                    trade_date=trade_date or "",
+                    portfolio_manager_text=portfolio_manager_text,
+                    parsed_decision=asdict(decision),
+                    limit_price=limit_price,
+                    stop_loss=stop_loss,
+                    take_profit=take_profit,
+                )
+                save_position_plans(self._position_plan_path(), plans)
+            elif action == "sell":
+                plans = clear_position_plan(
+                    plans, account_scope=account_scope, ticker=ticker
+                )
+                save_position_plans(self._position_plan_path(), plans)
+        else:
+            result.message = reason or "Execution Agent chose to hold."
+
+        return self._finish(
+            result,
+            ticker=ticker,
+            trade_date=trade_date,
+            portfolio_manager_text=portfolio_manager_text,
+        )
+
+    def _build_order_payload(
+        self,
+        *,
+        ticker: str,
+        action: str,
+        quantity: float,
+        limit_price: Optional[float],
+        stop_loss: Optional[float],
+    ) -> dict[str, Any]:
+        qty = quantity
+        attach_stop = action == "buy" and stop_loss is not None and stop_loss > 0
+        if attach_stop:
+            qty = math.floor(qty)
+        tif = str(self.config.get("alpaca_time_in_force") or "gtc")
+        if qty != int(qty):
+            tif = "day"
+        payload: dict[str, Any] = {
+            "symbol": ticker.upper(),
+            "qty": _format_number(qty),
+            "side": action,
+            "time_in_force": tif,
+        }
+        if limit_price:
+            payload["type"] = "limit"
+            payload["limit_price"] = _format_number(round(float(limit_price), 2))
+        else:
+            payload["type"] = "market"
+        if attach_stop and qty >= 1:
+            payload["order_class"] = "oto"
+            payload["stop_loss"] = {"stop_price": _format_number(round(float(stop_loss), 2))}
+        if self._config_bool("alpaca_extended_hours", default=False) and payload["type"] == "limit":
+            payload["extended_hours"] = True
+        return payload
+
+    def _cash_pct(self, decision: ParsedTradeDecision) -> float:
+        if decision.cash_allocation_pct is not None:
+            return float(decision.cash_allocation_pct)
+        return self._config_float("execution_fallback_cash_pct", default=_DEFAULT_FALLBACK_CASH_PCT)
+
+    def _get_client(self) -> AlpacaPaperClient | Any:
+        if self._client is not None:
+            return self._client
+        api_key = self.config.get("alpaca_api_key") or os.getenv("ALPACA_API_KEY") or ""
+        secret_key = self.config.get("alpaca_secret_key") or os.getenv("ALPACA_SECRET_KEY") or ""
+        if not api_key or not secret_key:
+            raise ValueError(
+                "Alpaca API key and secret are required when execution is enabled. "
+                "Set ALPACA_API_KEY and ALPACA_SECRET_KEY (paper keys only)."
+            )
+        base_url = (
+            self.config.get("alpaca_base_url")
+            or os.getenv("ALPACA_BASE_URL")
+            or PAPER_ALPACA_URL
+        )
+        timeout = self._config_float("alpaca_timeout_seconds", default=20.0)
+        return AlpacaPaperClient(
+            api_key=api_key,
+            secret_key=secret_key,
+            base_url=str(base_url),
+            timeout=timeout,
+        )
+
+    def _position_plan_path(self) -> str:
+        return str(
+            self.config.get("execution_position_plan_path")
+            or os.path.join(
+                os.path.expanduser("~"),
+                ".tradingagents",
+                "execution",
+                "position_plans.json",
+            )
+        )
+
+    def _journal_path(self) -> str:
+        return str(
+            self.config.get("execution_journal_path")
+            or os.path.join(
+                os.path.expanduser("~"),
+                ".tradingagents",
+                "execution",
+                "execution_journal.md",
+            )
+        )
+
+    def _finish(
+        self,
+        result: ExecutionResult,
+        *,
+        ticker: str,
+        trade_date: str | None,
+        portfolio_manager_text: str,
+    ) -> ExecutionResult:
+        try:
+            account_scope = None
+            if result.account_snapshot:
+                account_scope = result.account_snapshot.get("account_scope")
+            append_execution_journal(
+                path=self._journal_path(),
+                ticker=ticker,
+                account_scope=account_scope,
+                trade_date=trade_date,
+                portfolio_manager_text=portfolio_manager_text,
+                execution_report=result.to_dict(),
+            )
+        except Exception as exc:
+            logger.warning("Could not append execution journal: %s", exc)
+        return result
+
+    def _config_bool(self, key: str, *, default: bool) -> bool:
+        value = self.config.get(key)
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+    def _config_float(self, key: str, *, default: float) -> float:
+        value = self.config.get(key)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+
+def resolve_execution_action(
+    decision: ParsedTradeDecision,
+    *,
+    held_qty: float,
+    current_price: float | None,
+    position_plan: dict[str, Any] | None,
+    trade_date: str,
+    allow_short: bool = False,
+) -> tuple[str, str]:
+    """Map PM intent + stored horizon/stop into buy, sell, or hold."""
+    parsed = asdict(decision)
+    stop = decision.stop_loss
+    if stop is None and position_plan:
+        stop = _to_float(position_plan.get("stop_loss"))
+
+    if held_qty > 0:
+        if stop_loss_breached(current_price=current_price, stop_loss=stop):
+            return "sell", "Stop-loss / significant loss versus the stored plan."
+        blocked, reason = plan_blocks_sell(
+            plan=position_plan,
+            trade_date=trade_date,
+            parsed_decision=parsed,
+            current_price=current_price,
+        )
+        if blocked:
+            return "hold", reason
+        if decision.action == "sell":
+            return "sell", reason or "Portfolio Manager rated Sell; exiting the long position."
+        if decision.action == "buy":
+            return "hold", "Already holding this name; not spending more cash on an add."
+        return "hold", reason or "Holding the existing long position."
+
+    if decision.action == "buy":
+        return "buy", "Portfolio Manager rated Buy/Overweight; size from available cash only."
+    if decision.action == "sell":
+        if allow_short:
+            return "sell", "No long position; shorting is enabled."
+        return "hold", "No long position to sell; shorting is disabled."
+    return "hold", "Portfolio Manager rated Hold; no order."
+
+
+def shares_from_available_cash(*, cash: float, cash_pct: float, price: float) -> float:
+    """Integer-or-fractional shares funded only by Alpaca cash, never equity."""
+    if cash <= 0 or cash_pct <= 0 or price <= 0:
+        return 0.0
+    pct = min(100.0, max(0.0, cash_pct))
+    notional = min(cash, cash * (pct / 100.0))
+    qty = notional / price
+    qty = math.floor(qty * 10_000) / 10_000
+    if qty * price - cash > 1e-6:
+        qty = math.floor((cash / price) * 10_000) / 10_000
+    return max(0.0, qty)
+
+
+def format_execution_report(execution_report: dict[str, Any]) -> str:
+    """Render an execution_report dict as markdown for reports and the CLI."""
+    decision = execution_report.get("decision") or {}
+    lines = [
+        f"**Enabled**: {execution_report.get('enabled')}",
+        f"**Ticker**: {execution_report.get('ticker')}",
+        f"**Recommended action**: {execution_report.get('order_action')}",
+        f"**Percent of available cash**: {execution_report.get('cash_allocation_pct')}",
+        f"**Time horizon**: {execution_report.get('time_horizon') or decision.get('time_horizon') or ''}",
+        f"**PM rating**: {decision.get('rating')}",
+        f"**Order submitted**: {execution_report.get('order_submitted')}",
+        f"**Order type**: {execution_report.get('order_type')}",
+        f"**Quantity**: {execution_report.get('quantity')}",
+    ]
+    if execution_report.get("limit_price") is not None:
+        lines.append(f"**Limit price**: {execution_report.get('limit_price')}")
+    if execution_report.get("stop_loss") is not None:
+        lines.append(f"**Stop loss**: {execution_report.get('stop_loss')}")
+    if execution_report.get("take_profit") is not None:
+        lines.append(f"**Take profit**: {execution_report.get('take_profit')}")
+    if execution_report.get("estimated_notional") is not None:
+        lines.append(f"**Estimated notional**: {execution_report.get('estimated_notional')}")
+    if execution_report.get("alpaca_order_id"):
+        lines.append(f"**Alpaca order id**: {execution_report.get('alpaca_order_id')}")
+    if execution_report.get("alpaca_status"):
+        lines.append(f"**Alpaca status**: {execution_report.get('alpaca_status')}")
+    account = execution_report.get("account_snapshot") or {}
+    if account.get("cash") is not None:
+        lines.append(f"**Available cash**: {account.get('cash')}")
+    if execution_report.get("message"):
+        lines.extend(["", execution_report["message"]])
+    return "\n".join(lines)
+
+
+def _compact_account(account: dict[str, Any]) -> dict[str, Any]:
+    account_id = str(account.get("id") or "")
+    number = str(account.get("account_number") or "")
+    return {
+        "id": account_id,
+        "account_number": number,
+        "account_scope": _account_scope(account),
+        "cash": _to_float(account.get("cash")),
+        "buying_power": _to_float(account.get("buying_power")),
+        "equity": _to_float(account.get("equity") or account.get("portfolio_value")),
+        "long_market_value": _to_float(account.get("long_market_value")),
+        "status": account.get("status"),
+    }
+
+
+def _compact_position(position: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "symbol": str(position.get("symbol") or "").upper(),
+        "qty": _to_float(position.get("qty")),
+        "market_value": _to_float(position.get("market_value")),
+        "avg_entry_price": _to_float(position.get("avg_entry_price")),
+        "current_price": _to_float(position.get("current_price")),
+    }
+
+
+def _account_scope(account: dict[str, Any]) -> str:
+    account_id = str(account.get("id") or "")
+    number = str(account.get("account_number") or "")
+    return f"alpaca:{account_id[-8:] if account_id else 'unknown'}:{number[-4:] if number else 'na'}"
+
+
+def _position_qty(ticker: str, positions: list[dict[str, Any]]) -> float:
+    for position in positions:
+        if str(position.get("symbol") or "").upper() == ticker.upper():
+            return _to_float(position.get("qty")) or 0.0
+    return 0.0
+
+
+def _position_price(ticker: str, positions: list[dict[str, Any]]) -> Optional[float]:
+    for position in positions:
+        if str(position.get("symbol") or "").upper() == ticker.upper():
+            return _to_float(position.get("current_price"))
+    return None
+
+
+def _format_number(value: float) -> str:
+    if float(value) == int(value):
+        return str(int(value))
+    return f"{value:.4f}".rstrip("0").rstrip(".")
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tradingagents/execution/agent.py
+++ b/tradingagents/execution/agent.py
@@ -145,7 +145,7 @@ class ExecutionAgent:
     ) -> ExecutionResult:
         decision = parse_trade_decision(portfolio_manager_text, trader_text)
         cash_pct = self._cash_pct(decision)
-        enabled = self._config_bool("execution_enabled", default=False)
+        enabled = self._config_bool("execution_enabled", default=True)
 
         if not enabled:
             _, reason = resolve_execution_action(
@@ -170,8 +170,8 @@ class ExecutionAgent:
                     take_profit=decision.price_target,
                     time_horizon=decision.time_horizon,
                     message=(
-                        "Execution disabled. Set TRADINGAGENTS_EXECUTION_ENABLED=true "
-                        "to submit Alpaca paper trades. "
+                        "Execution disabled (recommendations only). "
+                        "Set TRADINGAGENTS_EXECUTION_ENABLED=true to submit Alpaca paper trades. "
                         f"Recommendation: {recommended} "
                         f"{cash_pct:g}% of available cash. {reason}"
                     ).strip(),

--- a/tradingagents/execution/journal.py
+++ b/tradingagents/execution/journal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 
 def append_execution_journal(
@@ -111,7 +111,7 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def _estimated_notional(report: dict[str, Any]) -> Optional[float]:
+def _estimated_notional(report: dict[str, Any]) -> float | None:
     quantity = _to_float(report.get("quantity"))
     price = _to_float(report.get("limit_price"))
     if quantity is None or price is None:
@@ -166,7 +166,7 @@ def _fmt_money(value: Any) -> str:
     return f"${number:,.2f}"
 
 
-def _to_float(value: Any) -> Optional[float]:
+def _to_float(value: Any) -> float | None:
     try:
         return float(value)
     except (TypeError, ValueError):

--- a/tradingagents/execution/journal.py
+++ b/tradingagents/execution/journal.py
@@ -1,0 +1,173 @@
+"""Append-only execution journal for preserving workflow context."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+def append_execution_journal(
+    *,
+    path: str,
+    ticker: str,
+    account_scope: str | None,
+    trade_date: str | None,
+    portfolio_manager_text: str,
+    execution_report: dict[str, Any],
+) -> None:
+    """Append one human-readable execution record to a markdown journal."""
+    journal_path = Path(path).expanduser()
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+
+    decision = execution_report.get("decision", {}) or {}
+    account = execution_report.get("account_snapshot", {}) or {}
+    positions = execution_report.get("positions_snapshot", []) or []
+    estimated_notional = _estimated_notional(execution_report)
+
+    lines = [
+        "",
+        "---",
+        "",
+        (
+            f"## {ticker.upper()} | Account: {account_scope or 'default'} | "
+            f"Trade date: {trade_date or 'unknown'} | Logged: {_now_iso()}"
+        ),
+        "",
+        "### Portfolio Manager",
+        f"- Rating: {decision.get('rating')}",
+        f"- Parsed action: {decision.get('action')}",
+        f"- Entry price: {_fmt(decision.get('entry_price'))}",
+        f"- Stop loss: {_fmt(decision.get('stop_loss'))}",
+        f"- Time horizon: {_fmt(decision.get('time_horizon'))}",
+        f"- Quick why: {_extract_quick_why(portfolio_manager_text)}",
+        "",
+        "### Execution Agent",
+        f"- Recommended action: {execution_report.get('order_action')}",
+        f"- Cash allocation %: {_fmt(execution_report.get('cash_allocation_pct'))}",
+        f"- Order submitted: {execution_report.get('order_submitted')}",
+        f"- Order type: {execution_report.get('order_type')}",
+        f"- Quantity: {_fmt(execution_report.get('quantity'))}",
+        f"- Limit price: {_fmt(execution_report.get('limit_price'))}",
+        f"- Estimated notional: {_fmt_money(estimated_notional)}",
+        f"- Stop loss attached: {execution_report.get('stop_loss_attached')}",
+        f"- Alpaca order id: {execution_report.get('alpaca_order_id') or ''}",
+        f"- Alpaca status: {execution_report.get('alpaca_status') or ''}",
+        f"- Message: {execution_report.get('message') or ''}",
+        "",
+        "### Account Snapshot",
+        f"- Cash (usable): {_fmt_money(account.get('cash'))}",
+        f"- Equity: {_fmt_money(account.get('equity') or account.get('portfolio_value'))}",
+        "",
+        "### Positions Snapshot",
+    ]
+
+    if positions:
+        for position in positions:
+            lines.append(
+                "- "
+                f"{position.get('symbol')}: qty={_fmt(position.get('qty'))}, "
+                f"market_value={_fmt_money(position.get('market_value'))}, "
+                f"avg_entry={_fmt_money(position.get('avg_entry_price'))}, "
+                f"current={_fmt_money(position.get('current_price'))}"
+            )
+    else:
+        lines.append("- No open positions reported.")
+
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("\n".join(lines).rstrip() + "\n")
+
+
+def load_execution_context(
+    *,
+    path: str,
+    ticker: str,
+    account_scope: str | None = None,
+    max_entries: int = 5,
+    max_chars: int = 4000,
+) -> str:
+    """Return recent same-ticker execution journal entries for later runs."""
+    journal_path = Path(path).expanduser()
+    if not journal_path.exists():
+        return ""
+
+    text = journal_path.read_text(encoding="utf-8")
+    blocks = [block.strip() for block in text.split("\n---\n") if block.strip()]
+    needle = f"## {ticker.upper()} |"
+    matching = [block for block in blocks if needle in block]
+    if account_scope:
+        scope_marker = f"| Account: {account_scope} |"
+        matching = [block for block in matching if scope_marker in block]
+    if not matching:
+        return ""
+
+    context = "\n\n---\n\n".join(matching[-max_entries:])
+    if len(context) <= max_chars:
+        return context
+    return context[-max_chars:]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _estimated_notional(report: dict[str, Any]) -> Optional[float]:
+    quantity = _to_float(report.get("quantity"))
+    price = _to_float(report.get("limit_price"))
+    if quantity is None or price is None:
+        return None
+    return quantity * price
+
+
+def _extract_quick_why(text: str) -> str:
+    for label in ("Executive Summary", "Investment Thesis"):
+        extracted = _extract_section(text, label)
+        if extracted:
+            return _squash(extracted, 500)
+    return _squash(text, 500)
+
+
+def _extract_section(text: str, label: str) -> str:
+    marker_options = [f"**{label}**:", f"{label}:"]
+    start = -1
+    marker = ""
+    for option in marker_options:
+        start = text.find(option)
+        if start >= 0:
+            marker = option
+            break
+    if start < 0:
+        return ""
+
+    body = text[start + len(marker) :]
+    next_section = body.find("\n\n**")
+    if next_section >= 0:
+        body = body[:next_section]
+    return body.strip()
+
+
+def _squash(text: str, limit: int) -> str:
+    squashed = " ".join((text or "").split())
+    if len(squashed) <= limit:
+        return squashed
+    return squashed[: limit - 3].rstrip() + "..."
+
+
+def _fmt(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _fmt_money(value: Any) -> str:
+    number = _to_float(value)
+    if number is None:
+        return ""
+    return f"${number:,.2f}"
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tradingagents/execution/parser.py
+++ b/tradingagents/execution/parser.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Literal, Optional
+from typing import Literal
 
 from tradingagents.agents.utils.rating import parse_rating
-
 
 TradeAction = Literal["buy", "sell", "hold"]
 
@@ -103,11 +103,11 @@ class ParsedTradeDecision:
 
     rating: str
     action: TradeAction
-    entry_price: Optional[float] = None
-    stop_loss: Optional[float] = None
-    price_target: Optional[float] = None
-    time_horizon: Optional[str] = None
-    cash_allocation_pct: Optional[float] = None
+    entry_price: float | None = None
+    stop_loss: float | None = None
+    price_target: float | None = None
+    time_horizon: str | None = None
+    cash_allocation_pct: float | None = None
     rating_source: str = "portfolio_manager"
     price_source: str = "portfolio_manager"
 
@@ -172,7 +172,7 @@ def parse_trade_decision(
     )
 
 
-def extract_time_horizon(text: str) -> Optional[str]:
+def extract_time_horizon(text: str) -> str | None:
     """Read a Time Horizon / estimated hold period from rendered markdown."""
     if not text:
         return None
@@ -189,7 +189,7 @@ def extract_time_horizon(text: str) -> Optional[str]:
     return None
 
 
-def extract_cash_allocation_pct(text: str) -> Optional[float]:
+def extract_cash_allocation_pct(text: str) -> float | None:
     """Extract a 0-100 allocation percent, preferring language about available cash."""
     if not text:
         return None
@@ -230,7 +230,7 @@ def _rating_to_action(rating: str) -> TradeAction:
     return "hold"
 
 
-def _extract_entry_price(text: str) -> Optional[float]:
+def _extract_entry_price(text: str) -> float | None:
     return _extract_price_from_text(
         text,
         label_re=_ENTRY_LABEL_RE,
@@ -240,7 +240,7 @@ def _extract_entry_price(text: str) -> Optional[float]:
     )
 
 
-def _extract_stop_loss(text: str, entry_price: Optional[float]) -> Optional[float]:
+def _extract_stop_loss(text: str, entry_price: float | None) -> float | None:
     return _extract_price_from_text(
         text,
         label_re=_STOP_LABEL_RE,
@@ -252,9 +252,9 @@ def _extract_stop_loss(text: str, entry_price: Optional[float]) -> Optional[floa
 
 def _extract_target_price(
     text: str,
-    entry_price: Optional[float],
-    stop_loss: Optional[float],
-) -> Optional[float]:
+    entry_price: float | None,
+    stop_loss: float | None,
+) -> float | None:
     return _extract_price_from_text(
         text,
         label_re=_TARGET_LABEL_RE,
@@ -268,9 +268,9 @@ def _extract_target_price(
 
 def _extract_upside_target_price(
     text: str,
-    entry_price: Optional[float],
-    stop_loss: Optional[float],
-) -> Optional[float]:
+    entry_price: float | None,
+    stop_loss: float | None,
+) -> float | None:
     if not text:
         return None
     for match in _UPSIDE_TARGET_RE.finditer(text):
@@ -289,7 +289,7 @@ def _extract_price_from_text(
     context_words: Iterable[str],
     ignore_words: Iterable[str],
     selector,
-) -> Optional[float]:
+) -> float | None:
     if not text:
         return None
 
@@ -340,14 +340,14 @@ def _should_skip_price_match(text: str, match: re.Match[str]) -> bool:
     return bool(_SKIP_PRICE_TRAILING_RE.match(trailing))
 
 
-def _to_float(value: str) -> Optional[float]:
+def _to_float(value: str) -> float | None:
     try:
         return float(value.replace(",", ""))
     except (TypeError, ValueError):
         return None
 
 
-def _clamp_pct(value: Optional[float]) -> Optional[float]:
+def _clamp_pct(value: float | None) -> float | None:
     if value is None:
         return None
     if value <= 0 or value > 100:
@@ -355,14 +355,14 @@ def _clamp_pct(value: Optional[float]) -> Optional[float]:
     return value
 
 
-def _select_entry_price(prices: list[float], _context: str = "") -> Optional[float]:
+def _select_entry_price(prices: list[float], _context: str = "") -> float | None:
     realistic = [price for price in prices if price >= 1]
     return realistic[0] if realistic else None
 
 
 def _select_stop_price(
-    prices: list[float], entry_price: Optional[float], context: str = ""
-) -> Optional[float]:
+    prices: list[float], entry_price: float | None, context: str = ""
+) -> float | None:
     realistic = [price for price in prices if price >= 1]
     if not realistic:
         return None
@@ -383,10 +383,10 @@ def _select_stop_price(
 
 def _select_target_price(
     prices: list[float],
-    entry_price: Optional[float],
-    stop_loss: Optional[float],
+    entry_price: float | None,
+    stop_loss: float | None,
     _context: str = "",
-) -> Optional[float]:
+) -> float | None:
     realistic = [price for price in prices if price >= 1]
     if not realistic:
         return None

--- a/tradingagents/execution/parser.py
+++ b/tradingagents/execution/parser.py
@@ -305,7 +305,9 @@ def _extract_price_from_text(
         if not line:
             continue
         lowered = line.lower()
-        if any(word in lowered for word in ignore_words):
+        if any(word in lowered for word in ignore_words) and not any(
+            word in lowered for word in context_words
+        ):
             continue
         if any(word in lowered for word in context_words):
             prices = _prices_in(line)

--- a/tradingagents/execution/parser.py
+++ b/tradingagents/execution/parser.py
@@ -1,0 +1,396 @@
+"""Parse Portfolio Manager and Trader prose into execution-ready parameters."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional
+
+from tradingagents.agents.utils.rating import parse_rating
+
+
+TradeAction = Literal["buy", "sell", "hold"]
+
+_PRICE_RE = re.compile(
+    r"(?<![\w.])\$?\s*(\d{1,4}(?:,\d{3})*(?:\.\d+)?)"
+    r"(?:\s*(?:-|to|–|—)\s*\$?\s*(\d{1,4}(?:,\d{3})*(?:\.\d+)?))?"
+    r"(?!\s*[%xX]|\w)",
+    re.IGNORECASE,
+)
+
+_ENTRY_LABEL_RE = re.compile(
+    r"(?:\*\*)?\b(?:entry price|entry level|entry zone|entry target|entry|"
+    r"enter(?:ing)?|initial entry|limit order|starter position|starter tranche|"
+    r"pullback zone|pullback area|buy zone|accumulation zone|add(?:\s+near|\s+at)?)"
+    r"\b(?:\*\*)?\s*(?::|-|at|around|near|~)?\s*",
+    re.IGNORECASE,
+)
+_STOP_LABEL_RE = re.compile(
+    r"(?:\*\*)?\b(?:stop loss|stop-loss|stop|protective stop|risk threshold|"
+    r"thesis invalidation|invalidated|invalidation|breaks down|below)"
+    r"\b(?:\*\*)?\s*(?::|-|at|around|near|~)?\s*",
+    re.IGNORECASE,
+)
+_TARGET_LABEL_RE = re.compile(
+    r"(?:\*\*)?\b(?:price target|target price|target|take profit|profit target)"
+    r"\b(?:\*\*)?\s*(?::|-|at|around|near|~)?\s*",
+    re.IGNORECASE,
+)
+_UPSIDE_TARGET_RE = re.compile(
+    r"(?:toward|towards|back toward|move back toward|upside(?:\s+target)?|profit(?:\s+taking)?(?:\s+levels?)?|"
+    r"target reflects .*? toward|aiming for .*? toward)[^\n]{0,80}",
+    re.IGNORECASE,
+)
+_SKIP_PRICE_TRAILING_RE = re.compile(
+    r"\s*(?:shares?|sessions?|days?|weeks?|months?|years?|tranches?|times?|closes?|atr)\b",
+    re.IGNORECASE,
+)
+_CASH_PCT_RE = re.compile(
+    r"(\d+(?:\.\d+)?)\s*%(?:\s*of\s+(?:the\s+)?"
+    r"(?:available\s+)?(?:cash|buying\s+power|usable\s+(?:cash|money|capital)|"
+    r"free\s+cash|capital|portfolio|equity))?",
+    re.IGNORECASE,
+)
+_POSITION_SIZING_RE = re.compile(
+    r"(?:\*\*)?position sizing(?:\*\*)?\s*:\s*(.+)",
+    re.IGNORECASE,
+)
+
+_ENTRY_WORDS = (
+    "entry",
+    "enter",
+    "buy",
+    "add",
+    "accumulate",
+    "limit order",
+    "starter position",
+    "starter tranche",
+    "pullback zone",
+    "pullback area",
+    "buy zone",
+    "accumulation zone",
+)
+_STOP_WORDS = (
+    "stop",
+    "stop-loss",
+    "risk threshold",
+    "invalidat",
+    "breaks down",
+    "below",
+)
+_TARGET_WORDS = ("price target", "target price", "profit target", "take profit", "target")
+_IGNORE_ENTRY_WORDS = ("price target", "target price", "stop", "time horizon")
+_HARD_STOP_WORDS = (
+    "hard invalidation",
+    "hard stop",
+    "structural break",
+    "exit remaining",
+    "thesis invalidation",
+)
+_CASH_HINTS = (
+    "cash",
+    "buying power",
+    "usable",
+    "available",
+    "free cash",
+    "deployable",
+)
+
+
+@dataclass(frozen=True)
+class ParsedTradeDecision:
+    """Decision distilled from the Portfolio Manager report and Trader plan."""
+
+    rating: str
+    action: TradeAction
+    entry_price: Optional[float] = None
+    stop_loss: Optional[float] = None
+    price_target: Optional[float] = None
+    time_horizon: Optional[str] = None
+    cash_allocation_pct: Optional[float] = None
+    rating_source: str = "portfolio_manager"
+    price_source: str = "portfolio_manager"
+
+    @property
+    def should_trade(self) -> bool:
+        return self.action in {"buy", "sell"}
+
+
+def parse_trade_decision(
+    portfolio_manager_text: str,
+    fallback_text: str | None = None,
+) -> ParsedTradeDecision:
+    """Parse the final PM text and optional trader fallback into a decision.
+
+    The Portfolio Manager remains authoritative for direction. Price levels,
+    time horizon, and cash-percent sizing are taken from the PM report first;
+    missing prices and sizing fall back to the Trader proposal.
+    """
+    pm_text = portfolio_manager_text or ""
+    trader_text = fallback_text or ""
+    rating = parse_rating(pm_text)
+    action = _rating_to_action(rating)
+
+    entry_price = _extract_entry_price(pm_text)
+    stop_loss = _extract_stop_loss(pm_text, entry_price)
+    price_target = _extract_target_price(pm_text, entry_price, stop_loss)
+    if price_target is None:
+        price_target = _extract_upside_target_price(pm_text, entry_price, stop_loss)
+    price_source = "portfolio_manager"
+
+    if entry_price is None and trader_text:
+        entry_price = _extract_entry_price(trader_text)
+        if entry_price is not None:
+            price_source = "trader_fallback"
+
+    if stop_loss is None and trader_text:
+        stop_loss = _extract_stop_loss(trader_text, entry_price)
+        if stop_loss is not None and price_source == "portfolio_manager":
+            price_source = "trader_fallback"
+
+    if price_target is None and trader_text:
+        price_target = _extract_target_price(trader_text, entry_price, stop_loss)
+        if price_target is None:
+            price_target = _extract_upside_target_price(trader_text, entry_price, stop_loss)
+        if price_target is not None and price_source == "portfolio_manager":
+            price_source = "trader_fallback"
+
+    time_horizon = extract_time_horizon(pm_text) or extract_time_horizon(trader_text)
+    cash_allocation_pct = extract_cash_allocation_pct(pm_text)
+    if cash_allocation_pct is None:
+        cash_allocation_pct = extract_cash_allocation_pct(trader_text)
+
+    return ParsedTradeDecision(
+        rating=rating,
+        action=action,
+        entry_price=entry_price,
+        stop_loss=stop_loss,
+        price_target=price_target,
+        time_horizon=time_horizon,
+        cash_allocation_pct=cash_allocation_pct,
+        price_source=price_source,
+    )
+
+
+def extract_time_horizon(text: str) -> Optional[str]:
+    """Read a Time Horizon / estimated hold period from rendered markdown."""
+    if not text:
+        return None
+    for marker in ("**Time Horizon**:", "Time Horizon:", "**Hold Period**:", "Hold Period:"):
+        start = text.find(marker)
+        if start < 0:
+            continue
+        body = text[start + len(marker) :].strip()
+        next_section = body.find("\n\n**")
+        if next_section >= 0:
+            body = body[:next_section]
+        line = body.split("\n", 1)[0].strip()
+        return line or None
+    return None
+
+
+def extract_cash_allocation_pct(text: str) -> Optional[float]:
+    """Extract a 0-100 allocation percent, preferring language about available cash."""
+    if not text:
+        return None
+
+    sizing_line = None
+    match = _POSITION_SIZING_RE.search(text)
+    if match:
+        sizing_line = match.group(1).strip()
+
+    candidates: list[tuple[int, float]] = []
+    for source in (sizing_line, text):
+        if not source:
+            continue
+        for pct_match in _CASH_PCT_RE.finditer(source):
+            value = _clamp_pct(_to_float(pct_match.group(1)))
+            if value is None:
+                continue
+            snippet = source[max(0, pct_match.start() - 40) : pct_match.end() + 40].lower()
+            rank = 0 if any(hint in snippet for hint in _CASH_HINTS) else 1
+            if source is sizing_line:
+                rank -= 1
+            candidates.append((rank, value))
+        if source is sizing_line:
+            break
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0])
+    return candidates[0][1]
+
+
+def _rating_to_action(rating: str) -> TradeAction:
+    normalized = rating.strip().lower()
+    if normalized in {"buy", "overweight"}:
+        return "buy"
+    if normalized in {"sell", "underweight"}:
+        return "sell"
+    return "hold"
+
+
+def _extract_entry_price(text: str) -> Optional[float]:
+    return _extract_price_from_text(
+        text,
+        label_re=_ENTRY_LABEL_RE,
+        context_words=_ENTRY_WORDS,
+        ignore_words=_IGNORE_ENTRY_WORDS,
+        selector=_select_entry_price,
+    )
+
+
+def _extract_stop_loss(text: str, entry_price: Optional[float]) -> Optional[float]:
+    return _extract_price_from_text(
+        text,
+        label_re=_STOP_LABEL_RE,
+        context_words=_STOP_WORDS,
+        ignore_words=("price target", "target price", "time horizon"),
+        selector=lambda prices, context: _select_stop_price(prices, entry_price, context),
+    )
+
+
+def _extract_target_price(
+    text: str,
+    entry_price: Optional[float],
+    stop_loss: Optional[float],
+) -> Optional[float]:
+    return _extract_price_from_text(
+        text,
+        label_re=_TARGET_LABEL_RE,
+        context_words=_TARGET_WORDS,
+        ignore_words=("time horizon",),
+        selector=lambda prices, context: _select_target_price(
+            prices, entry_price, stop_loss, context
+        ),
+    )
+
+
+def _extract_upside_target_price(
+    text: str,
+    entry_price: Optional[float],
+    stop_loss: Optional[float],
+) -> Optional[float]:
+    if not text:
+        return None
+    for match in _UPSIDE_TARGET_RE.finditer(text):
+        snippet = match.group(0)
+        prices = _prices_in(snippet)
+        chosen = _select_target_price(prices, entry_price, stop_loss, snippet)
+        if chosen is not None:
+            return chosen
+    return None
+
+
+def _extract_price_from_text(
+    text: str,
+    *,
+    label_re: re.Pattern[str],
+    context_words: Iterable[str],
+    ignore_words: Iterable[str],
+    selector,
+) -> Optional[float]:
+    if not text:
+        return None
+
+    for match in label_re.finditer(text):
+        snippet = text[match.end() : match.end() + 120]
+        prices = _prices_in(snippet)
+        chosen = selector(prices, snippet)
+        if chosen is not None:
+            return chosen
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        lowered = line.lower()
+        if any(word in lowered for word in ignore_words):
+            continue
+        if any(word in lowered for word in context_words):
+            prices = _prices_in(line)
+            chosen = selector(prices, line)
+            if chosen is not None:
+                return chosen
+
+    return None
+
+
+def _prices_in(text: str) -> list[float]:
+    prices: list[float] = []
+    for match in _PRICE_RE.finditer(text):
+        if _should_skip_price_match(text, match):
+            continue
+        price = _to_float(match.group(1))
+        if match.group(2) is not None:
+            end = _to_float(match.group(2))
+            if price is not None and end is not None:
+                price = min(price, end)
+        if price is None:
+            continue
+        if price not in prices:
+            prices.append(price)
+    return prices
+
+
+def _should_skip_price_match(text: str, match: re.Match[str]) -> bool:
+    trailing = text[match.end() : match.end() + 24]
+    return bool(_SKIP_PRICE_TRAILING_RE.match(trailing))
+
+
+def _to_float(value: str) -> Optional[float]:
+    try:
+        return float(value.replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp_pct(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if value <= 0 or value > 100:
+        return None
+    return value
+
+
+def _select_entry_price(prices: list[float], _context: str = "") -> Optional[float]:
+    realistic = [price for price in prices if price >= 1]
+    return realistic[0] if realistic else None
+
+
+def _select_stop_price(
+    prices: list[float], entry_price: Optional[float], context: str = ""
+) -> Optional[float]:
+    realistic = [price for price in prices if price >= 1]
+    if not realistic:
+        return None
+
+    if entry_price is not None:
+        floor = max(1.0, entry_price * 0.5)
+        below_entry = [price for price in realistic if floor <= price < entry_price]
+        if not below_entry:
+            below_entry = [price for price in realistic if price < entry_price]
+        if below_entry:
+            lowered = context.lower()
+            if any(word in lowered for word in _HARD_STOP_WORDS):
+                return min(below_entry)
+            return max(below_entry)
+
+    return realistic[0]
+
+
+def _select_target_price(
+    prices: list[float],
+    entry_price: Optional[float],
+    stop_loss: Optional[float],
+    _context: str = "",
+) -> Optional[float]:
+    realistic = [price for price in prices if price >= 1]
+    if not realistic:
+        return None
+
+    floor = max(value for value in (entry_price, stop_loss, 0) if value is not None)
+    above_floor = [price for price in realistic if price > floor]
+    if above_floor:
+        return max(above_floor)
+    return realistic[0]

--- a/tradingagents/execution/position_plan.py
+++ b/tradingagents/execution/position_plan.py
@@ -6,7 +6,7 @@ import json
 import re
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from dateutil.relativedelta import relativedelta
 
@@ -21,12 +21,12 @@ _WEEKS_RE = re.compile(r"(\d+)\s*weeks?", re.IGNORECASE)
 _YEARS_RE = re.compile(r"(\d+(?:\.\d+)?)\s*years?", re.IGNORECASE)
 
 
-def extract_time_horizon_from_pm(text: str) -> Optional[str]:
+def extract_time_horizon_from_pm(text: str) -> str | None:
     """Read **Time Horizon** from PM markdown (alias for the parser helper)."""
     return extract_time_horizon(text)
 
 
-def horizon_end_date(entry_date: str, horizon_text: Optional[str]) -> Optional[str]:
+def horizon_end_date(entry_date: str, horizon_text: str | None) -> str | None:
     """Return ISO end date using the longer bound of a range (e.g. 3-6 months -> 6 months)."""
     if not horizon_text or not entry_date:
         return None
@@ -36,7 +36,7 @@ def horizon_end_date(entry_date: str, horizon_text: Optional[str]) -> Optional[s
         return None
 
     text = horizon_text.strip().lower()
-    delta: Optional[relativedelta] = None
+    delta: relativedelta | None = None
 
     match = _MONTHS_RANGE_RE.search(text)
     if match:
@@ -132,7 +132,7 @@ def clear_position_plan(
     return plans
 
 
-def _parse_iso_day(value: str | None) -> Optional[date]:
+def _parse_iso_day(value: str | None) -> date | None:
     if not value:
         return None
     try:
@@ -202,7 +202,7 @@ def plan_blocks_sell(
     return False, ""
 
 
-def _to_float_optional(value: Any) -> Optional[float]:
+def _to_float_optional(value: Any) -> float | None:
     try:
         return float(value)
     except (TypeError, ValueError):

--- a/tradingagents/execution/position_plan.py
+++ b/tradingagents/execution/position_plan.py
@@ -1,0 +1,209 @@
+"""Per-ticker position plans: time horizon and stop tracking."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from dateutil.relativedelta import relativedelta
+
+from .parser import extract_time_horizon
+
+_MONTHS_RANGE_RE = re.compile(
+    r"(\d+)\s*(?:-|to|–|—)\s*(\d+)\s*months?",
+    re.IGNORECASE,
+)
+_MONTHS_SINGLE_RE = re.compile(r"(\d+)\s*months?", re.IGNORECASE)
+_WEEKS_RE = re.compile(r"(\d+)\s*weeks?", re.IGNORECASE)
+_YEARS_RE = re.compile(r"(\d+(?:\.\d+)?)\s*years?", re.IGNORECASE)
+
+
+def extract_time_horizon_from_pm(text: str) -> Optional[str]:
+    """Read **Time Horizon** from PM markdown (alias for the parser helper)."""
+    return extract_time_horizon(text)
+
+
+def horizon_end_date(entry_date: str, horizon_text: Optional[str]) -> Optional[str]:
+    """Return ISO end date using the longer bound of a range (e.g. 3-6 months -> 6 months)."""
+    if not horizon_text or not entry_date:
+        return None
+    try:
+        start = date.fromisoformat(str(entry_date)[:10])
+    except ValueError:
+        return None
+
+    text = horizon_text.strip().lower()
+    delta: Optional[relativedelta] = None
+
+    match = _MONTHS_RANGE_RE.search(text)
+    if match:
+        high = int(match.group(2))
+        delta = relativedelta(months=high)
+    else:
+        match = _MONTHS_SINGLE_RE.search(text)
+        if match:
+            delta = relativedelta(months=int(match.group(1)))
+        else:
+            match = _WEEKS_RE.search(text)
+            if match:
+                delta = relativedelta(weeks=int(match.group(1)))
+            else:
+                match = _YEARS_RE.search(text)
+                if match:
+                    months = max(1, int(float(match.group(1)) * 12))
+                    delta = relativedelta(months=months)
+
+    if delta is None:
+        return None
+    return (start + delta).isoformat()
+
+
+def load_position_plans(path: str) -> dict[str, Any]:
+    plan_path = Path(path).expanduser()
+    if not plan_path.exists():
+        return {}
+    try:
+        data = json.loads(plan_path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_position_plans(path: str, plans: dict[str, Any]) -> None:
+    plan_path = Path(path).expanduser()
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(json.dumps(plans, indent=2), encoding="utf-8")
+
+
+def plan_storage_key(*, account_scope: str | None, ticker: str) -> str:
+    scope = (account_scope or "default").strip().lower()
+    return f"{scope}:{ticker.upper()}"
+
+
+def upsert_position_plan(
+    plans: dict[str, Any],
+    *,
+    account_scope: str | None,
+    ticker: str,
+    trade_date: str,
+    portfolio_manager_text: str,
+    parsed_decision: dict[str, Any],
+    limit_price: float | None,
+    stop_loss: float | None,
+    take_profit: float | None,
+) -> dict[str, Any]:
+    """Record or refresh the active plan when opening or adding to a position."""
+    key = plan_storage_key(account_scope=account_scope, ticker=ticker)
+    horizon_raw = extract_time_horizon(portfolio_manager_text) or parsed_decision.get(
+        "time_horizon"
+    )
+    entry = str(trade_date)[:10]
+    existing = plans.get(key) or {}
+    if not existing.get("entry_date"):
+        existing["entry_date"] = entry
+    plans[key] = {
+        **existing,
+        "ticker": ticker.upper(),
+        "entry_date": existing.get("entry_date") or entry,
+        "time_horizon": horizon_raw,
+        "horizon_end_date": horizon_end_date(
+            existing.get("entry_date") or entry, horizon_raw
+        ),
+        "rating": parsed_decision.get("rating"),
+        "stop_loss": stop_loss
+        if stop_loss is not None
+        else parsed_decision.get("stop_loss"),
+        "take_profit": take_profit,
+        "entry_limit": limit_price,
+        "last_updated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    return plans
+
+
+def clear_position_plan(
+    plans: dict[str, Any], *, account_scope: str | None, ticker: str
+) -> dict[str, Any]:
+    """Drop the stored plan after a full exit."""
+    key = plan_storage_key(account_scope=account_scope, ticker=ticker)
+    plans.pop(key, None)
+    return plans
+
+
+def _parse_iso_day(value: str | None) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def stop_loss_breached(
+    *,
+    current_price: float | None,
+    stop_loss: float | None,
+) -> bool:
+    if current_price is None or stop_loss is None or stop_loss <= 0:
+        return False
+    return current_price < stop_loss
+
+
+def horizon_elapsed(*, plan: dict[str, Any] | None, trade_date: str) -> bool:
+    """True when the stored hold window is over (sell time)."""
+    if not plan:
+        return False
+    end = _parse_iso_day(plan.get("horizon_end_date"))
+    if end is None:
+        return False
+    today = _parse_iso_day(trade_date) or date.today()
+    return today > end
+
+
+def is_within_horizon(*, plan: dict[str, Any] | None, trade_date: str) -> bool:
+    if not plan:
+        return False
+    end = _parse_iso_day(plan.get("horizon_end_date"))
+    if end is None:
+        return False
+    today = _parse_iso_day(trade_date) or date.today()
+    return today <= end
+
+
+def plan_blocks_sell(
+    *,
+    plan: dict[str, Any] | None,
+    trade_date: str,
+    parsed_decision: dict[str, Any],
+    current_price: float | None,
+) -> tuple[bool, str]:
+    """True when an existing position should stay on plan (no discretionary exit)."""
+    stop = _to_float_optional(parsed_decision.get("stop_loss")) or _to_float_optional(
+        (plan or {}).get("stop_loss")
+    )
+    if stop_loss_breached(current_price=current_price, stop_loss=stop):
+        return False, "Stop-loss level breached; significant-loss exit allowed."
+
+    if not plan:
+        return False, ""
+
+    if is_within_horizon(plan=plan, trade_date=trade_date):
+        horizon = plan.get("time_horizon") or "thesis horizon"
+        return (
+            True,
+            f"Within plan window ({horizon}); holding unless the stop is hit.",
+        )
+
+    if horizon_elapsed(plan=plan, trade_date=trade_date):
+        return False, "Sell time: the estimated hold window has elapsed."
+
+    return False, ""
+
+
+def _to_float_optional(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -32,6 +32,7 @@ from tradingagents.agents.utils.memory import TradingMemoryLog
 from tradingagents.dataflows.config import set_config
 from tradingagents.dataflows.utils import safe_ticker_component
 from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.execution import ExecutionAgent, ExecutionResult
 from tradingagents.llm_clients import create_llm_client
 from tradingagents.reporting import write_report_tree
 
@@ -150,6 +151,7 @@ class TradingAgentsGraph:
         )
         self.reflector = Reflector(self.quick_thinking_llm)
         self.signal_processor = SignalProcessor(self.quick_thinking_llm)
+        self.execution_agent = ExecutionAgent(self.config)
 
         # State tracking
         self.curr_state = None
@@ -558,6 +560,10 @@ class TradingAgentsGraph:
         # Store current state for reflection.
         self.curr_state = final_state
 
+        execution_result = self.execute_trade_decision(company_name, final_state)
+        if execution_result is not None:
+            final_state["execution_report"] = execution_result.to_dict()
+
         # Log state to disk.
         self._log_state(trade_date, final_state)
 
@@ -603,6 +609,7 @@ class TradingAgentsGraph:
             },
             "investment_plan": final_state["investment_plan"],
             "final_trade_decision": final_state["final_trade_decision"],
+            "execution_report": final_state.get("execution_report"),
         }
 
         # Save to file. Reject ticker values that would escape the
@@ -618,3 +625,20 @@ class TradingAgentsGraph:
     def process_signal(self, full_signal):
         """Process a signal to extract the core decision."""
         return self.signal_processor.process_signal(full_signal)
+
+    def execute_trade_decision(
+        self, ticker: str, final_state: dict[str, Any]
+    ) -> ExecutionResult | None:
+        """Run the Execution Agent: always recommend, submit only if enabled."""
+        if not final_state:
+            return None
+        result = self.execution_agent.run(
+            ticker=ticker,
+            trade_date=str(final_state.get("trade_date", "")),
+            portfolio_manager_text=final_state.get("final_trade_decision", "")
+            or "",
+            trader_text=final_state.get("trader_investment_plan", "") or "",
+        )
+        if result.message:
+            logger.info("Execution agent: %s", result.message)
+        return result

--- a/tradingagents/reporting.py
+++ b/tradingagents/reporting.py
@@ -9,6 +9,8 @@ run produces the same on-disk report tree a CLI run does.
 from datetime import datetime
 from pathlib import Path
 
+from tradingagents.execution import format_execution_report
+
 
 def write_report_tree(final_state: dict, ticker: str, save_path) -> Path:
     """Save a completed run's reports to ``save_path``; return the complete-report path."""
@@ -94,6 +96,14 @@ def write_report_tree(final_state: dict, ticker: str, save_path) -> Path:
             portfolio_dir.mkdir(exist_ok=True)
             (portfolio_dir / "decision.md").write_text(risk["judge_decision"], encoding="utf-8")
             sections.append(f"## V. Portfolio Manager Decision\n\n### Portfolio Manager\n{risk['judge_decision']}")
+
+    # 6. Execution Agent
+    if final_state.get("execution_report"):
+        execution_dir = save_path / "6_execution"
+        execution_dir.mkdir(exist_ok=True)
+        execution_text = format_execution_report(final_state["execution_report"])
+        (execution_dir / "execution.md").write_text(execution_text, encoding="utf-8")
+        sections.append(f"## VI. Execution Agent\n\n{execution_text}")
 
     # Write consolidated report
     header = f"# Trading Analysis Report: {ticker}\n\nGenerated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"


### PR DESCRIPTION
This fork extends TradingAgents with an Execution Agent that runs after the Portfolio Manager finishes. It reads the Trader + PM write-up and turns the decision into an Alpaca paper trade. It is sized by a percentage of available cash, not total portfolio equity.

AI analysis → paper order.