### PR TITLE
fix(reddit): report failed fetches as unavailable; raise headerless-429 back-off to 60s

### DIFF
--- a/tests/test_reddit_fallback.py
+++ b/tests/test_reddit_fallback.py
@@ -86,9 +86,10 @@ class TestRssParsing:
         assert posts[0]["created_utc"] > 0
         assert "datacenter unit" in posts[0]["selftext"]
 
-    def test_malformed_xml_fails_open(self):
-        with patch.object(reddit, "urlopen", return_value=_resp(lambda: b"<<not xml>>")):
-            assert reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0) == []
+    def test_malformed_xml_raises_unavailable(self):
+        with patch.object(reddit, "urlopen", return_value=_resp(lambda: b"<<not xml>>")), \
+             pytest.raises(reddit.RedditUnavailable):
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
 
 
 @pytest.mark.unit
@@ -136,10 +137,10 @@ class TestRss429Backoff:
     def test_429_twice_gives_up_after_one_retry(self):
         err = HTTPError("url", 429, "Too Many Requests", {}, None)
         with patch.object(reddit, "urlopen", side_effect=[err, err]) as op, \
-             patch.object(reddit.time, "sleep"):
-            posts = reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
-        assert op.call_count == 2          # one retry, then gives up cleanly
-        assert posts == []
+             patch.object(reddit.time, "sleep"), \
+             pytest.raises(reddit.RedditUnavailable):
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        assert op.call_count == 2          # one retry, then reports unavailable
 
     def test_retry_after_header_is_honoured(self):
         err = HTTPError("url", 429, "Too Many Requests", {"Retry-After": "12"}, None)
@@ -174,9 +175,11 @@ class TestChunkedTransferErrorsHandled:
     """IncompleteRead/RemoteDisconnected come from http.client and are NOT
     OSErrors, so they were previously uncaught and crashed the pipeline (#1024)."""
 
-    def test_rss_incomplete_read_degrades_to_empty(self):
-        with patch.object(reddit, "urlopen", return_value=_raise(http.client.IncompleteRead(b""))):
-            assert reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0) == []
+    def test_rss_incomplete_read_reports_unavailable(self):
+        with patch.object(reddit, "urlopen",
+                          return_value=_raise(http.client.IncompleteRead(b""))), \
+             pytest.raises(reddit.RedditUnavailable):
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
 
     def test_json_incomplete_read_falls_back_to_rss(self):
         with patch.object(reddit, "urlopen", return_value=_raise(http.client.IncompleteRead(b""))), \
@@ -186,11 +189,14 @@ class TestChunkedTransferErrorsHandled:
 
     def test_oversized_rss_feed_is_refused_not_parsed(self):
         # A hostile/misbehaving endpoint streaming an unbounded body must not be
-        # read into memory before parsing; overflow degrades to an empty feed.
+        # read into memory before parsing; overflow is reported as unavailable
+        # (not rendered as "no posts found" — that would assert an absence of
+        # discussion we never observed).
         big = _resp(lambda: b"x" * 100)
         with patch.object(reddit, "_MAX_FEED_BYTES", 10), \
-             patch.object(reddit, "urlopen", return_value=big):
-            assert reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0) == []
+             patch.object(reddit, "urlopen", return_value=big), \
+             pytest.raises(reddit.RedditUnavailable):
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
 
 
 @pytest.mark.unit
@@ -241,3 +247,77 @@ class TestCryptoSearchTerm:
 
     def test_equity_passes_through(self):
         assert self._captured_ticker("NVDA") == "NVDA"
+
+
+_EMPTY_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+</feed>
+"""
+
+
+def _empty_atom_resp():
+    return _resp(lambda: _EMPTY_ATOM.encode("utf-8"))
+
+
+@pytest.mark.unit
+class TestUnavailableIsNotReportedAsAbsence:
+    """A failed fetch must never render as a claim that nobody is posting.
+
+    Reddit rate-limiting (429) previously produced the identical string as a
+    successful fetch that matched nothing, so the Sentiment Analyst read a
+    blocked request as community silence and lowered its confidence on the
+    strength of an event that never happened.
+    """
+
+    def test_rate_limited_sub_is_not_reported_as_no_posts(self):
+        err = HTTPError("url", 429, "Too Many Requests", {}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, err]), \
+             patch.object(reddit.time, "sleep"):
+            out = reddit.fetch_reddit_posts(
+                "NVDA", subreddits=("stocks",), inter_request_delay=0
+            )
+        assert "no posts found" not in out
+        assert "unavailable" in out
+
+    def test_genuinely_empty_sub_still_reports_no_posts(self):
+        with patch.object(reddit, "urlopen", return_value=_empty_atom_resp()):
+            out = reddit.fetch_reddit_posts(
+                "NVDA", subreddits=("stocks",), inter_request_delay=0
+            )
+        assert "no Reddit posts found" in out
+        assert "unavailable" not in out
+
+    def test_all_subs_unavailable_does_not_claim_blanket_absence(self):
+        err = HTTPError("url", 429, "Too Many Requests", {}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err] * 6), \
+             patch.object(reddit.time, "sleep"):
+            out = reddit.fetch_reddit_posts(
+                "NVDA",
+                subreddits=("wallstreetbets", "stocks", "investing"),
+                inter_request_delay=0,
+            )
+        assert "no Reddit posts found" not in out
+        assert "unavailable" in out
+
+    def test_mixed_empty_and_unavailable_distinguishes_both(self):
+        err = HTTPError("url", 429, "Too Many Requests", {}, None)
+        # r/stocks: clean empty feed. r/investing: 429 on both attempts.
+        with patch.object(
+            reddit, "urlopen",
+            side_effect=[_empty_atom_resp(), err, err],
+        ), patch.object(reddit.time, "sleep"):
+            out = reddit.fetch_reddit_posts(
+                "NVDA", subreddits=("stocks", "investing"), inter_request_delay=0
+            )
+        assert "r/stocks" in out and "no posts found" in out
+        assert "r/investing" in out and "unavailable" in out
+
+
+@pytest.mark.unit
+class TestEmptyIsNotAnError:
+    """The other half of the contract: a feed that answers with nothing is a
+    successful fetch, and must stay distinguishable from one that failed."""
+
+    def test_empty_feed_returns_empty_list_not_error(self):
+        with patch.object(reddit, "urlopen", return_value=_empty_atom_resp()):
+            assert reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0) == []

--- a/tests/test_reddit_fallback.py
+++ b/tests/test_reddit_fallback.py
@@ -158,16 +158,35 @@ class TestRss429Backoff:
             reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
         slept.assert_called_once_with(0.0)
 
-    def test_headerless_429_fallback_is_jittered(self):
-        # No Retry-After -> our own ~5s fallback, jittered so concurrent runs
-        # don't retry in lockstep (kept within a tight band).
+    def test_headerless_429_fallback_outlasts_reddits_throttle_window(self):
+        """No Retry-After -> our own fallback, jittered so concurrent runs don't
+        retry in lockstep. Its magnitude matters: measured 2026-09-01, a second
+        search request still 429s at 30s of spacing and succeeds at 60s, so a
+        5s fallback guaranteed the single retry failed too and the feed was
+        silently dropped."""
         err = HTTPError("url", 429, "Too Many Requests", {}, None)
         with patch.object(reddit, "urlopen", side_effect=[err, _atom_resp()]), \
              patch.object(reddit.time, "sleep") as slept:
             reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
         slept.assert_called_once()
         (wait,), _ = slept.call_args
-        assert 4.0 <= wait <= 6.0  # 5s +/-20% jitter
+        assert 48.0 <= wait <= 72.0  # 60s +/-20% jitter; must clear the measured ~60s window
+
+    def test_retry_after_is_honoured_beyond_the_old_thirty_second_cap(self):
+        # A server-supplied Retry-After is honoured exactly (no jitter); the old
+        # 30s cap sat below the measured throttle window and clipped honest values.
+        err = HTTPError("url", 429, "Too Many Requests", {"Retry-After": "90"}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, _atom_resp()]), \
+             patch.object(reddit.time, "sleep") as slept:
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        slept.assert_called_once_with(90.0)
+
+    def test_absurd_retry_after_is_still_capped(self):
+        err = HTTPError("url", 429, "Too Many Requests", {"Retry-After": "9999"}, None)
+        with patch.object(reddit, "urlopen", side_effect=[err, _atom_resp()]), \
+             patch.object(reddit.time, "sleep") as slept:
+            reddit._fetch_subreddit_rss("NVDA", "stocks", 5, 5.0)
+        slept.assert_called_once_with(120.0)
 
 
 @pytest.mark.unit

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
+from tradingagents.agents.analysts import sentiment_analyst
 from tradingagents.agents.analysts.sentiment_analyst import create_sentiment_analyst
 from tradingagents.agents.managers.research_manager import create_research_manager
 from tradingagents.agents.schemas import (
@@ -393,6 +394,28 @@ def _structured_sentiment_llm(captured: dict, report: SentimentReport | None = N
 
 @pytest.mark.unit
 class TestSentimentAnalystAgent:
+    @pytest.fixture(autouse=True)
+    def _stub_sources(self, monkeypatch):
+        """Stub the three upstream data sources.
+
+        These cases exercise the agent's structured-output and rendering paths,
+        not the data layer, but the node fetches Yahoo news, StockTwits and
+        Reddit for real. That made ``@pytest.mark.unit`` tests depend on the
+        network, and once Reddit throttles the run they each pay the full 429
+        backoff per subreddit. ``test_structured_agent_prompts.py`` already
+        stubs the same seams.
+        """
+        monkeypatch.setattr(
+            sentiment_analyst, "fetch_reddit_posts", lambda *a, **k: "<reddit stub>"
+        )
+        monkeypatch.setattr(
+            sentiment_analyst, "fetch_stocktwits_messages",
+            lambda *a, **k: "<stocktwits stub>",
+        )
+        stub_news = MagicMock()
+        stub_news.func = lambda *a, **k: "<news stub>"
+        monkeypatch.setattr(sentiment_analyst, "get_news", stub_news)
+
     def test_structured_path_produces_rendered_markdown(self):
         captured = {}
         report = SentimentReport(

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -117,9 +117,16 @@ def _strip_html(content: str) -> str:
     return " ".join(html.unescape(text).split())
 
 
-# Headerless-429 backoff when Reddit gives no Retry-After. Jittered so several
-# analyses sharing an IP don't retry in lockstep and re-collide on the limit.
-_RETRY_FALLBACK_SECONDS = 5.0
+# Headerless-429 backoff when Reddit gives no Retry-After. Reddit throttles
+# anonymous search hard and normally sends no header. Measured 2026-09-01 against
+# /r/{sub}/search.rss: a second request still 429s at 30s of spacing and succeeds
+# at 60s, so the earlier 5s fallback guaranteed the single retry failed too and a
+# throttled subreddit was always dropped. Jittered so several analyses sharing an
+# IP don't retry in lockstep and re-collide on the limit.
+_RETRY_FALLBACK_SECONDS = 60.0
+# Cap on an honoured Retry-After. 30s sat below the measured throttle window; the
+# cap only exists to stop a pathological header value hanging a run.
+_RETRY_AFTER_CAP_SECONDS = 120.0
 
 
 def _jitter(seconds: float, frac: float = 0.2) -> float:
@@ -129,14 +136,15 @@ def _jitter(seconds: float, frac: float = 0.2) -> float:
 
 
 def _retry_after_seconds(exc: HTTPError) -> float | None:
-    """Seconds to wait from a 429's ``Retry-After`` header, capped at 30s.
+    """Seconds to wait from a 429's ``Retry-After`` header, capped at
+    ``_RETRY_AFTER_CAP_SECONDS``.
 
     Returns ``None`` only when the header is absent or unparseable; a valid
     ``Retry-After: 0`` returns ``0.0`` (retry at once), not ``None``.
     """
     try:
         val = exc.headers.get("Retry-After") if getattr(exc, "headers", None) else None
-        return min(float(val), 30.0) if val is not None else None
+        return min(float(val), _RETRY_AFTER_CAP_SECONDS) if val is not None else None
     except (ValueError, TypeError, AttributeError):
         return None
 
@@ -271,9 +279,12 @@ def fetch_reddit_posts(
     """Fetch recent Reddit posts mentioning ``ticker`` across finance
     subreddits and return them as a formatted plaintext block.
 
-    ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests to
-    stay under Reddit's public per-IP rate limit; combined with the RSS-first
-    path it makes 429s rare even when several analyses run back-to-back.
+    ``inter_request_delay`` paces the (now RSS-only) per-subreddit requests, but
+    it does not on its own keep us under Reddit's anonymous search throttle:
+    measured 2026-09-01, the second request 429s at anything below ~60s of
+    spacing regardless of subreddit. Recovery is left to the per-request 429
+    backoff (``_RETRY_FALLBACK_SECONDS``), which costs nothing when we are not being
+    throttled — raising this delay instead would slow every run unconditionally.
 
     When ``start_date``/``end_date`` (yyyy-mm-dd) are given, posts are trimmed to
     that window so a historical run does not leak current discussion into a

--- a/tradingagents/dataflows/reddit.py
+++ b/tradingagents/dataflows/reddit.py
@@ -37,6 +37,21 @@ from .symbol_utils import crypto_base
 logger = logging.getLogger(__name__)
 
 
+class RedditUnavailable(Exception):
+    """A subreddit fetch failed and returned nothing we can trust.
+
+    Kept distinct from a successful fetch that matched no posts. Rendering a
+    failed fetch as "no posts found" asserts an absence of discussion that was
+    never observed, and the Sentiment Analyst reads that absence as a genuine
+    signal — a 429 became "the community is silent" and lowered its confidence.
+    """
+
+    def __init__(self, sub: str, reason: str):
+        self.sub = sub
+        self.reason = reason
+        super().__init__(f"r/{sub} unavailable: {reason}")
+
+
 def _within_window(posts, start_date, end_date):
     """Keep only posts published in [start_date, end_date] (look-ahead safe).
 
@@ -175,12 +190,12 @@ def _fetch_subreddit_rss(
             time.sleep(wait)
             return _fetch_subreddit_rss(ticker, sub, limit, timeout, _retry=False)
         logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
-        return []
+        raise RedditUnavailable(sub, f"HTTP {exc.code}") from exc
     except (OSError, http.client.HTTPException, ET.ParseError) as exc:
         # OSError covers URLError/TimeoutError/connection resets; HTTPException
         # covers chunked-transfer errors (IncompleteRead/BadStatusLine, #1024).
         logger.warning("Reddit RSS fetch failed for r/%s · %s: %s", sub, ticker, exc)
-        return []
+        raise RedditUnavailable(sub, type(exc).__name__) from exc
 
     posts = []
     for entry in root.findall("atom:entry", _ATOM_NS)[:limit]:
@@ -269,11 +284,19 @@ def fetch_reddit_posts(
     ticker = crypto_base(ticker) or ticker
     blocks = []
     total_posts = 0
+    sub_count = 0
+    unavailable: list[tuple[str, str]] = []
     for i, sub in enumerate(subreddits):
         if i > 0 and inter_request_delay:
             time.sleep(_jitter(inter_request_delay))
-        posts = _within_window(_fetch_subreddit(ticker, sub, limit_per_sub, timeout),
-                               start_date, end_date)
+        sub_count += 1
+        try:
+            fetched = _fetch_subreddit(ticker, sub, limit_per_sub, timeout)
+        except RedditUnavailable as exc:
+            unavailable.append((sub, exc.reason))
+            blocks.append(f"r/{sub}: <unavailable: {exc.reason}>")
+            continue
+        posts = _within_window(fetched, start_date, end_date)
         total_posts += len(posts)
         if not posts:
             blocks.append(f"r/{sub}: <no posts found mentioning {ticker.upper()} in the past 7 days>")
@@ -305,7 +328,17 @@ def fetch_reddit_posts(
             )
         blocks.append("\n".join(lines))
 
-    if total_posts == 0:
+    # The blanket "nobody posted anywhere" claim is only true when every
+    # subreddit actually answered. When some or all failed, the per-subreddit
+    # blocks carry an explicit <unavailable> marker instead, so a rate limit is
+    # never mistaken for community silence.
+    if unavailable and len(unavailable) == sub_count:
+        return (
+            "<Reddit unavailable: "
+            + ", ".join(f"r/{s} ({r})" for s, r in unavailable)
+            + ">"
+        )
+    if total_posts == 0 and not unavailable:
         return (
             f"<no Reddit posts found mentioning {ticker.upper()} across "
             f"{', '.join(f'r/{s}' for s in subreddits)} in the past 7 days>"


### PR DESCRIPTION
## Summary

Two related correctness fixes in `tradingagents/dataflows/reddit.py`, found while running v0.4.0 against NVDA and confirmed against the v0.4.1 base.

1. **A failed Reddit fetch was rendered as "no posts found".** `_fetch_subreddit_rss` returned `[]` for both "nothing matched" and "request failed", so a 429 produced the identical string as a genuinely empty search — and when every subreddit was throttled, the summary asserted there were no posts across all of them. The Sentiment Analyst treats that as a real signal: in a 2026-08-31 run it wrote *"r/stocks and r/investing are silent … keeps overall confidence low"* while the log showed both had returned `HTTP 429`. `stocktwits.py` already emits `<stocktwits unavailable: …>`; this brings Reddit in line.

2. **The headerless-429 back-off was an order of magnitude too short.** Measured against `/r/{sub}/search.rss`: a second request still 429s at 8 s, 10 s and 30 s of spacing and succeeds at 60 s. Reddit sends no `Retry-After`, so the 5 s fallback is what ran, which guaranteed the single retry also failed. Raising it to 60 s (jittered, headerless case only) recovers all three default subreddits in ~124 s where previously only the first request in a run succeeded. The `Retry-After` cap goes 30 s → 120 s for the same reason. `inter_request_delay` is intentionally unchanged: the back-off is adaptive and costs nothing when Reddit is not throttling.

Fix 1 is what made fix 2 diagnosable — once the failure stopped masquerading as an empty result, the retry that never succeeded became visible.

## Side effect worth knowing

`TestSentimentAnalystAgent` (5 tests, marked `unit`) only mocked the LLM and was fetching Yahoo, StockTwits and Reddit for real. With the longer back-off they went from ~15 s each to ~180 s each. Stubbing the three sources (the same seams `test_structured_agent_prompts.py` already stubs) drops the whole suite from ~100 s to ~5 s — most of the previous wall-clock was rate-limited network I/O.

## Evidence

| spacing between consecutive `search.rss` requests | 2nd request |
|---|---|
| 8 s / 10 s / 30 s | 429 |
| 60 s | 200 |

Before (2026-08-31 NVDA, r/stocks + r/investing both 429):
```
r/stocks: <no posts found mentioning NVDA in the past 7 days>
```
After, same conditions:
```
r/stocks: <unavailable: HTTP 429>
```
After, with the new back-off, default settings:
```
r/wallstreetbets — 5 recent posts …
r/stocks — 3 recent posts …
r/investing — 3 recent posts …
```

## Testing

- `pytest`: 660 passed, 2 skipped (bedrock / DeepSeek live) on top of v0.4.1 (`9dee508`)
- `ruff check`: clean
- Three pre-existing tests encoded the old silent-degradation contract by name (`…_fails_open`, `…_degrades_to_empty`, `…gives_up_after_one_retry`) and were updated; the v0.4.1 `test_oversized_rss_feed_is_refused_not_parsed` likewise now expects `RedditUnavailable`. Nine new tests cover the rate-limited / empty / all-failed / mixed renderings, the 60 s fallback band, and the widened `Retry-After` cap.
