### PR TITLE
Fall back to Alpha Vantage when Yahoo Finance fails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ NVIDIA_API_KEY=
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=
 
+# Alpha Vantage (stock/fundamentals/news fallback when Yahoo Finance is
+# unavailable). Free key: https://www.alphavantage.co/support/#api-key
+#ALPHA_VANTAGE_API_KEY=
+
 # Optional: a custom OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp,
 # relay). Select provider "openai_compatible" and set the base URL; the key is
 # optional (local servers need none).

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -137,10 +137,10 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # routed to vendors you didn't choose. For ordered fallback, list several,
     # e.g. "yfinance,alpha_vantage". "default" uses all available vendors.
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "core_stock_apis": "yfinance,alpha_vantage",       # Options: alpha_vantage, yfinance
+        "technical_indicators": "yfinance,alpha_vantage",  # Options: alpha_vantage, yfinance
+        "fundamental_data": "yfinance,alpha_vantage",      # Options: alpha_vantage, yfinance
+        "news_data": "yfinance,alpha_vantage",             # Options: alpha_vantage, yfinance
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },


### PR DESCRIPTION
## What changed

- `tradingagents/default_config.py`: the `core_stock_apis`, `technical_indicators`, `fundamental_data`, and `news_data` vendor entries now use the ordered fallback chain `"yfinance,alpha_vantage"` instead of `"yfinance"` alone.
- `.env.example`: documents `ALPHA_VANTAGE_API_KEY`, which was previously undocumented even though it's read directly by `alpha_vantage_common.get_api_key()`.

## Why

Yahoo Finance has been intermittently unavailable/rate-limiting. Rather than switching the default vendor outright (Yahoo is free/keyless with generally looser limits), this chains Alpha Vantage as an automatic fallback so requests only go to Alpha Vantage when Yahoo fails, per the existing "ordered fallback" mechanism already documented in `default_config.py`.

## Notes for reviewers

- Alpha Vantage's free tier is fairly tight (25 requests/day, 5/min), so it's meant as a fallback, not a primary vendor.
- No behavior changes for users who don't set `ALPHA_VANTAGE_API_KEY` — `get_api_key()` already raises a clear error if a code path needs it and it's unset, and the fallback only engages after Yahoo fails.
- This PR does not include unrelated local changes present in the working tree (a `stocktwits.py` WAF-bypass fix and a local `.env`-derived scratch file); those are intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)