### PR TITLE
feat(llm): add Meta Model API provider for Muse Spark models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ MISTRAL_API_KEY=
 MOONSHOT_API_KEY=
 GROQ_API_KEY=
 NVIDIA_API_KEY=
+META_API_KEY=
 
 # FRED (Federal Reserve macro data: rates, inflation, labor, growth). Free key: https://fred.stlouisfed.org/docs/api/api_key.html
 #FRED_API_KEY=

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ export ZHIPU_CN_API_KEY=...        # GLM via BigModel (China, open.bigmodel.cn)
 export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io)
 export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com)
 export OPENROUTER_API_KEY=...      # OpenRouter
+export META_API_KEY=...            # Meta Model API (Muse Spark)
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
 ```
 
@@ -197,7 +198,7 @@ An interface will appear showing results as they load, letting you track the age
 
 ### Implementation Details
 
-We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Ollama for local models, and Azure OpenAI for enterprise.
+We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Meta Model API (Muse Spark), Ollama for local models, and Azure OpenAI for enterprise.
 
 ### Python Usage
 
@@ -221,7 +222,7 @@ from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"        # e.g. openai, google, anthropic, deepseek, groq, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
+config["llm_provider"] = "openai"        # e.g. openai, google, anthropic, deepseek, groq, meta, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
 config["deep_think_llm"] = "gpt-5.5"     # Model for complex reasoning
 config["quick_think_llm"] = "gpt-5.4-mini" # Model for quick tasks
 config["max_debate_rounds"] = 2

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -359,6 +359,7 @@ def _llm_provider_table() -> list[tuple[str, str, str | None]]:
         ("Kimi (Moonshot)", "kimi", "https://api.moonshot.ai/v1"),
         ("Groq", "groq", "https://api.groq.com/openai/v1"),
         ("NVIDIA NIM", "nvidia", "https://integrate.api.nvidia.com/v1"),
+        ("Meta Model API", "meta", "https://api.meta.ai/v1"),
         ("Azure OpenAI", "azure", None),
         ("Amazon Bedrock", "bedrock", None),
         ("Ollama", "ollama", ollama_url),

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -22,7 +22,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         "qwen", "qwen-cn",
         "glm", "glm-cn",
         "minimax", "minimax-cn",
-        "openrouter", "azure", "ollama",
+        "openrouter", "azure", "ollama", "meta",
     }
     assert expected.issubset(PROVIDER_API_KEY_ENV.keys())
 
@@ -43,6 +43,7 @@ def test_every_select_llm_provider_choice_has_an_entry():
         ("minimax",    "MINIMAX_API_KEY"),
         ("minimax-cn", "MINIMAX_CN_API_KEY"),
         ("openrouter", "OPENROUTER_API_KEY"),
+        ("meta",       "META_API_KEY"),
     ],
 )
 def test_known_providers_resolve(provider, env_var):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -98,15 +98,21 @@ class TestMetaSpark:
     """Muse Spark rejects non-auto tool_choice; structured output goes
     through response_format json_schema (verified live)."""
 
-    def test_playground_ids_use_json_schema(self):
-        for model in ("rl-muse-spark-1-2-playground", "rl-muse-spark-1-1-playground"):
+    def test_documented_lineup_uses_json_schema(self):
+        for model in (
+            "muse-spark-1.3",
+            "muse-spark-1.2",
+            "muse-spark-1.1",
+            "muse-spark-1.3-contributor",
+            "muse-spark-1.2-contributor",
+        ):
             caps = get_capabilities(model)
             assert caps.supports_tool_choice is False
             assert caps.preferred_structured_method == "json_schema"
             assert caps.supports_json_schema is True
 
-    def test_public_ids_inherit_via_pattern(self):
-        for model in ("muse-spark-1.3", "muse-spark-1.3-contributor", "muse-spark-2.0"):
+    def test_future_versions_inherit_via_pattern(self):
+        for model in ("muse-spark-1.4", "muse-spark-2.0", "muse-spark-2.0-contributor"):
             caps = get_capabilities(model)
             assert caps.supports_tool_choice is False
             assert caps.preferred_structured_method == "json_schema"

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -94,6 +94,25 @@ class TestMinimaxExactMatches:
 
 
 @pytest.mark.unit
+class TestMetaSpark:
+    """Muse Spark rejects non-auto tool_choice; structured output goes
+    through response_format json_schema (verified live)."""
+
+    def test_playground_ids_use_json_schema(self):
+        for model in ("rl-muse-spark-1-2-playground", "rl-muse-spark-1-1-playground"):
+            caps = get_capabilities(model)
+            assert caps.supports_tool_choice is False
+            assert caps.preferred_structured_method == "json_schema"
+            assert caps.supports_json_schema is True
+
+    def test_public_ids_inherit_via_pattern(self):
+        for model in ("muse-spark-1.3", "muse-spark-1.3-contributor", "muse-spark-2.0"):
+            caps = get_capabilities(model)
+            assert caps.supports_tool_choice is False
+            assert caps.preferred_structured_method == "json_schema"
+
+
+@pytest.mark.unit
 class TestDefault:
     """Unknown / non-DeepSeek models get the permissive default."""
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -39,6 +39,7 @@ def test_registry_membership():
     ("kimi", "https://api.moonshot.ai/v1", NormalizedChatOpenAI, False),
     ("groq", "https://api.groq.com/openai/v1", NormalizedChatOpenAI, False),
     ("nvidia", "https://integrate.api.nvidia.com/v1", NormalizedChatOpenAI, False),
+    ("meta", "https://api.meta.ai/v1", NormalizedChatOpenAI, False),
     ("ollama", "http://localhost:11434/v1", NormalizedChatOpenAI, False),
 ])
 def test_registry_spec(provider, base_url, chat_class, responses):

--- a/tradingagents/llm_clients/api_key_env.py
+++ b/tradingagents/llm_clients/api_key_env.py
@@ -30,11 +30,12 @@ PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "minimax-cn": "MINIMAX_CN_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
     # Additional hosted OpenAI-compatible providers (model is user-specified).
-    # kimi -> Moonshot AI; nvidia -> NVIDIA NIM.
+    # kimi -> Moonshot AI; nvidia -> NVIDIA NIM; meta -> Meta Model API.
     "mistral":    "MISTRAL_API_KEY",
     "kimi":       "MOONSHOT_API_KEY",
     "groq":       "GROQ_API_KEY",
     "nvidia":     "NVIDIA_API_KEY",
+    "meta":       "META_API_KEY",
     # Local runtimes do not authenticate.
     "ollama":     None,
     # Generic OpenAI-compatible endpoint: the client reads this when set (keyed

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -118,10 +118,6 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "MiniMax-M2.1": _MINIMAX_THINKING,
     "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
     "MiniMax-M2": _MINIMAX_THINKING,
-    # Muse Spark playground IDs (verified against the live /v1/models
-    # endpoint); public muse-spark-1.x IDs are covered by the pattern below.
-    "rl-muse-spark-1-2-playground": _META_SPARK,
-    "rl-muse-spark-1-1-playground": _META_SPARK,
 }
 
 # Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``,

--- a/tradingagents/llm_clients/capabilities.py
+++ b/tradingagents/llm_clients/capabilities.py
@@ -82,6 +82,19 @@ _MINIMAX_THINKING = ModelCapabilities(
     requires_reasoning_split=True,
 )
 
+# Meta Model API (Muse Spark) accepts the tools array but only supports
+# ``tool_choice="auto"`` — langchain's function-spec dict form 400s with
+# "only auto is supported for tool_choice". Meta's documented structured
+# path is response_format json_schema with constrained decoding
+# (dev.meta.ai/docs/structured-output), so that is the preferred method.
+# Plain bind_tools without tool_choice still works for agentic tool loops.
+_META_SPARK = ModelCapabilities(
+    supports_tool_choice=False,
+    supports_json_mode=True,
+    supports_json_schema=True,
+    preferred_structured_method="json_schema",
+)
+
 _DEFAULT = ModelCapabilities(
     supports_tool_choice=True,
     supports_json_mode=True,
@@ -105,14 +118,19 @@ _BY_ID: dict[str, ModelCapabilities] = {
     "MiniMax-M2.1": _MINIMAX_THINKING,
     "MiniMax-M2.1-highspeed": _MINIMAX_THINKING,
     "MiniMax-M2": _MINIMAX_THINKING,
+    # Muse Spark playground IDs (verified against the live /v1/models
+    # endpoint); public muse-spark-1.x IDs are covered by the pattern below.
+    "rl-muse-spark-1-2-playground": _META_SPARK,
+    "rl-muse-spark-1-1-playground": _META_SPARK,
 }
 
-# Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``
-# or ``MiniMax-M3*`` variants inherit the thinking-mode quirks automatically.
+# Forward-compat patterns. New ``deepseek-v5-*`` / ``deepseek-reasoner-*``,
+# ``MiniMax-M3*``, or ``muse-spark-*`` variants inherit the quirks automatically.
 _BY_PATTERN: list[tuple[re.Pattern[str], ModelCapabilities]] = [
     (re.compile(r"^deepseek-v\d"), _DEEPSEEK_THINKING),
     (re.compile(r"^deepseek-reasoner"), _DEEPSEEK_THINKING),
     (re.compile(r"^MiniMax-M\d"), _MINIMAX_THINKING),
+    (re.compile(r"^muse-spark"), _META_SPARK),
 ]
 
 

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -178,6 +178,22 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # Generic OpenAI-compatible endpoint: the model is whatever the user's
     # server serves, so only "Custom model ID" is offered.
     "openai_compatible": _CUSTOM_ONLY,
+    # Meta Model API serves the small Muse Spark lineup, so the versions
+    # visible to the configured key are listed explicitly (verified against
+    # the live /v1/models endpoint). "Custom model ID" is the escape hatch
+    # for other tiers (e.g. public muse-spark-1.x IDs) or future releases.
+    "meta": {
+        "quick": [
+            ("Muse Spark 1.2 - Latest available, agentic + coding", "rl-muse-spark-1-2-playground"),
+            ("Muse Spark 1.1 - Previous version", "rl-muse-spark-1-1-playground"),
+            ("Custom model ID", "custom"),
+        ],
+        "deep": [
+            ("Muse Spark 1.2 - Latest available, agentic + coding", "rl-muse-spark-1-2-playground"),
+            ("Muse Spark 1.1 - Previous version", "rl-muse-spark-1-1-playground"),
+            ("Custom model ID", "custom"),
+        ],
+    },
     # Hosted OpenAI-compatible providers that serve many (and frequently
     # changing) models — offer "Custom model ID" rather than a list that goes
     # stale. The endpoint + key are wired by the provider; the user picks the

--- a/tradingagents/llm_clients/model_catalog.py
+++ b/tradingagents/llm_clients/model_catalog.py
@@ -78,6 +78,33 @@ _MINIMAX_MODELS: dict[str, list[ModelOption]] = {
 }
 
 
+# Meta Model API's Muse Spark lineup, per dev.meta.ai/docs/models.
+# Every version shares the same modalities and 1,048,576-token context window
+# and differs only by capability, so there is no separate fast tier — quick and
+# deep share one list. The "-contributor" variants are the same models at a
+# discount in exchange for permission to train on your prompts and completions,
+# so they are listed last and labelled. Keys are entitled to different subsets;
+# "Custom model ID" covers anything /v1/models reports that isn't listed here.
+_MUSE_SPARK_MODELS: dict[str, list[ModelOption]] = {
+    "quick": [
+        ("Muse Spark 1.3 - Latest, agentic + coding, 1M ctx", "muse-spark-1.3"),
+        ("Muse Spark 1.2 - Previous version, 1M ctx", "muse-spark-1.2"),
+        ("Muse Spark 1.1 - Original version, 1M ctx", "muse-spark-1.1"),
+        ("Muse Spark 1.3 Contributor - Discounted, trains on your data", "muse-spark-1.3-contributor"),
+        ("Muse Spark 1.2 Contributor - Discounted, trains on your data", "muse-spark-1.2-contributor"),
+        ("Custom model ID", "custom"),
+    ],
+    "deep": [
+        ("Muse Spark 1.3 - Latest, agentic + coding, 1M ctx", "muse-spark-1.3"),
+        ("Muse Spark 1.2 - Previous version, 1M ctx", "muse-spark-1.2"),
+        ("Muse Spark 1.1 - Original version, 1M ctx", "muse-spark-1.1"),
+        ("Muse Spark 1.3 Contributor - Discounted, trains on your data", "muse-spark-1.3-contributor"),
+        ("Muse Spark 1.2 Contributor - Discounted, trains on your data", "muse-spark-1.2-contributor"),
+        ("Custom model ID", "custom"),
+    ],
+}
+
+
 MODEL_OPTIONS: ProviderModeOptions = {
     "openai": {
         "quick": [
@@ -178,22 +205,8 @@ MODEL_OPTIONS: ProviderModeOptions = {
     # Generic OpenAI-compatible endpoint: the model is whatever the user's
     # server serves, so only "Custom model ID" is offered.
     "openai_compatible": _CUSTOM_ONLY,
-    # Meta Model API serves the small Muse Spark lineup, so the versions
-    # visible to the configured key are listed explicitly (verified against
-    # the live /v1/models endpoint). "Custom model ID" is the escape hatch
-    # for other tiers (e.g. public muse-spark-1.x IDs) or future releases.
-    "meta": {
-        "quick": [
-            ("Muse Spark 1.2 - Latest available, agentic + coding", "rl-muse-spark-1-2-playground"),
-            ("Muse Spark 1.1 - Previous version", "rl-muse-spark-1-1-playground"),
-            ("Custom model ID", "custom"),
-        ],
-        "deep": [
-            ("Muse Spark 1.2 - Latest available, agentic + coding", "rl-muse-spark-1-2-playground"),
-            ("Muse Spark 1.1 - Previous version", "rl-muse-spark-1-1-playground"),
-            ("Custom model ID", "custom"),
-        ],
-    },
+    # Meta Model API: the documented Muse Spark lineup (dev.meta.ai/docs/models).
+    "meta": _MUSE_SPARK_MODELS,
     # Hosted OpenAI-compatible providers that serve many (and frequently
     # changing) models — offer "Custom model ID" rather than a list that goes
     # stale. The endpoint + key are wired by the provider; the user picks the

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -185,7 +185,7 @@ class ProviderSpec:
     """Declarative config for one OpenAI-compatible provider.
 
     The OpenAI-compatible family (OpenAI, xAI, DeepSeek, Qwen, GLM, MiniMax,
-    OpenRouter, Ollama, and any user endpoint) all speak the same Chat
+    OpenRouter, Meta, Ollama, and any user endpoint) all speak the same Chat
     Completions API and differ only by these fields — so one row here replaces
     the former per-provider base-URL dict, auth handling, and client-class
     branches. Native Anthropic / Google use their own clients (genuinely
@@ -224,6 +224,9 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, ProviderSpec] = {
     "kimi":       ProviderSpec(base_url="https://api.moonshot.ai/v1"),
     "groq":       ProviderSpec(base_url="https://api.groq.com/openai/v1"),
     "nvidia":     ProviderSpec(base_url="https://integrate.api.nvidia.com/v1"),
+    # Meta Model API (dev.meta.ai): OpenAI-compatible Chat Completions
+    # serving the Muse Spark family; key from META_API_KEY.
+    "meta":       ProviderSpec(base_url="https://api.meta.ai/v1"),
     "ollama":     ProviderSpec(base_url="http://localhost:11434/v1", base_url_env="OLLAMA_BASE_URL",
                                key_optional=True, placeholder_key="ollama"),
     # Generic endpoint: user supplies base_url; key optional (keyless local).


### PR DESCRIPTION
Register Meta's OpenAI-compatible endpoint (https://api.meta.ai/v1) as the `meta` provider so Muse Spark models can back the agent graph.

- openai_client: `meta` row in OPENAI_COMPATIBLE_PROVIDERS
- api_key_env: `meta` -> META_API_KEY
- model_catalog: Muse Spark entries for the quick/deep pickers
- cli/utils: "Meta Model API" in the provider menu
- capabilities: Muse Spark rejects every tool_choice except "auto", so structured output goes through response_format json_schema instead of langchain's forced function-calling path
- .env.example, README: document META_API_KEY
- tests: registry, key-mapping and capability coverage for `meta`

Full suite: 580 passed, 2 skipped.