### PR TITLE
Add optional Parallel Search MCP ticker news provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ print(decision)
 
 See `tradingagents/default_config.py` for all configuration options.
 
+### Optional Parallel ticker news
+
+Install `pip install "tradingagents[parallel]"` and select Parallel for the
+`get_news` tool in the config you pass to `TradingAgentsGraph`:
+
+```python
+config = DEFAULT_CONFIG.copy()
+config["tool_vendors"] = {**config["tool_vendors"], "get_news": "parallel"}
+```
+
+This uses [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+at `https://search.parallel.ai/mcp` without a Parallel account or API key. Free
+access is rate limited. Once selected, agents can send ticker symbols, date
+windows, and generated news queries to Parallel during analysis. See Parallel's
+[terms](https://parallel.ai/customer-terms) and [privacy policy](https://parallel.ai/privacy-policy).
+
+Only ticker news is supported. Global news and insider transactions keep their
+existing providers. Remove the `get_news` override to disable Parallel. An
+explicit chain such as `"parallel,yfinance"` uses the existing ordered fallback
+behavior; neither the usual defaults nor the `"default"` sentinel enable Parallel.
+Failed attempts remain visible in the vendor logs.
+
+Results retain source links and excerpts, honor `news_article_limit`, and use the
+shared UTC date-window filter. Undated articles are excluded from historical
+windows, but may appear in live windows, just as with the existing news provider.
+Publication dates are source metadata, not archived page snapshots; excerpts can
+reflect later edits. Historical coverage can be sparse. Reports are capped at
+25,000 characters, responses at 2 MiB, and each exchange at 60 seconds. The
+adapter does not share conversation identifiers across calls because this
+provider interface has no conversation context.
+
 ## Persistence and Recovery
 
 TradingAgents persists two kinds of state across runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+parallel = [
+    "mcp>=1.10,<2",
+]
 dev = [
     "ruff>=0.15",
     "pytest>=8.0",

--- a/tests/test_parallel_news.py
+++ b/tests/test_parallel_news.py
@@ -1,0 +1,226 @@
+"""Optional news vendor contract; no network or MCP dependency needed here."""
+
+import asyncio
+import builtins
+import copy
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tradingagents.dataflows import parallel_news as news
+from tradingagents.dataflows.config import set_config
+from tradingagents.dataflows.errors import VendorNotConfiguredError
+
+
+def article(title="Inside", published="2025-05-09", **fields):
+    return {
+        "title": title,
+        "url": f"https://example.com/{title}",
+        "publish_date": published,
+        "excerpts": ["A financial news excerpt"],
+        **fields,
+    }
+
+
+def response(results, **fields):
+    return SimpleNamespace(
+        isError=False, structuredContent={"results": results, **fields}, content=[]
+    )
+
+
+@pytest.fixture
+def search(monkeypatch):
+    call = Mock(return_value=response([article()]))
+
+    async def run(arguments):
+        return call(arguments)
+
+    monkeypatch.setattr(news, "_search", run)
+    return call
+
+
+def test_historical_filter_and_limit_apply_after_filtering(search):
+    set_config({"news_article_limit": 2})
+    search.return_value = response([
+        article("Future", "2025-05-10T00:00:00Z"),
+        article("Old", "2025-04-30"),
+        article("Unknown", None),
+        article("BadDate", "not-a-date"),
+        article("Inside"),
+        article("Inside"),
+        article("Offset", "2025-05-10T01:00:00+05:00"),
+        article("OverLimit"),
+    ])
+    result = news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+    assert "Inside" in result and "Offset" in result
+    assert "https://example.com/Inside" in result
+    assert result.count("### Inside") == 1
+    for excluded in ("Future", "Old", "Unknown", "BadDate", "OverLimit"):
+        assert excluded not in result
+    arguments = search.call_args.args[0]
+    assert arguments["search_queries"] == ["AAPL company news 2025-05-01 2025-05-09"]
+    assert "2025-05-09" in arguments["objective"]
+
+
+def test_live_window_keeps_undated_news(search):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    search.return_value = response([article("Undated", None)])
+    assert "### Undated" in news.get_news_parallel("AAPL", today, today)
+
+
+@pytest.mark.parametrize("articles", [[], [article("Future", "2025-05-10")]])
+def test_empty_success_is_explicit(search, articles):
+    search.return_value = response(articles)
+    assert "No news found within" in news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+
+
+def test_tool_error_is_not_empty_success(search):
+    search.return_value.isError = True
+    with pytest.raises(RuntimeError, match="tool error"):
+        news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+
+
+@pytest.mark.parametrize("payload", [{}, {"results": None}, {"results": [None]}, {"results": [{"url": "bad"}]}])
+def test_malformed_payload_is_not_empty_success(search, payload):
+    search.return_value.structuredContent = payload
+    with pytest.raises(ValueError):
+        news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+
+
+def test_text_representation_and_warning(search, caplog):
+    search.return_value.structuredContent = None
+    search.return_value.content = [SimpleNamespace(type="text", text=json.dumps({
+        "results": [article()], "warnings": [{"type": "warning", "message": "Partial"}]
+    }))]
+    result = news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+    assert "### Inside" in result and "warnings" in result
+    assert "Partial" in caplog.text
+
+
+def test_output_bound_preserves_citation(search):
+    search.return_value = response([article(excerpts=["x" * 100_000])])
+    result = news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+    assert len(result) <= news.MAX_REPORT_CHARS
+    assert "https://example.com/Inside" in result
+    assert "[Excerpt truncated.]" in result
+
+
+def test_reversed_dates_rejected_before_request(search):
+    with pytest.raises(ValueError, match="start_date"):
+        news.get_news_parallel("AAPL", "2025-05-09", "2025-05-01")
+    search.assert_not_called()
+
+
+def test_missing_optional_dependency(monkeypatch):
+    original = builtins.__import__
+
+    def without_mcp(name, *args, **kwargs):
+        if name == "mcp":
+            raise ImportError("optional MCP is absent")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_mcp)
+    with pytest.raises(VendorNotConfiguredError, match=r"tradingagents\[parallel\]"):
+        news.get_news_parallel("AAPL", "2025-05-01", "2025-05-09")
+
+
+@pytest.mark.parametrize("vendor", ["default", "yfinance", "yfinance,alpha_vantage"])
+def test_existing_routes_never_invoke_parallel(monkeypatch, vendor):
+    from tradingagents.dataflows import interface
+
+    methods = copy.deepcopy(interface.VENDOR_METHODS)
+    av = Mock(side_effect=RuntimeError("AV failed"))
+    yf = Mock(side_effect=RuntimeError("Yahoo failed"))
+    parallel = Mock(return_value="unexpected")
+    methods["get_news"].update(alpha_vantage=av, yfinance=yf, parallel=parallel)
+    monkeypatch.setattr(interface, "VENDOR_METHODS", methods)
+    set_config({"tool_vendors": {"get_news": vendor}})
+    with pytest.raises(RuntimeError):
+        interface.route_to_vendor("get_news", "AAPL", "2025-05-01", "2025-05-09")
+    parallel.assert_not_called()
+    assert yf.called
+    assert av.called == (vendor != "yfinance")
+
+
+def test_explicit_parallel_failure_falls_back_in_order(monkeypatch, caplog):
+    from tradingagents.dataflows import interface
+
+    calls = []
+
+    def parallel(*args):
+        calls.append("parallel")
+        raise RuntimeError("Search failed")
+
+    def yahoo(*args):
+        calls.append("yfinance")
+        return "Yahoo news"
+
+    monkeypatch.setitem(interface.VENDOR_METHODS, "get_news", {"parallel": parallel, "yfinance": yahoo})
+    set_config({"tool_vendors": {"get_news": "parallel,yfinance"}})
+    assert interface.route_to_vendor("get_news", "AAPL", "2025-05-01", "2025-05-09") == "Yahoo news"
+    assert calls == ["parallel", "yfinance"]
+    assert "parallel" in caplog.text and "Search failed" in caplog.text
+
+
+def test_http_response_limit_stops_before_remaining_chunks(monkeypatch):
+    httpx = pytest.importorskip("httpx")
+    consumed = []
+    closed = []
+
+    class Body(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            for i in range(10):
+                consumed.append(i)
+                yield b"abcd"
+
+        async def aclose(self):
+            closed.append(True)
+
+    monkeypatch.setattr(news, "MAX_RESPONSE_BYTES", 8)
+
+    async def run():
+        transport = httpx.MockTransport(lambda request: httpx.Response(200, stream=Body()))
+        async with news._http_client(transport=transport, headers=None) as client:
+            with pytest.raises(ValueError, match="response exceeded"):
+                await client.get(news.ENDPOINT)
+
+    asyncio.run(run())
+    assert consumed == [0, 1, 2]
+    assert closed
+
+
+def test_http_redirect_does_not_forward_request():
+    httpx = pytest.importorskip("httpx")
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(307, headers={"location": "https://other.example/search"})
+
+    async def run():
+        async with news._http_client(transport=httpx.MockTransport(respond), headers=None) as client:
+            result = await client.post(news.ENDPOINT, json={"query": "ticker news"})
+            assert result.status_code == 307
+
+    asyncio.run(run())
+    assert len(requests) == 1
+    assert "authorization" not in requests[0].headers
+    assert "x-api-key" not in requests[0].headers
+    assert requests[0].headers["accept-encoding"] == "identity"
+
+
+def test_compressed_response_rejected_before_decoding():
+    httpx = pytest.importorskip("httpx")
+
+    async def run():
+        transport = httpx.MockTransport(lambda request: httpx.Response(
+            200, headers={"content-encoding": "gzip"}, stream=httpx.ByteStream(b"compressed")
+        ))
+        async with news._http_client(transport=transport) as client:
+            with pytest.raises(ValueError, match="compressed response"):
+                await client.get(news.ENDPOINT)
+
+    asyncio.run(run())

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -18,6 +18,7 @@ from .errors import (
     VendorRateLimitError,
 )
 from .fred import get_macro_data as get_fred_macro_data
+from .parallel_news import get_news_parallel
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
 from .y_finance import (
     get_balance_sheet as get_yfinance_balance_sheet,
@@ -82,6 +83,7 @@ VENDOR_LIST = [
     "fred",
     "polymarket",
     "alpha_vantage",
+    "parallel",
 ]
 
 # Optional enrichment categories. These add macro/event context to the news
@@ -124,6 +126,7 @@ VENDOR_METHODS = {
     "get_news": {
         "alpha_vantage": get_alpha_vantage_news,
         "yfinance": get_news_yfinance,
+        "parallel": get_news_parallel,
     },
     "get_global_news": {
         "yfinance": get_global_news_yfinance,
@@ -180,7 +183,8 @@ def route_to_vendor(method: str, *args, **kwargs):
     # vendors the user did not choose (#988/#289) — that returned data from an
     # unexpected source and caused cross-vendor inconsistencies. For multi-vendor
     # fallback, list them in order, e.g. data_vendors="yfinance,alpha_vantage".
-    # The "default" sentinel (no explicit config) uses all available vendors.
+    # Parallel sends queries to a separate search service and requires an
+    # explicit choice; keep the existing implicit fallback chain unchanged.
     explicit = [v for v in primary_vendors if v and v != "default"]
     if explicit:
         vendor_chain = [v for v in explicit if v in VENDOR_METHODS[method]]
@@ -190,7 +194,7 @@ def route_to_vendor(method: str, *args, **kwargs):
                 f"Available: {all_available_vendors}."
             )
     else:
-        vendor_chain = all_available_vendors
+        vendor_chain = [v for v in all_available_vendors if v != "parallel"]
 
     last_no_data: NoMarketDataError | None = None
     first_error: Exception | None = None

--- a/tradingagents/dataflows/parallel_news.py
+++ b/tradingagents/dataflows/parallel_news.py
@@ -1,0 +1,165 @@
+"""Explicitly selected, anonymous Parallel Search MCP ticker news."""
+
+import asyncio
+import contextlib
+import json
+import logging
+from datetime import datetime
+from urllib.parse import urlsplit
+
+from .config import get_config
+from .date_window import in_window
+from .errors import VendorNotConfiguredError
+
+logger = logging.getLogger(__name__)
+ENDPOINT = "https://search.parallel.ai/mcp"
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_REPORT_CHARS = 25_000
+
+
+def _http_client(**kwargs):
+    # Imports stay local so the default install does not require the MCP extra.
+    import httpx
+
+    class BoundedStream(httpx.AsyncByteStream):
+        def __init__(self, stream):
+            self.stream = stream
+
+        async def __aiter__(self):
+            size = 0
+            async for chunk in self.stream:
+                size += len(chunk)
+                if size > MAX_RESPONSE_BYTES:
+                    raise ValueError("Parallel response exceeded the 2 MiB limit")
+                yield chunk
+
+        async def aclose(self):
+            await self.stream.aclose()
+
+    async def bound_response(response):
+        if response.headers.get("content-encoding", "identity") != "identity":
+            raise ValueError("Parallel returned an unexpected compressed response")
+        response.stream = BoundedStream(response.stream)
+
+    headers = {"Accept-Encoding": "identity", **(kwargs.pop("headers", None) or {})}
+    return httpx.AsyncClient(
+        **kwargs,
+        follow_redirects=False,
+        headers=headers,
+        event_hooks={"response": [bound_response]},
+    )
+
+
+async def _search(arguments):
+    try:
+        import anyio
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+    except ImportError as exc:
+        raise VendorNotConfiguredError(
+            'Parallel news requires the optional dependency: pip install "tradingagents[parallel]"'
+        ) from exc
+
+    # Bound the whole exchange, including discovery and resource cleanup.
+    with anyio.fail_after(60):
+        async with streamablehttp_client(
+            ENDPOINT, timeout=15, sse_read_timeout=45, httpx_client_factory=_http_client
+        ) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                cursor = None
+                while True:
+                    listed = await session.list_tools(cursor=cursor)
+                    if any(tool.name == "web_search" for tool in listed.tools):
+                        break
+                    cursor = listed.nextCursor
+                    if not cursor:
+                        raise RuntimeError("Parallel MCP did not advertise web_search")
+                return await session.call_tool("web_search", arguments)
+
+
+def _payload(result):
+    if result.isError:
+        raise RuntimeError("Parallel MCP web_search returned a tool error")
+    payload = result.structuredContent
+    if payload is None:
+        text = [block.text for block in result.content if block.type == "text"]
+        if len(text) != 1:
+            raise ValueError("Parallel MCP returned an invalid search response")
+        payload = json.loads(text[0])
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        raise ValueError("Parallel MCP returned an invalid results list")
+    return payload
+
+
+def get_news_parallel(ticker: str, start_date: str, end_date: str) -> str:
+    """Search ticker news, then apply the same UTC date window as other news vendors.
+
+    Publication metadata is not a historical snapshot of a page's contents.
+    Results may be incomplete, especially for historical windows.
+    """
+    start = datetime.strptime(start_date, "%Y-%m-%d")
+    end = datetime.strptime(end_date, "%Y-%m-%d")
+    if start > end:
+        raise ValueError("start_date must not be after end_date")
+    if not isinstance(ticker, str) or not ticker.strip() or len(ticker) > 100:
+        raise ValueError("ticker must contain 1 to 100 characters")
+    limit = get_config()["news_article_limit"]
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        raise ValueError("news_article_limit must be a positive integer")
+
+    arguments = {
+        "objective": (
+            f"Find financial news about ticker {ticker} published from {start_date} "
+            f"through {end_date}. Return dated articles with source URLs and excerpts."
+        ),
+        "search_queries": [f"{ticker} company news {start_date} {end_date}"],
+    }
+    # Retain the attempted provider in logs even when the router falls back.
+    logger.info("Requesting ticker news from Parallel Search MCP")
+    payload = _payload(asyncio.run(_search(arguments)))
+    report = f"## {ticker} News via Parallel, from {start_date} to {end_date}:\n\n"
+    if payload.get("warnings"):
+        logger.warning("Parallel Search warnings: %s", payload["warnings"])
+        report += "Search returned warnings; results may be incomplete.\n\n"
+    count = 0
+    seen = set()
+    for article in payload["results"]:
+        if not isinstance(article, dict):
+            raise ValueError("Parallel MCP returned an invalid article")
+        url = article.get("url")
+        excerpts = article.get("excerpts")
+        title = article.get("title") or "Untitled"
+        if (
+            not isinstance(url, str)
+            or urlsplit(url).scheme not in {"http", "https"}
+            or not urlsplit(url).netloc
+            or not isinstance(title, str)
+            or not isinstance(excerpts, list)
+            or not all(isinstance(text, str) for text in excerpts)
+        ):
+            raise ValueError("Parallel MCP returned invalid article fields")
+        published = article.get("publish_date")
+        pub_dt = None
+        if published:
+            # Undated content follows the shared live/historical policy.
+            with contextlib.suppress(AttributeError, TypeError, ValueError):
+                pub_dt = datetime.fromisoformat(published.replace("Z", "+00:00"))
+        if not in_window(pub_dt, start, end) or url in seen:
+            continue
+        block = f"### {title}\nPublished: {published or 'unknown'}\nLink: {url}\n"
+        remaining = MAX_REPORT_CHARS - len(report) - len(block) - 100
+        if remaining < 0:
+            return report + "[Further results omitted: output limit.]\n"
+        excerpt = "\n".join(excerpts)
+        block += excerpt[:remaining]
+        if len(excerpt) > remaining:
+            block += "\n[Excerpt truncated.]"
+        report += block + "\n\n"
+        seen.add(url)
+        count += 1
+        if count >= limit:
+            break
+    if count == 0:
+        report += "No news found within the requested window.\n"
+    return report

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -135,7 +135,8 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # Category-level configuration (default for all tools in category).
     # The configured value is the exact vendor chain — requests are NOT silently
     # routed to vendors you didn't choose. For ordered fallback, list several,
-    # e.g. "yfinance,alpha_vantage". "default" uses all available vendors.
+    # e.g. "yfinance,alpha_vantage". "default" keeps the built-in vendor chain;
+    # optional Parallel ticker search requires an explicit choice for get_news.
     "data_vendors": {
         "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
         "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance


### PR DESCRIPTION
This adds Parallel as an optional ticker-news provider. Install `tradingagents[parallel]` and set `tool_vendors["get_news"] = "parallel"` to use it without a Parallel account or API key.

TradingAgents currently [defaults ticker news to yfinance](https://github.com/TauricResearch/TradingAgents/blob/9dee508c44662702281a8dbaad1f7b42179b5ba7/tradingagents/default_config.py#L143), with [Alpha Vantage as another option](https://github.com/TauricResearch/TradingAgents/blob/9dee508c44662702281a8dbaad1f7b42179b5ba7/tradingagents/dataflows/interface.py#L124-L132). There's no other web-search MCP in the repo. Neither news provider appears on Artificial Analysis' search leaderboard, so the comparisons below cover its other search providers.

The strongest comparisons I found in [Artificial Analysis' August 31 results](https://artificialanalysis.ai/agents/search-api) are below. Quality scores are out of 100, higher is better. Time per task includes model time plus search time, lower is better. I've named each mode because the differences matter.

| Comparison | Parallel | Other provider |
| --- | --- | --- |
| Tavily, BrowseComp accuracy | advanced: 76.5 | basic: 58.5 |
| Brave, DeepSearchQA F1 | advanced: 80.6 | web: 62.3, LLM context: 78.1 |
| You.com, DeepSearchQA F1 | advanced: 80.6 | snippets: 63.4, highlights: 76.7 |
| Exa, BrowseComp accuracy | advanced: 76.5 | fast: 60.5, instant: 65.0, auto: 73.5 |
| TinyFish, DeepSearchQA F1 | advanced: 80.6 | web: 67.2 |
| Keenable, BrowseComp accuracy | advanced: 76.5 | realtime: 64.0, pro: 65.5 |
| Firecrawl, DeepSearchQA F1 | advanced: 80.6 | Search: 73.6 |
| Perplexity, Time per task | fast: 19.4s | low: 37.3s, high: 29.7s, medium: 28.8s |

Parallel advanced's biggest quality margins here are 18 points over Tavily basic on BrowseComp and 18.3 points over Brave web on DeepSearchQA. Parallel fast also has the lowest time per task across all 19 API variants. Perplexity medium still leads the overall Search Index, 80 versus 75 for Parallel advanced. [Source](https://artificialanalysis.ai/agents/search-api).

That's a useful reason to try Parallel for broader ticker research. [AA tests direct API modes in its own agent harness](https://artificialanalysis.ai/methodology/search-api); this anonymous MCP adapter doesn't select those modes, and these scores don't measure TradingAgents' news quality. They also don't establish that Parallel should replace yfinance as the default.

The adapter uses the Python MCP SDK, keeps source links and excerpts, and applies the existing UTC date-window filter and `news_article_limit`. Existing defaults, the `default` fallback chain, and explicitly ordered providers keep their behavior. Global news and insider transactions stay with their existing providers.

When selected, agents send ticker symbols, date windows, and generated queries to Parallel. Free access is rate limited. The README covers setup, disabling it, data transfer, and the limits of publication-date filtering: pages can be edited later, so these are not historical snapshots.

Validation: 36 focused tests passed, along with `ruff check .` and `git diff --check`. Anonymous searches through the actual `route_to_vendor("get_news", ...)` path passed with MCP SDK 1.29.1 and the minimum supported 1.10.0, including initialization, discovery, and invocation. Checks used prebuilt dependencies; no repository build, full test suite, or full graph analysis was run.

I work at Parallel, which operates this service.
