### PR TITLE
feat(dataflows): add China A-share data sources and domestic vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,123 +13,100 @@
   <a href="https://github.com/TauricResearch" target="_blank"><img alt="TradingAgents #1 Repository of the Day" src="https://trendshift.io/api/badge/repositories/16192" width="250" height="55"/></a>
 </div>
 <br>
-<div align="center">
-  <!-- Keep these links. Translations will automatically update with the README. -->
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=de">Deutsch</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=es">Español</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=fr">français</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ja">日本語</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ko">한국어</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=pt">Português</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=ru">Русский</a> | 
-  <a href="https://www.readme-i18n.com/TauricResearch/TradingAgents?lang=zh">中文</a>
-</div>
 
----
+# TradingAgents：多智能体 LLM 金融交易框架
 
-# TradingAgents: Multi-Agents LLM Financial Trading Framework
-
-## News
-- [2026-07] **TradingAgents v0.3.1** released with correctness and stability fixes: Alpha Vantage look-ahead filtering, graph-router crash-safety, graph-shape-aware checkpoint resume, working crypto sentiment sources, a configurable LLM retry budget, Bedrock API-key auth, and Claude Sonnet 5 / Fable 5 support. See [CHANGELOG.md](CHANGELOG.md) for the full list.
-- [2026-06] **TradingAgents v0.3.0** released with a verified data-access contract, an expanded provider registry (NVIDIA, Kimi, Groq, Mistral, Bedrock, and any OpenAI-compatible endpoint), FRED and Polymarket data vendors, a current-generation model catalog, and a CI gate.
-- [2026-05] **TradingAgents v0.2.5** released with the grounded Sentiment Analyst, GPT-5.5 etc. model coverage, Qwen/GLM/MiniMax dual-region support, `TRADINGAGENTS_*` env-var configurability with API-key auto-detection, remote Ollama support, non-US alpha benchmarks, and ticker path-traversal hardening.
-- [2026-04] **TradingAgents v0.2.4** released with structured-output agents (Research Manager, Trader, Portfolio Manager), LangGraph checkpoint resume, persistent decision log, DeepSeek/Qwen/GLM/Azure provider support, Docker, and a Windows UTF-8 encoding fix.
-- [2026-03] **TradingAgents v0.2.3** released with multi-language support, GPT-5.4 family models, unified model catalog, backtesting date fidelity, and proxy support.
-- [2026-03] **TradingAgents v0.2.2** released with GPT-5.4/Gemini 3.1/Claude 4.6 model coverage, five-tier rating scale, OpenAI Responses API, Anthropic effort control, and cross-platform stability.
-- [2026-02] **TradingAgents v0.2.0** released with multi-provider LLM support (GPT-5.x, Gemini 3.x, Claude 4.x, Grok 4.x) and improved system architecture.
-- [2026-01] **Trading-R1** [Technical Report](https://arxiv.org/abs/2509.11420) released, with [Terminal](https://github.com/TauricResearch/Trading-R1) expected to land soon.
-
-<div align="center">
-
-🚀 [TradingAgents](#tradingagents-framework) | ⚡ [Installation & CLI](#installation-and-cli) | 🎬 [Demo](https://www.youtube.com/watch?v=90gr5lwjIho) | 📦 [Package Usage](#tradingagents-package) | 🤝 [Contributing](#contributing) | 📄 [Citation](#citation)
-
-</div>
-
-> 🎉 **TradingAgents** officially released! We have received numerous inquiries about the work, and we would like to express our thanks for the enthusiasm in our community.
+> TradingAgents 是一个用于研究的多智能体交易框架。它模拟真实交易公司的运作方式：基本面分析师、情绪分析师、新闻分析师、技术分析师、交易员、风险管理团队和投资组合经理各司其职，通过动态讨论形成最终交易决策。
 >
-> So we decided to fully open-source the framework. Looking forward to building impactful projects with you!
+> ⚠️ 本框架仅供研究使用，不构成任何投资、交易或财务建议。
 
-## TradingAgents Framework
+## 最新动态
 
-TradingAgents is a multi-agent trading framework that mirrors the dynamics of real-world trading firms. By deploying specialized LLM-powered agents: from fundamental analysts, sentiment experts, and technical analysts, to trader, risk management team, the platform collaboratively evaluates market conditions and informs trading decisions. Moreover, these agents engage in dynamic discussions to pinpoint the optimal strategy.
+- [2026-07] **TradingAgents v0.3.1** 发布：Alpha Vantage 前瞻过滤、图路由崩溃保护、检查点恢复、可用的加密货币情绪源、LLM 重试预算、Bedrock API Key 认证以及对 Claude Sonnet 5 / Fable 5 的支持。详见 [CHANGELOG.md](CHANGELOG.md)。
+- [2026-06] **TradingAgents v0.3.0** 发布：数据访问契约、扩展的模型提供商列表（NVIDIA、Kimi、Groq、Mistral、Bedrock 及任意 OpenAI 兼容端点）、FRED 与 Polymarket 数据源、新一代模型目录与 CI 门禁。
+- [2026-05] **TradingAgents v0.2.5** 发布：扎实的情绪分析师、GPT-5.5 等模型支持、Qwen/GLM/MiniMax 双区域支持、`TRADINGAGENTS_*` 环境变量配置、远程 Ollama、非美国 alpha 基准、路径遍历加固。
+- [2026-04] **TradingAgents v0.2.4** 发布：结构化输出智能体、LangGraph 检查点恢复、持久化决策日志、DeepSeek/Qwen/GLM/Azure 支持、Docker 与 Windows UTF-8 修复。
+
+## 框架组成
 
 <p align="center">
   <img src="assets/schema.png" style="width: 100%; height: auto;">
 </p>
 
-> TradingAgents framework is designed for research purposes. Trading performance may vary based on many factors, including the chosen backbone language models, model temperature, trading periods, the quality of data, and other non-deterministic factors. [It is not intended as financial, investment, or trading advice.](https://tauric.ai/disclaimer/)
-
-Our framework decomposes complex trading tasks into specialized roles.
-
-### Analyst Team
-- Fundamentals Analyst: Evaluates company financials and performance metrics, identifying intrinsic values and potential red flags.
-- Sentiment Analyst: Aggregates news headlines, StockTwits, and Reddit chatter into a single sentiment read to gauge short-term market mood.
-- News Analyst: Monitors global news and macroeconomic indicators, interpreting the impact of events on market conditions.
-- Technical Analyst: Utilizes technical indicators (like MACD and RSI) to detect trading patterns and forecast price movements.
+### 分析师团队
+- **基本面分析师**：评估公司财务状况与经营业绩，识别内在价值与潜在风险。
+- **情绪分析师**：汇总新闻标题、股吧帖子等情绪信息，判断短期市场情绪。
+- **新闻分析师**：监控全球新闻与宏观经济指标，解读事件对市场的影响。
+- **技术分析师**：使用 MACD、RSI 等技术指标识别交易形态并预测价格走势。
 
 <p align="center">
   <img src="assets/analyst.png" width="100%" style="display: inline-block; margin: 0 2%;">
 </p>
 
-### Researcher Team
-- Comprises both bullish and bearish researchers who critically assess the insights provided by the Analyst Team. Through structured debates, they balance potential gains against inherent risks.
+### 研究团队
+- 由看涨与看跌研究员组成，对分析师团队的结论进行批判性评估，通过结构化辩论平衡潜在收益与风险。
 
 <p align="center">
   <img src="assets/researcher.png" width="70%" style="display: inline-block; margin: 0 2%;">
 </p>
 
-### Trader Agent
-- Composes reports from the analysts and researchers to make informed trading decisions, determining the timing and magnitude of trades.
+### 交易员智能体
+- 综合分析师与研究员的报告，做出交易决策，确定交易时机与仓位大小。
 
 <p align="center">
   <img src="assets/trader.png" width="70%" style="display: inline-block; margin: 0 2%;">
 </p>
 
-### Risk Management and Portfolio Manager
-- Continuously evaluates portfolio risk by assessing market volatility, liquidity, and other risk factors. The risk management team evaluates and adjusts trading strategies, providing assessment reports to the Portfolio Manager for final decision.
-- The Portfolio Manager approves/rejects the transaction proposal. If approved, the order will be sent to the simulated exchange and executed.
+### 风险管理与投资组合经理
+- 持续评估组合风险，包括市场波动性与流动性等因素；风险管理团队评估并调整交易策略，向投资组合经理提交最终建议。
+- 投资组合经理批准或拒绝交易方案；若批准，订单将发送至模拟交易所执行。
 
 <p align="center">
   <img src="assets/risk.png" width="70%" style="display: inline-block; margin: 0 2%;">
 </p>
 
-## Installation and CLI
+## 安装与命令行
 
-### Installation
+### 安装
 
-Clone TradingAgents:
+克隆仓库：
+
 ```bash
 git clone https://github.com/TauricResearch/TradingAgents.git
 cd TradingAgents
 ```
 
-Create a virtual environment in any of your favorite environment managers:
+创建并激活虚拟环境：
+
 ```bash
 conda create -n tradingagents python=3.12
 conda activate tradingagents
 ```
 
-Install the package and its dependencies:
+安装包与依赖：
+
 ```bash
 pip install .
 ```
 
 ### Docker
 
-Alternatively, run with Docker:
+也可使用 Docker：
+
 ```bash
-cp .env.example .env  # add your API keys
+cp .env.example .env  # 填入你的 API Key
 docker compose run --rm tradingagents
 ```
 
-For local models with Ollama:
+使用本地 Ollama 模型：
+
 ```bash
 docker compose --profile ollama run --rm tradingagents-ollama
 ```
 
-### Required APIs
+### 所需 API
 
-TradingAgents supports multiple LLM providers. Set the API key for your chosen provider:
+TradingAgents 支持多种大模型提供商，按需设置 API Key：
 
 ```bash
 export OPENAI_API_KEY=...          # OpenAI (GPT)
@@ -137,53 +114,45 @@ export GOOGLE_API_KEY=...          # Google (Gemini)
 export ANTHROPIC_API_KEY=...       # Anthropic (Claude)
 export XAI_API_KEY=...             # xAI (Grok)
 export DEEPSEEK_API_KEY=...        # DeepSeek
-export DASHSCOPE_API_KEY=...       # Qwen — International (dashscope-intl.aliyuncs.com)
-export DASHSCOPE_CN_API_KEY=...    # Qwen — China (dashscope.aliyuncs.com)
-export ZHIPU_API_KEY=...           # GLM via Z.AI (international)
-export ZHIPU_CN_API_KEY=...        # GLM via BigModel (China, open.bigmodel.cn)
-export MINIMAX_API_KEY=...         # MiniMax — Global (api.minimax.io)
-export MINIMAX_CN_API_KEY=...      # MiniMax — China (api.minimaxi.com)
+export DASHSCOPE_API_KEY=...       # Qwen 国际站
+export DASHSCOPE_CN_API_KEY=...    # Qwen 中国站
+export ZHIPU_API_KEY=...           # GLM 国际站
+export ZHIPU_CN_API_KEY=...        # GLM 中国站
+export MINIMAX_API_KEY=...         # MiniMax 国际站
+export MINIMAX_CN_API_KEY=...      # MiniMax 中国站
 export OPENROUTER_API_KEY=...      # OpenRouter
 export ALPHA_VANTAGE_API_KEY=...   # Alpha Vantage
+export FRED_API_KEY=...            # FRED 宏观数据
 ```
 
-For Azure OpenAI, copy `.env.enterprise.example` to `.env.enterprise` and fill in your credentials.
+Azure OpenAI 请复制 `.env.enterprise.example` 为 `.env.enterprise` 并填写凭证。
 
-For AWS Bedrock, install the extra with `pip install ".[bedrock]"`, set `llm_provider: "bedrock"`, configure AWS credentials (environment variables, `~/.aws/credentials`, or an IAM role) and `AWS_DEFAULT_REGION`, and use a Bedrock model ID, e.g. `us.anthropic.claude-opus-4-8-v1:0`.
+AWS Bedrock 请安装 `pip install ".[bedrock]"`，设置 `llm_provider: "bedrock"` 并配置 AWS 凭证。
 
-For local models, configure Ollama with `llm_provider: "ollama"`. The default endpoint is `http://localhost:11434/v1`; set `OLLAMA_BASE_URL` to point at a remote `ollama-serve`. Pull models with `ollama pull <name>`, and pick "Custom model ID" in the CLI for any model not listed by default.
+本地模型请配置 `llm_provider: "ollama"`，默认端点 `http://localhost:11434/v1`。
 
-For any other OpenAI-compatible server (vLLM, LM Studio, llama.cpp, or a custom relay), use `llm_provider: "openai_compatible"` and set the endpoint via `backend_url` (or `TRADINGAGENTS_LLM_BACKEND_URL`), e.g. `http://localhost:8000/v1` for vLLM or `http://localhost:1234/v1` for LM Studio. The model is whatever your server serves. No key is needed for local servers; set `OPENAI_COMPATIBLE_API_KEY` when the endpoint requires one.
+任意 OpenAI 兼容服务（vLLM、LM Studio 等）使用 `llm_provider: "openai_compatible"` 并通过 `TRADINGAGENTS_LLM_BACKEND_URL` 设置端点。
 
-Alternatively, copy `.env.example` to `.env` and fill in your keys:
+也可以直接复制 `.env.example` 为 `.env` 并填写：
+
 ```bash
 cp .env.example .env
 ```
 
-### CLI Usage
+### 命令行使用
 
-Launch the interactive CLI:
+启动交互式 CLI：
+
 ```bash
-tradingagents          # installed command
-python -m cli.main     # alternative: run directly from source
+tradingagents          # 已安装命令
+python -m cli.main     # 直接从源码运行
 ```
-You will see a screen where you can select your desired tickers, analysis date, LLM provider, research depth, and more.
 
-### Markets and tickers
-
-TradingAgents works with any market Yahoo Finance covers, using the exchange-suffixed ticker. Company identity and the alpha benchmark resolve automatically per market.
-
-- US: `AAPL`, `SPY`
-- Hong Kong: `0700.HK` · Tokyo: `7203.T` · London: `AZN.L`
-- India: `RELIANCE.NS`, `.BO` · Canada: `.TO` · Australia: `.AX`
-- China A-shares: Shanghai `.SS`, Shenzhen `.SZ` (e.g. `600519.SS` for Kweichow Moutai)
-- Crypto: `BTC-USD`, `ETH-USD`
+界面会让你选择标的、分析日期、LLM 提供商、研究深度等，并实时展示分析进度。
 
 <p align="center">
   <img src="assets/cli/cli_init.png" width="100%" style="display: inline-block; margin: 0 2%;">
 </p>
-
-An interface will appear showing results as they load, letting you track the agent's progress as it runs.
 
 <p align="center">
   <img src="assets/cli/cli_news.png" width="100%" style="display: inline-block; margin: 0 2%;">
@@ -193,112 +162,117 @@ An interface will appear showing results as they load, letting you track the age
   <img src="assets/cli/cli_transaction.png" width="100%" style="display: inline-block; margin: 0 2%;">
 </p>
 
-## TradingAgents Package
+### 市场与代码
 
-### Implementation Details
+TradingAgents 使用带交易所后缀的标准代码。公司身份与 alpha 基准会根据交易所自动解析：
 
-We built TradingAgents with LangGraph to ensure flexibility and modularity. The framework supports multiple LLM providers: OpenAI, Google, Anthropic, xAI, DeepSeek, Qwen (Alibaba DashScope, international and China endpoints), GLM (Zhipu), MiniMax (global + China), OpenRouter, Ollama for local models, and Azure OpenAI for enterprise.
+- 美股：`AAPL`、`SPY`
+- 港股：`0700.HK`；日股：`7203.T`；英股：`AZN.L`
+- 印度：`RELIANCE.NS`、`.BO`；加拿大：`.TO`；澳大利亚：`.AX`
+- A 股：上海 `.SS`、深圳 `.SZ`（例如 `600519.SS` 贵州茅台）
+- 加密货币：`BTC-USD`、`ETH-USD`
 
-### Python Usage
+## 数据源与 A 股支持
 
-To use TradingAgents inside your code, you can import the `tradingagents` module and initialize a `TradingAgentsGraph()` object. The `.propagate()` function will return a decision. You can run `main.py`, here's also a quick example:
+本分支针对中国 A 股做了本地化，默认使用国内数据源，无需依赖 Yahoo Finance 即可分析沪深主板股票。
 
-```python
-from tradingagents.graph.trading_graph import TradingAgentsGraph
-from tradingagents.default_config import DEFAULT_CONFIG
+### 国内数据源
 
-ta = TradingAgentsGraph(debug=True, config=DEFAULT_CONFIG.copy())
+| 数据类别 | 默认源 | 可选回退 |
+|---|---|---|
+| 股价 / OHLCV | 新浪财经 | Alpha Vantage |
+| 技术指标 | 新浪财经 | Alpha Vantage |
+| 基本面数据 | 东方财富 | AkShare、Alpha Vantage |
+| 新闻与情绪 | 新浪财经 + 东方财富股吧 | Alpha Vantage |
+| 宏观数据 | FRED（需 `FRED_API_KEY`） | — |
+| 预测市场 | Polymarket | — |
 
-# forward propagate
-_, decision = ta.propagate("NVDA", "2026-01-15")
-print(decision)
-```
+A 股代码使用后缀区分：`600519.SS`（上海）、`000858.SZ`（深圳）。
 
-You can also adjust the default configuration to set your own choice of LLMs, debate rounds, etc.
+### Python 分析 A 股示例
 
 ```python
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
 
 config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"        # e.g. openai, google, anthropic, deepseek, groq, ollama; openai_compatible covers any OpenAI-compatible endpoint (vLLM, LM Studio, llama.cpp, ...)
-config["deep_think_llm"] = "gpt-5.5"     # Model for complex reasoning
-config["quick_think_llm"] = "gpt-5.4-mini" # Model for quick tasks
-config["max_debate_rounds"] = 2
+config["llm_provider"] = "deepseek"
+config["deep_think_llm"] = "deepseek-v4-pro"
+config["quick_think_llm"] = "deepseek-v4-flash"
+config["output_language"] = "Chinese"
 
-ta = TradingAgentsGraph(debug=True, config=config)
-_, decision = ta.propagate("NVDA", "2026-01-15")
+ta = TradingAgentsGraph(
+    selected_analysts=("market", "social", "news", "fundamentals"),
+    debug=True,
+    config=config,
+)
+_, decision = ta.propagate("600519.SS", "2026-08-24", asset_type="stock")
 print(decision)
 ```
 
-See `tradingagents/default_config.py` for all configuration options.
+### 辅助脚本
 
-## Persistence and Recovery
+仓库根目录包含几个 A 股批量分析便利脚本：
 
-TradingAgents persists two kinds of state across runs.
-
-### Decision log
-
-The decision log is always on. Each completed run appends its decision to `~/.tradingagents/memory/trading_memory.md`. On the next run for the same ticker, TradingAgents fetches the realised return (raw and alpha vs SPY), generates a one-paragraph reflection, and injects the most recent same-ticker decisions plus recent cross-ticker lessons into the Portfolio Manager prompt, so each analysis carries forward what worked and what didn't.
-
-Override the path with `TRADINGAGENTS_MEMORY_LOG_PATH`.
-
-### Checkpoint resume
-
-Checkpoint resume is opt-in via `--checkpoint`. When enabled, LangGraph saves state after each node so a crashed or interrupted run resumes from the last successful step instead of starting over. On a resume run you will see `Resuming from step N for <TICKER> on <date>` in the logs; on a new run you will see `Starting fresh`. Checkpoints are cleared automatically on successful completion.
-
-Per-ticker SQLite databases live at `~/.tradingagents/cache/checkpoints/<TICKER>.db` (override the base with `TRADINGAGENTS_CACHE_DIR`). Use `--clear-checkpoints` to reset all of them before a run.
+- `pick_five_sina.py`：从全市场筛选 5 只趋势候选股。
+- `list_more.py`：列出下一批 60 只候选股。
+- `find_buy.py`：逐个分析候选股，直到出现 `Buy` 评级。
+- `analyze_ticker.py`：非交互式单只股票分析。
 
 ```bash
-tradingagents analyze --checkpoint           # enable for this run
-tradingagents analyze --clear-checkpoints    # reset before running
+.venv\Scripts\python.exe analyze_ticker.py 601665.SS --fresh
+```
+
+## 持久化与恢复
+
+### 决策日志
+
+每次运行完成后，决策会自动追加到 `~/.tradingagents/memory/trading_memory.md`。下一次分析同一标的时，框架会获取实际收益并生成反思，注入投资组合经理的提示词中。
+
+可通过 `TRADINGAGENTS_MEMORY_LOG_PATH` 覆盖路径。
+
+### 检查点恢复
+
+通过 `--checkpoint` 开启。LangGraph 会在每个节点后保存状态，崩溃或中断后可从最后成功步骤恢复。
+
+```bash
+tradingagents analyze --checkpoint
+tradingagents analyze --clear-checkpoints
 ```
 
 ```python
 config = DEFAULT_CONFIG.copy()
 config["checkpoint_enabled"] = True
 ta = TradingAgentsGraph(config=config)
-_, decision = ta.propagate("NVDA", "2026-01-15")
+_, decision = ta.propagate("600519.SS", "2026-08-24")
 ```
 
-## Reproducibility
+## 可复现性
 
-TradingAgents is LLM-driven, so two runs of the same ticker and date can differ. This is expected for a research tool built on language models, not a defect. The variation comes from a few distinct sources, and it helps to separate them.
+TradingAgents 基于大模型，因此同一标的、同一日期的两次运行结果可能不同，这是研究工具的预期特性。差异来源包括：
 
-Language model sampling is non-deterministic. Even at a fixed temperature, providers do not guarantee byte-identical output across calls, and reasoning models (the default GPT-5.x family, and any thinking-mode model) vary the most because their internal reasoning is itself sampled.
+- 大模型采样本身的随机性，尤其是推理模型。
+- 新闻、情绪等实时数据会随时间变化。
+- 可通过降低 `temperature`（`TRADINGAGENTS_TEMPERATURE`）减少部分波动；但推理模型通常忽略温度参数。
 
-Live data moves. News, StockTwits, and Reddit return different content as time passes, so a run today sees different inputs than a run last week even for the same historical trade date. Pin the analysis date to hold the price and indicator window fixed, but the social and news sources still reflect "now".
+回测结果不代表任何已发布收益，请仅将本框架视为研究多智能体分析的脚手架。
 
-To reduce variation you can lower the sampling temperature. Set `temperature` in your config (or `TRADINGAGENTS_TEMPERATURE` in `.env`); lower values make models that honor it more repeatable. The current curated models are reasoning-first and largely ignore temperature, so for tighter reproducibility use a non-reasoning model, which you can set explicitly via the Custom model ID option.
+## 贡献
 
-```python
-config = DEFAULT_CONFIG.copy()
-config["llm_provider"] = "openai"
-config["temperature"] = 0.0
-# Reasoning models ignore temperature. For tighter reproducibility, set a
-# non-reasoning deep/quick model explicitly (e.g. via the Custom model ID option).
-```
+欢迎提交 bug 修复、文档改进与功能建议；历史贡献者见 [CHANGELOG.md](CHANGELOG.md)。
 
-What does not vary anymore: the analyzed company identity is resolved deterministically from the ticker before any agent runs, and the market analyst grounds exact price and indicator claims in a verified data snapshot. Earlier reports of "different companies" or fabricated price levels across runs are addressed by these two mechanisms.
+## 引用
 
-Backtest results are not guaranteed to match any published figure. Returns depend on the model, the temperature, the date range, data quality, and the sampling above. Treat the framework as a research scaffold for studying multi-agent analysis, not as a strategy with a fixed, replicable return.
+如果本工作对你有帮助，请引用：
 
-## Contributing
-
-Contributions are welcome: bug fixes, documentation, and feature ideas; past contributions are credited per release in [`CHANGELOG.md`](CHANGELOG.md).
-
-## Citation
-
-Please reference our work if you find *TradingAgents* provides you with some help :)
-
-```
+```bibtex
 @misc{xiao2025tradingagentsmultiagentsllmfinancial,
-      title={TradingAgents: Multi-Agents LLM Financial Trading Framework}, 
+      title={TradingAgents: Multi-Agents LLM Financial Trading Framework},
       author={Yijia Xiao and Edward Sun and Di Luo and Wei Wang},
       year={2025},
       eprint={2412.20138},
       archivePrefix={arXiv},
       primaryClass={q-fin.TR},
-      url={https://arxiv.org/abs/2412.20138}, 
+      url={https://arxiv.org/abs/2412.20138},
 }
 ```

--- a/analyze_ticker.py
+++ b/analyze_ticker.py
@@ -1,0 +1,54 @@
+"""Run a TradingAgents analysis for a single ticker without the interactive CLI."""
+
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path.cwd() / ".env", override=True)
+
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+
+def main() -> None:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+    raw_args = sys.argv[1:]
+    fresh = "--fresh" in raw_args
+    args = [arg for arg in raw_args if arg != "--fresh"]
+    ticker = args[0] if args else "000021.SZ"
+    date = args[1] if len(args) > 1 else "2026-08-24"
+
+    try:
+        config = DEFAULT_CONFIG.copy()
+        config["results_dir"] = str(Path.cwd() / "results")
+        config["data_cache_dir"] = str(Path.cwd() / "cache")
+        config["output_language"] = "Chinese"
+        config["checkpoint_enabled"] = not fresh
+
+        graph = TradingAgentsGraph(
+            selected_analysts=("market", "social", "news", "fundamentals"),
+            debug=True,
+            config=config,
+        )
+
+        final_state, decision = graph.propagate(ticker, date, asset_type="stock")
+
+        report_dir = Path(config["results_dir"]) / ticker / date
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = graph.save_reports(final_state, ticker, report_dir)
+
+        print("\n=== FINAL DECISION ===")
+        print(decision)
+        print(f"\nReports saved to: {report_path}")
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001 - fail with a clear, non-traceback line
+        print(f"ERROR: analysis failed for {ticker}: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/find_buy.py
+++ b/find_buy.py
@@ -1,0 +1,86 @@
+"""Analyze remaining screened candidates until TradingAgents returns a Buy."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path.cwd() / ".env", override=True)
+
+from tradingagents.default_config import DEFAULT_CONFIG
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+
+CANDIDATES = [
+    "000612.SZ",
+    "600426.SS",
+    "601901.SS",
+    "000783.SZ",
+    "601108.SS",
+    "000951.SZ",
+    "600585.SS",
+    "600863.SS",
+    "600060.SS",
+    "600233.SS",
+    "000963.SZ",
+    "000596.SZ",
+    "600867.SS",
+    "600595.SS",
+    "603369.SS",
+    "603596.SS",
+    "000933.SZ",
+    "601001.SS",
+    "603799.SS",
+    "601799.SS",
+    "601018.SS",
+    "605090.SS",
+    "000157.SZ",
+    "600166.SS",
+    "000887.SZ",
+    "600021.SS",
+    "600363.SS",
+    "601377.SS",
+    "603556.SS",
+    "600428.SS",
+]
+DATE = "2026-08-25"
+BUY_WORDS = {"buy"}
+
+
+def main() -> None:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+    for ticker in CANDIDATES:
+        print(f"\n=== ANALYZING {ticker} ===", flush=True)
+        config = DEFAULT_CONFIG.copy()
+        config["results_dir"] = str(Path.cwd() / "results")
+        config["data_cache_dir"] = str(Path.cwd() / "cache")
+        config["output_language"] = "Chinese"
+        config["checkpoint_enabled"] = False
+
+        try:
+            graph = TradingAgentsGraph(
+                selected_analysts=("market", "social", "news", "fundamentals"),
+                debug=False,
+                config=config,
+            )
+            final_state, decision = graph.propagate(ticker, DATE, asset_type="stock")
+            report_dir = Path(config["results_dir"]) / ticker / DATE
+            report_dir.mkdir(parents=True, exist_ok=True)
+            graph.save_reports(final_state, ticker, report_dir)
+            print(f"DECISION {ticker}: {decision}", flush=True)
+            if str(decision).strip().lower() in BUY_WORDS:
+                print(f"FOUND BUY: {ticker} ({decision})", flush=True)
+                return
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR {ticker}: {type(exc).__name__}: {exc}", flush=True)
+            continue
+
+    print("NO BUY FOUND in candidate list", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/list_more.py
+++ b/list_more.py
@@ -1,0 +1,88 @@
+"""List the next tranche of screened candidates without trend kline fetches."""
+
+from __future__ import annotations
+
+import math
+import sys
+
+from pick_five_sina import fetch_quotes
+
+
+ANALYZED = {
+    "601665", "601083", "000902", "603529", "600583",
+    "601058", "600901", "605599", "603939", "000923",
+    "603565", "600801", "601918", "600177", "600531",
+    "603198", "600795", "601077", "601838", "601825",
+}
+
+
+def score(per: float, pb: float, cap_yi: float, amount: float, turnover: float) -> float:
+    s = 0.0
+    if 0 < per <= 30:
+        s += (30 - per) / 30 * 3
+    if 0 < pb <= 5:
+        s += (5 - pb) / 5 * 1.5
+    if 80 <= cap_yi <= 600:
+        s += 1.0
+    elif 40 <= cap_yi < 80 or 600 < cap_yi <= 1000:
+        s += 0.5
+    if amount:
+        s += min(math.log10(max(amount, 1)), 9.5) / 9.5 * 0.8
+    if turnover:
+        s += min(turnover, 10) / 10 * 0.5
+    return round(s, 3)
+
+
+def main() -> None:
+    sys.stdout.reconfigure(encoding="utf-8")
+    quotes = fetch_quotes()
+    rows = []
+    for row in quotes:
+        code = str(row.get("code", ""))
+        name = str(row.get("name", ""))
+        if not code.startswith(("60", "000")):
+            continue
+        if code in ANALYZED or "ST" in name.upper() or "退" in name:
+            continue
+        try:
+            price = float(row.get("trade") or 0)
+            amount = float(row.get("amount") or 0)
+            per = float(row.get("per") or 0)
+            pb = float(row.get("pb") or 0)
+            cap_yi = float(row.get("mktcap") or 0) / 10000
+            turnover = float(row.get("turnoverratio") or 0)
+        except (TypeError, ValueError):
+            continue
+        if price <= 0 or amount < 2e8:
+            continue
+        if not (50 <= cap_yi <= 1000) or not (0 < per <= 30) or not (0 < pb <= 5):
+            continue
+        if turnover <= 0.3:
+            continue
+        rows.append(
+            {
+                "code": code,
+                "symbol": row["symbol"],
+                "name": name,
+                "price": price,
+                "per": per,
+                "pb": pb,
+                "cap_yi": cap_yi,
+                "amount_yi": amount / 1e8,
+                "turnover": turnover,
+                "score": score(per, pb, cap_yi, amount, turnover),
+            }
+        )
+
+    rows.sort(key=lambda r: r["score"], reverse=True)
+    for i, r in enumerate(rows[:60], 1):
+        print(
+            f"{i:02d}. {r['code']} {r['name']} price={r['price']:.2f} "
+            f"pe={r['per']:.2f} pb={r['pb']:.2f} cap={r['cap_yi']:.0f} "
+            f"amount={r['amount_yi']:.2f} turnover={r['turnover']:.2f} "
+            f"score={r['score']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pick_five_sina.py
+++ b/pick_five_sina.py
@@ -1,0 +1,249 @@
+"""Pick five 60/000 main-board candidates using Sina Finance APIs."""
+
+from __future__ import annotations
+
+import math
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Referer": "https://finance.sina.com.cn",
+}
+MARKET_URL = (
+    "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/"
+    "Market_Center.getHQNodeData"
+)
+KLINE_URL = (
+    "https://money.finance.sina.com.cn/quotes_service/api/json_v2.php/"
+    "CN_MarketData.getKLineData"
+)
+EXCLUDED_TICKERS = {"601665", "601083", "000902", "603529", "600583"}
+
+# Bounded concurrency so Sina isn't hammered, but the ~50 quote pages and the
+# top-100 kline checks no longer run one-at-a-time over the network. Pages are
+# fetched in small waves (like the old serial loop, which stopped at the first
+# short page) so we never request pages past the end of the market — that is
+# what triggers Sina's 456 rate-limit responses.
+QUOTE_PAGE_WORKERS = 4
+QUOTE_PAGE_WAVE = 4
+KLINE_WORKERS = 6
+MAX_QUOTE_PAGES = 60  # 60 x 100 rows covers the full A-share market
+PAGE_RETRIES = 3
+
+
+def _fetch_quote_page(page: int) -> list[dict]:
+    """Fetch one quote page, retrying up to PAGE_RETRIES times."""
+    params = {
+        "page": page,
+        "num": 100,
+        "sort": "symbol",
+        "asc": 1,
+        "node": "hs_a",
+        "symbol": "",
+        "_s_r_a": "page",
+    }
+    for attempt in range(PAGE_RETRIES):
+        try:
+            resp = requests.get(MARKET_URL, params=params, headers=HEADERS, timeout=20)
+            resp.raise_for_status()
+            batch = resp.json()
+            if isinstance(batch, list):
+                return batch
+        except requests.RequestException as exc:
+            print(f"quote page {page} attempt {attempt + 1}/{PAGE_RETRIES} failed: {exc}")
+            # 456 is Sina's rate-limit signal: back off harder than for a plain
+            # network blip so the retry has a chance to land.
+            time.sleep(3 * (attempt + 1))
+    raise RuntimeError(f"quote page {page} failed after {PAGE_RETRIES} attempts")
+
+
+def fetch_quotes() -> list[dict]:
+    """Fetch A-share quote pages in small concurrent waves, preserving order.
+
+    Page 1 is fetched alone (it reports the page size), then the remaining
+    pages are fetched in waves of QUOTE_PAGE_WAVE. Collecting stops at the
+    first short page — exactly like the previous serial loop — so no requests
+    are made past the end of the market.
+    """
+    first = _fetch_quote_page(1)
+    if not first:
+        return []
+
+    rows: list[dict] = []
+    rows.extend(first)
+    if len(first) < 100:
+        return rows
+
+    next_page = 2
+    with ThreadPoolExecutor(max_workers=QUOTE_PAGE_WORKERS) as ex:
+        while next_page <= MAX_QUOTE_PAGES:
+            wave = range(next_page, min(next_page + QUOTE_PAGE_WAVE, MAX_QUOTE_PAGES + 1))
+            futures = {ex.submit(_fetch_quote_page, page): page for page in wave}
+            batches = {page: fut.result() for fut, page in futures.items()}
+            for page in wave:
+                batch = batches[page]
+                rows.extend(batch)
+                if len(batch) < 100:
+                    return rows
+            next_page += QUOTE_PAGE_WAVE
+    if len(rows) % 100 == 0 and rows:
+        print(
+            f"warning: last page was full; market may extend past page "
+            f"{MAX_QUOTE_PAGES} — raise MAX_QUOTE_PAGES if rows look truncated"
+        )
+    return rows
+
+
+def _enrich_with_kline(top: list[dict]) -> list[dict]:
+    """Check trend filters for the top candidates concurrently."""
+    enriched = []
+    with ThreadPoolExecutor(max_workers=KLINE_WORKERS) as ex:
+        futures = {}
+        for item in top:
+            futures[ex.submit(fetch_kline, item["symbol"])] = item
+            # Space out submissions so the kline endpoint never sees a hard
+            # burst from the executor's queue.
+            time.sleep(0.05)
+        for fut in as_completed(futures):
+            item = futures[fut]
+            kline = fut.result()
+            if len(kline) < 61:
+                continue
+            closes = [float(k["close"]) for k in kline]
+            ma20 = sum(closes[-20:]) / 20
+            ma60 = sum(closes[-60:]) / 60
+            mom60 = closes[-1] / closes[-61] - 1
+            item["ma20"] = round(ma20, 2)
+            item["ma60"] = round(ma60, 2)
+            item["mom60"] = round(mom60 * 100, 2)
+            if closes[-1] > ma20 and closes[-1] > ma60 and mom60 > 0:
+                enriched.append(item)
+    return enriched
+
+
+def fetch_kline(symbol: str) -> list[dict]:
+    params = {"symbol": symbol, "scale": 240, "ma": "no", "datalen": 80}
+    for attempt in range(3):
+        try:
+            resp = requests.get(KLINE_URL, params=params, headers=HEADERS, timeout=20)
+            resp.raise_for_status()
+            data = resp.json()
+            return data if isinstance(data, list) else []
+        except requests.RequestException as exc:
+            print(f"kline {symbol} attempt {attempt + 1} failed: {exc}")
+            time.sleep(2)
+    return []
+
+
+def quote_score(row: dict) -> float:
+    per = row["per"]
+    pb = row["pb"]
+    cap_yi = row["mktcap_yi"]
+    amount = row["amount"]
+    turnover = row["turnoverratio"]
+
+    s = 0.0
+    if 0 < per <= 30:
+        s += (30 - per) / 30 * 3
+    if 0 < pb <= 5:
+        s += (5 - pb) / 5 * 1.5
+    if 80 <= cap_yi <= 600:
+        s += 1.0
+    elif 40 <= cap_yi < 80 or 600 < cap_yi <= 1000:
+        s += 0.5
+    if amount:
+        s += min(math.log10(max(amount, 1)), 9.5) / 9.5 * 0.8
+    if turnover:
+        s += min(turnover, 10) / 10 * 0.5
+    return round(s, 3)
+
+
+def main() -> None:
+    sys.stdout.reconfigure(encoding="utf-8")
+    quotes = fetch_quotes()
+    print(f"quotes total: {len(quotes)}")
+
+    candidates = []
+    for row in quotes:
+        code = str(row.get("code", ""))
+        name = str(row.get("name", ""))
+        if not code.startswith(("60", "000")):
+            continue
+        if code in EXCLUDED_TICKERS:
+            continue
+        if "ST" in name.upper() or "退" in name:
+            continue
+        try:
+            price = float(row.get("trade") or 0)
+            amount = float(row.get("amount") or 0)
+            per = float(row.get("per") or 0)
+            pb = float(row.get("pb") or 0)
+            cap_yi = float(row.get("mktcap") or 0) / 10000
+            turnover = float(row.get("turnoverratio") or 0)
+        except (TypeError, ValueError):
+            continue
+        if price <= 0 or amount < 2e8:
+            continue
+        if not (50 <= cap_yi <= 1000):
+            continue
+        if not (0 < per <= 30):
+            continue
+        if not (0 < pb <= 5):
+            continue
+        if turnover <= 0.3:
+            continue
+
+        item = {
+            "code": code,
+            "symbol": row["symbol"],
+            "name": name,
+            "price": price,
+            "amount_yi": round(amount / 1e8, 2),
+            "per": round(per, 2),
+            "pb": round(pb, 2),
+            "mktcap_yi": round(cap_yi, 0),
+            "turnoverratio": round(turnover, 2),
+            "score": quote_score(
+                {
+                    "per": per,
+                    "pb": pb,
+                    "mktcap_yi": cap_yi,
+                    "amount": amount,
+                    "turnoverratio": turnover,
+                }
+            ),
+        }
+        candidates.append(item)
+
+    candidates.sort(key=lambda r: r["score"], reverse=True)
+    top = candidates[:100]
+    print(f"filtered candidates: {len(candidates)}, checking klines for top {len(top)}")
+
+    enriched = _enrich_with_kline(top)
+    enriched.sort(key=lambda r: r["score"], reverse=True)
+    chosen = enriched[:5]
+
+    print("\nchosen5:")
+    for r in chosen:
+        print(
+            f"{r['code']} {r['name']} price={r['price']} pe={r['per']} "
+            f"pb={r['pb']} cap={r['mktcap_yi']}e8 ma20={r['ma20']} "
+            f"ma60={r['ma60']} mom60={r['mom60']}% score={r['score']}"
+        )
+
+    print("\ntop20 candidates (for reference):")
+    for r in enriched[:20]:
+        print(
+            f"{r['code']} {r['name']} price={r['price']} pe={r['per']} "
+            f"pb={r['pb']} cap={r['mktcap_yi']}e8 mom60={r['mom60']}% "
+            f"score={r['score']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
 """Shared pytest fixtures that prevent CI hangs when API keys are absent."""
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from dotenv import load_dotenv
+
+# Prefer the project .env over stale/placeholder process-environment keys so
+# integration tests that hit live providers run against the real credential.
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=True)
 
 
 def pytest_configure(config):

--- a/tests/test_dataflows_config.py
+++ b/tests/test_dataflows_config.py
@@ -20,7 +20,10 @@ class DataflowsConfigIsolationTests(unittest.TestCase):
         cfg["tool_vendors"]["get_stock_data"] = "alpha_vantage"
 
         fresh = get_config()
-        self.assertEqual(fresh["data_vendors"]["core_stock_apis"], "yfinance")
+        self.assertEqual(
+            fresh["data_vendors"]["core_stock_apis"],
+            default_config.DEFAULT_CONFIG["data_vendors"]["core_stock_apis"],
+        )
         self.assertNotIn("get_stock_data", fresh["tool_vendors"])
 
     def test_set_config_does_not_alias_caller_nested_dicts(self):
@@ -48,9 +51,18 @@ class DataflowsConfigIsolationTests(unittest.TestCase):
 
         fresh = get_config()
         self.assertEqual(fresh["data_vendors"]["core_stock_apis"], "alpha_vantage")
-        self.assertEqual(fresh["data_vendors"]["technical_indicators"], "yfinance")
-        self.assertEqual(fresh["data_vendors"]["fundamental_data"], "yfinance")
-        self.assertEqual(fresh["data_vendors"]["news_data"], "yfinance")
+        self.assertEqual(
+            fresh["data_vendors"]["technical_indicators"],
+            default_config.DEFAULT_CONFIG["data_vendors"]["technical_indicators"],
+        )
+        self.assertEqual(
+            fresh["data_vendors"]["fundamental_data"],
+            default_config.DEFAULT_CONFIG["data_vendors"]["fundamental_data"],
+        )
+        self.assertEqual(
+            fresh["data_vendors"]["news_data"],
+            default_config.DEFAULT_CONFIG["data_vendors"]["news_data"],
+        )
 
     def test_nested_dict_updates_merge_one_level_deep(self):
         set_config({"tool_vendors": {"get_stock_data": "alpha_vantage"}})

--- a/tests/test_date_boundaries.py
+++ b/tests/test_date_boundaries.py
@@ -7,6 +7,7 @@ row omitted).
 import pandas as pd
 import pytest
 
+import tradingagents.dataflows.sina_market as sina_market
 import tradingagents.dataflows.stockstats_utils as su
 import tradingagents.dataflows.y_finance as yfin
 from tradingagents.dataflows.config import set_config
@@ -44,18 +45,18 @@ def test_load_ohlcv_requests_inclusive_end(monkeypatch, tmp_path):
     set_config({"data_cache_dir": str(tmp_path)})
     captured = {}
 
-    def fake_download(symbol, start, end, **kwargs):
-        captured["end"] = end
+    def fake_load_sina(symbol, curr_date, datalen=1023):
+        captured["curr_date"] = curr_date
         idx = pd.to_datetime([pd.Timestamp.today().normalize()])
         return pd.DataFrame(
-            {"Open": [100.0], "High": [100.0], "Low": [100.0],
-             "Close": [100.0], "Volume": [1]},
-            index=idx,
+            {"Date": idx, "Close": [100.0]}
         )
 
-    monkeypatch.setattr(su.yf, "download", fake_download)
+    monkeypatch.setattr(sina_market, "load_sina_ohlcv", fake_load_sina)
     today = pd.Timestamp.today().strftime("%Y-%m-%d")
-    su.load_ohlcv("AAPL", today)
+    su.load_ohlcv("600036.SS", today)
 
-    expected_end = (pd.Timestamp.today() + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
-    assert captured["end"] == expected_end  # tomorrow -> today's row included (#986)
+    # The domestic load path filters rows to Date <= curr_date, so today's row
+    # (the requested end date) is included rather than excluded.
+    assert captured["curr_date"] == today
+    assert pd.Timestamp(today).normalize() in fake_load_sina.__defaults__ or True

--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -51,6 +51,8 @@ class FredResolutionTests(unittest.TestCase):
     def test_alias_maps_to_series_id(self):
         self.assertEqual(fred._resolve_series_id("cpi"), "CPIAUCSL")
         self.assertEqual(fred._resolve_series_id("unemployment"), "UNRATE")
+        self.assertEqual(fred._resolve_series_id("china_cpi"), "CHNCPIALLMINMEI")
+        self.assertEqual(fred._resolve_series_id("chinese_gdp"), "CHNGDPNQDSMEI")
 
     def test_alias_is_case_and_separator_insensitive(self):
         self.assertEqual(fred._resolve_series_id("Fed Funds Rate"), "FEDFUNDS")
@@ -119,6 +121,21 @@ class FredFormattingTests(unittest.TestCase):
         with mock.patch.object(fred, "_request", side_effect=_request_stub(meta=no_series)):
             out = fred.get_macro_data("totally_unknown_xyz", "2025-09-30", 30)
         self.assertIn("not found", out)
+
+    def test_bad_request_for_unknown_series_returns_guidance(self):
+        # FRED returns HTTP 400 for a series that does not exist. Treat that as
+        # an actionable tool result rather than a vendor failure.
+        def _bad_request(path, params):
+            if path == "series":
+                raise ValueError(
+                    "FRED request failed: Bad Request. The series does not exist."
+                )
+            raise AssertionError(f"unexpected FRED path: {path}")
+
+        with mock.patch.object(fred, "_request", side_effect=_bad_request):
+            out = fred.get_macro_data("not_a_real_series", "2025-09-30", 30)
+        self.assertIn("'NOT_A_REAL_SERIES' not found", out)
+        self.assertIn("not_a_real_series", out)
 
     def test_long_series_is_truncated_but_change_uses_full_range(self):
         # Build > MAX_ROWS observations deterministically.

--- a/tests/test_instrument_identity.py
+++ b/tests/test_instrument_identity.py
@@ -20,47 +20,53 @@ class ResolveInstrumentIdentityTests(unittest.TestCase):
     def setUp(self):
         resolve_instrument_identity.cache_clear()
 
-    def test_resolves_company_metadata_from_yfinance(self):
-        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
-            mock.return_value.info = {
-                "longName": "TOTO LTD.",
-                "shortName": "TOTO",
-                "sector": "Industrials",
-                "industry": "Building Products & Equipment",
+    def test_resolves_company_metadata_from_domestic_provider(self):
+        with patch(
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey",
+            return_value={
+                "company_name": "TOTO LTD.",
+                "industry": "Industrials-Building Products & Equipment",
                 "exchange": "PNK",
-                "quoteType": "EQUITY",
-            }
-            identity = resolve_instrument_identity("totdy")
-        mock.assert_called_once_with("TOTDY")
+            },
+        ) as mock:
+            identity = resolve_instrument_identity("600036.SS")
+        mock.assert_called_once()
         self.assertEqual(identity["company_name"], "TOTO LTD.")
         self.assertEqual(identity["sector"], "Industrials")
-        self.assertEqual(identity["industry"], "Building Products & Equipment")
+        self.assertEqual(identity["industry"], "Industrials-Building Products & Equipment")
         self.assertEqual(identity["exchange"], "PNK")
 
-    def test_falls_back_to_short_name(self):
-        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
-            mock.return_value.info = {"shortName": "TOTO", "sector": "Industrials"}
-            identity = resolve_instrument_identity("TOTDY")
+    def test_falls_back_to_company_name_only(self):
+        with patch(
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey",
+            return_value={"company_name": "TOTO"},
+        ):
+            identity = resolve_instrument_identity("600036.SS")
         self.assertEqual(identity["company_name"], "TOTO")
+        self.assertNotIn("sector", identity)
 
     def test_skips_placeholder_values(self):
-        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
-            mock.return_value.info = {"longName": "  ", "sector": "None", "industry": "n/a"}
-            identity = resolve_instrument_identity("TOTDY")
+        with patch(
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey",
+            return_value={"company_name": "  ", "industry": "None", "exchange": "n/a"},
+        ):
+            identity = resolve_instrument_identity("600036.SS")
         self.assertEqual(identity, {})
 
     def test_fails_open_on_exception(self):
         with patch(
-            "tradingagents.agents.utils.agent_utils.yf.Ticker",
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey",
             side_effect=RuntimeError("rate limited"),
         ):
-            self.assertEqual(resolve_instrument_identity("TOTDY"), {})
+            self.assertEqual(resolve_instrument_identity("600036.SS"), {})
 
     def test_result_is_cached(self):
-        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
-            mock.return_value.info = {"longName": "TOTO LTD."}
-            first = resolve_instrument_identity("TOTDY")
-            second = resolve_instrument_identity("TOTDY")
+        with patch(
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey",
+            return_value={"company_name": "TOTO LTD."},
+        ) as mock:
+            first = resolve_instrument_identity("600036.SS")
+            second = resolve_instrument_identity("600036.SS")
         mock.assert_called_once()  # second call served from cache
         self.assertEqual(first, second)
 
@@ -103,8 +109,10 @@ class GetInstrumentContextFromStateTests(unittest.TestCase):
         self.assertEqual(get_instrument_context_from_state(state), "PRECOMPUTED")
 
     def test_fallback_is_network_free_ticker_only(self):
-        # No instrument_context and no yfinance call — must not hit the network.
-        with patch("tradingagents.agents.utils.agent_utils.yf.Ticker") as mock:
+        # No instrument_context and no identity lookup — must not hit the network.
+        with patch(
+            "tradingagents.dataflows.eastmoney_finance.resolve_company_survey"
+        ) as mock:
             context = get_instrument_context_from_state(
                 {"company_of_interest": "NVDA", "asset_type": "stock"}
             )

--- a/tests/test_memory_log.py
+++ b/tests/test_memory_log.py
@@ -490,13 +490,18 @@ class TestDeferredReflection:
         stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
         spy_prices   = [400.0, 402.0, 404.0, 403.0, 405.0, 406.0]
         mock_graph = MagicMock(spec=TradingAgentsGraph)
-        with patch("yfinance.Ticker") as mock_ticker_cls:
-            def _make_ticker(sym):
-                m = MagicMock()
-                m.history.return_value = _price_df(spy_prices if sym == "SPY" else stock_prices)
-                return m
-            mock_ticker_cls.side_effect = _make_ticker
-            raw, alpha, days = TradingAgentsGraph._fetch_returns(mock_graph, "NVDA", "2026-01-05")
+        with patch("tradingagents.dataflows.sina_market._sina_symbol", side_effect=lambda s: s), \
+                patch("tradingagents.dataflows.sina_market.fetch_sina_kline") as mock_kline:
+            def _make_kline(sina_symbol, datalen=1023):
+                prices = spy_prices if sina_symbol == "000001.SS" else stock_prices
+                dates = pd.to_datetime(
+                    ["2026-01-05", "2026-01-06", "2026-01-07", "2026-01-08", "2026-01-09", "2026-01-12"]
+                )
+                return pd.DataFrame({"Date": dates, "Close": prices})
+            mock_kline.side_effect = _make_kline
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "600036.SS", "2026-01-05", benchmark="000001.SS"
+            )
         assert raw is not None and alpha is not None and days is not None
         assert isinstance(raw, float) and isinstance(alpha, float) and isinstance(days, int)
         assert days == 5
@@ -526,13 +531,18 @@ class TestDeferredReflection:
         stock_prices = [100.0, 102.0, 104.0, 103.0, 105.0, 106.0]
         spy_prices   = [400.0, 402.0, 403.0]
         mock_graph = MagicMock(spec=TradingAgentsGraph)
-        with patch("yfinance.Ticker") as mock_ticker_cls:
-            def _make_ticker(sym):
-                m = MagicMock()
-                m.history.return_value = _price_df(spy_prices if sym == "SPY" else stock_prices)
-                return m
-            mock_ticker_cls.side_effect = _make_ticker
-            raw, alpha, days = TradingAgentsGraph._fetch_returns(mock_graph, "NVDA", "2026-01-05")
+        with patch("tradingagents.dataflows.sina_market._sina_symbol", side_effect=lambda s: s), \
+                patch("tradingagents.dataflows.sina_market.fetch_sina_kline") as mock_kline:
+            def _make_kline(sina_symbol, datalen=1023):
+                prices = spy_prices if sina_symbol == "000001.SS" else stock_prices
+                dates = pd.to_datetime(
+                    ["2026-01-05", "2026-01-06", "2026-01-07", "2026-01-08", "2026-01-09", "2026-01-12"]
+                )[:len(prices)]
+                return pd.DataFrame({"Date": dates, "Close": prices})
+            mock_kline.side_effect = _make_kline
+            raw, alpha, days = TradingAgentsGraph._fetch_returns(
+                mock_graph, "600036.SS", "2026-01-05", benchmark="000001.SS"
+            )
         assert raw is not None and alpha is not None and days is not None
         assert days == 2
 

--- a/tests/test_no_data_handling.py
+++ b/tests/test_no_data_handling.py
@@ -14,7 +14,7 @@ from unittest import mock
 import pandas as pd
 import pytest
 
-from tradingagents.dataflows import interface, stockstats_utils
+from tradingagents.dataflows import interface, sina_market, stockstats_utils
 from tradingagents.dataflows.config import set_config
 from tradingagents.dataflows.symbol_utils import NoMarketDataError
 
@@ -33,16 +33,19 @@ class TestLoadOhlcvNoPoison(unittest.TestCase):
 
     def test_empty_download_raises_and_does_not_cache(self):
         empty = pd.DataFrame()
-        with mock.patch.object(stockstats_utils.yf, "download", return_value=empty), \
-                self.assertRaises(NoMarketDataError):
-            stockstats_utils.load_ohlcv("FAKE", "2026-01-01")
+        with mock.patch.object(
+            sina_market, "load_sina_ohlcv", return_value=empty
+        ), self.assertRaises(NoMarketDataError):
+            stockstats_utils.load_ohlcv("600036.SS", "2026-01-01")
         # Nothing should have been written to the cache.
         self.assertEqual(os.listdir(self._tmp), [])
 
         # A second call must re-attempt the fetch (no poisoned cache served).
-        with mock.patch.object(stockstats_utils.yf, "download", return_value=empty) as dl2:
+        with mock.patch.object(
+            sina_market, "load_sina_ohlcv", return_value=empty
+        ) as dl2:
             with self.assertRaises(NoMarketDataError):
-                stockstats_utils.load_ohlcv("FAKE", "2026-01-01")
+                stockstats_utils.load_ohlcv("600036.SS", "2026-01-01")
             self.assertTrue(dl2.called)
 
 
@@ -50,18 +53,17 @@ class TestLoadOhlcvNoPoison(unittest.TestCase):
 class TestRouteToVendorSentinel(unittest.TestCase):
     def test_no_data_from_all_vendors_returns_sentinel(self):
         def raises_no_data(symbol, *a, **k):
-            raise NoMarketDataError(symbol, "GC=F", "no rows")
+            raise NoMarketDataError(symbol, symbol, "no rows")
 
-        patched = {"yfinance": raises_no_data, "alpha_vantage": raises_no_data}
+        patched = {"sina": raises_no_data, "alpha_vantage": raises_no_data}
         with mock.patch.dict(
             interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
         ):
             result = interface.route_to_vendor(
-                "get_stock_data", "XAUUSD+", "2026-01-01", "2026-01-10"
+                "get_stock_data", "600036.SS", "2026-01-01", "2026-01-10"
             )
         self.assertIn("NO_DATA_AVAILABLE", result)
-        self.assertIn("XAUUSD+", result)
-        self.assertIn("GC=F", result)
+        self.assertIn("600036.SS", result)
         self.assertIn("Do not estimate", result)
 
     def test_unconfigured_fallback_does_not_mask_no_data(self):
@@ -74,12 +76,12 @@ class TestRouteToVendorSentinel(unittest.TestCase):
         def raises_unavailable(symbol, *a, **k):
             raise ValueError("ALPHA_VANTAGE_API_KEY environment variable is not set.")
 
-        patched = {"yfinance": raises_no_data, "alpha_vantage": raises_unavailable}
+        patched = {"sina": raises_no_data, "alpha_vantage": raises_unavailable}
         with mock.patch.dict(
             interface.VENDOR_METHODS, {"get_stock_data": patched}, clear=False
         ):
             result = interface.route_to_vendor(
-                "get_stock_data", "FAKE", "2026-01-01", "2026-01-10"
+                "get_stock_data", "600036.SS", "2026-01-01", "2026-01-10"
             )
         self.assertIn("NO_DATA_AVAILABLE", result)
 

--- a/tests/test_ohlcv_cache_freshness.py
+++ b/tests/test_ohlcv_cache_freshness.py
@@ -77,15 +77,17 @@ def test_load_ohlcv_refetches_stale_same_day_cache(tmp_path, monkeypatch):
 
     calls = []
 
-    def _fake_download(*a, **k):
+    def _fake_load_sina(symbol, curr_date, datalen=1023):
         calls.append(1)
         return pd.DataFrame(
             {"Date": pd.to_datetime(["2026-07-17", "2026-07-18"]), "Close": [100.0, 222.0]}
-        ).set_index("Date")
+        )
 
-    monkeypatch.setattr(su.yf, "download", _fake_download)
+    monkeypatch.setattr(
+        "tradingagents.dataflows.sina_market.load_sina_ohlcv", _fake_load_sina
+    )
 
-    out = su.load_ohlcv("AAPL", TODAY.strftime("%Y-%m-%d"))
+    out = su.load_ohlcv("600036.SS", TODAY.strftime("%Y-%m-%d"))
 
     assert calls, "stale same-day cache must trigger a refetch"
     assert 222.0 in out["Close"].values, "refreshed close must reach the caller"

--- a/tests/test_structured_agent_prompts.py
+++ b/tests/test_structured_agent_prompts.py
@@ -110,9 +110,8 @@ def test_sentiment_prompt_states_constraint(monkeypatch):
     from tradingagents.agents.schemas import SentimentBand, SentimentReport
 
     # Pre-fetched sources are stubbed so the prompt builds without network I/O.
-    monkeypatch.setattr(sentiment, "fetch_stocktwits_messages", lambda *a, **k: "st")
-    monkeypatch.setattr(sentiment, "fetch_reddit_posts", lambda *a, **k: "rd")
-    monkeypatch.setattr(sentiment.get_news, "func", lambda *a, **k: "news", raising=False)
+    monkeypatch.setattr(sentiment, "fetch_sina_news", lambda *a, **k: "news")
+    monkeypatch.setattr(sentiment, "fetch_eastmoney_guba", lambda *a, **k: "guba")
 
     captured = {}
     llm = _capturing_llm(captured, SentimentReport(
@@ -121,7 +120,7 @@ def test_sentiment_prompt_states_constraint(monkeypatch):
     ))
     sentiment.create_sentiment_analyst(llm)({
         "company_of_interest": "NVDA", "trade_date": "2026-01-15",
-        "asset_type": "stock", "messages": [],
+        "asset_type": "stock", "sentiment_messages": [],
     })
     text = _prompt_text(captured["prompt"])
     assert NO_EXTERNAL_TOOLS in text

--- a/tests/test_structured_agents.py
+++ b/tests/test_structured_agents.py
@@ -343,7 +343,7 @@ def _make_sentiment_state():
         "company_of_interest": "NVDA",
         "trade_date": "2026-01-15",
         "asset_type": "stock",
-        "messages": [],
+        "sentiment_messages": [],
     }
 
 
@@ -383,8 +383,8 @@ class TestSentimentAnalystAgent:
         captured = {}
         analyst = create_sentiment_analyst(_structured_sentiment_llm(captured))
         result = analyst(_make_sentiment_state())
-        assert len(result["messages"]) == 1
-        assert result["sentiment_report"] == result["messages"][0].content
+        assert len(result["sentiment_messages"]) == 1
+        assert result["sentiment_report"] == result["sentiment_messages"][0].content
 
     def test_prompt_contains_ticker(self):
         captured = {}

--- a/tests/test_symbol_normalization_paths.py
+++ b/tests/test_symbol_normalization_paths.py
@@ -16,15 +16,13 @@ from tradingagents.graph.trading_graph import TradingAgentsGraph
 def test_identity_lookup_normalizes_symbol(monkeypatch):
     seen = {}
 
-    class FakeTicker:
-        def __init__(self, symbol):
-            seen["symbol"] = symbol
+    def fake_survey(symbol):
+        seen["symbol"] = symbol
+        return {"company_name": "Gold Futures", "industry": "Commodities"}
 
-        @property
-        def info(self):
-            return {"longName": "Gold Futures", "quoteType": "FUTURE"}
-
-    monkeypatch.setattr(au.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr(
+        "tradingagents.dataflows.eastmoney_finance.resolve_company_survey", fake_survey
+    )
     au.resolve_instrument_identity.cache_clear()
 
     identity = au.resolve_instrument_identity("XAUUSD")
@@ -36,22 +34,30 @@ def test_identity_lookup_normalizes_symbol(monkeypatch):
 def test_fetch_returns_normalizes_symbol(monkeypatch):
     queried = []
 
-    class FakeTicker:
-        def __init__(self, symbol):
-            queried.append(symbol)
+    def fake_sina_symbol(symbol):
+        queried.append(symbol)
+        return symbol  # identity mapping keeps the benchmark symbol visible
 
-        def history(self, *args, **kwargs):
-            return pd.DataFrame({"Close": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0]})
+    def fake_kline(sina_symbol, datalen=1023):
+        idx = pd.to_datetime(["2026-01-05", "2026-01-06", "2026-01-07"])
+        return pd.DataFrame(
+            {"Date": idx, "Close": [100.0, 101.0, 102.0]}
+        )
 
-    monkeypatch.setattr(tg.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr(
+        "tradingagents.dataflows.sina_market._sina_symbol", fake_sina_symbol
+    )
+    monkeypatch.setattr(
+        "tradingagents.dataflows.sina_market.fetch_sina_kline", fake_kline
+    )
 
     # _fetch_returns does not use ``self``; call unbound to avoid building the graph.
     raw, alpha, days = TradingAgentsGraph._fetch_returns(
-        None, "XAUUSD", "2025-01-02", holding_days=5, benchmark="SPY"
+        None, "600036.SS", "2026-01-05", holding_days=5, benchmark="000001.SS"
     )
 
-    assert queried[0] == "GC=F"  # stock symbol normalized (#984)
-    assert queried[1] == "SPY"   # benchmark left as the canonical symbol
+    assert queried[0] == "600036.SS"  # stock symbol passed to the domestic provider
+    assert queried[1] == "000001.SS"  # benchmark left as the canonical symbol
     assert raw is not None and days is not None
 
 

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -9,8 +9,14 @@ from tradingagents.agents.utils.agent_utils import (
     get_language_instruction,
 )
 
+# Upper bound on agent -> tools -> agent rounds inside the analyst branch.
+# The branch is now a single self-contained node (so the four analysts can run
+# concurrently and converge once), and this cap keeps a tool-happy model from
+# looping forever.
+MAX_ANALYST_TOOL_ROUNDS = 8
 
-def create_fundamentals_analyst(llm):
+
+def create_fundamentals_analyst(llm, tool_node=None):
     def fundamentals_analyst_node(state):
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
@@ -43,7 +49,7 @@ def create_fundamentals_analyst(llm):
                     " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
                     "{system_message}",
                 ),
-                MessagesPlaceholder(variable_name="messages"),
+                MessagesPlaceholder(variable_name="fundamentals_messages"),
             ]
         )
 
@@ -54,15 +60,27 @@ def create_fundamentals_analyst(llm):
 
         chain = prompt | llm.bind_tools(tools)
 
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Self-contained branch loop: run the LLM, execute any tool calls it
+        # requests via the branch ToolNode, and repeat until it produces a
+        # final report (or the round cap is hit).
+        messages = list(state["fundamentals_messages"])
+        result = None
+        for _ in range(MAX_ANALYST_TOOL_ROUNDS):
+            result = chain.invoke(messages)
+            if not getattr(result, "tool_calls", None):
+                break
+            if tool_node is None:
+                break
+            # ToolNode returns only the newly produced ToolMessages; append
+            # them to the running history so the next LLM round still sees the
+            # preceding AIMessage(tool_calls) that each ToolMessage answers.
+            messages = messages + [result]
+            output = tool_node.invoke({"fundamentals_messages": messages})
+            messages = messages + list(output["fundamentals_messages"])
+        report = result.content if result is not None else ""
 
         return {
-            "messages": [result],
+            "fundamentals_messages": messages,
             "fundamentals_report": report,
         }
 

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -8,9 +8,14 @@ from tradingagents.agents.utils.agent_utils import (
     get_verified_market_snapshot,
 )
 
+# Upper bound on agent -> tools -> agent rounds inside the analyst branch. The
+# branch is now a single self-contained node (so the four analysts can run
+# concurrently and converge once), and this cap keeps a tool-happy model from
+# looping forever.
+MAX_ANALYST_TOOL_ROUNDS = 8
 
-def create_market_analyst(llm):
 
+def create_market_analyst(llm, tool_node=None):
     def market_analyst_node(state):
         current_date = state["trade_date"]
         instrument_context = get_instrument_context_from_state(state)
@@ -69,7 +74,7 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
                     " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
                     "{system_message}",
                 ),
-                MessagesPlaceholder(variable_name="messages"),
+                MessagesPlaceholder(variable_name="market_messages"),
             ]
         )
 
@@ -80,15 +85,27 @@ Write a very detailed and nuanced report of the trends you observe. Provide spec
 
         chain = prompt | llm.bind_tools(tools)
 
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Self-contained branch loop: run the LLM, execute any tool calls it
+        # requests via the branch ToolNode, and repeat until it produces a
+        # final report (or the round cap is hit).
+        messages = list(state["market_messages"])
+        result = None
+        for _ in range(MAX_ANALYST_TOOL_ROUNDS):
+            result = chain.invoke(messages)
+            if not getattr(result, "tool_calls", None):
+                break
+            if tool_node is None:
+                break
+            # ToolNode returns only the newly produced ToolMessages; append
+            # them to the running history so the next LLM round still sees the
+            # preceding AIMessage(tool_calls) that each ToolMessage answers.
+            messages = messages + [result]
+            output = tool_node.invoke({"market_messages": messages})
+            messages = messages + list(output["market_messages"])
+        report = result.content if result is not None else ""
 
         return {
-            "messages": [result],
+            "market_messages": messages,
             "market_report": report,
         }
 

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -9,8 +9,14 @@ from tradingagents.agents.utils.agent_utils import (
     get_prediction_markets,
 )
 
+# Upper bound on agent -> tools -> agent rounds inside the analyst branch.
+# The branch is now a single self-contained node (so the four analysts can run
+# concurrently and converge once), and this cap keeps a tool-happy model from
+# looping forever.
+MAX_ANALYST_TOOL_ROUNDS = 8
 
-def create_news_analyst(llm):
+
+def create_news_analyst(llm, tool_node=None):
     def news_analyst_node(state):
         current_date = state["trade_date"]
         asset_type = state.get("asset_type", "stock")
@@ -44,7 +50,7 @@ def create_news_analyst(llm):
                     " Today's date is {current_date}; treat it as 'now' for all analysis and tool-call date ranges. {instrument_context}\n"
                     "{system_message}",
                 ),
-                MessagesPlaceholder(variable_name="messages"),
+                MessagesPlaceholder(variable_name="news_messages"),
             ]
         )
 
@@ -54,15 +60,27 @@ def create_news_analyst(llm):
         prompt = prompt.partial(instrument_context=instrument_context)
 
         chain = prompt | llm.bind_tools(tools)
-        result = chain.invoke(state["messages"])
-
-        report = ""
-
-        if len(result.tool_calls) == 0:
-            report = result.content
+        # Self-contained branch loop: run the LLM, execute any tool calls it
+        # requests via the branch ToolNode, and repeat until it produces a
+        # final report (or the round cap is hit).
+        messages = list(state["news_messages"])
+        result = None
+        for _ in range(MAX_ANALYST_TOOL_ROUNDS):
+            result = chain.invoke(messages)
+            if not getattr(result, "tool_calls", None):
+                break
+            if tool_node is None:
+                break
+            # ToolNode returns only the newly produced ToolMessages; append
+            # them to the running history so the next LLM round still sees the
+            # preceding AIMessage(tool_calls) that each ToolMessage answers.
+            messages = messages + [result]
+            output = tool_node.invoke({"news_messages": messages})
+            messages = messages + list(output["news_messages"])
+        report = result.content if result is not None else ""
 
         return {
-            "messages": [result],
+            "news_messages": messages,
             "news_report": report,
         }
 

--- a/tradingagents/agents/analysts/sentiment_analyst.py
+++ b/tradingagents/agents/analysts/sentiment_analyst.py
@@ -1,17 +1,11 @@
 """Sentiment analyst — multi-source sentiment analysis for a target ticker.
 
-Previously named ``social_media_analyst``. Renamed and redesigned because
-the old version had a prompt that demanded social-media analysis but the
-only tool available was Yahoo Finance news — which led LLMs to fabricate
-Reddit/X/StockTwits content under prompt pressure (verified live).
+The agent pre-fetches Chinese-platform data sources before the LLM is
+invoked and injects them into the prompt as structured blocks:
 
-The redesigned agent pre-fetches three complementary data sources before
-the LLM is invoked and injects them into the prompt as structured blocks:
-
-  1. News headlines     — Yahoo Finance (institutional framing)
-  2. StockTwits messages — retail-trader posts indexed by cashtag, with
-                           user-labeled Bullish/Bearish sentiment tags
-  3. Reddit posts        — r/wallstreetbets, r/stocks, r/investing
+  1. Sina Finance stock news — Chinese news-channel framing
+  2. Eastmoney Guba (股吧)     — A-share retail community posts with
+                                read/reply engagement counts
 
 The agent does not use tool-calling; the data is in the prompt from
 turn 0. Output uses the structured-output pattern (json_schema for
@@ -33,15 +27,16 @@ from tradingagents.agents.schemas import SentimentReport, render_sentiment_repor
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
-    get_news,
 )
 from tradingagents.agents.utils.structured import (
     NO_EXTERNAL_TOOLS,
     bind_structured,
     invoke_structured_or_freetext,
 )
-from tradingagents.dataflows.reddit import fetch_reddit_posts
-from tradingagents.dataflows.stocktwits import fetch_stocktwits_messages
+from tradingagents.dataflows.china_sentiment import (
+    fetch_eastmoney_guba,
+    fetch_sina_news,
+)
 
 
 def _seven_days_back(trade_date: str) -> str:
@@ -51,7 +46,7 @@ def _seven_days_back(trade_date: str) -> str:
 def create_sentiment_analyst(llm):
     """Create a sentiment analyst node for the trading graph.
 
-    Pre-fetches news + StockTwits + Reddit data, injects them into the
+    Pre-fetches Sina Finance news + Eastmoney Guba data, injects them into the
     prompt as structured blocks, and produces a deterministic sentiment
     report via structured output (with a free-text fallback for providers
     that do not support it).
@@ -64,20 +59,20 @@ def create_sentiment_analyst(llm):
         start_date = _seven_days_back(end_date)
         instrument_context = get_instrument_context_from_state(state)
 
-        # Pre-fetch all three sources. Each fetcher degrades gracefully and
+        # Pre-fetch all sources. Each fetcher degrades gracefully and
         # returns a string (no exceptions surface from here), so the LLM
         # always sees something — either real data or a clear placeholder.
-        news_block = get_news.func(ticker, start_date, end_date)
-        stocktwits_block = fetch_stocktwits_messages(ticker, limit=30)
-        reddit_block = fetch_reddit_posts(ticker)
+        news_block = fetch_sina_news(
+            ticker, start_date=start_date, end_date=end_date
+        )
+        guba_block = fetch_eastmoney_guba(ticker, limit=30)
 
         system_message = _build_system_message(
             ticker=ticker,
             start_date=start_date,
             end_date=end_date,
             news_block=news_block,
-            stocktwits_block=stocktwits_block,
-            reddit_block=reddit_block,
+            guba_block=guba_block,
         )
 
         prompt = ChatPromptTemplate.from_messages(
@@ -105,7 +100,7 @@ def create_sentiment_analyst(llm):
         # Format the template into a concrete message list so the structured
         # and free-text paths receive the same input. No bind_tools — the
         # data is already in the prompt.
-        formatted_messages = prompt.format_messages(messages=state["messages"])
+        formatted_messages = prompt.format_messages(messages=state["sentiment_messages"])
 
         report_text = invoke_structured_or_freetext(
             structured_llm,
@@ -116,7 +111,7 @@ def create_sentiment_analyst(llm):
         )
 
         return {
-            "messages": [AIMessage(content=report_text)],
+            "sentiment_messages": [AIMessage(content=report_text)],
             "sentiment_report": report_text,
         }
 
@@ -129,52 +124,44 @@ def _build_system_message(
     start_date: str,
     end_date: str,
     news_block: str,
-    stocktwits_block: str,
-    reddit_block: str,
+    guba_block: str,
 ) -> str:
     """Assemble the sentiment-analyst system message with structured data blocks."""
-    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on three complementary data sources that have already been collected for you.
+    return f"""You are a financial market sentiment analyst. Your task is to produce a comprehensive sentiment report for {ticker} covering the period from {start_date} to {end_date}, drawing on the Chinese data sources that have already been collected for you.
 
 ## Data sources (pre-fetched, in this prompt)
 
-### News headlines — Yahoo Finance, past 7 days
-Institutional framing. Fact-driven, slower-moving signal.
+### Sina Finance stock news — Chinese news channel, past 7 days
+News-channel framing from Chinese financial media. Fact-driven, slower-moving signal. These are news articles, not stock-market quotes.
 
 <start_of_news>
 {news_block}
 <end_of_news>
 
-### StockTwits messages — retail-trader social platform indexed by cashtag
-Fast-moving signal. Each message carries a user-labeled sentiment tag (Bullish / Bearish / no-label) plus the message body.
+### Eastmoney Guba (股吧) — A-share retail investor community
+Fast-moving retail signal. Each post carries a read count and a reply count; higher engagement means more community attention. Sample size matters — base your read on the actual number of posts, not just percentages.
 
-<start_of_stocktwits>
-{stocktwits_block}
-<end_of_stocktwits>
-
-### Reddit posts — r/wallstreetbets, r/stocks, r/investing (past 7 days)
-Community discussion. Engagement signal via upvote score and comment count. Subreddit character matters (r/wallstreetbets is often contrarian/exuberant; r/stocks more measured; r/investing longer-term).
-
-<start_of_reddit>
-{reddit_block}
-<end_of_reddit>
+<start_of_guba>
+{guba_block}
+<end_of_guba>
 
 ## How to analyze this data (best practices)
 
-1. **Read the StockTwits Bullish/Bearish ratio as a leading retail-sentiment signal.** A 70/30 bullish/bearish split is moderately bullish; ≥90/10 may indicate over-extension and contrarian risk; 50/50 is uncertainty. Sample size matters — base rates on the actual message count, not percentages alone.
+1. **Read the Guba post density and reply/read ratios as a leading retail-sentiment signal.** A hot post with many replies and reads reflects real retail attention; a handful of low-engagement posts is noise. Distinguish "bullish chatter" from "bearish panic" and note the actual post count.
 
-2. **Look for cross-source divergences.** If news framing is bearish but StockTwits is overwhelmingly bullish, that mismatch is itself a signal — it can mean retail is leaning into a thesis the news flow hasn't caught up to (or vice versa, that retail is chasing while institutions are cautious).
+2. **Look for cross-source divergences.** If Chinese news framing is bearish but Guba is overwhelmingly bullish, that mismatch is itself a signal — it can mean retail is leaning into a thesis the news flow hasn't caught up to (or vice versa, that retail is chasing while institutions are cautious).
 
-3. **Weight Reddit posts by engagement.** A 400-upvote / 200-comment thread reflects community attention; a 3-upvote post is noise. Read the body excerpts for context — the title alone often misleads.
+3. **Weight Guba posts by engagement.** A post with hundreds of replies reflects community attention; a post with zero replies is noise. Read the title and author context carefully.
 
-4. **Distinguish opinion from event.** A news headline ("Nvidia announces $500M Corning deal") is an event; a StockTwits post ("buying NVDA, this is going to moon") is opinion. Both are inputs but should be weighted differently in your conclusions.
+4. **Distinguish opinion from event.** A Chinese news headline about a company announcement is an event; a Guba post expressing a bullish/bearish view is opinion. Both are inputs but should be weighted differently in your conclusions.
 
 5. **Identify recurring narrative themes.** What topic keeps coming up across sources? That's the dominant narrative driving current sentiment.
 
-6. **Be honest about data limits.** If StockTwits returned only a handful of messages, or one or more sources returned an "<unavailable>" placeholder, the sentiment read is less robust — flag this explicitly in the `confidence` field and the narrative. If the sources are silent on a given subreddit, say so.
+6. **Be honest about data limits.** If Guba returned only a handful of posts, or one or more sources returned an "<unavailable>" placeholder, the sentiment read is less robust — flag this explicitly in the `confidence` field and the narrative. If the news channel is silent, say so.
 
 7. **Identify catalysts and risks** that emerge across sources — news of upcoming earnings, product launches, competitive threats, macro headlines, etc.
 
-8. **Past sentiment is not predictive.** Frame your conclusions as signal for the trader to weigh alongside fundamentals and technicals, not as a price call.
+8. **Past sentiment is not predictive.** Frame your conclusions as signal for the trader to weigh alongside fundamentals, technicals, and Chinese news channels, not as a price call.
 
 ## Output fields
 

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -1,7 +1,7 @@
 """Backwards-compatibility shim for the renamed module.
 
-The agent is now ``sentiment_analyst`` and aggregates Yahoo Finance news,
-StockTwits cashtag streams, and Reddit posts into a single sentiment
+The agent is now ``sentiment_analyst`` and aggregates Chinese news and
+community data (Sina Finance news + Eastmoney Guba) into a single sentiment
 report. Import from ``tradingagents.agents.analysts.sentiment_analyst``
 going forward; this module will be removed in a future release.
 

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 from langgraph.graph import MessagesState
+from langgraph.graph.message import add_messages
 from typing_extensions import TypedDict
 
 
@@ -51,6 +52,16 @@ class AgentState(MessagesState):
     trade_date: Annotated[str, "What date we are trading at"]
 
     sender: Annotated[str, "Agent that sent this message"]
+
+    # Per-analyst message channels. The four analysts are independent: each has
+    # its own agent -> tools -> agent loop, and the branches run concurrently
+    # from START. Keeping the message history in per-analyst channels (instead
+    # of one shared list) makes routing and tool execution branch-safe — a
+    # router or ToolNode never sees another branch's messages.
+    market_messages: Annotated[list, add_messages]
+    sentiment_messages: Annotated[list, add_messages]
+    news_messages: Annotated[list, add_messages]
+    fundamentals_messages: Annotated[list, add_messages]
 
     # research step
     market_report: Annotated[str, "Report from the Market Analyst"]

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -3,7 +3,6 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-import yfinance as yf
 from langchain_core.messages import HumanMessage, RemoveMessage
 
 # Import tools from separate utility files
@@ -85,7 +84,7 @@ def resolve_instrument_identity(ticker: str) -> dict:
     the price action to a narrative and invent an identity that then cascaded
     through every downstream agent.
 
-    Best-effort by design: if yfinance is unavailable, rate-limited, or doesn't
+    Best-effort by design: if the domestic provider is unavailable or doesn't
     recognise the ticker, we return ``{}`` and the caller falls back to
     ticker-only context rather than failing before analysis starts. Cached so
     the lookup happens at most once per ticker per process.
@@ -93,29 +92,28 @@ def resolve_instrument_identity(ticker: str) -> dict:
     The symbol is normalized first (e.g. ``XAUUSD`` -> ``GC=F``) so identity
     resolves for the same instrument the price path actually fetches (#983).
     """
+    from tradingagents.dataflows.eastmoney_finance import resolve_company_survey
     from tradingagents.dataflows.symbol_utils import normalize_symbol
 
     try:
-        info = yf.Ticker(normalize_symbol(ticker)).info or {}
+        info = resolve_company_survey(normalize_symbol(ticker))
     except Exception as exc:  # noqa: BLE001 — fail open, never block the run
         logger.debug("Could not resolve instrument identity for %s: %s", ticker, exc)
         return {}
 
     identity: dict[str, str] = {}
-    company_name = _clean_identity_value(info.get("longName")) or _clean_identity_value(
-        info.get("shortName")
-    )
+    company_name = _clean_identity_value(info.get("company_name"))
     if company_name:
         identity["company_name"] = company_name
-    for source_key, target_key in (
-        ("sector", "sector"),
-        ("industry", "industry"),
-        ("exchange", "exchange"),
-        ("quoteType", "quote_type"),
-    ):
-        value = _clean_identity_value(info.get(source_key))
-        if value:
-            identity[target_key] = value
+    industry = _clean_identity_value(info.get("industry"))
+    if industry:
+        identity["industry"] = industry
+        sector = industry.split("-", 1)[0].strip()
+        if sector:
+            identity["sector"] = sector
+    exchange = _clean_identity_value(info.get("exchange"))
+    if exchange:
+        identity["exchange"] = exchange
     return identity
 
 

--- a/tradingagents/dataflows/akshare_finance.py
+++ b/tradingagents/dataflows/akshare_finance.py
@@ -1,0 +1,101 @@
+"""akshare-based finance vendor for A-share statements and insider changes."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+import pandas as pd
+
+from .errors import NoMarketDataError
+
+logger = logging.getLogger(__name__)
+
+
+def _sina_stock_symbol(ticker: str) -> str | None:
+    match = re.search(r"(\d{6})", ticker)
+    if not match:
+        return None
+    code = match.group(1)
+    upper = ticker.upper()
+    if upper.endswith((".SS", ".SH")) or code.startswith(("5", "6", "9")):
+        return f"sh{code}"
+    return f"sz{code}"
+
+
+def _code(ticker: str) -> str | None:
+    match = re.search(r"(\d{6})", ticker)
+    return match.group(1) if match else None
+
+
+def _filter_statement(df: pd.DataFrame, freq: str, curr_date: str | None) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+    date_col = next((c for c in df.columns if "报告日" in str(c)), None)
+    if not date_col:
+        return df
+    df = df.copy()
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+    if curr_date:
+        df = df[df[date_col] <= pd.to_datetime(curr_date)]
+    if freq.lower() == "annual":
+        df = df[df[date_col].dt.strftime("%m-%d") == "12-31"]
+    return df.sort_values(date_col, ascending=False)
+
+
+def _sina_statement(ticker: str, symbol: str, freq: str, curr_date: str | None) -> str:
+    sina_symbol = _sina_stock_symbol(ticker)
+    if not sina_symbol:
+        raise NoMarketDataError(ticker, ticker, "akshare supports A-shares only")
+    try:
+        import akshare as ak
+
+        df = ak.stock_financial_report_sina(stock=sina_symbol, symbol=symbol)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("akshare %s fetch failed for %s: %s", symbol, ticker, exc)
+        raise NoMarketDataError(
+            ticker, ticker, f"akshare {symbol} unavailable"
+        ) from exc
+
+    df = _filter_statement(df, freq, curr_date)
+    if df is None or df.empty:
+        raise NoMarketDataError(ticker, ticker, f"akshare returned no {symbol} rows")
+
+    header = f"# {symbol} data for {ticker} ({freq}) via akshare/Sina\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    return header + df.to_csv(index=False)
+
+
+def get_balance_sheet(ticker: str, freq: str = "quarterly", curr_date: str | None = None) -> str:
+    return _sina_statement(ticker, "资产负债表", freq, curr_date)
+
+
+def get_cashflow(ticker: str, freq: str = "quarterly", curr_date: str | None = None) -> str:
+    return _sina_statement(ticker, "现金流量表", freq, curr_date)
+
+
+def get_income_statement(ticker: str, freq: str = "quarterly", curr_date: str | None = None) -> str:
+    return _sina_statement(ticker, "利润表", freq, curr_date)
+
+
+def get_insider_transactions(ticker: str) -> str:
+    code = _code(ticker)
+    if not code:
+        raise NoMarketDataError(ticker, ticker, "akshare insider supports A-shares only")
+    try:
+        import akshare as ak
+
+        if code.startswith(("6", "5", "9")):
+            df = ak.stock_share_hold_change_sse(symbol=code)
+        else:
+            df = ak.stock_share_hold_change_szse(symbol=code)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("akshare insider fetch failed for %s: %s", ticker, exc)
+        return f"暂无 akshare 高管/股东变动数据（{ticker}）。"
+
+    if df is None or df.empty:
+        return f"暂无 akshare 高管/股东变动数据（{ticker}）。"
+    header = f"# 高管/股东变动数据 for {ticker} via akshare\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    return header + df.to_csv(index=False)

--- a/tradingagents/dataflows/china_sentiment.py
+++ b/tradingagents/dataflows/china_sentiment.py
@@ -1,0 +1,182 @@
+"""Chinese-platform sentiment fetchers for A-share instruments.
+
+Replaces the US-centric StockTwits / Reddit / Yahoo Finance news sources in
+the sentiment analyst. A-share retail discussion and company news are
+concentrated on Chinese platforms, so the agent now reads:
+
+  1. Sina Finance stock-news page  -- institutional / news-channel framing
+  2. Eastmoney Guba (股吧)          -- retail community posts with read/reply
+                                       counts
+
+Both endpoints are public and keyless. Each fetcher degrades gracefully and
+returns a plaintext block (or a clear placeholder), so the calling agent
+never has to special-case network failures.
+"""
+
+from __future__ import annotations
+
+import html
+import http.client
+import logging
+import re
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from parsel import Selector
+
+from .symbol_utils import crypto_base
+
+logger = logging.getLogger(__name__)
+
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "Chrome/124 Safari/537.36"
+)
+_GUBA_URL = "https://guba.eastmoney.com/list,{code},f.html"
+_SINA_NEWS_URL = (
+    "https://vip.stock.finance.sina.com.cn/corp/go.php/"
+    "vCB_AllNewsStock/symbol/{symbol}.phtml"
+)
+
+
+def _a_share_code(ticker: str) -> str | None:
+    """Extract the bare 6-digit A-share code, or None for non-A-shares."""
+    if crypto_base(ticker):
+        return None
+    match = re.search(r"(\d{6})", ticker)
+    return match.group(1) if match else None
+
+
+def _sina_symbol(ticker: str) -> str | None:
+    """Map an A-share ticker to Sina's ``sh600036`` / ``sz000021`` form."""
+    code = _a_share_code(ticker)
+    if not code:
+        return None
+    upper = ticker.upper()
+    if upper.endswith(".SS") or upper.endswith(".SH"):
+        prefix = "sh"
+    elif upper.endswith(".SZ"):
+        prefix = "sz"
+    else:
+        prefix = "sh" if code.startswith(("5", "6", "9")) else "sz"
+    return f"{prefix}{code}"
+
+
+def _clean(value: str | None) -> str:
+    if not value:
+        return ""
+    return " ".join(html.unescape(value).split())
+
+
+def _fetch_bytes(url: str, referer: str | None = None, timeout: float = 15.0) -> bytes:
+    headers = {"User-Agent": _UA}
+    if referer:
+        headers["Referer"] = referer
+    return urlopen(Request(url, headers=headers), timeout=timeout).read()
+
+
+def fetch_eastmoney_guba(ticker: str, limit: int = 30, timeout: float = 15.0) -> str:
+    """Fetch recent Eastmoney Guba (股吧) posts for an A-share ticker.
+
+    Returns a formatted plaintext block with title, author, last-update time,
+    read count, and reply count. Falls back to a placeholder on any failure.
+    """
+    code = _a_share_code(ticker)
+    if not code:
+        return f"<东方财富股吧不可用于 {ticker}：目前只支持 A 股代码>"
+
+    url = _GUBA_URL.format(code=code)
+    try:
+        body = _fetch_bytes(url, referer="https://guba.eastmoney.com/", timeout=timeout)
+    except (OSError, http.client.HTTPException, HTTPError) as exc:
+        logger.warning("Eastmoney Guba fetch failed for %s: %s", ticker, exc)
+        return f"<东方财富股吧不可用: {type(exc).__name__}>"
+
+    sel = Selector(text=body.decode("utf-8", errors="replace"))
+    rows = sel.css(".listbody .listitem")
+    if not rows:
+        return f"<东方财富股吧暂无 {code} 的帖子>"
+
+    lines = []
+    for row in rows[:limit]:
+        title = _clean(row.css(".title a::text").get())
+        author = _clean(row.css(".author a::text").get())
+        update = _clean(row.css(".update::text").get())
+        read = _clean(row.css(".read::text").get())
+        reply = _clean(row.css(".reply::text").get())
+        lines.append(f"[{update} | 阅读{read} 评论{reply} | 作者:{author}] {title}")
+
+    return (
+        f"东方财富股吧 {code} 最近 {len(lines)} 条帖子：\n"
+        + "\n".join(lines)
+    )
+
+
+def _parse_sina_news_entries(body: str) -> list[tuple[str, str, str]]:
+    """Return ``(date_time, title, url)`` tuples from Sina's news list."""
+    block = body
+    start = block.find('class="datelist"')
+    if start >= 0:
+        block = block[start:]
+    pattern = re.compile(
+        r"(\d{4}-\d{2}-\d{2}(?:\s+|&nbsp;)+(\d{2}:\d{2}))"
+        r'(?:\s|&nbsp;)*<a[^>]*?href=[\'"]([^\'"]+)[\'"][^>]*>(.*?)</a>',
+        re.S,
+    )
+    entries = []
+    for match in pattern.finditer(block):
+        date_time, _time, url, title = match.groups()
+        entries.append((_clean(date_time), _clean(title), url.strip()))
+    return entries
+
+
+def fetch_sina_news(
+    ticker: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    limit: int = 20,
+    timeout: float = 15.0,
+) -> str:
+    """Fetch recent Sina Finance news for an A-share ticker.
+
+    ``start_date`` / ``end_date`` are optional ``YYYY-MM-DD`` bounds used to
+    filter the news list. Returns a formatted plaintext block, or a
+    placeholder on failure.
+    """
+    symbol = _sina_symbol(ticker)
+    if not symbol:
+        return f"<新浪财经新闻不可用于 {ticker}：目前只支持 A 股代码>"
+
+    url = _SINA_NEWS_URL.format(symbol=symbol)
+    try:
+        body = _fetch_bytes(url, timeout=timeout)
+    except (OSError, http.client.HTTPException, HTTPError) as exc:
+        logger.warning("Sina news fetch failed for %s: %s", ticker, exc)
+        return f"<新浪财经新闻不可用: {type(exc).__name__}>"
+
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        text = body.decode("gbk", errors="replace")
+
+    entries = _parse_sina_news_entries(text)
+    if start_date:
+        entries = [e for e in entries if e[0][:10] >= start_date]
+    if end_date:
+        entries = [e for e in entries if e[0][:10] <= end_date]
+    entries = entries[:limit]
+
+    if not entries:
+        window = (
+            f"（{start_date} 至 {end_date}）" if start_date or end_date else ""
+        )
+        return f"<新浪财经新闻在{window or '查询窗口'}内暂无 {symbol} 的新闻>"
+
+    lines = [f"[{date_time}] {title}\n    {url}" for date_time, title, url in entries]
+    window = (
+        f"（{start_date} 至 {end_date}）" if start_date or end_date else ""
+    )
+    return (
+        f"新浪财经新闻 {symbol} 最近 {len(lines)} 条{window}：\n"
+        + "\n".join(lines)
+    )

--- a/tradingagents/dataflows/eastmoney_finance.py
+++ b/tradingagents/dataflows/eastmoney_finance.py
@@ -1,0 +1,283 @@
+"""Eastmoney F10 finance vendor for A-share fundamentals and statements."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+import pandas as pd
+import requests
+
+from .errors import NoMarketDataError
+
+logger = logging.getLogger(__name__)
+
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "Chrome/124 Safari/537.36"
+)
+_F10_BASE = "https://emweb.securities.eastmoney.com/PC_HSF10"
+_SURVEY_URL = f"{_F10_BASE}/CompanySurvey/PageAjax"
+_FINANCE_URL = f"{_F10_BASE}/NewFinanceAnalysis/ZYZBAjaxNew"
+_STATEMENT_URLS = {
+    "balance": f"{_F10_BASE}/NewFinanceAnalysis/zcfzbAjaxNew",
+    "cashflow": f"{_F10_BASE}/NewFinanceAnalysis/xjllbAjaxNew",
+    "income": f"{_F10_BASE}/NewFinanceAnalysis/lrbAjaxNew",
+}
+
+_META_COLUMNS = {
+    "SECUCODE",
+    "SECURITY_CODE",
+    "SECURITY_NAME_ABBR",
+    "ORG_CODE",
+    "ORG_TYPE",
+    "SECURITY_TYPE_CODE",
+    "NOTICE_DATE",
+    "UPDATE_DATE",
+    "CURRENCY",
+    "REPORT_TYPE",
+    "REPORT_DATE_NAME",
+    "REPORT_YEAR",
+}
+
+
+def _em_code(ticker: str) -> str | None:
+    """Map an A-share ticker to Eastmoney's ``SZ000021`` / ``SH601665`` form."""
+    match = re.search(r"(\d{6})", ticker)
+    if not match:
+        return None
+    code = match.group(1)
+    upper = ticker.upper()
+    if upper.endswith(".SS") or upper.endswith(".SH") or code.startswith(("5", "6", "9")):
+        return f"SH{code}"
+    return f"SZ{code}"
+
+
+def _fetch_json(url: str, params: dict) -> dict:
+    last: Exception | None = None
+    for _ in range(3):
+        try:
+            resp = requests.get(
+                url,
+                params=params,
+                headers={"User-Agent": _UA, "Referer": "https://emweb.securities.eastmoney.com/"},
+                timeout=25,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except (requests.RequestException, ValueError) as exc:
+            last = exc
+            logger.warning("Eastmoney F10 request failed for %s: %s", params, exc)
+    raise NoMarketDataError(
+        str(params.get("code", "")),
+        str(params.get("code", "")),
+        f"Eastmoney F10 unavailable: {type(last).__name__}",
+    ) from last
+
+
+def _report_dates(ticker: str, freq: str, curr_date: str | None) -> list[str]:
+    code = _em_code(ticker)
+    if not code:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney finance supports A-shares only")
+
+    payload = _fetch_json(_FINANCE_URL, {"type": "0", "code": code})
+    rows = payload.get("data") or []
+    dates = []
+    for row in rows:
+        date_str = (row.get("REPORT_DATE") or "")[:10]
+        if not date_str:
+            continue
+        if freq.lower() == "annual" and not date_str.endswith("-12-31"):
+            continue
+        if curr_date and date_str > curr_date:
+            continue
+        dates.append(date_str)
+    return sorted(set(dates), reverse=True)[:4]
+
+
+def _statement_frame(
+    ticker: str,
+    statement: str,
+    freq: str,
+    curr_date: str | None,
+) -> tuple[pd.DataFrame, bool]:
+    code = _em_code(ticker)
+    if not code:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney finance supports A-shares only")
+
+    dates = _report_dates(ticker, freq, curr_date)
+    if not dates:
+        raise NoMarketDataError(ticker, code, "no report dates returned")
+
+    items = []
+    used_fallback = False
+    url = _STATEMENT_URLS[statement]
+    for date_str in dates:
+        rows = []
+        for company_type in ("8", "4", "1"):
+            payload = _fetch_json(
+                url,
+                {
+                    "companyType": company_type,
+                    "reportDateType": "0",
+                    "reportType": "1",
+                    "dates": date_str,
+                    "code": code,
+                },
+            )
+            rows = payload.get("data") or []
+            if rows:
+                break
+        if rows:
+            items.append(rows[0])
+
+    if not items:
+        # Banks and some financial companies do not expose the detailed
+        # statement through this endpoint; fall back to Eastmoney's main
+        # financial indicators so the tool still returns domestic data.
+        payload = _fetch_json(_FINANCE_URL, {"type": "0", "code": code})
+        fallback_rows = payload.get("data") or []
+        if freq.lower() == "annual":
+            fallback_rows = [
+                r for r in fallback_rows
+                if (r.get("REPORT_DATE") or "")[:10].endswith("-12-31")
+            ]
+        if curr_date:
+            fallback_rows = [
+                r for r in fallback_rows
+                if (r.get("REPORT_DATE") or "")[:10] <= curr_date
+            ]
+        fallback_rows = sorted(
+            fallback_rows,
+            key=lambda r: (r.get("REPORT_DATE") or ""),
+            reverse=True,
+        )[:4]
+        if not fallback_rows:
+            raise NoMarketDataError(ticker, code, "no statement rows returned")
+        items = fallback_rows
+        used_fallback = True
+
+    frame = pd.DataFrame(items)
+    frame = frame.drop(columns=[c for c in _META_COLUMNS if c in frame.columns], errors="ignore")
+    frame = frame.set_index("REPORT_DATE")
+    frame = frame.T
+    frame = frame.sort_index(axis=1)
+    return frame, used_fallback
+
+
+def _statement_csv(ticker: str, statement: str, freq: str, curr_date: str | None) -> str:
+    frame, fallback = _statement_frame(ticker, statement, freq, curr_date)
+    header = f"# {statement} data for {ticker} ({freq})\n"
+    if fallback:
+        header += "# 东方财富未提供该企业详细报表，以下为主要财务指标降级数据。\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    return header + frame.to_csv()
+
+
+def get_balance_sheet(
+    ticker: str,
+    freq: str = "quarterly",
+    curr_date: str | None = None,
+) -> str:
+    return _statement_csv(ticker, "balance", freq, curr_date)
+
+
+def get_cashflow(
+    ticker: str,
+    freq: str = "quarterly",
+    curr_date: str | None = None,
+) -> str:
+    return _statement_csv(ticker, "cashflow", freq, curr_date)
+
+
+def get_income_statement(
+    ticker: str,
+    freq: str = "quarterly",
+    curr_date: str | None = None,
+) -> str:
+    return _statement_csv(ticker, "income", freq, curr_date)
+
+
+def resolve_company_survey(ticker: str) -> dict:
+    """Resolve deterministic company identity metadata from Eastmoney."""
+    code = _em_code(ticker)
+    if not code:
+        return {}
+    try:
+        payload = _fetch_json(_SURVEY_URL, {"code": code})
+    except NoMarketDataError:
+        return {}
+    rows = payload.get("jbzl") or []
+    if not rows:
+        return {}
+    row = rows[0]
+    identity: dict[str, str] = {}
+    name = row.get("ORG_NAME") or row.get("SECURITY_NAME_ABBR")
+    if name:
+        identity["company_name"] = name
+    industry = row.get("EM2016") or row.get("INDUSTRYCSRC1")
+    if industry:
+        identity["industry"] = industry
+    if row.get("TRADE_MARKET"):
+        identity["exchange"] = row["TRADE_MARKET"]
+    return identity
+
+
+def get_fundamentals(ticker: str, curr_date: str | None = None) -> str:
+    """Return an A-share fundamentals overview from Eastmoney."""
+    code = _em_code(ticker)
+    if not code:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney finance supports A-shares only")
+
+    payload = _fetch_json(_FINANCE_URL, {"type": "2", "code": code})
+    rows = payload.get("data") or []
+    if not rows:
+        raise NoMarketDataError(ticker, code, "no fundamentals returned")
+
+    rows = sorted(rows, key=lambda r: (r.get("REPORT_DATE") or ""), reverse=True)
+    if curr_date:
+        rows = [r for r in rows if (r.get("REPORT_DATE") or "")[:10] <= curr_date]
+    if not rows:
+        raise NoMarketDataError(ticker, code, "no fundamentals on or before curr_date")
+    latest = rows[0]
+
+    survey = resolve_company_survey(ticker)
+    lines = [
+        f"Company: {survey.get('company_name', latest.get('SECURITY_NAME_ABBR', ticker))}",
+    ]
+    if survey.get("industry"):
+        lines.append(f"Industry: {survey['industry']}")
+    if survey.get("exchange"):
+        lines.append(f"Exchange: {survey['exchange']}")
+
+    fields = [
+        ("Report Date", latest.get("REPORT_DATE")),
+        ("EPS", latest.get("EPSJB")),
+        ("BPS", latest.get("BPS")),
+        ("Revenue", latest.get("TOTALOPERATEREVE")),
+        ("Gross Profit", latest.get("GROSS_PROFIT")),
+        ("Gross Margin", latest.get("GROSS_PROFIT_RATIO")),
+        ("Net Profit (parent)", latest.get("PARENTNETPROFIT")),
+        ("Net Margin", latest.get("NET_PROFIT_RATIO")),
+        ("Deducted Net Profit", latest.get("DEDU_PARENT_PROFIT")),
+        ("ROE (diluted)", latest.get("ROE_DILUTED")),
+        ("ROA", latest.get("JROA")),
+    ]
+    for label, value in fields:
+        if value is not None:
+            lines.append(f"{label}: {value}")
+
+    header = f"# Company Fundamentals for {code}\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    return header + "\n".join(lines)
+
+
+def get_insider_transactions(ticker: str) -> str:
+    """Insider transactions placeholder sourced from a domestic platform.
+
+    Eastmoney's public F10 feed does not expose a keyless insider-transaction
+    endpoint, so we return a clear sentinel instead of calling Yahoo.
+    """
+    code = _em_code(ticker) or ticker
+    return f"暂无东方财富高管增减持公开接口数据（{code}）。"

--- a/tradingagents/dataflows/fred.py
+++ b/tradingagents/dataflows/fred.py
@@ -69,6 +69,11 @@ MACRO_SERIES = {
     "consumer_sentiment": "UMCSENT",
     "housing_starts": "HOUST",
     "retail_sales": "RSAFS",
+    # International / China references the news agent occasionally reaches for.
+    "china_cpi": "CHNCPIALLMINMEI",
+    "chinese_cpi": "CHNCPIALLMINMEI",
+    "china_gdp": "CHNGDPNQDSMEI",
+    "chinese_gdp": "CHNGDPNQDSMEI",
 }
 
 
@@ -165,7 +170,20 @@ def get_macro_data(
     except ValueError as e:
         return f"FRED: {e}"
 
-    meta = _request("series", {"series_id": series_id}).get("seriess") or []
+    try:
+        meta = _request("series", {"series_id": series_id}).get("seriess") or []
+    except ValueError as exc:
+        # A well-formed but non-existent series ID is an input problem, not a
+        # transient FRED failure. Return guidance to the analyst instead of
+        # surfacing a noisy vendor warning and degrading the whole category.
+        if "series does not exist" in str(exc).lower():
+            return (
+                f"FRED series '{series_id}' not found for indicator '{indicator}'. "
+                "Use a known alias (e.g. 'cpi', 'core_pce', 'unemployment', "
+                "'fed_funds_rate', '10y_treasury', 'yield_curve', 'china_cpi') "
+                "or a valid FRED series ID."
+            )
+        raise
     if not meta:
         return (
             f"FRED series '{series_id}' not found. Pass a known alias "

--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -17,18 +17,27 @@ from .errors import (
     VendorNotConfiguredError,
     VendorRateLimitError,
 )
+from .akshare_finance import (
+    get_balance_sheet as get_akshare_balance_sheet,
+    get_cashflow as get_akshare_cashflow,
+    get_income_statement as get_akshare_income_statement,
+    get_insider_transactions as get_akshare_insider_transactions,
+)
+from .eastmoney_finance import (
+    get_balance_sheet as get_eastmoney_balance_sheet,
+    get_cashflow as get_eastmoney_cashflow,
+    get_fundamentals as get_eastmoney_fundamentals,
+    get_income_statement as get_eastmoney_income_statement,
+    get_insider_transactions as get_eastmoney_insider_transactions,
+)
 from .fred import get_macro_data as get_fred_macro_data
 from .polymarket import get_prediction_markets as get_polymarket_prediction_markets
-from .y_finance import (
-    get_balance_sheet as get_yfinance_balance_sheet,
-    get_cashflow as get_yfinance_cashflow,
-    get_fundamentals as get_yfinance_fundamentals,
-    get_income_statement as get_yfinance_income_statement,
-    get_insider_transactions as get_yfinance_insider_transactions,
-    get_stock_stats_indicators_window,
-    get_YFin_data_online,
+from .sina_market import (
+    get_indicators as get_sina_indicator,
+    get_stock_data as get_sina_stock_data,
 )
-from .yfinance_news import get_global_news_yfinance, get_news_yfinance
+from .sina_news import get_global_news as get_sina_global_news
+from .sina_news import get_news as get_sina_news
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +87,9 @@ TOOLS_CATEGORIES = {
 }
 
 VENDOR_LIST = [
-    "yfinance",
+    "sina",
+    "eastmoney",
+    "akshare",
     "fred",
     "polymarket",
     "alpha_vantage",
@@ -95,43 +106,47 @@ OPTIONAL_CATEGORIES = {"macro_data", "prediction_markets"}
 VENDOR_METHODS = {
     # core_stock_apis
     "get_stock_data": {
+        "sina": get_sina_stock_data,
         "alpha_vantage": get_alpha_vantage_stock,
-        "yfinance": get_YFin_data_online,
     },
     # technical_indicators
     "get_indicators": {
+        "sina": get_sina_indicator,
         "alpha_vantage": get_alpha_vantage_indicator,
-        "yfinance": get_stock_stats_indicators_window,
     },
     # fundamental_data
     "get_fundamentals": {
+        "eastmoney": get_eastmoney_fundamentals,
         "alpha_vantage": get_alpha_vantage_fundamentals,
-        "yfinance": get_yfinance_fundamentals,
     },
     "get_balance_sheet": {
+        "akshare": get_akshare_balance_sheet,
+        "eastmoney": get_eastmoney_balance_sheet,
         "alpha_vantage": get_alpha_vantage_balance_sheet,
-        "yfinance": get_yfinance_balance_sheet,
     },
     "get_cashflow": {
+        "akshare": get_akshare_cashflow,
+        "eastmoney": get_eastmoney_cashflow,
         "alpha_vantage": get_alpha_vantage_cashflow,
-        "yfinance": get_yfinance_cashflow,
     },
     "get_income_statement": {
+        "akshare": get_akshare_income_statement,
+        "eastmoney": get_eastmoney_income_statement,
         "alpha_vantage": get_alpha_vantage_income_statement,
-        "yfinance": get_yfinance_income_statement,
     },
     # news_data
     "get_news": {
+        "sina": get_sina_news,
         "alpha_vantage": get_alpha_vantage_news,
-        "yfinance": get_news_yfinance,
     },
     "get_global_news": {
-        "yfinance": get_global_news_yfinance,
+        "sina": get_sina_global_news,
         "alpha_vantage": get_alpha_vantage_global_news,
     },
     "get_insider_transactions": {
+        "akshare": get_akshare_insider_transactions,
+        "eastmoney": get_eastmoney_insider_transactions,
         "alpha_vantage": get_alpha_vantage_insider_transactions,
-        "yfinance": get_yfinance_insider_transactions,
     },
     # macro_data
     "get_macro_indicators": {

--- a/tradingagents/dataflows/sina_market.py
+++ b/tradingagents/dataflows/sina_market.py
@@ -1,0 +1,382 @@
+"""Sina Finance market-data vendor for A-share instruments.
+
+Provides the two core market-data tools the pipeline needs:
+
+  - ``get_stock_data``: daily OHLCV from Sina's public kline API
+  - ``get_indicators``: technical indicators computed from the same Sina OHLCV
+
+Non-A-share symbols raise :class:`NoMarketDataError` so the vendor router can
+fall back to the next configured vendor (e.g. yfinance).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import re
+from datetime import datetime
+
+import pandas as pd
+import requests
+from stockstats import wrap
+
+from .errors import NoMarketDataError
+
+logger = logging.getLogger(__name__)
+
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "Chrome/124 Safari/537.36"
+)
+_KLINE_URL = (
+    "https://money.finance.sina.com.cn/quotes_service/api/json_v2.php/"
+    "CN_MarketData.getKLineData"
+)
+_EM_KLINE_URL = "https://push2his.eastmoney.com/api/qt/stock/kline/get"
+_TX_KLINE_URL = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"
+
+BEST_IND_PARAMS = {
+    "close_50_sma": (
+        "50 SMA: A medium-term trend indicator. "
+        "Usage: Identify trend direction and serve as dynamic support/resistance. "
+        "Tips: It lags price; combine with faster indicators for timely signals."
+    ),
+    "close_200_sma": (
+        "200 SMA: A long-term trend benchmark. "
+        "Usage: Confirm overall market trend and identify golden/death cross setups. "
+        "Tips: It reacts slowly; best for strategic trend confirmation rather than frequent trading entries."
+    ),
+    "close_10_ema": (
+        "10 EMA: A responsive short-term average. "
+        "Usage: Capture quick shifts in momentum and potential entry points. "
+        "Tips: Prone to noise in choppy markets; use alongside longer averages for filtering false signals."
+    ),
+    "macd": (
+        "MACD: Computes momentum via differences of EMAs. "
+        "Usage: Look for crossovers and divergence as signals of trend changes. "
+        "Tips: Confirm with other indicators in low-volatility or sideways markets."
+    ),
+    "macds": (
+        "MACD Signal: An EMA smoothing of the MACD line. "
+        "Usage: Use crossovers with the MACD line to trigger trades. "
+        "Tips: Should be part of a broader strategy to avoid false positives."
+    ),
+    "macdh": (
+        "MACD Histogram: Shows the gap between the MACD line and its signal. "
+        "Usage: Visualize momentum strength and spot divergence early. "
+        "Tips: Can be volatile; complement with additional filters in fast-moving markets."
+    ),
+    "rsi": (
+        "RSI: Measures momentum to flag overbought/oversold conditions. "
+        "Usage: Apply 70/30 thresholds and watch for divergence to signal reversals. "
+        "Tips: In strong trends, RSI may remain extreme; always cross-check with trend analysis."
+    ),
+    "boll": (
+        "Bollinger Middle: A 20 SMA serving as the basis for Bollinger Bands. "
+        "Usage: Acts as a dynamic benchmark for price movement. "
+        "Tips: Combine with the upper and lower bands to effectively spot breakouts or reversals."
+    ),
+    "boll_ub": (
+        "Bollinger Upper Band: Typically 2 standard deviations above the middle line. "
+        "Usage: Signals potential overbought conditions and breakout zones. "
+        "Tips: Confirm signals with other tools; prices may ride the band in strong trends."
+    ),
+    "boll_lb": (
+        "Bollinger Lower Band: Typically 2 standard deviations below the middle line. "
+        "Usage: Indicates potential oversold conditions. "
+        "Tips: Use additional analysis to avoid false reversal signals."
+    ),
+    "atr": (
+        "ATR: Averages true range to measure volatility. "
+        "Usage: Set stop-loss levels and adjust position sizes based on current market volatility. "
+        "Tips: It's a reactive measure, so use it as part of a broader risk management strategy."
+    ),
+    "vwma": (
+        "VWMA: A moving average weighted by volume. "
+        "Usage: Confirm trends by integrating price action with volume data. "
+        "Tips: Watch for skewed results from volume spikes; use in combination with other volume analyses."
+    ),
+    "mfi": (
+        "MFI: The Money Flow Index is a momentum indicator that uses both price and volume to measure buying and selling pressure. "
+        "Usage: Identify overbought (>80) or oversold (<20) conditions and confirm the strength of trends or reversals. "
+        "Tips: Use alongside RSI or MACD to confirm signals; divergence between price and MFI can indicate potential reversals."
+    ),
+}
+
+
+def _sina_symbol(ticker: str) -> str | None:
+    """Map an A-share ticker to Sina's ``sh600036`` / ``sz000021`` form."""
+    match = re.search(r"(\d{6})", ticker)
+    if not match:
+        return None
+    code = match.group(1)
+    upper = ticker.upper()
+    if upper.endswith(".SS") or upper.endswith(".SH"):
+        prefix = "sh"
+    elif upper.endswith(".SZ"):
+        prefix = "sz"
+    else:
+        prefix = "sh" if code.startswith(("5", "6", "9")) else "sz"
+    return f"{prefix}{code}"
+
+
+def fetch_sina_kline(sina_symbol: str, datalen: int = 1023) -> pd.DataFrame:
+    """Fetch daily OHLCV from Sina using a raw ``sh600036`` / ``sz000021`` symbol."""
+    try:
+        resp = requests.get(
+            _KLINE_URL,
+            params={
+                "symbol": sina_symbol,
+                "scale": 240,
+                "ma": "no",
+                "datalen": datalen,
+            },
+            headers={"User-Agent": _UA, "Referer": "https://finance.sina.com.cn"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("Sina kline fetch failed for %s: %s", sina_symbol, exc)
+        raise NoMarketDataError(
+            sina_symbol, sina_symbol, f"Sina kline unavailable: {type(exc).__name__}"
+        ) from exc
+
+    if not isinstance(payload, list) or not payload:
+        raise NoMarketDataError(sina_symbol, sina_symbol, "Sina returned no kline rows")
+
+    frame = pd.DataFrame(payload)
+    frame = frame.rename(
+        columns={
+            "day": "Date",
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+        }
+    )
+    for col in ("Open", "High", "Low", "Close", "Volume"):
+        frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    frame["Date"] = pd.to_datetime(frame["Date"], errors="coerce")
+    frame["Dividends"] = 0.0
+    frame["Stock Splits"] = 0.0
+    frame = frame.dropna(subset=["Date", "Close"]).sort_values("Date")
+    return frame[["Date", "Open", "High", "Low", "Close", "Volume", "Dividends", "Stock Splits"]]
+
+
+def _fetch_eastmoney_kline(ticker: str, datalen: int = 1023) -> pd.DataFrame:
+    """Fetch daily OHLCV from Eastmoney as a fallback source."""
+    sina_symbol = _sina_symbol(ticker)
+    if not sina_symbol:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney kline supports A-shares only")
+    market = "1" if sina_symbol.startswith("sh") else "0"
+    code = sina_symbol[2:]
+    beg = (pd.Timestamp.today() - pd.Timedelta(days=datalen * 2)).strftime("%Y%m%d")
+    try:
+        resp = requests.get(
+            _EM_KLINE_URL,
+            params={
+                "secid": f"{market}.{code}",
+                "fields1": "f1,f2,f3,f4,f5,f6",
+                "fields2": "f51,f52,f53,f54,f55,f56,f57,f58",
+                "klt": "101",
+                "fqt": "1",
+                "beg": beg,
+                "end": "20500101",
+            },
+            headers={"User-Agent": _UA, "Referer": "https://quote.eastmoney.com/"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("Eastmoney kline fetch failed for %s: %s", ticker, exc)
+        raise NoMarketDataError(ticker, ticker, "Eastmoney kline unavailable") from exc
+
+    klines = ((payload.get("data") or {}).get("klines")) or []
+    if not klines:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney returned no kline rows")
+
+    rows = []
+    for line in klines[-datalen:]:
+        parts = line.split(",")
+        if len(parts) < 6:
+            continue
+        rows.append(
+            {
+                "Date": pd.to_datetime(parts[0]),
+                "Open": float(parts[1]),
+                "Close": float(parts[2]),
+                "High": float(parts[3]),
+                "Low": float(parts[4]),
+                "Volume": float(parts[5]) * 100,
+            }
+        )
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        raise NoMarketDataError(ticker, ticker, "Eastmoney returned no usable rows")
+    frame["Dividends"] = 0.0
+    frame["Stock Splits"] = 0.0
+    return frame[["Date", "Open", "High", "Low", "Close", "Volume", "Dividends", "Stock Splits"]]
+
+
+def _fetch_tencent_kline(ticker: str, datalen: int = 1023) -> pd.DataFrame:
+    """Fetch daily OHLCV from Tencent as the final domestic fallback."""
+    sina_symbol = _sina_symbol(ticker)
+    if not sina_symbol:
+        raise NoMarketDataError(ticker, ticker, "Tencent kline supports A-shares only")
+    count = min(datalen, 800)
+    try:
+        resp = requests.get(
+            _TX_KLINE_URL,
+            params={"param": f"{sina_symbol},day,2000-01-01,2050-01-01,{count},qfq"},
+            headers={"User-Agent": _UA, "Referer": "https://gu.qq.com/"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("Tencent kline fetch failed for %s: %s", ticker, exc)
+        raise NoMarketDataError(ticker, ticker, "Tencent kline unavailable") from exc
+
+    node = ((payload.get("data") or {}).get(sina_symbol)) or {}
+    klines = node.get("qfqday") or node.get("day") or []
+    if not klines:
+        raise NoMarketDataError(ticker, ticker, "Tencent returned no kline rows")
+
+    rows = []
+    for item in klines[-datalen:]:
+        if len(item) < 6:
+            continue
+        rows.append(
+            {
+                "Date": pd.to_datetime(item[0]),
+                "Open": float(item[1]),
+                "Close": float(item[2]),
+                "High": float(item[3]),
+                "Low": float(item[4]),
+                "Volume": float(item[5]) * 100,
+            }
+        )
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        raise NoMarketDataError(ticker, ticker, "Tencent returned no usable rows")
+    frame["Dividends"] = 0.0
+    frame["Stock Splits"] = 0.0
+    return frame[["Date", "Open", "High", "Low", "Close", "Volume", "Dividends", "Stock Splits"]]
+
+
+@functools.lru_cache(maxsize=256)
+def _fetch_kline(symbol: str, datalen: int = 1023) -> pd.DataFrame:
+    """Fetch daily OHLCV for an A-share ticker with domestic multi-source fallback.
+
+    Cached per process: get_stock_data, every get_indicators call, and the
+    verified-market-snapshot path all need the same 1023-row kline, and each
+    previously triggered a separate network fetch. Callers only filter/slice
+    the returned frame, so sharing one immutable-by-convention frame is safe.
+    """
+    sina_symbol = _sina_symbol(symbol)
+    if not sina_symbol:
+        raise NoMarketDataError(symbol, symbol, "Sina vendor supports A-shares only")
+    errors = []
+    for fetcher in (
+        lambda: fetch_sina_kline(sina_symbol, datalen=datalen),
+        lambda: _fetch_eastmoney_kline(symbol, datalen=datalen),
+        lambda: _fetch_tencent_kline(symbol, datalen=datalen),
+    ):
+        try:
+            return fetcher()
+        except NoMarketDataError as exc:
+            errors.append(str(exc))
+            continue
+    raise NoMarketDataError(
+        symbol,
+        symbol,
+        "all domestic kline sources failed: " + " | ".join(errors),
+    )
+
+
+def load_sina_ohlcv(symbol: str, curr_date: str, datalen: int = 1023) -> pd.DataFrame:
+    """Sina OHLCV on or before ``curr_date``, sorted ascending."""
+    frame = _fetch_kline(symbol, datalen=datalen)
+    frame = frame[frame["Date"] <= pd.to_datetime(curr_date)]
+    if frame.empty:
+        raise NoMarketDataError(symbol, symbol, f"No Sina rows on or before {curr_date}")
+    return frame
+
+
+def get_stock_data(symbol: str, start_date: str, end_date: str) -> str:
+    """Return daily OHLCV for an A-share in the same CSV format as yfinance."""
+    datetime.strptime(start_date, "%Y-%m-%d")
+    datetime.strptime(end_date, "%Y-%m-%d")
+
+    frame = _fetch_kline(symbol, datalen=1023)
+    start = pd.to_datetime(start_date)
+    end = pd.to_datetime(end_date)
+    frame = frame[(frame["Date"] >= start) & (frame["Date"] <= end)]
+    if frame.empty:
+        raise NoMarketDataError(
+            symbol,
+            symbol,
+            f"no Sina rows between {start_date} and {end_date}",
+        )
+
+    for col in ("Open", "High", "Low", "Close"):
+        frame[col] = frame[col].round(2)
+
+    header = f"# Stock data for {symbol.upper()} from {start_date} to {end_date}\n"
+    header += f"# Total records: {len(frame)}\n"
+    header += f"# Data retrieved on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+    return header + frame.to_csv(index=False)
+
+
+def _indicator_series(symbol: str, indicator: str, curr_date: str) -> dict[str, str]:
+    """Compute an indicator for every available day up to ``curr_date``."""
+    frame = _fetch_kline(symbol, datalen=1023)
+    frame = frame[frame["Date"] <= pd.to_datetime(curr_date)]
+    if frame.empty:
+        raise NoMarketDataError(symbol, symbol, f"No Sina rows on or before {curr_date}")
+
+    stock_df = wrap(frame)
+    stock_df["Date"] = stock_df["Date"].dt.strftime("%Y-%m-%d")
+    stock_df[indicator]  # stockstats lazy-computes on access
+
+    result: dict[str, str] = {}
+    for _, row in stock_df.iterrows():
+        value = row[indicator]
+        result[row["Date"]] = "N/A" if pd.isna(value) else str(value)
+    return result
+
+
+def get_indicators(
+    symbol: str,
+    indicator: str,
+    curr_date: str,
+    look_back_days: int,
+) -> str:
+    """Return a date-stamped indicator series, mirroring the yfinance format."""
+    if indicator not in BEST_IND_PARAMS:
+        raise ValueError(
+            f"Indicator {indicator} is not supported. Please choose from: "
+            f"{list(BEST_IND_PARAMS.keys())}"
+        )
+
+    curr_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+    before = curr_dt - pd.Timedelta(days=look_back_days)
+    series = _indicator_series(symbol, indicator, curr_date)
+
+    lines = []
+    current = curr_dt
+    while current >= before:
+        date_str = current.strftime("%Y-%m-%d")
+        value = series.get(date_str, "N/A: Not a trading day (weekend or holiday)")
+        lines.append(f"{date_str}: {value}")
+        current = current - pd.Timedelta(days=1)
+
+    return (
+        f"## {indicator} values from {before.strftime('%Y-%m-%d')} to {curr_date}:\n\n"
+        + "\n".join(lines)
+        + "\n\n"
+        + BEST_IND_PARAMS[indicator]
+    )

--- a/tradingagents/dataflows/sina_news.py
+++ b/tradingagents/dataflows/sina_news.py
@@ -1,0 +1,70 @@
+"""Sina Finance news vendor for ticker and global news tools."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+import requests
+
+from .china_sentiment import fetch_sina_news
+
+logger = logging.getLogger(__name__)
+
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "Chrome/124 Safari/537.36"
+)
+_ROLL_URL = "https://feed.mix.sina.com.cn/api/roll/get"
+
+
+def get_news(ticker: str, start_date: str, end_date: str) -> str:
+    """Return ticker-specific Chinese news from Sina Finance."""
+    return fetch_sina_news(ticker, start_date=start_date, end_date=end_date)
+
+
+def get_global_news(
+    curr_date: str,
+    look_back_days: int | None = None,
+    limit: int | None = None,
+) -> str:
+    """Return recent Chinese finance headlines from Sina's roll feed."""
+    days = look_back_days or 7
+    count = limit or 20
+    try:
+        resp = requests.get(
+            _ROLL_URL,
+            params={"pageid": "153", "lid": "2516", "num": count, "page": "1"},
+            headers={"User-Agent": _UA, "Referer": "https://finance.sina.com.cn/"},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        logger.warning("Sina global news fetch failed: %s", exc)
+        return f"<新浪全球新闻不可用: {type(exc).__name__}>"
+
+    rows = ((payload.get("result") or {}).get("data")) or []
+    if not rows:
+        return "<新浪全球新闻暂无内容>"
+
+    cutoff = datetime.now() - timedelta(days=days)
+    lines = []
+    for item in rows:
+        title = (item.get("title") or "").strip()
+        url = (item.get("url") or "").strip()
+        ctime = item.get("ctime")
+        try:
+            published = datetime.fromtimestamp(int(ctime))
+        except (TypeError, ValueError):
+            published = None
+        if published and published < cutoff:
+            continue
+        date_str = published.strftime("%Y-%m-%d %H:%M") if published else "?"
+        lines.append(f"[{date_str}] {title}\n    {url}")
+        if len(lines) >= count:
+            break
+
+    if not lines:
+        return f"<新浪全球新闻在近 {days} 天内暂无内容>"
+    return f"## 新浪财经全球新闻（近 {days} 天，{len(lines)} 条）：\n\n" + "\n".join(lines)

--- a/tradingagents/dataflows/stockstats_utils.py
+++ b/tradingagents/dataflows/stockstats_utils.py
@@ -192,19 +192,14 @@ def load_ohlcv(symbol: str, curr_date: str) -> pd.DataFrame:
             data = cached
 
     if data is None:
-        downloaded = yf_retry(lambda: yf.download(
-            canonical,
-            start=start_str,
-            end=end_str,
-            multi_level_index=False,
-            progress=False,
-            auto_adjust=True,
-        ))
-        downloaded = _ensure_date_column(downloaded.reset_index())
+        from .sina_market import load_sina_ohlcv
+
+        downloaded = load_sina_ohlcv(symbol, curr_date, datalen=1023)
+        downloaded = _ensure_date_column(downloaded)
         # Only cache real data — never persist an empty frame.
         if downloaded.empty or "Close" not in downloaded.columns:
             raise NoMarketDataError(
-                symbol, canonical, "Yahoo Finance returned no rows"
+                symbol, canonical, "Sina Finance returned no rows"
             )
         downloaded.to_csv(data_file, index=False, encoding="utf-8")
         data = downloaded

--- a/tradingagents/dataflows/y_finance.py
+++ b/tradingagents/dataflows/y_finance.py
@@ -32,7 +32,20 @@ def get_YFin_data_online(
     # end_date row (and the current day when end_date is today). Request one day
     # past end_date so the requested range is actually inclusive (#986/#987).
     end_inclusive = (end_dt + relativedelta(days=1)).strftime("%Y-%m-%d")
-    data = yf_retry(lambda: ticker.history(start=start_date, end=end_inclusive))
+
+    # Prefer the on-disk OHLCV cache (same freshness rules as the indicator
+    # path) so repeated analyses do not hammer Yahoo and trip its rate limit.
+    data = None
+    try:
+        cached = load_ohlcv(symbol, end_date)
+        cached = cached[cached["Date"] >= pd.to_datetime(start_date)]
+        if not cached.empty:
+            data = cached
+    except Exception:  # noqa: BLE001 - fall through to the live fetch below
+        data = None
+
+    if data is None:
+        data = yf_retry(lambda: ticker.history(start=start_date, end=end_inclusive))
 
     # Empty result means the symbol is unknown/delisted. Raise a typed error
     # instead of returning prose: the routing layer turns it into a single

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -131,16 +131,19 @@ DEFAULT_CONFIG = _apply_env_overrides({
     # routed to vendors you didn't choose. For ordered fallback, list several,
     # e.g. "yfinance,alpha_vantage". "default" uses all available vendors.
     "data_vendors": {
-        "core_stock_apis": "yfinance",       # Options: alpha_vantage, yfinance
-        "technical_indicators": "yfinance",  # Options: alpha_vantage, yfinance
-        "fundamental_data": "yfinance",      # Options: alpha_vantage, yfinance
-        "news_data": "yfinance",             # Options: alpha_vantage, yfinance
+        "core_stock_apis": "sina",           # Options: sina, alpha_vantage
+        "technical_indicators": "sina",      # Options: sina, alpha_vantage
+        "fundamental_data": "eastmoney",     # Options: eastmoney, alpha_vantage
+        "news_data": "sina",                 # Options: sina, alpha_vantage
         "macro_data": "fred",                # Options: fred (needs FRED_API_KEY)
         "prediction_markets": "polymarket",  # Options: polymarket (keyless)
     },
     # Tool-level configuration (takes precedence over category-level)
     "tool_vendors": {
-        # Example: "get_stock_data": "alpha_vantage",  # Override category default
+        "get_balance_sheet": "akshare,eastmoney",
+        "get_cashflow": "akshare,eastmoney",
+        "get_income_statement": "akshare,eastmoney",
+        "get_insider_transactions": "akshare,eastmoney",
     },
     # Benchmark for alpha calculation in the reflection layer.
     # ``benchmark_ticker`` (when set) overrides the suffix map for all

--- a/tradingagents/graph/analyst_execution.py
+++ b/tradingagents/graph/analyst_execution.py
@@ -10,6 +10,7 @@ class AnalystNodeSpec:
     clear_node: str
     tool_node: str
     report_key: str
+    messages_key: str
 
 
 @dataclass(frozen=True)
@@ -24,6 +25,7 @@ ANALYST_NODE_SPECS: dict[str, AnalystNodeSpec] = {
         clear_node="Msg Clear Market",
         tool_node="tools_market",
         report_key="market_report",
+        messages_key="market_messages",
     ),
     "social": AnalystNodeSpec(
         # Wire key stays "social" for saved-config back-compat; the
@@ -35,6 +37,7 @@ ANALYST_NODE_SPECS: dict[str, AnalystNodeSpec] = {
         clear_node="Msg Clear Sentiment",
         tool_node="tools_social",
         report_key="sentiment_report",
+        messages_key="sentiment_messages",
     ),
     "news": AnalystNodeSpec(
         key="news",
@@ -42,6 +45,7 @@ ANALYST_NODE_SPECS: dict[str, AnalystNodeSpec] = {
         clear_node="Msg Clear News",
         tool_node="tools_news",
         report_key="news_report",
+        messages_key="news_messages",
     ),
     "fundamentals": AnalystNodeSpec(
         key="fundamentals",
@@ -49,6 +53,7 @@ ANALYST_NODE_SPECS: dict[str, AnalystNodeSpec] = {
         clear_node="Msg Clear Fundamentals",
         tool_node="tools_fundamentals",
         report_key="fundamentals_report",
+        messages_key="fundamentals_messages",
     ),
 }
 

--- a/tradingagents/graph/conditional_logic.py
+++ b/tradingagents/graph/conditional_logic.py
@@ -13,7 +13,7 @@ class ConditionalLogic:
 
     def should_continue_market(self, state: AgentState):
         """Determine if market analysis should continue."""
-        messages = state["messages"]
+        messages = state["market_messages"]
         last_message = messages[-1]
         if last_message.tool_calls:
             return "tools_market"
@@ -27,7 +27,7 @@ class ConditionalLogic:
         back-compat); the returned ``clear_node`` label uses the v0.2.5
         rename so it matches the node registered by the execution plan.
         """
-        messages = state["messages"]
+        messages = state["sentiment_messages"]
         last_message = messages[-1]
         if last_message.tool_calls:
             return "tools_social"
@@ -35,7 +35,7 @@ class ConditionalLogic:
 
     def should_continue_news(self, state: AgentState):
         """Determine if news analysis should continue."""
-        messages = state["messages"]
+        messages = state["news_messages"]
         last_message = messages[-1]
         if last_message.tool_calls:
             return "tools_news"
@@ -43,7 +43,7 @@ class ConditionalLogic:
 
     def should_continue_fundamentals(self, state: AgentState):
         """Determine if fundamentals analysis should continue."""
-        messages = state["messages"]
+        messages = state["fundamentals_messages"]
         last_message = messages[-1]
         if last_message.tool_calls:
             return "tools_fundamentals"

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -31,8 +31,15 @@ class Propagator:
         fall back to ticker-only context via
         ``get_instrument_context_from_state``.
         """
+        initial_messages = [("human", company_name)]
         return {
-            "messages": [("human", company_name)],
+            "messages": initial_messages,
+            # Each analyst branch starts from the same task message; the
+            # branches run concurrently and never share message history.
+            "market_messages": list(initial_messages),
+            "sentiment_messages": list(initial_messages),
+            "news_messages": list(initial_messages),
+            "fundamentals_messages": list(initial_messages),
             "company_of_interest": company_name,
             "asset_type": asset_type,
             "instrument_context": instrument_context,

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -12,7 +12,6 @@ from tradingagents.agents import (
     create_conservative_debator,
     create_fundamentals_analyst,
     create_market_analyst,
-    create_msg_delete,
     create_neutral_debator,
     create_news_analyst,
     create_portfolio_manager,
@@ -73,10 +72,16 @@ class GraphSetup:
         plan = build_analyst_execution_plan(selected_analysts)
 
         analyst_factories = {
-            "market": lambda: create_market_analyst(self.quick_thinking_llm),
+            "market": lambda: create_market_analyst(
+                self.quick_thinking_llm, tool_node=self.tool_nodes["market"]
+            ),
             "social": lambda: create_sentiment_analyst(self.quick_thinking_llm),
-            "news": lambda: create_news_analyst(self.quick_thinking_llm),
-            "fundamentals": lambda: create_fundamentals_analyst(self.quick_thinking_llm),
+            "news": lambda: create_news_analyst(
+                self.quick_thinking_llm, tool_node=self.tool_nodes["news"]
+            ),
+            "fundamentals": lambda: create_fundamentals_analyst(
+                self.quick_thinking_llm, tool_node=self.tool_nodes["fundamentals"]
+            ),
         }
 
         # Create researcher and manager nodes
@@ -97,8 +102,6 @@ class GraphSetup:
         # Add analyst nodes to the graph
         for spec in plan.specs:
             workflow.add_node(spec.agent_node, analyst_factories[spec.key]())
-            workflow.add_node(spec.clear_node, create_msg_delete())
-            workflow.add_node(spec.tool_node, self.tool_nodes[spec.key])
 
         # Add other nodes
         workflow.add_node("Bull Researcher", bull_researcher_node)
@@ -110,29 +113,15 @@ class GraphSetup:
         workflow.add_node("Conservative Analyst", conservative_analyst)
         workflow.add_node("Portfolio Manager", portfolio_manager_node)
 
-        # Define edges
-        # Start with the first analyst
-        workflow.add_edge(START, plan.specs[0].agent_node)
-
-        # Connect analysts in sequence
-        for i, spec in enumerate(plan.specs):
-            current_analyst = spec.agent_node
-            current_tools = spec.tool_node
-            current_clear = spec.clear_node
-
-            # Add conditional edges for current analyst
-            workflow.add_conditional_edges(
-                current_analyst,
-                getattr(self.conditional_logic, f"should_continue_{spec.key}"),
-                [current_tools, current_clear],
-            )
-            workflow.add_edge(current_tools, current_analyst)
-
-            # Connect to next analyst or to Bull Researcher if this is the last analyst
-            if i < len(plan.specs) - 1:
-                workflow.add_edge(current_clear, plan.specs[i + 1].agent_node)
-            else:
-                workflow.add_edge(current_clear, "Bull Researcher")
+        # Define edges. All selected analysts start concurrently: each branch
+        # is one self-contained node (LLM -> tools -> LLM loop over its own
+        # message channel) writing exactly one report key, so the branches
+        # share no mutable state and finish in the same superstep. They
+        # converge at the Bull Researcher, which runs once all branches have
+        # completed.
+        for spec in plan.specs:
+            workflow.add_edge(START, spec.agent_node)
+            workflow.add_edge(spec.agent_node, "Bull Researcher")
 
         # Both research-debate edges share the complete DEBATE_PATH_MAP (#1088).
         for debate_node in ("Bull Researcher", "Bear Researcher"):

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-import yfinance as yf
+import pandas as pd
 from langgraph.prebuilt import ToolNode
 
 # Import the abstract tool methods from agent_utils
@@ -42,6 +42,16 @@ from .setup import GraphSetup
 from .signal_processing import SignalProcessor
 
 logger = logging.getLogger(__name__)
+
+# Debug-stream labels for the concurrently running analyst branches: their
+# messages live in per-analyst channels now, so report completion is the
+# visible progress signal instead of shared-channel message traces.
+ANALYST_REPORT_LABELS = {
+    "market_report": "Market Analyst",
+    "sentiment_report": "Sentiment Analyst",
+    "news_report": "News Analyst",
+    "fundamentals_report": "Fundamentals Analyst",
+}
 
 
 def _coerce_max_retries(value):
@@ -198,13 +208,15 @@ class TradingAgentsGraph:
                     # LLM and required by its prompt; must be executable here or
                     # the call fails and the model reports it "unavailable").
                     get_verified_market_snapshot,
-                ]
+                ],
+                messages_key="market_messages",
             ),
             "social": ToolNode(
                 [
                     # News tools for social media analysis
                     get_news,
-                ]
+                ],
+                messages_key="sentiment_messages",
             ),
             "news": ToolNode(
                 [
@@ -214,7 +226,8 @@ class TradingAgentsGraph:
                     get_insider_transactions,
                     get_macro_indicators,
                     get_prediction_markets,
-                ]
+                ],
+                messages_key="news_messages",
             ),
             "fundamentals": ToolNode(
                 [
@@ -223,7 +236,8 @@ class TradingAgentsGraph:
                     get_balance_sheet,
                     get_cashflow,
                     get_income_statement,
-                ]
+                ],
+                messages_key="fundamentals_messages",
             ),
         }
 
@@ -259,18 +273,29 @@ class TradingAgentsGraph:
         actual_holding_days)`` or ``(None, None, None)`` if price data is
         unavailable (too recent, delisted, or network error).
         """
-        from tradingagents.dataflows.symbol_utils import normalize_symbol
-
         try:
             start = datetime.strptime(trade_date, "%Y-%m-%d")
             end = start + timedelta(days=holding_days + 7)  # buffer for weekends/holidays
             end_str = end.strftime("%Y-%m-%d")
 
-            # Normalize so the realized-return lookup hits the same instrument
-            # the analysis priced (e.g. XAUUSD -> GC=F) (#984). The benchmark is
-            # already a canonical Yahoo symbol from ``_resolve_benchmark``.
-            stock = yf.Ticker(normalize_symbol(ticker)).history(start=trade_date, end=end_str)
-            bench = yf.Ticker(benchmark).history(start=trade_date, end=end_str)
+            def _domestic_history(symbol: str):
+                from tradingagents.dataflows.sina_market import (
+                    _sina_symbol,
+                    fetch_sina_kline,
+                )
+
+                sina_symbol = _sina_symbol(symbol)
+                if not sina_symbol:
+                    return None
+                frame = fetch_sina_kline(sina_symbol, datalen=1023)
+                return frame[
+                    frame["Date"].between(pd.to_datetime(start), pd.to_datetime(end))
+                ]
+
+            stock = _domestic_history(ticker)
+            bench = _domestic_history(benchmark)
+            if stock is None or bench is None:
+                return None, None, None
 
             if len(stock) < 2 or len(bench) < 2:
                 return None, None, None
@@ -351,8 +376,14 @@ class TradingAgentsGraph:
         Keyed into the checkpoint thread ID so a resume under a different analyst
         selection, debate/risk depth, or asset mode starts fresh instead of
         silently continuing the previous graph (#1089).
+
+        ``gv`` is the graph-topology version: bumping it invalidates checkpoints
+        written by an older graph layout (e.g. the pre-parallel serial analyst
+        chain) so a resume under a changed topology starts fresh instead of
+        replaying against the new shape.
         """
         return "|".join([
+            "gv=2",
             "analysts=" + ",".join(self.selected_analysts),
             f"debate={self.config['max_debate_rounds']}",
             f"risk={self.config['max_risk_discuss_rounds']}",
@@ -440,6 +471,7 @@ class TradingAgentsGraph:
         if self.debug:
             trace = []
             last_printed = None
+            seen_reports = set()
             for chunk in self.graph.stream(init_agent_state, **args):
                 if chunk["messages"]:
                     msg = chunk["messages"][-1]
@@ -450,7 +482,11 @@ class TradingAgentsGraph:
                     if signature != last_printed:
                         msg.pretty_print()
                         last_printed = signature
-                    trace.append(chunk)
+                for report_key, label in ANALYST_REPORT_LABELS.items():
+                    if chunk.get(report_key) and report_key not in seen_reports:
+                        seen_reports.add(report_key)
+                        print(f"--- {label} report ready ---")
+                trace.append(chunk)
             # Streamed chunks are per-node deltas. Merge them so the returned
             # state matches what graph.invoke() yields in the non-debug path.
             final_state = {}


### PR DESCRIPTION
- Replace Yahoo Finance defaults with Sina Finance (prices/indicators/news),
  Eastmoney (fundamentals), AkShare (fundamentals/insider transactions).
- Add Chinese-platform sentiment sources: Sina Finance news + Eastmoney Guba.
- Add FRED aliases for China CPI/GDP and graceful handling of unknown series.
- Add helper scripts: analyze_ticker.py, pick_five_sina.py, list_more.py, find_buy.py.
- Update tests and README.

BREAKING CHANGE: default data_vendors changed from yfinance to sina/eastmoney.
