### PR TITLE
feat: add first-class portfolio context to graph inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ print(decision)
 
 See `tradingagents/default_config.py` for all configuration options.
 
+### Portfolio context (optional)
+
+`propagate()` accepts an optional, broker-neutral `PortfolioContext` snapshot describing current holdings and capital. When provided, the Trader, risk analysts, and Portfolio Manager ground their sizing language in it; when omitted, they are told explicitly that no portfolio context was given instead of assuming a flat portfolio. A context with empty `positions` means a known flat portfolio — this is distinct from providing no context at all.
+
+```python
+from tradingagents.agents.schemas import PortfolioContext
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.default_config import DEFAULT_CONFIG
+
+ta = TradingAgentsGraph(debug=True, config=DEFAULT_CONFIG.copy())
+
+context = PortfolioContext(
+    positions=[{"symbol": "NVDA", "quantity": 10.0, "average_entry_price": 150.0}],
+    cash=25000.0,
+    portfolio_value=120000.0,
+    as_of="2026-01-15",
+    source="paper-broker",
+)
+
+_, decision = ta.propagate("NVDA", "2026-01-15", portfolio_context=context)
+print(decision)
+```
+
+Existing calls without `portfolio_context` keep working unchanged. The CLI accepts the same snapshot as a JSON file:
+
+```bash
+tradingagents analyze --portfolio-context /path/to/portfolio.json
+```
+
+Saved run state records whether a context was present (`portfolio_context_present`) together with the snapshot used. The contract carries no credentials, account identifiers, or broker dependencies.
+
 ## Persistence and Recovery
 
 TradingAgents persists two kinds of state across runs.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ context = PortfolioContext(
     portfolio_value=120000.0,
     as_of="2026-01-15",
     source="paper-broker",
+    currency="USD",
 )
 
 _, decision = ta.propagate("NVDA", "2026-01-15", portfolio_context=context)
@@ -264,6 +265,8 @@ tradingagents analyze --portfolio-context /path/to/portfolio.json
 ```
 
 Saved run state records whether a context was present (`portfolio_context_present`) together with the snapshot used. The contract carries no credentials, account identifiers, or broker dependencies.
+
+`currency` is an optional reporting label only; TradingAgents does not perform FX conversion. A changed snapshot starts a fresh checkpointed run instead of resuming stale portfolio state.
 
 ## Persistence and Recovery
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import sys
 import time
@@ -7,6 +8,7 @@ from functools import wraps
 from pathlib import Path
 
 import typer
+from pydantic import ValidationError
 from rich import box
 from rich.align import Align
 from rich.console import Console
@@ -41,6 +43,7 @@ from cli.utils import (
     select_research_depth,
     select_shallow_thinking_agent,
 )
+from tradingagents.agents.schemas import PortfolioContext
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.graph.analyst_execution import (
     AnalystWallTimeTracker,
@@ -1001,7 +1004,37 @@ def _build_run_config(selections: dict, checkpoint: bool | None) -> dict:
     return config
 
 
-def run_analysis(checkpoint: bool | None = None):
+def load_portfolio_context_file(path_str: str) -> dict:
+    """Load and validate a ``PortfolioContext`` JSON file for ``--portfolio-context``.
+
+    Returns the snapshot as plain JSON-safe data ready for
+    ``Propagator.create_initial_state``. Raises ``typer.BadParameter`` with an
+    actionable message for a missing file, malformed JSON, or schema
+    violations — the CLI must fail at startup rather than run with a silently
+    degraded (or empty-looking) portfolio.
+    """
+    path = Path(path_str).expanduser()
+    if not path.is_file():
+        raise typer.BadParameter(f"portfolio context file not found: {path_str}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(
+            f"portfolio context file is not valid JSON: {path_str} ({exc})"
+        ) from exc
+    try:
+        context = PortfolioContext.model_validate(raw)
+    except ValidationError as exc:
+        raise typer.BadParameter(
+            f"portfolio context file failed validation: {path_str}\n{exc}"
+        ) from exc
+    return context.model_dump(mode="json")
+
+
+def run_analysis(
+    checkpoint: bool | None = None,
+    portfolio_context_path: str | None = None,
+):
     # First get all user selections
     selections = get_user_selections()
 
@@ -1114,14 +1147,24 @@ def run_analysis(checkpoint: bool | None = None):
         # Resolve the instrument identity once here so all agents anchor to
         # the real company (#814); the CLI builds state directly rather than
         # going through propagate(), so this must happen on the CLI path too.
+        # An optional broker-neutral portfolio snapshot (``--portfolio-context``)
+        # is threaded through the same way; when omitted the state records
+        # None so decision nodes see "not provided" rather than a flat
+        # portfolio (#1166).
         instrument_context = graph.resolve_instrument_context(
             selections["ticker"], selections["asset_type"]
+        )
+        portfolio_context = (
+            load_portfolio_context_file(portfolio_context_path)
+            if portfolio_context_path
+            else None
         )
         init_agent_state = graph.propagator.create_initial_state(
             selections["ticker"],
             selections["analysis_date"],
             asset_type=selections["asset_type"],
             instrument_context=instrument_context,
+            portfolio_context=portfolio_context,
         )
         # Pass callbacks to graph config for tool execution tracking
         # (LLM tracking is handled separately via LLM constructor)
@@ -1314,13 +1357,22 @@ def analyze(
         "--clear-checkpoints",
         help="Delete all saved checkpoints before running (force fresh start).",
     ),
+    portfolio_context: str | None = typer.Option(
+        None,
+        "--portfolio-context",
+        help="Path to a JSON file with an optional broker-neutral portfolio "
+        "snapshot (positions, cash, capital). When omitted, decision nodes "
+        "are told explicitly that no portfolio context was provided.",
+    ),
 ):
     if clear_checkpoints:
         from tradingagents.graph.checkpointer import clear_all_checkpoints
         n = clear_all_checkpoints(DEFAULT_CONFIG["data_cache_dir"])
         console.print(f"[yellow]Cleared {n} checkpoint(s).[/yellow]")
     try:
-        run_analysis(checkpoint=checkpoint)
+        run_analysis(
+            checkpoint=checkpoint, portfolio_context_path=portfolio_context
+        )
     except _NO_CONSOLE_ERRORS:
         # A terminal with no console buffer cannot host the interactive prompts.
         # Emit one actionable line on stderr instead of a prompt_toolkit

--- a/cli/main.py
+++ b/cli/main.py
@@ -1173,8 +1173,11 @@ def run_analysis(
         # Recompile with a checkpointer and inject the thread_id so --checkpoint
         # actually saves and resumes on the CLI path (#1249); a no-op when
         # checkpointing is disabled. Torn down in the finally below.
+        # The portfolio snapshot participates in the checkpoint identity so a
+        # changed snapshot starts fresh instead of resuming stale state (#1166).
         checkpoint_tid = graph.begin_checkpoint(
-            selections["ticker"], selections["analysis_date"], selections["asset_type"]
+            selections["ticker"], selections["analysis_date"], selections["asset_type"],
+            portfolio_context=portfolio_context,
         )
         if checkpoint_tid is not None:
             args.setdefault("config", {}).setdefault("configurable", {})["thread_id"] = checkpoint_tid
@@ -1289,7 +1292,8 @@ def run_analysis(
             # Clean run: drop this run's checkpoint so a later run starts fresh.
             # A mid-stream failure skips this, keeping the checkpoint for resume.
             graph.clear_checkpoint_on_success(
-                selections["ticker"], selections["analysis_date"], selections["asset_type"]
+                selections["ticker"], selections["analysis_date"], selections["asset_type"],
+                portfolio_context=portfolio_context,
             )
         finally:
             # Always restore the plain uncheckpointed graph, even on failure.

--- a/tests/test_portfolio_context.py
+++ b/tests/test_portfolio_context.py
@@ -1,0 +1,543 @@
+"""First-class, broker-neutral portfolio context for graph inputs (#1166).
+
+The Trader, risk analysts, and Portfolio Manager can produce sizing and
+Buy/Overweight/Hold/Underweight/Sell guidance, but the graph previously had
+no typed representation of current holdings and capital. These tests pin the
+input contract:
+
+- ``PortfolioContext`` / ``PositionSnapshot`` schema validation
+- ``None`` (not provided) is distinct from a known flat portfolio
+- a deterministic renderer focused on the instrument under analysis
+- the context reaching Trader / risk / Portfolio Manager prompts
+- ``propagate(..., portfolio_context=...)`` wiring with full backward
+  compatibility for existing calls
+- the ``--portfolio-context`` CLI file loader
+- saved-state metadata recording whether context was present
+
+All tests are credential-free, network-free, and deterministic.
+"""
+from __future__ import annotations
+
+import functools
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+from pydantic import ValidationError
+
+from tradingagents.agents.managers.portfolio_manager import create_portfolio_manager
+from tradingagents.agents.risk_mgmt.aggressive_debator import create_aggressive_debator
+from tradingagents.agents.risk_mgmt.conservative_debator import create_conservative_debator
+from tradingagents.agents.risk_mgmt.neutral_debator import create_neutral_debator
+from tradingagents.agents.schemas import (
+    PortfolioContext,
+    PortfolioDecision,
+    PortfolioRating,
+    PositionSnapshot,
+    TraderAction,
+    TraderProposal,
+    render_portfolio_context,
+)
+from tradingagents.agents.trader.trader import create_trader
+from tradingagents.agents.utils.agent_utils import (
+    MISSING_PORTFOLIO_CONTEXT_NOTICE,
+    get_portfolio_context_from_state,
+    portfolio_prompt_block,
+)
+from tradingagents.graph.propagation import Propagator, normalize_portfolio_context
+
+
+def _sample_context() -> PortfolioContext:
+    return PortfolioContext(
+        positions=[
+            PositionSnapshot(
+                symbol="NVDA", quantity=10.0, market_value=1895.0,
+                average_entry_price=150.0,
+            ),
+            PositionSnapshot(symbol="MSFT", quantity=5.0),
+        ],
+        cash=25000.0,
+        portfolio_value=120000.0,
+        buying_power=50000.0,
+        as_of="2026-01-15",
+        source="paper-broker",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPortfolioContextSchema:
+    def test_empty_is_valid_known_flat(self):
+        ctx = PortfolioContext()
+        assert ctx.positions == []
+        assert ctx.cash is None
+        assert ctx.portfolio_value is None
+        assert ctx.buying_power is None
+        assert ctx.as_of is None
+        assert ctx.source is None
+
+    def test_valid_with_position(self):
+        ctx = _sample_context()
+        assert len(ctx.positions) == 2
+        assert ctx.position_for("nvda") is not None  # case-insensitive
+        assert ctx.position_for("AAPL") is None
+
+    def test_symbol_blank_rejected(self):
+        with pytest.raises(ValidationError):
+            PositionSnapshot(symbol="   ", quantity=1.0)
+
+    def test_quantity_malformed_rejected(self):
+        with pytest.raises(ValidationError):
+            PositionSnapshot(symbol="NVDA", quantity="abc")  # type: ignore[arg-type]
+
+    def test_non_finite_numbers_rejected(self):
+        with pytest.raises(ValidationError):
+            PositionSnapshot(symbol="NVDA", quantity=float("nan"))
+        with pytest.raises(ValidationError):
+            PortfolioContext(cash=float("inf"))
+
+    def test_positions_must_be_a_list(self):
+        with pytest.raises(ValidationError):
+            PortfolioContext(positions={"NVDA": 10.0})  # type: ignore[arg-type]
+
+    def test_json_round_trip(self):
+        ctx = _sample_context()
+        dumped = ctx.model_dump(mode="json")
+        json.dumps(dumped)  # must be JSON-serializable for checkpoints
+        assert PortfolioContext.model_validate(dumped) == ctx
+        assert PortfolioContext.model_validate_json(ctx.model_dump_json()) == ctx
+
+
+# ---------------------------------------------------------------------------
+# Renderer semantics: missing vs empty vs populated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPortfolioRendering:
+    def test_missing_context_notice(self):
+        block = portfolio_prompt_block({"company_of_interest": "NVDA"})
+        assert block == MISSING_PORTFOLIO_CONTEXT_NOTICE
+        assert "flat" not in block.lower()
+        assert "0" not in block  # must not invent a zero position
+
+    def test_none_state_value_is_missing(self):
+        assert get_portfolio_context_from_state({"portfolio_context": None}) is None
+
+    def test_empty_positions_is_known_flat(self):
+        block = portfolio_prompt_block({
+            "company_of_interest": "NVDA",
+            "portfolio_context": PortfolioContext().model_dump(mode="json"),
+        })
+        assert "flat" in block.lower()
+        assert MISSING_PORTFOLIO_CONTEXT_NOTICE not in block
+
+    def test_current_position_rendered_with_facts(self):
+        text = render_portfolio_context(_sample_context(), "NVDA")
+        assert "10" in text and "NVDA" in text
+        assert "$1,895.00" in text
+        assert "$150.00" in text
+        assert "$25,000.00" in text  # cash
+        assert "$120,000.00" in text  # portfolio value
+        assert "2026-01-15" in text and "paper-broker" in text
+
+    def test_other_holdings_summarized_not_dumped(self):
+        text = render_portfolio_context(_sample_context(), "AAPL")
+        assert "no current AAPL position" in text
+        assert "2 other position(s)" in text
+        assert "MSFT" not in text  # focus the current symbol; full data stays in state
+        assert "{" not in text and "}" not in text  # never str(dict)
+
+    def test_missing_capital_labelled(self):
+        text = render_portfolio_context(PortfolioContext(), "NVDA")
+        assert "no capital figures provided" in text
+
+    def test_typed_model_accepted_from_state(self):
+        ctx = _sample_context()
+        assert get_portfolio_context_from_state({"portfolio_context": ctx}) == ctx
+
+
+# ---------------------------------------------------------------------------
+# Agent prompt propagation (fake LLMs, no network)
+# ---------------------------------------------------------------------------
+
+
+def _capturing_structured_trader(captured: dict):
+    proposal = TraderProposal(action=TraderAction.BUY, reasoning="grounded case")
+    structured = MagicMock()
+    structured.invoke.side_effect = lambda prompt: (
+        captured.__setitem__("prompt", prompt) or proposal
+    )
+    llm = MagicMock()
+    llm.with_structured_output.return_value = structured
+    return llm
+
+
+def _capturing_structured_pm(captured: dict):
+    decision = PortfolioDecision(
+        rating=PortfolioRating.HOLD,
+        executive_summary="Hold; await catalyst.",
+        investment_thesis="Balanced debate.",
+    )
+    structured = MagicMock()
+    structured.invoke.side_effect = lambda prompt: (
+        captured.__setitem__("prompt", prompt) or decision
+    )
+    llm = MagicMock()
+    llm.with_structured_output.return_value = structured
+    return llm
+
+
+def _capturing_debator_llm(captured: dict):
+    llm = MagicMock()
+    llm.invoke.side_effect = lambda prompt: (
+        captured.__setitem__("prompt", prompt)
+        or MagicMock(content="Debate argument.")
+    )
+    return llm
+
+
+def _prompt_text(prompt) -> str:
+    if isinstance(prompt, str):
+        return prompt
+    parts = []
+    for m in prompt:
+        parts.append(
+            m.get("content", "") if isinstance(m, dict) else getattr(m, "content", "")
+        )
+    return "\n".join(str(p) for p in parts)
+
+
+def _trader_state(**overrides):
+    state = {
+        "company_of_interest": "NVDA",
+        "investment_plan": "**Recommendation**: Buy",
+        "market_report": "Current price $189.5; ATR 4.2.",
+    }
+    state.update(overrides)
+    return state
+
+
+def _pm_state(**overrides):
+    state = {
+        "company_of_interest": "NVDA",
+        "risk_debate_state": {
+            "history": "h", "aggressive_history": "a",
+            "conservative_history": "c", "neutral_history": "n",
+            "current_aggressive_response": "", "current_conservative_response": "",
+            "current_neutral_response": "", "latest_speaker": "Neutral", "count": 1,
+        },
+        "investment_plan": "plan",
+        "trader_investment_plan": "trader plan",
+    }
+    state.update(overrides)
+    return state
+
+
+def _risk_state(**overrides):
+    state = {
+        "company_of_interest": "NVDA",
+        "market_report": "m", "sentiment_report": "s",
+        "news_report": "n", "fundamentals_report": "f",
+        "trader_investment_plan": "Buy NVDA.",
+        "risk_debate_state": {
+            "history": "", "aggressive_history": "", "conservative_history": "",
+            "neutral_history": "", "current_aggressive_response": "",
+            "current_conservative_response": "", "current_neutral_response": "",
+            "latest_speaker": "", "count": 0,
+        },
+    }
+    state.update(overrides)
+    return state
+
+
+@pytest.mark.unit
+class TestDecisionNodePrompts:
+    def test_trader_prompt_gets_context(self):
+        captured = {}
+        create_trader(_capturing_structured_trader(captured))(
+            _trader_state(
+                portfolio_context=_sample_context().model_dump(mode="json")
+            )
+        )
+        text = _prompt_text(captured["prompt"])
+        assert "Portfolio Context:" in text
+        assert "10" in text and "NVDA" in text
+
+    def test_trader_prompt_missing_notice_without_context(self):
+        """Backward compatible: old-style states without the key still work."""
+        captured = {}
+        create_trader(_capturing_structured_trader(captured))(_trader_state())
+        assert MISSING_PORTFOLIO_CONTEXT_NOTICE in _prompt_text(captured["prompt"])
+
+    def test_pm_prompt_gets_context(self):
+        captured = {}
+        create_portfolio_manager(_capturing_structured_pm(captured))(
+            _pm_state(portfolio_context=_sample_context().model_dump(mode="json"))
+        )
+        text = _prompt_text(captured["prompt"])
+        assert "Portfolio Context:" in text
+        assert "$25,000.00" in text
+
+    def test_pm_prompt_missing_notice_without_context(self):
+        captured = {}
+        create_portfolio_manager(_capturing_structured_pm(captured))(_pm_state())
+        assert MISSING_PORTFOLIO_CONTEXT_NOTICE in _prompt_text(captured["prompt"])
+
+    @pytest.mark.parametrize(
+        "factory",
+        [create_aggressive_debator, create_conservative_debator, create_neutral_debator],
+        ids=["aggressive", "conservative", "neutral"],
+    )
+    def test_risk_debators_get_context(self, factory):
+        captured = {}
+        factory(_capturing_debator_llm(captured))(
+            _risk_state(
+                portfolio_context=_sample_context().model_dump(mode="json")
+            )
+        )
+        assert "Portfolio Context:" in captured["prompt"]
+
+    @pytest.mark.parametrize(
+        "factory",
+        [create_aggressive_debator, create_conservative_debator, create_neutral_debator],
+        ids=["aggressive", "conservative", "neutral"],
+    )
+    def test_risk_debators_missing_notice_without_context(self, factory):
+        captured = {}
+        factory(_capturing_debator_llm(captured))(_risk_state())
+        assert MISSING_PORTFOLIO_CONTEXT_NOTICE in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Graph wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGraphWiring:
+    def test_initial_state_defaults_to_missing(self):
+        state = Propagator().create_initial_state("NVDA", "2026-01-10")
+        assert state["portfolio_context"] is None
+
+    def test_initial_state_accepts_model_and_dict(self):
+        ctx = _sample_context()
+        from_model = Propagator().create_initial_state(
+            "NVDA", "2026-01-10", portfolio_context=ctx
+        )["portfolio_context"]
+        from_dict = Propagator().create_initial_state(
+            "NVDA", "2026-01-10", portfolio_context=ctx.model_dump(mode="json")
+        )["portfolio_context"]
+        assert from_model == from_dict
+        json.dumps(from_model)  # checkpoint-safe
+
+    def test_initial_state_rejects_malformed(self):
+        with pytest.raises(ValidationError):
+            Propagator().create_initial_state(
+                "NVDA", "2026-01-10", portfolio_context={"cash": "lots"}
+            )
+
+    def test_normalize_helper(self):
+        assert normalize_portfolio_context(None) is None
+        dumped = normalize_portfolio_context(_sample_context())
+        assert PortfolioContext.model_validate(dumped) == _sample_context()
+
+    def test_propagate_threads_context(self, tmp_path):
+        """propagate() forwards portfolio_context to state creation (mocked graph)."""
+        from tradingagents.agents.utils.memory import TradingMemoryLog
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        fake_state = {
+            "final_trade_decision": "Rating: Buy\nBuy NVDA.",
+            "company_of_interest": "NVDA",
+            "trade_date": "2026-01-10",
+            "market_report": "", "sentiment_report": "", "news_report": "",
+            "fundamentals_report": "",
+            "investment_debate_state": {
+                "bull_history": "", "bear_history": "", "history": "",
+                "current_response": "", "judge_decision": "",
+            },
+            "investment_plan": "", "trader_investment_plan": "",
+            "risk_debate_state": {
+                "aggressive_history": "", "conservative_history": "",
+                "neutral_history": "", "history": "", "judge_decision": "",
+                "current_aggressive_response": "", "current_conservative_response": "",
+                "current_neutral_response": "", "count": 1, "latest_speaker": "",
+            },
+        }
+        mock_graph = MagicMock()
+        mock_graph.memory_log = TradingMemoryLog(
+            {"memory_log_path": str(tmp_path / "mem.md")}
+        )
+        mock_graph.log_states_dict = {}
+        mock_graph.debug = False
+        mock_graph.config = {"results_dir": str(tmp_path)}
+        mock_graph.graph.invoke.return_value = fake_state
+        mock_graph.propagator = Propagator()
+        mock_graph.propagator.get_graph_args = MagicMock(return_value={})
+        mock_graph.propagator.create_initial_state = MagicMock(
+            wraps=mock_graph.propagator.create_initial_state
+        )
+        mock_graph.signal_processor.process_signal.return_value = "Buy"
+        mock_graph.process_signal = functools.partial(
+            TradingAgentsGraph.process_signal, mock_graph
+        )
+        mock_graph._run_graph = functools.partial(
+            TradingAgentsGraph._run_graph, mock_graph
+        )
+        ctx = _sample_context()
+        TradingAgentsGraph.propagate(
+            mock_graph, "NVDA", "2026-01-10", portfolio_context=ctx
+        )
+        _, kwargs = mock_graph.propagator.create_initial_state.call_args
+        assert kwargs["portfolio_context"] == ctx
+
+    def test_propagate_without_context_stays_backward_compatible(self, tmp_path):
+        """Existing propagate(ticker, date) calls pass portfolio_context=None."""
+        from tradingagents.agents.utils.memory import TradingMemoryLog
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        fake_state = {
+            "final_trade_decision": "Rating: Hold\nHold NVDA.",
+            "company_of_interest": "NVDA",
+            "trade_date": "2026-01-10",
+            "market_report": "", "sentiment_report": "", "news_report": "",
+            "fundamentals_report": "",
+            "investment_debate_state": {
+                "bull_history": "", "bear_history": "", "history": "",
+                "current_response": "", "judge_decision": "",
+            },
+            "investment_plan": "", "trader_investment_plan": "",
+            "risk_debate_state": {
+                "aggressive_history": "", "conservative_history": "",
+                "neutral_history": "", "history": "", "judge_decision": "",
+                "current_aggressive_response": "", "current_conservative_response": "",
+                "current_neutral_response": "", "count": 1, "latest_speaker": "",
+            },
+        }
+        mock_graph = MagicMock()
+        mock_graph.memory_log = TradingMemoryLog(
+            {"memory_log_path": str(tmp_path / "mem.md")}
+        )
+        mock_graph.log_states_dict = {}
+        mock_graph.debug = False
+        mock_graph.config = {"results_dir": str(tmp_path)}
+        mock_graph.graph.invoke.return_value = fake_state
+        mock_graph.propagator = Propagator()
+        mock_graph.propagator.get_graph_args = MagicMock(return_value={})
+        mock_graph.propagator.create_initial_state = MagicMock(
+            wraps=mock_graph.propagator.create_initial_state
+        )
+        mock_graph.signal_processor.process_signal.return_value = "Hold"
+        mock_graph.process_signal = functools.partial(
+            TradingAgentsGraph.process_signal, mock_graph
+        )
+        mock_graph._run_graph = functools.partial(
+            TradingAgentsGraph._run_graph, mock_graph
+        )
+        _, signal = TradingAgentsGraph.propagate(mock_graph, "NVDA", "2026-01-10")
+        assert signal == "Hold"
+        _, kwargs = mock_graph.propagator.create_initial_state.call_args
+        assert kwargs["portfolio_context"] is None
+
+
+# ---------------------------------------------------------------------------
+# Saved-state metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSavedStateMetadata:
+    def _bare_graph(self, tmp_path):
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        g = object.__new__(TradingAgentsGraph)
+        g.config = {"results_dir": str(tmp_path)}
+        g.ticker = "NVDA"
+        g.log_states_dict = {}
+        return g
+
+    def _final_state(self, **overrides):
+        state = {
+            "company_of_interest": "NVDA",
+            "trade_date": "2026-01-10",
+            "market_report": "", "sentiment_report": "", "news_report": "",
+            "fundamentals_report": "",
+            "investment_debate_state": {
+                "bull_history": "", "bear_history": "", "history": "",
+                "current_response": "", "judge_decision": "",
+            },
+            "trader_investment_plan": "",
+            "risk_debate_state": {
+                "aggressive_history": "", "conservative_history": "",
+                "neutral_history": "", "history": "", "judge_decision": "",
+            },
+            "investment_plan": "",
+            "final_trade_decision": "Rating: Hold",
+        }
+        state.update(overrides)
+        return state
+
+    def test_present_context_recorded(self, tmp_path):
+        g = self._bare_graph(tmp_path)
+        dumped = _sample_context().model_dump(mode="json")
+        g._log_state("2026-01-10", self._final_state(portfolio_context=dumped))
+        logged = g.log_states_dict["2026-01-10"]
+        assert logged["portfolio_context_present"] is True
+        assert logged["portfolio_context"] == dumped
+
+    def test_missing_context_recorded_as_absent(self, tmp_path):
+        g = self._bare_graph(tmp_path)
+        g._log_state("2026-01-10", self._final_state(portfolio_context=None))
+        logged = g.log_states_dict["2026-01-10"]
+        assert logged["portfolio_context_present"] is False
+        assert logged["portfolio_context"] is None
+
+
+# ---------------------------------------------------------------------------
+# CLI loader
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPortfolioContextFileLoader:
+    def test_valid_file(self, tmp_path):
+        from cli.main import load_portfolio_context_file
+
+        payload = {
+            "positions": [{"symbol": "NVDA", "quantity": 10}],
+            "cash": 1000.0,
+            "as_of": "2026-01-15",
+            "source": "manual",
+        }
+        path = tmp_path / "portfolio.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        loaded = load_portfolio_context_file(str(path))
+        assert PortfolioContext.model_validate(loaded) == PortfolioContext.model_validate(payload)
+
+    def test_missing_file(self, tmp_path):
+        from cli.main import load_portfolio_context_file
+
+        with pytest.raises(typer.BadParameter, match="not found"):
+            load_portfolio_context_file(str(tmp_path / "nope.json"))
+
+    def test_malformed_json(self, tmp_path):
+        from cli.main import load_portfolio_context_file
+
+        path = tmp_path / "bad.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(typer.BadParameter, match="not valid JSON"):
+            load_portfolio_context_file(str(path))
+
+    def test_schema_violation(self, tmp_path):
+        from cli.main import load_portfolio_context_file
+
+        path = tmp_path / "invalid.json"
+        path.write_text(json.dumps({"cash": "lots"}), encoding="utf-8")
+        with pytest.raises(typer.BadParameter, match="failed validation"):
+            load_portfolio_context_file(str(path))

--- a/tests/test_portfolio_context.py
+++ b/tests/test_portfolio_context.py
@@ -45,7 +45,12 @@ from tradingagents.agents.utils.agent_utils import (
     get_portfolio_context_from_state,
     portfolio_prompt_block,
 )
-from tradingagents.graph.propagation import Propagator, normalize_portfolio_context
+from tradingagents.graph.propagation import (
+    MISSING_PORTFOLIO_FINGERPRINT,
+    Propagator,
+    normalize_portfolio_context,
+    portfolio_context_fingerprint,
+)
 
 
 def _sample_context() -> PortfolioContext:
@@ -62,6 +67,7 @@ def _sample_context() -> PortfolioContext:
         buying_power=50000.0,
         as_of="2026-01-15",
         source="paper-broker",
+        currency="USD",
     )
 
 
@@ -139,12 +145,15 @@ class TestPortfolioRendering:
 
     def test_current_position_rendered_with_facts(self):
         text = render_portfolio_context(_sample_context(), "NVDA")
-        assert "10" in text and "NVDA" in text
-        assert "$1,895.00" in text
-        assert "$150.00" in text
-        assert "$25,000.00" in text  # cash
-        assert "$120,000.00" in text  # portfolio value
+        assert "10 units" in text and "NVDA" in text
+        assert "shares" not in text
+        assert "1,895.00 USD" in text
+        assert "avg entry 150.00" in text  # quote currency: no portfolio label
+        assert "USD" not in text.split("avg entry")[1].split("\n")[0]
+        assert "25,000.00 USD" in text  # cash
+        assert "120,000.00 USD" in text  # portfolio value
         assert "2026-01-15" in text and "paper-broker" in text
+        assert "$" not in text
 
     def test_other_holdings_summarized_not_dumped(self):
         text = render_portfolio_context(_sample_context(), "AAPL")
@@ -282,7 +291,7 @@ class TestDecisionNodePrompts:
         )
         text = _prompt_text(captured["prompt"])
         assert "Portfolio Context:" in text
-        assert "$25,000.00" in text
+        assert "25,000.00 USD" in text
 
     def test_pm_prompt_missing_notice_without_context(self):
         captured = {}
@@ -541,3 +550,197 @@ class TestPortfolioContextFileLoader:
         path.write_text(json.dumps({"cash": "lots"}), encoding="utf-8")
         with pytest.raises(typer.BadParameter, match="failed validation"):
             load_portfolio_context_file(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Optional currency label (market-neutral display, no FX conversion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPortfolioCurrency:
+    def test_defaults_to_none(self):
+        assert PortfolioContext().currency is None
+
+    def test_normalized_to_uppercase(self):
+        assert PortfolioContext(currency="usd").currency == "USD"
+        assert PortfolioContext(currency="  jpy ").currency == "JPY"
+
+    def test_blank_rejected(self):
+        with pytest.raises(ValidationError):
+            PortfolioContext(currency="   ")
+
+    def test_currency_participates_in_round_trip(self):
+        ctx = PortfolioContext(currency="EUR", cash=100.0)
+        assert PortfolioContext.model_validate(ctx.model_dump(mode="json")) == ctx
+
+
+@pytest.mark.unit
+class TestMarketNeutralRendering:
+    def test_no_currency_renders_bare_numbers(self):
+        ctx = PortfolioContext(
+            positions=[PositionSnapshot(symbol="NVDA", quantity=10.0, market_value=1895.0)],
+            cash=25000.0,
+        )
+        text = render_portfolio_context(ctx, "NVDA")
+        assert "1,895.00" in text
+        assert "25,000.00" in text
+        assert "$" not in text
+
+    def test_crypto_quantity_uses_units(self):
+        ctx = PortfolioContext(
+            positions=[PositionSnapshot(symbol="BTC-USD", quantity=0.5)],
+        )
+        text = render_portfolio_context(ctx, "BTC-USD")
+        assert "0.5 units" in text
+        assert "shares" not in text
+
+    def test_jpy_snapshot_has_no_dollar_sign(self):
+        ctx = PortfolioContext(
+            currency="JPY",
+            positions=[
+                PositionSnapshot(
+                    symbol="7203.T", quantity=100.0, market_value=280000.0,
+                    average_entry_price=2700.0,
+                )
+            ],
+            cash=100000.0,
+            as_of="2026-01-15",
+            source="paper-broker",
+        )
+        text = render_portfolio_context(ctx, "7203.T")
+        assert "280,000.00 JPY" in text
+        assert "100,000.00 JPY" in text
+        assert "100 units" in text
+        assert "$" not in text
+        # Entry price is quoted in the instrument's own currency, which may
+        # differ from the portfolio currency: no inherited label.
+        assert "avg entry 2,700.00" in text
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fingerprint for checkpoint identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPortfolioFingerprint:
+    def test_deterministic(self):
+        assert portfolio_context_fingerprint(_sample_context()) == (
+            portfolio_context_fingerprint(_sample_context())
+        )
+
+    def test_model_vs_dict_agree(self):
+        ctx = _sample_context()
+        assert portfolio_context_fingerprint(ctx) == (
+            portfolio_context_fingerprint(ctx.model_dump(mode="json"))
+        )
+
+    def test_dict_key_order_irrelevant(self):
+        a = {"cash": 1000.0, "positions": [{"symbol": "NVDA", "quantity": 10.0}]}
+        b = {"positions": [{"quantity": 10.0, "symbol": "NVDA"}], "cash": 1000.0}
+        assert portfolio_context_fingerprint(a) == portfolio_context_fingerprint(b)
+
+    def test_position_order_irrelevant(self):
+        a = _sample_context()
+        b = _sample_context()
+        b.positions = list(reversed(b.positions))
+        assert portfolio_context_fingerprint(a) == portfolio_context_fingerprint(b)
+
+    def test_changed_holdings_change_fingerprint(self):
+        base = portfolio_context_fingerprint(_sample_context())
+
+        changed_qty = _sample_context()
+        changed_qty.positions[0].quantity = 30.0
+        assert portfolio_context_fingerprint(changed_qty) != base
+
+        changed_cash = _sample_context()
+        changed_cash.cash = 1.0
+        assert portfolio_context_fingerprint(changed_cash) != base
+
+        changed_value = _sample_context()
+        changed_value.portfolio_value = 1.0
+        assert portfolio_context_fingerprint(changed_value) != base
+
+        changed_power = _sample_context()
+        changed_power.buying_power = 1.0
+        assert portfolio_context_fingerprint(changed_power) != base
+
+        changed_list = _sample_context()
+        changed_list.positions = changed_list.positions[:1]
+        assert portfolio_context_fingerprint(changed_list) != base
+
+        changed_asof = _sample_context()
+        changed_asof.as_of = "2026-01-16"
+        assert portfolio_context_fingerprint(changed_asof) != base
+
+        changed_source = _sample_context()
+        changed_source.source = "manual"
+        assert portfolio_context_fingerprint(changed_source) != base
+
+        changed_currency = _sample_context()
+        changed_currency.currency = "EUR"
+        assert portfolio_context_fingerprint(changed_currency) != base
+
+    def test_missing_is_fixed_marker(self):
+        assert portfolio_context_fingerprint(None) == MISSING_PORTFOLIO_FINGERPRINT
+        assert MISSING_PORTFOLIO_FINGERPRINT == "none"
+
+    def test_missing_differs_from_known_empty(self):
+        """Missing context must never share checkpoint identity with a flat portfolio."""
+        assert portfolio_context_fingerprint(None) != (
+            portfolio_context_fingerprint(PortfolioContext())
+        )
+
+    def test_fingerprint_is_short_hex_without_holdings(self):
+        fp = portfolio_context_fingerprint(_sample_context())
+        assert len(fp) == 16
+        int(fp, 16)  # hex
+        assert "NVDA" not in fp and "{" not in fp
+
+
+@pytest.mark.unit
+class TestCheckpointIdentity:
+    def _signature(self, stub_config, portfolio_context=None):
+        from tradingagents.graph.trading_graph import TradingAgentsGraph
+
+        stub = MagicMock()
+        stub.config = stub_config
+        stub.selected_analysts = ("market",)
+        return TradingAgentsGraph._run_signature(stub, "stock", portfolio_context)
+
+    def test_default_signature_marks_missing(self):
+        config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+        assert "portfolio=none" in self._signature(config)
+
+    def test_same_snapshot_same_signature(self):
+        config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+        assert self._signature(config, _sample_context()) == (
+            self._signature(config, _sample_context().model_dump(mode="json"))
+        )
+
+    def test_changed_snapshot_changes_signature(self):
+        config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+        changed = _sample_context()
+        changed.positions[0].quantity = 30.0
+        assert self._signature(config, _sample_context()) != (
+            self._signature(config, changed)
+        )
+
+    def test_stale_checkpoint_unreachable(self):
+        """A changed snapshot routes to a different checkpoint thread, so an
+        old-context checkpoint can never be resumed by a new-context run."""
+        from tradingagents.graph.checkpointer import thread_id
+
+        config = {"max_debate_rounds": 1, "max_risk_discuss_rounds": 1}
+        changed = _sample_context()
+        changed.positions[0].quantity = 30.0
+        sig_old = self._signature(config, _sample_context())
+        sig_new = self._signature(config, changed)
+        assert thread_id("NVDA", "2026-01-10", sig_old) != (
+            thread_id("NVDA", "2026-01-10", sig_new)
+        )
+        # ...while an unchanged snapshot reproduces the identical thread.
+        assert thread_id("NVDA", "2026-01-10", sig_old) == (
+            thread_id("NVDA", "2026-01-10", self._signature(config, _sample_context()))
+        )

--- a/tradingagents/agents/managers/portfolio_manager.py
+++ b/tradingagents/agents/managers/portfolio_manager.py
@@ -14,6 +14,7 @@ from tradingagents.agents.schemas import PortfolioDecision, render_pm_decision
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
+    portfolio_prompt_block,
 )
 from tradingagents.agents.utils.structured import (
     NO_EXTERNAL_TOOLS,
@@ -27,6 +28,9 @@ def create_portfolio_manager(llm):
 
     def portfolio_manager_node(state) -> dict:
         instrument_context = get_instrument_context_from_state(state)
+        # Optional broker-neutral snapshot of current holdings and capital;
+        # an explicit "not provided" notice when absent (#1166).
+        portfolio_block = portfolio_prompt_block(state)
 
         history = state["risk_debate_state"]["history"]
         risk_debate_state = state["risk_debate_state"]
@@ -56,6 +60,7 @@ def create_portfolio_manager(llm):
 **Context:**
 - Research Manager's investment plan: **{research_plan}**
 - Trader's transaction proposal: **{trader_plan}**
+- {portfolio_block}
 {lessons_line}
 **Risk Analysts Debate History:**
 {history}

--- a/tradingagents/agents/risk_mgmt/aggressive_debator.py
+++ b/tradingagents/agents/risk_mgmt/aggressive_debator.py
@@ -2,6 +2,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
     opponent_argument_or_opening,
+    portfolio_prompt_block,
 )
 
 
@@ -23,6 +24,7 @@ def create_aggressive_debator(llm):
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
         instrument_context = get_instrument_context_from_state(state)
+        portfolio_block = portfolio_prompt_block(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -33,6 +35,7 @@ def create_aggressive_debator(llm):
 Your task is to create a compelling case for the trader's decision by questioning and critiquing the conservative and neutral stances to demonstrate why your high-reward perspective offers the best path forward. Incorporate insights from the following sources into your arguments:
 
 {instrument_context}
+{portfolio_block}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/risk_mgmt/conservative_debator.py
+++ b/tradingagents/agents/risk_mgmt/conservative_debator.py
@@ -2,6 +2,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
     opponent_argument_or_opening,
+    portfolio_prompt_block,
 )
 
 
@@ -23,6 +24,7 @@ def create_conservative_debator(llm):
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
         instrument_context = get_instrument_context_from_state(state)
+        portfolio_block = portfolio_prompt_block(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -33,6 +35,7 @@ def create_conservative_debator(llm):
 Your task is to actively counter the arguments of the Aggressive and Neutral Analysts, highlighting where their views may overlook potential threats or fail to prioritize sustainability. Respond directly to their points, drawing from the following data sources to build a convincing case for a low-risk approach adjustment to the trader's decision:
 
 {instrument_context}
+{portfolio_block}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/risk_mgmt/neutral_debator.py
+++ b/tradingagents/agents/risk_mgmt/neutral_debator.py
@@ -2,6 +2,7 @@ from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
     opponent_argument_or_opening,
+    portfolio_prompt_block,
 )
 
 
@@ -23,6 +24,7 @@ def create_neutral_debator(llm):
         news_report = state["news_report"]
         fundamentals_report = state["fundamentals_report"]
         instrument_context = get_instrument_context_from_state(state)
+        portfolio_block = portfolio_prompt_block(state)
 
         trader_decision = state["trader_investment_plan"]
 
@@ -33,6 +35,7 @@ def create_neutral_debator(llm):
 Your task is to challenge both the Aggressive and Conservative Analysts, pointing out where each perspective may be overly optimistic or overly cautious. Use insights from the following data sources to support a moderate, sustainable strategy to adjust the trader's decision:
 
 {instrument_context}
+{portfolio_block}
 Market Research Report: {market_research_report}
 Social Media Sentiment Report: {sentiment_report}
 Latest World Affairs Report: {news_report}

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -330,6 +330,23 @@ class PortfolioContext(BaseModel):
         default=None,
         description="Optional snapshot origin label (e.g. 'paper-broker', 'manual').",
     )
+    currency: str | None = Field(
+        default=None,
+        description=(
+            "Optional portfolio reporting currency label (e.g. 'USD', 'JPY'). "
+            "Display-only; TradingAgents performs no FX conversion."
+        ),
+    )
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        cleaned = v.strip().upper()
+        if not cleaned:
+            raise ValueError("currency must be a non-empty label or omitted")
+        return cleaned
 
     def position_for(self, symbol: str) -> PositionSnapshot | None:
         """Return the position matching ``symbol`` (case-insensitive), if any."""
@@ -340,8 +357,17 @@ class PortfolioContext(BaseModel):
         return None
 
 
-def _format_money(value: float) -> str:
-    return f"${value:,.2f}"
+def _format_amount(value: float, currency: str | None = None) -> str:
+    """Format an amount with an optional ISO-style currency label.
+
+    No currency symbols are used: ``$`` is ambiguous across USD/CAD/AUD/HKD,
+    and the framework is market-neutral (non-US equities, crypto). Amounts
+    without a currency render as bare numbers.
+    """
+    text = f"{value:,.2f}"
+    if currency:
+        return f"{text} {currency.strip().upper()}"
+    return text
 
 
 def render_portfolio_context(context: PortfolioContext, symbol: str) -> str:
@@ -350,6 +376,12 @@ def render_portfolio_context(context: PortfolioContext, symbol: str) -> str:
     Only the current instrument's position is itemised; the remaining
     holdings are summarised by count so prompts stay small and stable.
     Never renders ``str(dict)``: every line is an explicit, labelled fact.
+
+    Market-neutral: quantities use generic ``units`` (stocks, ETFs, crypto),
+    and amounts carry the optional portfolio ``currency`` label only. The
+    average entry price is quoted in the instrument's own quote currency,
+    which may differ from the portfolio currency, so it never inherits the
+    portfolio currency label.
     """
     lines = ["Portfolio Context:"]
     snapshot = context.as_of or "timestamp not recorded"
@@ -358,23 +390,29 @@ def render_portfolio_context(context: PortfolioContext, symbol: str) -> str:
 
     capital = []
     if context.portfolio_value is not None:
-        capital.append(f"portfolio value {_format_money(context.portfolio_value)}")
+        capital.append(
+            f"portfolio value {_format_amount(context.portfolio_value, context.currency)}"
+        )
     if context.cash is not None:
-        capital.append(f"cash {_format_money(context.cash)}")
+        capital.append(f"cash {_format_amount(context.cash, context.currency)}")
     if context.buying_power is not None:
-        capital.append(f"buying power {_format_money(context.buying_power)}")
+        capital.append(
+            f"buying power {_format_amount(context.buying_power, context.currency)}"
+        )
     lines.append(
         "- Capital: " + ("; ".join(capital) if capital else "no capital figures provided")
     )
 
     current = context.position_for(symbol)
     if current is not None:
-        detail = f"- Current {current.symbol} position: {current.quantity:g} shares"
+        detail = f"- Current {current.symbol} position: {current.quantity:g} units"
         extras = []
         if current.market_value is not None:
-            extras.append(f"market value {_format_money(current.market_value)}")
+            extras.append(
+                f"market value {_format_amount(current.market_value, context.currency)}"
+            )
         if current.average_entry_price is not None:
-            extras.append(f"avg entry {_format_money(current.average_entry_price)}")
+            extras.append(f"avg entry {_format_amount(current.average_entry_price)}")
         if extras:
             detail += f" ({'; '.join(extras)})"
         lines.append(detail + ".")

--- a/tradingagents/agents/schemas.py
+++ b/tradingagents/agents/schemas.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # LLMs sometimes write a placeholder string ("None", "N/A", ...) into an optional
 # numeric field instead of omitting it. Coerce those to None so the structured
@@ -253,6 +253,139 @@ def render_pm_decision(decision: PortfolioDecision) -> str:
     if decision.time_horizon:
         parts.extend(["", f"**Time Horizon**: {decision.time_horizon}"])
     return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Portfolio Context (#1166)
+# ---------------------------------------------------------------------------
+
+
+class PositionSnapshot(BaseModel):
+    """A single instrument holding inside a portfolio snapshot.
+
+    Broker-neutral by design: no account identifiers, order ids, credentials,
+    or broker-specific fields. Quantity is signed (negative for short) and in
+    the instrument's native share/coin units.
+    """
+
+    model_config = ConfigDict(allow_inf_nan=False)
+
+    symbol: str = Field(
+        description="Instrument symbol exactly as the caller tracks it (e.g. 'NVDA').",
+    )
+    quantity: float = Field(
+        description="Signed position size in native units (negative for short).",
+    )
+    market_value: float | None = Field(
+        default=None,
+        description="Optional current market value in the portfolio currency.",
+    )
+    average_entry_price: float | None = Field(
+        default=None,
+        description="Optional average entry price in the instrument's quote currency.",
+    )
+
+    @field_validator("symbol")
+    @classmethod
+    def _strip_symbol(cls, v: str) -> str:
+        cleaned = v.strip()
+        if not cleaned:
+            raise ValueError("symbol must be a non-empty string")
+        return cleaned
+
+
+class PortfolioContext(BaseModel):
+    """Optional, broker-neutral snapshot of the portfolio being analysed.
+
+    Threaded through the graph as plain JSON-safe data so it survives
+    checkpointing. ``None`` at the graph entrypoint means the context was not
+    provided; a ``PortfolioContext`` with empty ``positions`` means a known
+    flat portfolio. The two states are deliberately distinct: agents must not
+    present sizing guidance as portfolio-grounded when no context was given.
+    """
+
+    model_config = ConfigDict(allow_inf_nan=False)
+
+    positions: list[PositionSnapshot] = Field(
+        default_factory=list,
+        description="Open positions. Empty means a known flat portfolio.",
+    )
+    cash: float | None = Field(
+        default=None,
+        description="Optional available cash in the portfolio currency.",
+    )
+    portfolio_value: float | None = Field(
+        default=None,
+        description="Optional total portfolio value in the portfolio currency.",
+    )
+    buying_power: float | None = Field(
+        default=None,
+        description="Optional buying power in the portfolio currency.",
+    )
+    as_of: str | None = Field(
+        default=None,
+        description="Optional snapshot timestamp (ISO-8601 expected, free-form accepted).",
+    )
+    source: str | None = Field(
+        default=None,
+        description="Optional snapshot origin label (e.g. 'paper-broker', 'manual').",
+    )
+
+    def position_for(self, symbol: str) -> PositionSnapshot | None:
+        """Return the position matching ``symbol`` (case-insensitive), if any."""
+        wanted = symbol.strip().upper()
+        for position in self.positions:
+            if position.symbol.upper() == wanted:
+                return position
+        return None
+
+
+def _format_money(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def render_portfolio_context(context: PortfolioContext, symbol: str) -> str:
+    """Render a deterministic portfolio block focused on ``symbol``.
+
+    Only the current instrument's position is itemised; the remaining
+    holdings are summarised by count so prompts stay small and stable.
+    Never renders ``str(dict)``: every line is an explicit, labelled fact.
+    """
+    lines = ["Portfolio Context:"]
+    snapshot = context.as_of or "timestamp not recorded"
+    origin = context.source or "unspecified"
+    lines.append(f"- Snapshot: {snapshot} (source: {origin})")
+
+    capital = []
+    if context.portfolio_value is not None:
+        capital.append(f"portfolio value {_format_money(context.portfolio_value)}")
+    if context.cash is not None:
+        capital.append(f"cash {_format_money(context.cash)}")
+    if context.buying_power is not None:
+        capital.append(f"buying power {_format_money(context.buying_power)}")
+    lines.append(
+        "- Capital: " + ("; ".join(capital) if capital else "no capital figures provided")
+    )
+
+    current = context.position_for(symbol)
+    if current is not None:
+        detail = f"- Current {current.symbol} position: {current.quantity:g} shares"
+        extras = []
+        if current.market_value is not None:
+            extras.append(f"market value {_format_money(current.market_value)}")
+        if current.average_entry_price is not None:
+            extras.append(f"avg entry {_format_money(current.average_entry_price)}")
+        if extras:
+            detail += f" ({'; '.join(extras)})"
+        lines.append(detail + ".")
+    elif not context.positions:
+        lines.append("- Holdings: known flat portfolio, no open positions.")
+    else:
+        lines.append(
+            f"- Holdings: no current {symbol.strip() or 'requested-instrument'} position; "
+            f"{len(context.positions)} other position(s) held."
+        )
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -10,6 +10,7 @@ from tradingagents.agents.schemas import TraderProposal, render_trader_proposal
 from tradingagents.agents.utils.agent_utils import (
     get_instrument_context_from_state,
     get_language_instruction,
+    portfolio_prompt_block,
 )
 from tradingagents.agents.utils.structured import (
     NO_EXTERNAL_TOOLS,
@@ -25,6 +26,10 @@ def create_trader(llm):
         company_name = state["company_of_interest"]
         instrument_context = get_instrument_context_from_state(state)
         investment_plan = state["investment_plan"]
+        # Optional broker-neutral snapshot of current holdings and capital.
+        # Renders an explicit "not provided" notice when absent so the Trader
+        # never mistakes a missing portfolio for a flat one (#1166).
+        portfolio_block = portfolio_prompt_block(state)
         # The research plan digests the debate but loses exact price structure;
         # give the Trader the technical market report so entry/stop levels are
         # grounded in real ATR / support-resistance / current price (#1167). The
@@ -61,6 +66,7 @@ def create_trader(llm):
                     f"{instrument_context}\n\n"
                     f"{report_section}"
                     f"Proposed Investment Plan:\n{investment_plan}\n\n"
+                    f"{portfolio_block}\n\n"
                     f"Make an informed, strategic trading decision."
                 ),
             },

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -49,6 +49,12 @@ class AgentState(MessagesState):
     asset_type: Annotated[str, "Asset type under analysis such as stock or crypto"]
     instrument_context: Annotated[str, "Deterministic ticker identity resolved at run start"]
     trade_date: Annotated[str, "What date we are trading at"]
+    portfolio_context: Annotated[
+        dict | None,
+        "Optional broker-neutral portfolio snapshot (positions, cash, capital) "
+        "as plain JSON-safe data. None means the context was not provided, "
+        "which is distinct from a known-empty portfolio.",
+    ]
 
     sender: Annotated[str, "Agent that sent this message"]
 

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -7,6 +7,7 @@ import yfinance as yf
 from langchain_core.messages import HumanMessage, RemoveMessage
 
 # Import tools from separate utility files
+from tradingagents.agents.schemas import PortfolioContext, render_portfolio_context
 from tradingagents.agents.utils.core_stock_tools import get_stock_data
 from tradingagents.agents.utils.fundamental_data_tools import (
     get_balance_sheet,
@@ -42,6 +43,8 @@ __all__ = [
     "build_instrument_context",
     "resolve_instrument_identity",
     "get_instrument_context_from_state",
+    "get_portfolio_context_from_state",
+    "portfolio_prompt_block",
     "get_language_instruction",
     "create_msg_delete",
 ]
@@ -199,6 +202,44 @@ def get_instrument_context_from_state(state: Mapping[str, Any]) -> str:
         str(state["company_of_interest"]),
         state.get("asset_type", "stock"),
     )
+
+
+#: Prompt block used when the run was started without a portfolio context.
+#: States explicitly that holdings are unknown so agents do not present
+#: sizing guidance as portfolio-grounded (#1166).
+MISSING_PORTFOLIO_CONTEXT_NOTICE = (
+    "No portfolio context was provided for this run. Do not claim knowledge "
+    "of current holdings, cash, or exposure, and do not present "
+    "position-sizing guidance as grounded in actual positions."
+)
+
+
+def get_portfolio_context_from_state(state: Mapping[str, Any]) -> PortfolioContext | None:
+    """Return the typed portfolio context for the current run, if any.
+
+    The state carries the snapshot as plain JSON-safe data (so checkpoints
+    stay serializable); it is validated back into a ``PortfolioContext``
+    here. ``None`` means the context was not provided — which is distinct
+    from a known flat portfolio (a context with empty ``positions``).
+    """
+    raw = state.get("portfolio_context")
+    if raw is None:
+        return None
+    if isinstance(raw, PortfolioContext):
+        return raw
+    return PortfolioContext.model_validate(raw)
+
+
+def portfolio_prompt_block(state: Mapping[str, Any]) -> str:
+    """Render the deterministic portfolio block for decision-node prompts.
+
+    Returns the missing-context notice when no snapshot was provided, else
+    the snapshot rendered with focus on the instrument under analysis.
+    """
+    context = get_portfolio_context_from_state(state)
+    if context is None:
+        return MISSING_PORTFOLIO_CONTEXT_NOTICE
+    return render_portfolio_context(context, str(state.get("company_of_interest", "")))
 
 
 def create_msg_delete():

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -2,10 +2,30 @@
 
 from typing import Any
 
+from tradingagents.agents.schemas import PortfolioContext
 from tradingagents.agents.utils.agent_states import (
     InvestDebateState,
     RiskDebateState,
 )
+
+
+def normalize_portfolio_context(
+    portfolio_context: PortfolioContext | dict | None,
+) -> dict | None:
+    """Normalize a caller-supplied portfolio context to JSON-safe state data.
+
+    Accepts a ``PortfolioContext`` or its ``dict`` form; ``None`` is passed
+    through and means the context was not provided. Validation failures raise
+    ``pydantic.ValidationError`` so a malformed snapshot fails at run start
+    rather than silently degrading into an empty portfolio.
+    """
+    if portfolio_context is None:
+        return None
+    if isinstance(portfolio_context, PortfolioContext):
+        context = portfolio_context
+    else:
+        context = PortfolioContext.model_validate(portfolio_context)
+    return context.model_dump(mode="json")
 
 
 class Propagator:
@@ -22,6 +42,7 @@ class Propagator:
         asset_type: str = "stock",
         past_context: str = "",
         instrument_context: str = "",
+        portfolio_context: PortfolioContext | dict | None = None,
     ) -> dict[str, Any]:
         """Create the initial state for the agent graph.
 
@@ -30,6 +51,11 @@ class Propagator:
         ``TradingAgentsGraph.resolve_instrument_context``). When empty, agents
         fall back to ticker-only context via
         ``get_instrument_context_from_state``.
+
+        ``portfolio_context`` is the optional broker-neutral portfolio
+        snapshot (see ``PortfolioContext``). When omitted, the state records
+        ``None`` so decision nodes can distinguish "not provided" from a
+        known flat portfolio.
         """
         return {
             "messages": [("human", company_name)],
@@ -38,6 +64,7 @@ class Propagator:
             "instrument_context": instrument_context,
             "trade_date": str(trade_date),
             "past_context": past_context,
+            "portfolio_context": normalize_portfolio_context(portfolio_context),
             "investment_debate_state": InvestDebateState(
                 {
                     "bull_history": "",

--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -1,5 +1,7 @@
 # TradingAgents/graph/propagation.py
 
+import hashlib
+import json
 from typing import Any
 
 from tradingagents.agents.schemas import PortfolioContext
@@ -7,6 +9,12 @@ from tradingagents.agents.utils.agent_states import (
     InvestDebateState,
     RiskDebateState,
 )
+
+#: Checkpoint-identity marker for runs started without a portfolio context.
+#: Deliberately distinct from the fingerprint of any provided context —
+#: including a known-empty one — so "not provided" never resumes (or is
+#: resumed by) a portfolio-grounded run (#1166).
+MISSING_PORTFOLIO_FINGERPRINT = "none"
 
 
 def normalize_portfolio_context(
@@ -26,6 +34,38 @@ def normalize_portfolio_context(
     else:
         context = PortfolioContext.model_validate(portfolio_context)
     return context.model_dump(mode="json")
+
+
+def portfolio_context_fingerprint(
+    portfolio_context: PortfolioContext | dict | None,
+) -> str:
+    """Return a short deterministic fingerprint of a portfolio context.
+
+    The fingerprint folds the whole normalized snapshot (positions, capital,
+    timestamp, source, currency) into the checkpoint identity: a crashed run
+    resumes only when the snapshot is unchanged, while a changed snapshot
+    routes to a different checkpoint thread and starts fresh — never a
+    partial resume mixing two snapshots in one run.
+
+    Canonicalization details:
+
+    - ``None`` maps to ``MISSING_PORTFOLIO_FINGERPRINT`` (never equal to a
+      provided context, not even a known-empty one).
+    - dict key order is irrelevant (``sort_keys=True``).
+    - position order is irrelevant (sorted by symbol, then full content).
+    - only the 16-char hex digest is returned: no holdings leak into thread
+      ids, filenames, or logs. Never uses ``hash()`` (process-randomized).
+    """
+    if portfolio_context is None:
+        return MISSING_PORTFOLIO_FINGERPRINT
+    normalized = normalize_portfolio_context(portfolio_context)
+    positions = sorted(
+        normalized.get("positions", []),
+        key=lambda p: (p["symbol"].upper(), json.dumps(p, sort_keys=True)),
+    )
+    canonical = {**normalized, "positions": positions}
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 class Propagator:

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -37,7 +37,7 @@ from tradingagents.reporting import write_report_tree
 
 from .checkpointer import checkpoint_step, clear_checkpoint, get_checkpointer, thread_id
 from .conditional_logic import ConditionalLogic
-from .propagation import Propagator
+from .propagation import Propagator, portfolio_context_fingerprint
 from .reflection import Reflector
 from .setup import GraphSetup
 from .signal_processing import SignalProcessor
@@ -387,18 +387,28 @@ class TradingAgentsGraph:
         td = str(trade_date)
         return td if td < datetime.now().strftime("%Y-%m-%d") else None
 
-    def _run_signature(self, asset_type: str) -> str:
+    def _run_signature(
+        self,
+        asset_type: str,
+        portfolio_context: PortfolioContext | dict | None = None,
+    ) -> str:
         """Graph-shape inputs that must invalidate a checkpoint if changed.
 
         Keyed into the checkpoint thread ID so a resume under a different analyst
         selection, debate/risk depth, or asset mode starts fresh instead of
         silently continuing the previous graph (#1089).
+
+        The portfolio snapshot participates through a deterministic fingerprint
+        (not the raw JSON): the same snapshot resumes, a changed snapshot
+        starts a fresh run rather than continuing with stale holdings, and a
+        missing context never shares a checkpoint with a provided one (#1166).
         """
         return "|".join([
             "analysts=" + ",".join(self.selected_analysts),
             f"debate={self.config['max_debate_rounds']}",
             f"risk={self.config['max_risk_discuss_rounds']}",
             f"asset={asset_type}",
+            f"portfolio={portfolio_context_fingerprint(portfolio_context)}",
         ])
 
     def propagate(
@@ -435,14 +445,23 @@ class TradingAgentsGraph:
         # Resolve any pending memory-log entries for this ticker before the pipeline runs.
         self._resolve_pending_entries(company_name)
 
-        with self.checkpoint_scope(company_name, trade_date, asset_type) as thread_id_value:
+        with self.checkpoint_scope(
+            company_name, trade_date, asset_type,
+            portfolio_context=portfolio_context,
+        ) as thread_id_value:
             return self._run_graph(
                 company_name, trade_date, asset_type=asset_type,
                 checkpoint_thread_id=thread_id_value,
                 portfolio_context=portfolio_context,
             )
 
-    def begin_checkpoint(self, company_name, trade_date, asset_type: str = "stock") -> str | None:
+    def begin_checkpoint(
+        self,
+        company_name,
+        trade_date,
+        asset_type: str = "stock",
+        portfolio_context: PortfolioContext | dict | None = None,
+    ) -> str | None:
         """Recompile the graph with a per-ticker checkpointer and return the
         ``thread_id`` to inject into the stream/invoke ``config`` (or ``None``
         when checkpointing is disabled).
@@ -456,7 +475,7 @@ class TradingAgentsGraph:
         self._resuming = False
         if not self.config.get("checkpoint_enabled"):
             return None
-        signature = self._run_signature(asset_type)
+        signature = self._run_signature(asset_type, portfolio_context)
         self._checkpointer_ctx = get_checkpointer(self.config["data_cache_dir"], company_name)
         saver = self._checkpointer_ctx.__enter__()
         self.graph = self.workflow.compile(checkpointer=saver)
@@ -490,19 +509,34 @@ class TradingAgentsGraph:
         self._resuming = False
 
     @contextmanager
-    def checkpoint_scope(self, company_name, trade_date, asset_type: str = "stock"):
+    def checkpoint_scope(
+        self,
+        company_name,
+        trade_date,
+        asset_type: str = "stock",
+        portfolio_context: PortfolioContext | dict | None = None,
+    ):
         """Context-manager form of begin/end_checkpoint for the propagate path."""
         try:
-            yield self.begin_checkpoint(company_name, trade_date, asset_type)
+            yield self.begin_checkpoint(
+                company_name, trade_date, asset_type,
+                portfolio_context=portfolio_context,
+            )
         finally:
             self.end_checkpoint()
 
-    def clear_checkpoint_on_success(self, company_name, trade_date, asset_type: str = "stock"):
+    def clear_checkpoint_on_success(
+        self,
+        company_name,
+        trade_date,
+        asset_type: str = "stock",
+        portfolio_context: PortfolioContext | dict | None = None,
+    ):
         """Drop a completed run's checkpoint so a later run starts fresh (#1249)."""
         if self.config.get("checkpoint_enabled"):
             clear_checkpoint(
                 self.config["data_cache_dir"], company_name, str(trade_date),
-                self._run_signature(asset_type),
+                self._run_signature(asset_type, portfolio_context),
             )
 
     def save_reports(self, final_state, ticker, save_path=None) -> Path:
@@ -585,7 +619,10 @@ class TradingAgentsGraph:
         )
 
         # Clear checkpoint on successful completion to avoid stale state.
-        self.clear_checkpoint_on_success(company_name, trade_date, asset_type)
+        self.clear_checkpoint_on_success(
+            company_name, trade_date, asset_type,
+            portfolio_context=portfolio_context,
+        )
 
         return final_state, self.process_signal(final_state["final_trade_decision"])
 

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -11,7 +11,7 @@ from typing import Any
 import yfinance as yf
 from langgraph.prebuilt import ToolNode
 
-# Import the abstract tool methods from agent_utils
+from tradingagents.agents.schemas import PortfolioContext
 from tradingagents.agents.utils.agent_utils import (
     build_instrument_context,
     get_balance_sheet,
@@ -401,7 +401,13 @@ class TradingAgentsGraph:
             f"asset={asset_type}",
         ])
 
-    def propagate(self, company_name, trade_date, asset_type: str = "stock"):
+    def propagate(
+        self,
+        company_name,
+        trade_date,
+        asset_type: str = "stock",
+        portfolio_context: PortfolioContext | dict | None = None,
+    ):
         """Run the trading agents graph for a company on a specific date.
 
         ``asset_type`` selects between the stock pipeline (default) and the
@@ -410,6 +416,13 @@ class TradingAgentsGraph:
         ``checkpoint_enabled`` is set in config, the graph is recompiled with
         a per-ticker SqliteSaver so a crashed run can resume from the last
         successful node on a subsequent invocation with the same ticker+date.
+
+        ``portfolio_context`` is an optional broker-neutral
+        :class:`~tradingagents.agents.schemas.PortfolioContext` (or its dict
+        form) describing current holdings and capital. When provided it is
+        threaded through the Trader, risk, and Portfolio Manager prompts;
+        when omitted those nodes are told explicitly that no portfolio
+        context was given, instead of assuming a flat portfolio.
 
         Returns ``(final_state, signal)`` where ``signal`` is one of the 5-tier
         ratings (Buy / Overweight / Hold / Underweight / Sell) or ``"REVIEW"``
@@ -426,6 +439,7 @@ class TradingAgentsGraph:
             return self._run_graph(
                 company_name, trade_date, asset_type=asset_type,
                 checkpoint_thread_id=thread_id_value,
+                portfolio_context=portfolio_context,
             )
 
     def begin_checkpoint(self, company_name, trade_date, asset_type: str = "stock") -> str | None:
@@ -507,7 +521,8 @@ class TradingAgentsGraph:
         return write_report_tree(final_state, ticker, save_path)
 
     def _run_graph(self, company_name, trade_date, asset_type: str = "stock",
-                   checkpoint_thread_id: str | None = None):
+                   checkpoint_thread_id: str | None = None,
+                   portfolio_context: PortfolioContext | dict | None = None):
         """Execute the graph and write the resulting state to disk and memory log."""
         # Initialize state — inject memory log context for PM and the
         # deterministically resolved instrument identity for all agents. On a
@@ -523,6 +538,7 @@ class TradingAgentsGraph:
             asset_type=asset_type,
             past_context=past_context,
             instrument_context=instrument_context,
+            portfolio_context=portfolio_context,
         )
         args = self.propagator.get_graph_args()
 
@@ -578,6 +594,13 @@ class TradingAgentsGraph:
         self.log_states_dict[str(trade_date)] = {
             "company_of_interest": final_state["company_of_interest"],
             "trade_date": final_state["trade_date"],
+            # Whether a portfolio snapshot was provided, and the snapshot
+            # itself when present, so saved runs identify which context the
+            # Trader / risk / Portfolio Manager decisions were grounded in.
+            # A missing context (None) is recorded as absent rather than as
+            # an empty portfolio (#1166).
+            "portfolio_context_present": final_state.get("portfolio_context") is not None,
+            "portfolio_context": final_state.get("portfolio_context"),
             "market_report": final_state["market_report"],
             "sentiment_report": final_state["sentiment_report"],
             "news_report": final_state["news_report"],


### PR DESCRIPTION
## Summary

Adds an optional, broker-neutral portfolio context to the canonical TradingAgents graph input so Trader / risk / Portfolio Manager decisions can distinguish between:

- a known current position / portfolio snapshot
- a known empty portfolio
- portfolio context that was not provided

This addresses the input-contract gap discussed in #1166.

## Why

TradingAgents can currently produce sizing and Buy/Overweight/Hold/Underweight/Sell guidance, but the graph does not have a first-class typed representation of current holdings and capital.

Downstream wrappers can inject this information through prose, but that makes behavior inconsistent and can make a missing portfolio look like a flat portfolio.

## Scope

This PR intentionally does **not** add:

- broker connectivity
- order execution
- Alpaca dependencies
- automatic trading
- portfolio optimization

It only adds the portfolio input contract and threads it through the existing decision flow:

- `PositionSnapshot` / `PortfolioContext` schemas plus a deterministic renderer focused on the instrument under analysis (`tradingagents/agents/schemas.py`)
- `AgentState.portfolio_context` carried as JSON-safe data so checkpoints stay serializable
- `propagate(..., portfolio_context=...)` threading through `Propagator.create_initial_state`
- prompt blocks for Trader, the three risk debators, and Portfolio Manager (research-team prompts stay portfolio-blind); an explicit "not provided" notice when absent
- `--portfolio-context <json file>` CLI flag with fail-fast validation
- saved run state records `portfolio_context_present` plus the snapshot used
- checkpoint identity includes a deterministic portfolio-context fingerprint, so a changed snapshot starts a fresh run instead of resuming stale portfolio state
- renderer is market-neutral; optional currency is shown as an ISO-style label and quantities use generic units
- README documentation with a Python example

Note on open PR #1125 (read-only IBKR context for batch analysis): that change is broker-specific and batch-scoped, while this proposal is the broker-neutral counterpart on the canonical `propagate()` path. The two are complementary; happy to rebase or narrow scope per maintainer preference.

The design was informed by a downstream paper-trading integration where explicit missing-vs-empty portfolio semantics were required, but this PR keeps the upstream contract broker-neutral.

## Backward compatibility

Existing calls remain valid:

```python
ta.propagate("NVDA", "2026-01-15")
```

Portfolio context is optional. No new required env vars, no new runtime dependencies, no network calls in tests.

## Tests

- 55 new credential-free, network-free tests (`tests/test_portfolio_context.py`): schema validation, missing-vs-empty semantics, deterministic rendering, Trader / risk / Portfolio Manager prompt injection, `propagate()` wiring with backward-compat, saved-state metadata, CLI file loader, checkpoint fingerprint regressions, market-neutral rendering (USD / no-currency / JPY / crypto)
- Full suite: 708 passed, 2 skipped (baseline 653 passed before this change — no regressions)
- `ruff check .`, `compileall`, and `git diff --check` all green

### Checkpoint safety

Portfolio context participates in checkpoint identity through a deterministic hash.
A crashed run is resumed only when the portfolio snapshot is unchanged; if holdings or capital change, the next invocation starts a fresh run rather than continuing with stale state.

Related: #1166

