### PR TITLE
feat(cli_agent): run the analyst methodology on a coding-agent subscription

### DIFF
--- a/.claude/skills/trading-analysis/SKILL.md
+++ b/.claude/skills/trading-analysis/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: trading-analysis
+description: >-
+  Run the full TradingAgents multi-agent methodology (analysts -> bull/bear
+  debate -> research manager -> trader -> risk debate -> portfolio manager) on
+  a single ticker for a point-in-time date, using a research bundle instead of
+  per-token LLM API calls. Trigger when the user asks to "analyze <ticker>",
+  "run trading analysis", "what's the call on <stock>", or names a ticker + a
+  date. Produces the same report tree as `python -m cli.main`.
+---
+
+# Trading analysis (subscription-priced)
+
+You reproduce the TradingAgents pipeline yourself, reasoning over a pre-built
+data bundle. No `tradingagents` LLM calls — you ARE the analyst team.
+
+## Inputs
+
+`/trading-analysis <TICKER> <YYYY-MM-DD> [analysts] [--rounds N]`
+
+- **TICKER** — Yahoo symbol with exchange suffix (`RELIANCE.NS`, `^NSEI`, `TCS.NS`). If the user gives a bare Indian name, add `.NS`.
+- **DATE** — the point-in-time "now". All data is filtered to on-or-before this date; never reference anything after it.
+- **analysts** — subset of `market,news,fundamentals` (default all three). Skip `news` only if the user asks.
+- **--rounds N** — bull/bear and risk debate rounds (default 1).
+
+## Step 0 — Pre-flight
+
+```bash
+source .venv/bin/activate
+python -m cli_agent.check_ticker <TICKER>
+```
+
+- `NO DATA` / `WEAK` (few bars / thin volume / SME) → stop and tell the user; don't burn effort on a run that can't produce a sound call.
+- For an **ETF**, also warn that you can't see NAV premium/discount — flag it in the final report.
+
+## Step 1 — Build the bundle
+
+```bash
+python -m cli_agent.research_bundle <TICKER> <DATE> --analysts <analysts>
+```
+
+Read the written file fully (`cli_agent/bundles/<TICKER>_<DATE>.md`). It has:
+`Instrument context`, `MARKET DATA` (verified snapshot + price history + per-indicator tables), `FUNDAMENTALS` (point-in-time statements; profile withheld by design), `NEWS & MACRO`.
+
+**The "Verified market snapshot" block is the source of truth** for any exact price / band / RSI / MACD / MA value. If the price-history table disagrees, flag the discrepancy — never invent a reconciled number. Do not claim a historically-validated bounce or an exact % move unless the bundle's dated rows support it.
+
+## Step 2 — Analyst reports
+
+Write each as its own markdown report, detailed and evidence-based, ending with a Markdown summary table and a line `FINAL TRANSACTION PROPOSAL: **BUY/HOLD/SELL**`.
+
+### Market Analyst
+Pick **up to 8 complementary** indicators for the current regime (trend / momentum / volatility / volume — don't double up, e.g. not both rsi and stochrsi). For each, read its value and trajectory from the bundle. Cover: trend structure (10 EMA / 50 SMA / 200 SMA, price vs each), momentum (RSI level + path, MACD line/signal/histogram + whether it's widening or converging), volatility (Bollinger position, ATR regime and stop implications), volume confirmation (VWMA vs price). Give explicit resistance/support levels. Note data caveats (e.g. 50 SMA == 200 SMA ⇒ short history; anomalous single bars).
+
+### Fundamentals Analyst
+Work the annual + quarterly income statement, balance sheet, cash flow, and insider transactions. Trace multi-year trends (revenue, margins, EBITDA, net income, FCF, debt, equity, inventory, cash). Call out inflections and inconsistencies. **For an index/ETF**: state that company-style fundamentals don't apply, note it's expected, and defer to technical + macro. Profile/valuation being "withheld" is the point-in-time guard, not a failure.
+
+### News Analyst
+Summarize ticker news and global/macro headlines relevant to the instrument. Ground macro claims in the FRED tables if present; if `FRED_API_KEY` was not set, say macro data was unavailable rather than guessing. For an Indian instrument, note when global feeds carry little India-relevant signal and recommend NSE/BSE filings + Indian financial media as supplements. No fabricated figures.
+
+## Step 3 — Research debate (`--rounds N`, default 1)
+
+- **Bull Researcher** — evidence-based case for the position: growth, edge, positive indicators; engage the bear's points directly, conversational, not a data dump.
+- **Bear Researcher** — case against: risks, competitive weakness, negative indicators; rebut the bull specifically.
+- Repeat for N rounds, each side responding to the last.
+
+## Step 4 — Research Manager
+
+Evaluate the debate on merits (not who spoke last). Output:
+- **Recommendation** — exactly one of: **Buy / Overweight / Hold / Underweight / Sell**. Choose Hold when evidence is balanced, conflicting, ambiguous, or thin — don't manufacture a direction.
+- **Rationale** — which arguments won and why, cite specifics.
+- **Strategic Actions** — numbered, concrete.
+
+## Step 5 — Trader
+
+Turn the plan into a proposal, grounding price levels in the Market Analyst's price structure (current price, support/resistance, ATR):
+- **Action** — Buy / Sell / Hold
+- **Reasoning**
+- **Entry Price** — absolute price level in the quote currency (not a %, not a range), or omit
+- **Stop Loss** — absolute price level
+- **Position Sizing** — explicit
+- `FINAL TRANSACTION PROPOSAL: **BUY/SELL/HOLD**`
+
+## Step 6 — Risk debate (`--rounds N`)
+
+Three analysts argue over the Trader's proposal, each rebutting the other two:
+- **Aggressive** — champion upside / high-reward positioning.
+- **Conservative** — capital preservation, downside, volatility.
+- **Neutral** — balanced; challenge both extremes.
+
+## Step 7 — Portfolio Manager (final)
+
+Synthesize the risk debate. Output:
+- **Rating** — exactly one of **Buy / Overweight / Hold / Underweight / Sell** (Hold if genuinely balanced/ambiguous).
+- **Executive Summary** — the actionable call in 3-5 sentences (exit/trim/add %, levels, horizon).
+- **Investment Thesis** — grounded in specific analyst evidence.
+- **Price Target**, **Time Horizon**.
+- If ETF: restate the NAV-premium blind spot.
+
+## Step 8 — Write the report tree
+
+Create `reports/<TICKER>_<UTC timestamp YYYYMMDD_HHMMSS>/` and write:
+
+```
+1_analysts/market.md          1_analysts/news.md          1_analysts/fundamentals.md
+2_research/bull.md   2_research/bear.md   2_research/manager.md
+3_trading/trader.md
+4_risk/aggressive.md   4_risk/conservative.md   4_risk/neutral.md
+5_portfolio/decision.md
+complete_report.md            # all of the above concatenated with section headers
+```
+
+Match the format of any existing folder under `reports/`. Then give the user:
+the final **Rating**, the one-paragraph thesis, key levels, horizon, and any data caveats (FRED missing, thin news, ETF premium, anomalous bars).
+
+## Batch
+
+For several tickers, loop Steps 0-8 per ticker and finish with a summary table
+(ticker → rating → target → one-line why). Reuse one bundle per ticker.
+
+## Cost note
+
+The only spend here is your own agent turns. If the user wants the true
+independent-agent debate with the LangGraph orchestrator, that's
+`python -m cli.main` (Anthropic API, ~$0.50-1.50/run) — offer it only for a
+final high-stakes second opinion.

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ __marimo__/
 # Enterprise env file (secrets) and generated run reports
 .env.enterprise
 reports/
+
+# CLI-agent workflow: generated research bundles
+cli_agent/bundles/

--- a/cli_agent/README.md
+++ b/cli_agent/README.md
@@ -1,0 +1,55 @@
+# cli_agent — run TradingAgents on a coding-agent subscription
+
+The upstream framework drives ~15 LLM agents through the Anthropic (or other)
+API, billed per token — roughly $0.50–1.50 per ticker. This directory lets a
+CLI coding agent (Claude Code, Codex, …) run the **same methodology** on its
+flat subscription instead.
+
+## How it works
+
+1. **`research_bundle.py`** assembles a point-in-time data bundle for one
+   ticker — verified market snapshot, price history, per-indicator tables,
+   fundamentals (annual + quarterly statements), ticker + macro news — reusing
+   the framework's own dataflow layer, including its look-ahead guards. **Zero
+   LLM calls.**
+2. The **`trading-analysis` skill** (`.claude/skills/trading-analysis/`) tells
+   the agent to read that bundle and work through every role — Market /
+   Fundamentals / News analyst → bull vs bear debate → Research Manager →
+   Trader → Aggressive / Conservative / Neutral risk debate → Portfolio
+   Manager — writing the same `reports/<ticker>_<timestamp>/` tree the real CLI
+   produces.
+3. **`check_ticker.py`** is a pre-flight: catches missing exchange suffixes,
+   dead symbols, recent IPOs with too little history, SME-platform tickers,
+   and thin volume before you spend a run on them.
+
+## Usage
+
+```bash
+source .venv/bin/activate
+
+# pre-flight
+python -m cli_agent.check_ticker RELIANCE.NS TCS.NS ^NSEI
+
+# build a bundle (writes cli_agent/bundles/<ticker>_<date>.md)
+python -m cli_agent.research_bundle RELIANCE.NS 2026-09-08
+python -m cli_agent.research_bundle ^NSEI 2026-09-08 --analysts market,news
+
+# then, in Claude Code:
+/trading-analysis RELIANCE.NS 2026-09-08
+```
+
+The skill runs `check_ticker` and `research_bundle` itself, so
+`/trading-analysis <ticker> <date>` is usually all you need.
+
+## Notes
+
+- **FRED macro** is skipped unless `FRED_API_KEY` is set (free key:
+  <https://fred.stlouisfed.org/docs/api/api_key.html>). Add it to `.env`.
+- **Prediction markets** (Polymarket) are off by default — pass
+  `--prediction-markets` to include them; they often time out.
+- The date is a point-in-time "now": everything is filtered to on-or-before it.
+- This trades the framework's true independent multi-agent debate for one agent
+  role-playing the sequence. Same data, same prompts, much cheaper. For a
+  final high-stakes second opinion, `python -m cli.main` still runs the real
+  orchestrator against the API.
+- Not financial advice. Research tooling only.

--- a/cli_agent/__init__.py
+++ b/cli_agent/__init__.py
@@ -1,0 +1,7 @@
+"""CLI-agent workflow: run the TradingAgents methodology on a coding-agent
+subscription (Claude Code / Codex / ...) instead of per-token LLM API spend.
+
+- research_bundle.py : point-in-time data bundle, no LLM calls
+- check_ticker.py    : pre-flight ticker validation
+- see .claude/skills/trading-analysis/ for the reasoning workflow
+"""

--- a/cli_agent/check_ticker.py
+++ b/cli_agent/check_ticker.py
@@ -1,0 +1,65 @@
+"""Sanity-check a ticker before committing a full analysis.
+
+    python -m cli_agent.check_ticker RELIANCE.NS TCS.NS SUNLITE-SM.NS
+
+Flags the failure modes that waste an analysis run: missing exchange suffix,
+no data, too little history (recent IPOs), SME-platform tickers, thin volume.
+It cannot detect ETF NAV-premium dislocations -- check market price vs iNAV
+manually for ETFs.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import yfinance as yf
+
+MIN_ROWS = 60
+THIN_VOLUME = 50_000
+
+
+def check(symbol: str) -> None:
+    label = f"{symbol:16}"
+    try:
+        h = yf.Ticker(symbol).history(period="1y")
+    except Exception as exc:  # noqa: BLE001
+        print(f"{label} ERROR   {exc}")
+        return
+
+    if h.empty:
+        if "." not in symbol:
+            hint = f"  -> add an exchange suffix, e.g. {symbol}.NS (NSE) / .BO (BSE)"
+        elif symbol.upper().endswith(("-SM.NS", "-SM.BO")):
+            hint = "  -> SME/Emerge platform stock; no usable history on Yahoo"
+        else:
+            hint = ""
+        print(f"{label} NO DATA{hint}")
+        return
+
+    rows = len(h)
+    last = h.index[-1].date()
+    close = round(float(h["Close"].iloc[-1]), 2)
+    med_vol = int(h["Volume"].median())
+
+    problems = []
+    if rows < MIN_ROWS:
+        problems.append(f"only {rows} bars in 1y (need >= {MIN_ROWS})")
+    if med_vol < THIN_VOLUME:
+        problems.append(f"thin: median volume {med_vol:,}/day")
+
+    verdict = "OK   " if not problems else "WEAK "
+    note = "" if not problems else "  -- " + "; ".join(problems)
+    print(f"{label} {verdict}  {rows} bars | last {last} | close {close} | med vol {med_vol:,}{note}")
+
+
+def main() -> None:
+    symbols = sys.argv[1:]
+    if not symbols:
+        print(__doc__)
+        sys.exit(1)
+    for s in symbols:
+        check(s)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli_agent/research_bundle.py
+++ b/cli_agent/research_bundle.py
@@ -1,0 +1,241 @@
+"""Build a point-in-time research bundle for one ticker, with NO LLM calls.
+
+This assembles everything the TradingAgents analyst agents would normally
+fetch -- verified market snapshot, price history, indicators, fundamentals,
+news, macro, prediction markets -- into a single markdown file. A CLI coding
+agent (Claude Code, Codex, ...) then reasons over that file following the
+`trading-analysis` skill, so the multi-agent methodology runs on a flat
+subscription instead of per-token API spend.
+
+    python -m cli_agent.research_bundle RELIANCE.NS 2026-09-08
+    python -m cli_agent.research_bundle ^NSEI 2026-09-08 --analysts market,news
+    python -m cli_agent.research_bundle TCS.NS 2026-09-08 --out /tmp/bundles
+
+Every data pull is wrapped: a vendor error (e.g. FRED key missing, no news)
+is written into the bundle verbatim, exactly as the real agents would see it,
+rather than aborting the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import threading
+from pathlib import Path
+
+# Loads .env (FRED_API_KEY etc.) and applies TRADINGAGENTS_* overrides.
+import tradingagents  # noqa: F401
+from tradingagents.dataflows.interface import route_to_vendor
+from tradingagents.dataflows.market_data_validator import (
+    DEFAULT_SNAPSHOT_INDICATORS,
+    build_verified_market_snapshot,
+)
+from tradingagents.dataflows.symbol_utils import normalize_symbol
+from tradingagents.default_config import DEFAULT_CONFIG
+
+try:
+    from tradingagents.agents.utils.agent_utils import (
+        build_instrument_context,
+        resolve_instrument_identity,
+    )
+except Exception:  # pragma: no cover - keep the bundle usable if utils move
+    build_instrument_context = None
+    resolve_instrument_identity = None
+
+ANALYSTS = ("market", "news", "fundamentals")
+PRICE_LOOKBACK_DAYS = 220          # ~10 months of sessions for trend context
+MACRO_SERIES = ("fed_funds_rate", "10y_treasury", "cpi", "unemployment", "yield_curve")
+PREDICTION_TOPICS = ("Fed rate cut", "recession 2026", "India economy")
+CALL_TIMEOUT_S = 30               # a slow vendor never hangs the whole bundle
+
+
+def _section(title: str) -> str:
+    return f"\n\n{'=' * 78}\n## {title}\n{'=' * 78}\n"
+
+
+def _try(label: str, fn) -> str:
+    """Run a data pull in a watchdog thread; return its text or a visible note.
+
+    Vendor calls (FRED, Polymarket, yfinance) can hang or 30s-retry; the daemon
+    thread lets the bundle move on and still exit cleanly.
+    """
+    box: dict[str, str] = {}
+
+    def _run() -> None:
+        try:
+            out = fn()
+            box["ok"] = str(out).strip() or f"_{label}: empty result_"
+        except Exception as exc:  # noqa: BLE001 - the error itself is useful signal
+            box["ok"] = f"_{label}: unavailable -- {type(exc).__name__}: {exc}_"
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(CALL_TIMEOUT_S)
+    if t.is_alive():
+        return f"_{label}: timed out after {CALL_TIMEOUT_S}s (vendor slow/unreachable)_"
+    return box.get("ok", f"_{label}: no result_")
+
+
+def _daterange(curr_date: str, days: int) -> tuple[str, str]:
+    end = dt.date.fromisoformat(curr_date)
+    start = end - dt.timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+def _instrument_context(raw: str, canonical: str) -> str:
+    if resolve_instrument_identity is None or build_instrument_context is None:
+        return f"Ticker: `{raw}` (canonical `{canonical}`)"
+    try:
+        identity = resolve_instrument_identity(raw)
+    except Exception:  # noqa: BLE001
+        identity = {}
+    return build_instrument_context(canonical, "stock", identity)
+
+
+def build_market_section(canonical: str, curr_date: str) -> str:
+    out = [_section("MARKET DATA (as of " + curr_date + ")")]
+    out.append(
+        "> The verified snapshot below is the SOURCE OF TRUTH for any exact "
+        "price / band / indicator value. If the price-history table disagrees, "
+        "flag the discrepancy -- do not invent a reconciled number.\n"
+    )
+    out.append("### Verified market snapshot\n")
+    out.append(_try("verified snapshot", lambda: build_verified_market_snapshot(canonical, curr_date, 30)))
+
+    start, end = _daterange(curr_date, PRICE_LOOKBACK_DAYS)
+    out.append(f"\n### Price history ({start} to {end})\n")
+    out.append(_try("price history", lambda: route_to_vendor("get_stock_data", canonical, start, end)))
+
+    indicators = list(DEFAULT_SNAPSHOT_INDICATORS) + ["vwma"]
+    out.append("\n### Indicator detail (60-day window per indicator)\n")
+    for ind in indicators:
+        out.append(f"\n**{ind}**\n")
+        out.append(_try(ind, lambda ind=ind: route_to_vendor("get_indicators", canonical, ind, curr_date, 60)))
+    return "\n".join(out)
+
+
+def build_fundamentals_section(canonical: str, curr_date: str) -> str:
+    out = [_section("FUNDAMENTALS (point-in-time, as of " + curr_date + ")")]
+    out.append(
+        "> For an index or ETF, most of these return NO_DATA / withheld -- that "
+        "is expected, not a failure. Note it and defer to technical + macro.\n"
+    )
+    out.append("### Company overview\n")
+    out.append(_try("fundamentals overview", lambda: route_to_vendor("get_fundamentals", canonical, curr_date)))
+    for name, method in (
+        ("Income statement", "get_income_statement"),
+        ("Balance sheet", "get_balance_sheet"),
+        ("Cash flow", "get_cashflow"),
+    ):
+        for freq in ("annual", "quarterly"):
+            out.append(f"\n### {name} ({freq})\n")
+            out.append(_try(f"{name} {freq}", lambda m=method, f=freq: route_to_vendor(m, canonical, f, curr_date)))
+    out.append("\n### Insider transactions\n")
+    out.append(_try("insider transactions", lambda: route_to_vendor("get_insider_transactions", canonical)))
+    return "\n".join(out)
+
+
+def build_news_section(canonical: str, curr_date: str, prediction_markets: bool = False) -> str:
+    out = [_section("NEWS & MACRO (as of " + curr_date + ")")]
+    start, end = _daterange(curr_date, DEFAULT_CONFIG.get("global_news_lookback_days", 7) * 2)
+    out.append(f"### Ticker news ({start} to {end})\n")
+    out.append(_try("ticker news", lambda: route_to_vendor("get_news", canonical, start, end)))
+
+    out.append("\n### Global / macro headlines\n")
+    out.append(_try("global news", lambda: route_to_vendor("get_global_news", curr_date, None, None)))
+
+    out.append("\n### Macro indicators (FRED)\n")
+    if not os.environ.get("FRED_API_KEY"):
+        out.append(
+            "_FRED_API_KEY not set -- macro series skipped. Add a free key from "
+            "https://fred.stlouisfed.org/docs/api/api_key.html to .env to enable._"
+        )
+    else:
+        for series in MACRO_SERIES:
+            out.append(f"\n**{series}**\n")
+            out.append(_try(series, lambda s=series: route_to_vendor("get_macro_indicators", s, curr_date, None)))
+
+    if prediction_markets:
+        out.append("\n### Prediction markets\n")
+        for topic in PREDICTION_TOPICS:
+            out.append(f"\n**{topic}**\n")
+            out.append(_try(topic, lambda t=topic: route_to_vendor("get_prediction_markets", t, 5)))
+    return "\n".join(out)
+
+
+BUILDERS = {
+    "market": build_market_section,
+    "fundamentals": build_fundamentals_section,
+    "news": build_news_section,
+}
+
+
+def build_bundle(
+    raw_ticker: str,
+    curr_date: str,
+    analysts: list[str],
+    prediction_markets: bool = False,
+) -> str:
+    canonical = normalize_symbol(raw_ticker)
+    dt.date.fromisoformat(curr_date)  # validate
+
+    header = [
+        f"# Research bundle: {raw_ticker}",
+        "",
+        f"- Requested ticker: `{raw_ticker}`",
+        f"- Canonical (Yahoo) symbol: `{canonical}`",
+        f"- Analysis date (point-in-time 'now'): **{curr_date}**",
+        f"- Generated: {dt.datetime.now().isoformat(timespec='seconds')}",
+        f"- Sections: {', '.join(analysts)}",
+        "",
+        "## Instrument context",
+        "",
+        _instrument_context(raw_ticker, canonical),
+        "",
+        f"> All data below is filtered to on-or-before the analysis date. "
+        f"Treat {curr_date} as today. Do not reference anything after it.",
+    ]
+    body = []
+    for a in analysts:
+        if a == "news":
+            body.append(build_news_section(canonical, curr_date, prediction_markets))
+        elif a in BUILDERS:
+            body.append(BUILDERS[a](canonical, curr_date))
+    return "\n".join(header) + "\n" + "\n".join(body) + "\n"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Point-in-time research bundle (no LLM calls).")
+    p.add_argument("ticker", help="e.g. RELIANCE.NS, ^NSEI, TCS.NS")
+    p.add_argument("date", help="analysis date, YYYY-MM-DD (treated as 'now')")
+    p.add_argument(
+        "--analysts",
+        default=",".join(ANALYSTS),
+        help=f"comma list from {ANALYSTS} (default: all)",
+    )
+    p.add_argument("--out", default=str(Path(__file__).parent / "bundles"), help="output directory")
+    p.add_argument(
+        "--prediction-markets",
+        action="store_true",
+        help="also pull Polymarket odds (often slow / times out; off by default)",
+    )
+    args = p.parse_args()
+
+    analysts = [a.strip().lower() for a in args.analysts.split(",") if a.strip()]
+    unknown = [a for a in analysts if a not in BUILDERS]
+    if unknown:
+        p.error(f"unknown analyst(s): {unknown}; choose from {list(BUILDERS)}")
+
+    bundle = build_bundle(args.ticker, args.date, analysts, args.prediction_markets)
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    safe = args.ticker.replace("/", "_").replace("\\", "_")
+    out_file = out_dir / f"{safe}_{args.date}.md"
+    out_file.write_text(bundle, encoding="utf-8")
+    print(f"Wrote {out_file}  ({len(bundle):,} chars)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a per-token-free path to the TradingAgents methodology:

- cli_agent/research_bundle.py: assembles a point-in-time data bundle (verified market snapshot, price history, per-indicator tables, annual+quarterly fundamentals, ticker + macro news) from the existing dataflow layer, including its look-ahead guards. No LLM calls. Slow vendors are watchdog-timed so nothing hangs the bundle; FRED is gated on FRED_API_KEY, Polymarket is opt-in.
- cli_agent/check_ticker.py: pre-flight validation (missing suffix, dead symbol, recent IPO, SME platform, thin volume).
- .claude/skills/trading-analysis/SKILL.md: walks a CLI agent through the full pipeline (analysts -> bull/bear -> research manager -> trader -> risk debate -> portfolio manager) over the bundle, writing the same reports/ tree as python -m cli.main.

Nothing in tradingagents/ or cli/ is modified.